### PR TITLE
Serialize phase vocabularies with json.dumps and add tests

### DIFF
--- a/generators/js_lira.py
+++ b/generators/js_lira.py
@@ -1,5 +1,8 @@
 """JavaScript Generator for Lira Journey interactivity"""
 
+import json
+
+
 class LiraJSGenerator:
     """Generate JavaScript for journey interactivity with mobile support"""
     
@@ -7,33 +10,34 @@ class LiraJSGenerator:
     def generate(character_data):
         """Generate JS with vocabulary data from character JSON"""
         
-        # Build vocabulary object from character data
-        vocab_js = "const phaseVocabularies = {\n"
-        
+        # Build vocabulary object from character data using JSON serialization
+        phase_vocabularies = {}
+
         for phase in character_data.get('journey_phases', []):
-            phase_id = phase['id']
-            vocab_js += f"    {phase_id}: {{\n"
-            vocab_js += f"        title: '{phase['title']}',\n"
-            vocab_js += f"        description: '{phase['description']}',\n"
-            vocab_js += "        words: [\n"
-            
+            phase_id = phase.get('id')
+            if not phase_id:
+                continue
+
+            words = []
             for word in phase.get('vocabulary', []):
-                # Escape single quotes in sentences
-                sentence = word.get('sentence', '').replace("'", "\\'")
-                sentence_trans = word.get('sentence_translation', '').replace("'", "\\'")
-                
-                vocab_js += f"            {{\n"
-                vocab_js += f"                word: '{word['german']}',\n"
-                vocab_js += f"                translation: '{word['russian']}',\n"
-                vocab_js += f"                transcription: '{word['transcription']}',\n"
-                vocab_js += f"                sentence: '{sentence}',\n"
-                vocab_js += f"                sentenceTranslation: '{sentence_trans}'\n"
-                vocab_js += f"            }},\n"
-            
-            vocab_js += "        ]\n"
-            vocab_js += "    },\n"
-        
-        vocab_js += "};\n\n"
+                words.append({
+                    'word': word.get('german', ''),
+                    'translation': word.get('russian', ''),
+                    'transcription': word.get('transcription', ''),
+                    'sentence': word.get('sentence', ''),
+                    'sentenceTranslation': word.get('sentence_translation', ''),
+                })
+
+            phase_vocabularies[phase_id] = {
+                'title': phase.get('title', ''),
+                'description': phase.get('description', ''),
+                'words': words,
+            }
+
+        vocab_js = (
+            "const phaseVocabularies = "
+            f"{json.dumps(phase_vocabularies, ensure_ascii=False, indent=4)};\n\n"
+        )
         
         # Add enhanced mobile-friendly interaction code
         vocab_js += '''

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite package for comic-website project."""

--- a/tests/test_js_lira_generator.py
+++ b/tests/test_js_lira_generator.py
@@ -1,0 +1,70 @@
+"""Unit tests for the Lira JavaScript generator."""
+
+import json
+import unittest
+
+from generators.js_lira import LiraJSGenerator
+
+
+class LiraJSGeneratorTests(unittest.TestCase):
+    """Verify special character handling in generated JavaScript."""
+
+    def test_generate_handles_quotes_and_newlines(self):
+        """The generator should preserve special characters in JSON output."""
+
+        character_data = {
+            'journey_phases': [
+                {
+                    'id': 'phase1',
+                    'title': "Эдмунд's \"choice\"",
+                    'description': 'Первая строка\nВторая строка',
+                    'vocabulary': [
+                        {
+                            'german': 'die Entscheidung',
+                            'russian': 'решение',
+                            'transcription': '[энт-ШАЙ-дӯнг]',
+                            'sentence': 'Er flüstert: "Das ist Edmunds Weg."\nUnd geht.',
+                            'sentence_translation': 'Он шепчет: "Это путь Эдмунда."\nИ уходит.',
+                        }
+                    ],
+                }
+            ]
+        }
+
+        script = LiraJSGenerator.generate(character_data)
+
+        # Extract JSON portion of the script and validate it can round-trip
+        self.assertIn('const phaseVocabularies = ', script)
+        separator = ';' + '\n' * 2
+        self.assertIn(separator, script)
+        json_part, _ = script.split(separator, 1)
+        json_str = json_part.replace('const phaseVocabularies = ', '', 1)
+        payload = json.loads(json_str)
+
+        self.assertIn('phase1', payload)
+
+        phase_payload = payload['phase1']
+        self.assertEqual(phase_payload['title'], character_data['journey_phases'][0]['title'])
+        self.assertEqual(
+            phase_payload['description'],
+            character_data['journey_phases'][0]['description'],
+        )
+
+        [word_payload] = phase_payload['words']
+        [word_source] = character_data['journey_phases'][0]['vocabulary']
+
+        self.assertEqual(word_payload['word'], word_source['german'])
+        self.assertEqual(word_payload['translation'], word_source['russian'])
+        self.assertEqual(word_payload['transcription'], word_source['transcription'])
+        self.assertEqual(word_payload['sentence'], word_source['sentence'])
+        self.assertEqual(
+            word_payload['sentenceTranslation'],
+            word_source['sentence_translation'],
+        )
+
+        # ensure_ascii=False keeps non-latin characters intact in the script output
+        self.assertIn('решение', script)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- build the `phaseVocabularies` object as a Python dictionary and serialize it with `json.dumps(..., ensure_ascii=False)`
- keep the existing interaction script untouched while injecting the JSON as `const phaseVocabularies = …;`
- add a unittest that verifies special characters (quotes, apostrophes, newlines, Cyrillic) round-trip correctly through the generator

## Testing
- python -m unittest discover

------
https://chatgpt.com/codex/tasks/task_e_68cd40bd49408320ad4a38aec447655b