### PR TITLE
feat: add interactive Lira journey map

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -128,3 +128,34 @@ h1 {
     font-size: 0.9em;
     opacity: 0.9;
 }
+
+#lira-journey {
+    margin-top: 40px;
+}
+.journey-map {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    padding: 0;
+}
+.journey-map .phase {
+    flex: 1 1 250px;
+    padding: 15px;
+    border: 2px solid #333;
+    border-radius: 10px;
+    background: #fafafa;
+}
+.journey-map .phase.final {
+    border-color: #c00;
+    background: #ffecec;
+}
+.journey-map h3 {
+    margin-top: 0;
+}
+.journey-map .phase ul {
+    display: none;
+}
+.journey-map .phase.open ul {
+    display: block;
+}

--- a/index.html
+++ b/index.html
@@ -142,6 +142,63 @@
                 </div>
             </div>
         </div>
+        <section id="lira-journey">
+          <h2>🗺️ Путешествие Лира</h2>
+          <ol class="journey-map">
+            <li class="phase">
+              <h3>1. Тремор</h3>
+              <p>Лира оказывается в мире немецкого языка.</p>
+              <ul>
+                <li>das Chaos</li><li>das Ende</li><li>das Blatt</li>
+                <li>das Blut</li><li>das Alter</li>
+              </ul>
+            </li>
+            <li class="phase">
+              <h3>2. Утверждение</h3>
+              <p>Отрабатываем произношение и ударения.</p>
+              <ul>
+                <li>das Exil</li><li>das Fenster</li><li>das Gefolge</li>
+                <li>die Zeit</li><li>der Weg</li>
+              </ul>
+            </li>
+            <li class="phase">
+              <h3>3. Утешение</h3>
+              <p>Слова поддержки и дружбы.</p>
+              <ul>
+                <li>die Hilfe</li><li>der Freund</li><li>das Herz</li>
+                <li>die Hoffnung</li><li>das Vertrauen</li>
+              </ul>
+            </li>
+            <li class="phase">
+              <h3>4. Борьба</h3>
+              <p>Практикуем глаголы и порядок слов.</p>
+              <ul>
+                <li>kämpfen</li><li>lernen</li><li>fragen</li>
+                <li>sehen</li><li>denken</li>
+              </ul>
+            </li>
+            <li class="phase">
+              <h3>5. Хитрость</h3>
+              <p>Ассоциации и мнемоника.</p>
+              <ul>
+                <li>auflösen</li><li>mitkommen</li><li>verstehen</li>
+                <li>vorsprechen</li><li>zurückgehen</li>
+              </ul>
+            </li>
+            <li class="phase">
+              <h3>6. Лира</h3>
+              <p>Пишем мини‑историю.</p>
+            </li>
+            <li class="phase final">
+              <h3>7. Тёмная Лира</h3>
+              <p>Квест‑проверка знаний.</p>
+            </li>
+          </ol>
+        </section>
     </div>
+    <script>
+    document.querySelectorAll('.journey-map .phase').forEach(p =>
+      p.addEventListener('click', () => p.classList.toggle('open')));
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add "Путешествие Лира" journey map to homepage with clickable phases
- style the journey map section
- include small script to expand word lists

## Testing
- `python -m py_compile data/full_stress_dictionary_v2.py && rm -r data/__pycache__`


------
https://chatgpt.com/codex/tasks/task_e_68c536ecdb3883208ff6a0768fce9235