### PR TITLE
feat: move Lira journey map to dedicated page

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -129,33 +129,13 @@ h1 {
     opacity: 0.9;
 }
 
-#lira-journey {
-    margin-top: 40px;
+#main-nav {
+    text-align: center;
+    margin-bottom: 30px;
 }
-.journey-map {
-    list-style: none;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px;
-    padding: 0;
-}
-.journey-map .phase {
-    flex: 1 1 250px;
-    padding: 15px;
-    border: 2px solid #333;
-    border-radius: 10px;
-    background: #fafafa;
-}
-.journey-map .phase.final {
-    border-color: #c00;
-    background: #ffecec;
-}
-.journey-map h3 {
-    margin-top: 0;
-}
-.journey-map .phase ul {
-    display: none;
-}
-.journey-map .phase.open ul {
-    display: block;
+
+#main-nav a {
+    color: white;
+    text-decoration: none;
+    font-weight: bold;
 }

--- a/css/lira-journey.css
+++ b/css/lira-journey.css
@@ -1,0 +1,37 @@
+#lira-journey {
+    margin-top: 40px;
+}
+
+.journey-map {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    padding: 0;
+}
+
+.journey-map .phase {
+    flex: 1 1 250px;
+    padding: 15px;
+    border: 2px solid #333;
+    border-radius: 10px;
+    background: #fafafa;
+}
+
+.journey-map .phase.final {
+    border-color: #c00;
+    background: #ffecec;
+}
+
+.journey-map h3 {
+    margin-top: 0;
+}
+
+.journey-map .phase ul {
+    display: none;
+}
+
+.journey-map .phase.open ul {
+    display: block;
+}
+

--- a/index.html
+++ b/index.html
@@ -32,7 +32,10 @@
                 </div>
             </div>
         </div>
-        
+        <nav id="main-nav">
+          <a href="lira-journey.html">Путешествие Лира</a>
+        </nav>
+
         <!-- ТОМ 1: MACHT -->
         <div class="volume volume-1">
             <h2>📖 Band 1: MACHT (Власть)</h2>
@@ -142,63 +145,6 @@
                 </div>
             </div>
         </div>
-        <section id="lira-journey">
-          <h2>🗺️ Путешествие Лира</h2>
-          <ol class="journey-map">
-            <li class="phase">
-              <h3>1. Тремор</h3>
-              <p>Лира оказывается в мире немецкого языка.</p>
-              <ul>
-                <li>das Chaos</li><li>das Ende</li><li>das Blatt</li>
-                <li>das Blut</li><li>das Alter</li>
-              </ul>
-            </li>
-            <li class="phase">
-              <h3>2. Утверждение</h3>
-              <p>Отрабатываем произношение и ударения.</p>
-              <ul>
-                <li>das Exil</li><li>das Fenster</li><li>das Gefolge</li>
-                <li>die Zeit</li><li>der Weg</li>
-              </ul>
-            </li>
-            <li class="phase">
-              <h3>3. Утешение</h3>
-              <p>Слова поддержки и дружбы.</p>
-              <ul>
-                <li>die Hilfe</li><li>der Freund</li><li>das Herz</li>
-                <li>die Hoffnung</li><li>das Vertrauen</li>
-              </ul>
-            </li>
-            <li class="phase">
-              <h3>4. Борьба</h3>
-              <p>Практикуем глаголы и порядок слов.</p>
-              <ul>
-                <li>kämpfen</li><li>lernen</li><li>fragen</li>
-                <li>sehen</li><li>denken</li>
-              </ul>
-            </li>
-            <li class="phase">
-              <h3>5. Хитрость</h3>
-              <p>Ассоциации и мнемоника.</p>
-              <ul>
-                <li>auflösen</li><li>mitkommen</li><li>verstehen</li>
-                <li>vorsprechen</li><li>zurückgehen</li>
-              </ul>
-            </li>
-            <li class="phase">
-              <h3>6. Лира</h3>
-              <p>Пишем мини‑историю.</p>
-            </li>
-            <li class="phase final">
-              <h3>7. Тёмная Лира</h3>
-              <p>Квест‑проверка знаний.</p>
-            </li>
-          </ol>
-        </section>
     </div>
-    <script>
-    document.querySelectorAll('.journey-map .phase').forEach(p =>
-      p.addEventListener('click', () => p.classList.toggle('open')));
-    </script>
 </body>
 </html>

--- a/lira-journey.html
+++ b/lira-journey.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Путешествие Лира</title>
+    <link rel="stylesheet" href="css/index.css">
+    <link rel="stylesheet" href="css/lira-journey.css">
+</head>
+<body>
+    <div class="container">
+        <section id="lira-journey">
+          <h2>🗺️ Путешествие Лира</h2>
+          <ol class="journey-map">
+            <li class="phase">
+              <h3>1. Тремор</h3>
+              <p>Лира оказывается в мире немецкого языка.</p>
+              <ul>
+                <li>das Chaos</li><li>das Ende</li><li>das Blatt</li>
+                <li>das Blut</li><li>das Alter</li>
+              </ul>
+            </li>
+            <li class="phase">
+              <h3>2. Утверждение</h3>
+              <p>Отрабатываем произношение и ударения.</p>
+              <ul>
+                <li>das Exil</li><li>das Fenster</li><li>das Gefolge</li>
+                <li>die Zeit</li><li>der Weg</li>
+              </ul>
+            </li>
+            <li class="phase">
+              <h3>3. Утешение</h3>
+              <p>Слова поддержки и дружбы.</p>
+              <ul>
+                <li>die Hilfe</li><li>der Freund</li><li>das Herz</li>
+                <li>die Hoffnung</li><li>das Vertrauen</li>
+              </ul>
+            </li>
+            <li class="phase">
+              <h3>4. Борьба</h3>
+              <p>Практикуем глаголы и порядок слов.</p>
+              <ul>
+                <li>kämpfen</li><li>lernen</li><li>fragen</li>
+                <li>sehen</li><li>denken</li>
+              </ul>
+            </li>
+            <li class="phase">
+              <h3>5. Хитрость</h3>
+              <p>Ассоциации и мнемоника.</p>
+              <ul>
+                <li>auflösen</li><li>mitkommen</li><li>verstehen</li>
+                <li>vorsprechen</li><li>zurückgehen</li>
+              </ul>
+            </li>
+            <li class="phase">
+              <h3>6. Лира</h3>
+              <p>Пишем мини‑историю.</p>
+            </li>
+            <li class="phase final">
+              <h3>7. Тёмная Лира</h3>
+              <p>Квест‑проверка знаний.</p>
+            </li>
+          </ol>
+        </section>
+    </div>
+    <script>
+    document.querySelectorAll('.journey-map .phase').forEach(p =>
+      p.addEventListener('click', () => p.classList.toggle('open')));
+    </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- extract Lira's journey map into standalone `lira-journey.html`
- add navigation link on home page and move journey styles to its own stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c53d0f7a508320bfd81abf9ad5b322