### PR TITLE
Add answer forms metadata for exercises

### DIFF
--- a/data/characters/albany.json
+++ b/data/characters/albany.json
@@ -15,56 +15,85 @@
           "russian": "молчание",
           "transcription": "[дас ШВАЙ-ген]",
           "sentence": "Mein Schweigen macht mich zum Mitschuldigen.",
-          "sentence_translation": "Моё молчание делает меня соучастником."
+          "sentence_translation": "Моё молчание делает меня соучастником.",
+          "answer_forms": [
+            "молчание"
+          ]
         },
         {
           "german": "die Schwäche",
           "russian": "слабость",
           "transcription": "[ди ШВЕ-хе]",
           "sentence": "Meine Schwäche erlaubt das Böse zu wachsen.",
-          "sentence_translation": "Моя слабость позволяет злу расти."
+          "sentence_translation": "Моя слабость позволяет злу расти.",
+          "answer_forms": [
+            "слабость"
+          ]
         },
         {
           "german": "die Ehe",
           "russian": "брак",
           "transcription": "[ди Э-е]",
           "sentence": "Die Ehe bindet mich an eine grausame Frau.",
-          "sentence_translation": "Брак связывает меня с жестокой женой."
+          "sentence_translation": "Брак связывает меня с жестокой женой.",
+          "answer_forms": [
+            "брак"
+          ]
         },
         {
           "german": "dulden",
           "russian": "терпеть",
           "transcription": "[ДУЛЬ-ден]",
           "sentence": "Ich dulde ihre Grausamkeit zu lange.",
-          "sentence_translation": "Я слишком долго терплю её жестокость."
+          "sentence_translation": "Я слишком долго терплю её жестокость.",
+          "answer_forms": [
+            "терпеть",
+            "терплю"
+          ]
         },
         {
           "german": "passiv",
           "russian": "пассивный",
           "transcription": "[па-СИФ]",
           "sentence": "Passiv schaue ich dem Unrecht zu.",
-          "sentence_translation": "Пассивно я наблюдаю за несправедливостью."
+          "sentence_translation": "Пассивно я наблюдаю за несправедливостью.",
+          "answer_forms": [
+            "пассивный",
+            "пассивно"
+          ]
         },
         {
           "german": "nachgeben",
           "russian": "уступать",
           "transcription": "[НАХ-ге-бен]",
           "sentence": "Zu oft gebe ich ihrem Willen nach.",
-          "sentence_translation": "Слишком часто я уступаю её воле."
+          "sentence_translation": "Слишком часто я уступаю её воле.",
+          "answer_forms": [
+            "уступать",
+            "уступаю"
+          ]
         },
         {
           "german": "zögern",
           "russian": "колебаться",
           "transcription": "[ЦЁ-герн]",
           "sentence": "Ich zögere, wenn ich handeln sollte.",
-          "sentence_translation": "Я колеблюсь, когда должен действовать."
+          "sentence_translation": "Я колеблюсь, когда должен действовать.",
+          "answer_forms": [
+            "колебаться",
+            "колеблюсь"
+          ]
         },
         {
           "german": "mild",
           "russian": "мягкий",
           "transcription": "[МИЛЬД]",
           "sentence": "Meine milde Art wird als Schwäche gesehen.",
-          "sentence_translation": "Моя мягкость воспринимается как слабость."
+          "sentence_translation": "Моя мягкость воспринимается как слабость.",
+          "answer_forms": [
+            "мягкий",
+            "мягкая"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -86,49 +115,72 @@
           "russian": "сомнение",
           "transcription": "[дер ЦВАЙ-фель]",
           "sentence": "Der Zweifel an ihrer Güte wächst in mir.",
-          "sentence_translation": "Сомнение в её доброте растёт во мне."
+          "sentence_translation": "Сомнение в её доброте растёт во мне.",
+          "answer_forms": [
+            "сомнение"
+          ]
         },
         {
           "german": "das Gewissen",
           "russian": "совесть",
           "transcription": "[дас ге-ВИ-сен]",
           "sentence": "Mein Gewissen beginnt mich zu quälen.",
-          "sentence_translation": "Моя совесть начинает мучить меня."
+          "sentence_translation": "Моя совесть начинает мучить меня.",
+          "answer_forms": [
+            "совесть"
+          ]
         },
         {
           "german": "das Unbehagen",
           "russian": "беспокойство",
           "transcription": "[дас УН-бе-ха-ген]",
           "sentence": "Ein tiefes Unbehagen erfüllt meine Seele.",
-          "sentence_translation": "Глубокое беспокойство наполняет мою душу."
+          "sentence_translation": "Глубокое беспокойство наполняет мою душу.",
+          "answer_forms": [
+            "беспокойство"
+          ]
         },
         {
           "german": "hinterfragen",
           "russian": "подвергать сомнению",
           "transcription": "[ХИН-тер-фра-ген]",
           "sentence": "Ich beginne ihre Taten zu hinterfragen.",
-          "sentence_translation": "Я начинаю подвергать сомнению её поступки."
+          "sentence_translation": "Я начинаю подвергать сомнению её поступки.",
+          "answer_forms": [
+            "подвергать сомнению"
+          ]
         },
         {
           "german": "beunruhigen",
           "russian": "тревожить",
           "transcription": "[бе-УН-ру-и-ген]",
           "sentence": "Ihre Grausamkeit beunruhigt mich zunehmend.",
-          "sentence_translation": "Её жестокость всё больше тревожит меня."
+          "sentence_translation": "Её жестокость всё больше тревожит меня.",
+          "answer_forms": [
+            "тревожить"
+          ]
         },
         {
           "german": "unsicher",
           "russian": "неуверенный",
           "transcription": "[УН-зи-хер]",
           "sentence": "Ich werde unsicher in meinem Schweigen.",
-          "sentence_translation": "Я становлюсь неуверенным в своём молчании."
+          "sentence_translation": "Я становлюсь неуверенным в своём молчании.",
+          "answer_forms": [
+            "неуверенный",
+            "неуверенным"
+          ]
         },
         {
           "german": "grübeln",
           "russian": "размышлять",
           "transcription": "[ГРЮ-бельн]",
           "sentence": "Nachts grüble ich über richtig und falsch.",
-          "sentence_translation": "Ночами я размышляю о правильном и неправильном."
+          "sentence_translation": "Ночами я размышляю о правильном и неправильном.",
+          "answer_forms": [
+            "размышлять",
+            "размышляю"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -150,56 +202,86 @@
           "russian": "осознание",
           "transcription": "[ди ер-КЕНТ-нис]",
           "sentence": "Die Erkenntnis ihrer Bosheit erschüttert mich.",
-          "sentence_translation": "Осознание её злобы потрясает меня."
+          "sentence_translation": "Осознание её злобы потрясает меня.",
+          "answer_forms": [
+            "осознание"
+          ]
         },
         {
           "german": "das Entsetzen",
           "russian": "ужас",
           "transcription": "[дас энт-ЗЕ-цен]",
           "sentence": "Mit Entsetzen sehe ich ihr wahres Gesicht.",
-          "sentence_translation": "С ужасом я вижу её истинное лицо."
+          "sentence_translation": "С ужасом я вижу её истинное лицо.",
+          "answer_forms": [
+            "ужас",
+            "ужасом"
+          ]
         },
         {
           "german": "erwachen",
           "russian": "пробуждаться",
           "transcription": "[ер-ВА-хен]",
           "sentence": "Endlich erwache ich aus meiner Blindheit.",
-          "sentence_translation": "Наконец я пробуждаюсь от своей слепоты."
+          "sentence_translation": "Наконец я пробуждаюсь от своей слепоты.",
+          "answer_forms": [
+            "пробуждаться",
+            "пробуждаюсь"
+          ]
         },
         {
           "german": "begreifen",
           "russian": "понимать",
           "transcription": "[бе-ГРАЙ-фен]",
           "sentence": "Ich begreife das Ausmaß ihrer Grausamkeit.",
-          "sentence_translation": "Я понимаю масштаб её жестокости."
+          "sentence_translation": "Я понимаю масштаб её жестокости.",
+          "answer_forms": [
+            "понимать",
+            "понимаю"
+          ]
         },
         {
           "german": "erschrecken",
           "russian": "пугаться",
           "transcription": "[ер-ШРЕК-кен]",
           "sentence": "Ihre Taten erschrecken mein gutes Herz.",
-          "sentence_translation": "Её поступки пугают моё доброе сердце."
+          "sentence_translation": "Её поступки пугают моё доброе сердце.",
+          "answer_forms": [
+            "пугаться",
+            "пугают"
+          ]
         },
         {
           "german": "aufwachen",
           "russian": "просыпаться",
           "transcription": "[АУФ-ва-хен]",
           "sentence": "Ich wache auf aus meinem langen Schlaf.",
-          "sentence_translation": "Я просыпаюсь от долгого сна."
+          "sentence_translation": "Я просыпаюсь от долгого сна.",
+          "answer_forms": [
+            "просыпаться",
+            "просыпаюсь"
+          ]
         },
         {
           "german": "klar sehen",
           "russian": "ясно видеть",
           "transcription": "[КЛАР ЗЕ-ен]",
           "sentence": "Zum ersten Mal sehe ich klar.",
-          "sentence_translation": "Впервые я вижу ясно."
+          "sentence_translation": "Впервые я вижу ясно.",
+          "answer_forms": [
+            "ясно видеть",
+            "ясно вижу"
+          ]
         },
         {
           "german": "die Verwandlung",
           "russian": "превращение",
           "transcription": "[ди фер-ВАНД-лунг]",
           "sentence": "Eine Verwandlung beginnt in meiner Seele.",
-          "sentence_translation": "Превращение начинается в моей душе."
+          "sentence_translation": "Превращение начинается в моей душе.",
+          "answer_forms": [
+            "превращение"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -221,49 +303,74 @@
           "russian": "спор",
           "transcription": "[дер ШТРАЙТ]",
           "sentence": "Der Streit mit meiner Frau eskaliert.",
-          "sentence_translation": "Спор с моей женой обостряется."
+          "sentence_translation": "Спор с моей женой обостряется.",
+          "answer_forms": [
+            "спор"
+          ]
         },
         {
           "german": "der Mut",
           "russian": "мужество",
           "transcription": "[дер МУТ]",
           "sentence": "Endlich finde ich den Mut zu widersprechen.",
-          "sentence_translation": "Наконец я нахожу мужество возражать."
+          "sentence_translation": "Наконец я нахожу мужество возражать.",
+          "answer_forms": [
+            "мужество"
+          ]
         },
         {
           "german": "der Widerstand",
           "russian": "сопротивление",
           "transcription": "[дер ВИ-дер-штанд]",
           "sentence": "Mein Widerstand gegen das Böse beginnt.",
-          "sentence_translation": "Моё сопротивление злу начинается."
+          "sentence_translation": "Моё сопротивление злу начинается.",
+          "answer_forms": [
+            "сопротивление"
+          ]
         },
         {
           "german": "konfrontieren",
           "russian": "противостоять",
           "transcription": "[кон-фрон-ТИ-рен]",
           "sentence": "Ich konfrontiere sie mit ihrer Grausamkeit.",
-          "sentence_translation": "Я противостою ей с её жестокостью."
+          "sentence_translation": "Я противостою ей с её жестокостью.",
+          "answer_forms": [
+            "противостоять",
+            "противостою"
+          ]
         },
         {
           "german": "anklagen",
           "russian": "обвинять",
           "transcription": "[АН-кла-ген]",
           "sentence": "Ich klage sie ihrer Unmenschlichkeit an.",
-          "sentence_translation": "Я обвиняю её в бесчеловечности."
+          "sentence_translation": "Я обвиняю её в бесчеловечности.",
+          "answer_forms": [
+            "обвинять",
+            "обвиняю"
+          ]
         },
         {
           "german": "sich wehren",
           "russian": "защищаться",
           "transcription": "[зих ВЕ-рен]",
           "sentence": "Ich wehre mich gegen ihre Tyrannei.",
-          "sentence_translation": "Я защищаюсь от её тирании."
+          "sentence_translation": "Я защищаюсь от её тирании.",
+          "answer_forms": [
+            "защищаться",
+            "защищаюсь"
+          ]
         },
         {
           "german": "aufbegehren",
           "russian": "восставать",
           "transcription": "[АУФ-бе-ге-рен]",
           "sentence": "Ich begehre auf gegen das Unrecht.",
-          "sentence_translation": "Я восстаю против несправедливости."
+          "sentence_translation": "Я восстаю против несправедливости.",
+          "answer_forms": [
+            "восставать",
+            "восстаю"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -285,56 +392,84 @@
           "russian": "мораль",
           "transcription": "[ди мо-РАЛЬ]",
           "sentence": "Die Moral leitet nun meine Entscheidungen.",
-          "sentence_translation": "Мораль теперь руководит моими решениями."
+          "sentence_translation": "Мораль теперь руководит моими решениями.",
+          "answer_forms": [
+            "мораль"
+          ]
         },
         {
           "german": "die Gerechtigkeit",
           "russian": "справедливость",
           "transcription": "[ди ге-РЕХ-тиг-кайт]",
           "sentence": "Für Gerechtigkeit will ich kämpfen.",
-          "sentence_translation": "За справедливость я хочу бороться."
+          "sentence_translation": "За справедливость я хочу бороться.",
+          "answer_forms": [
+            "справедливость"
+          ]
         },
         {
           "german": "die Entscheidung",
           "russian": "решение",
           "transcription": "[ди энт-ШАЙ-дунг]",
           "sentence": "Meine Entscheidung steht fest: ich wähle das Gute.",
-          "sentence_translation": "Моё решение твёрдо: я выбираю добро."
+          "sentence_translation": "Моё решение твёрдо: я выбираю добро.",
+          "answer_forms": [
+            "решение"
+          ]
         },
         {
           "german": "wählen",
           "russian": "выбирать",
           "transcription": "[ВЕ-лен]",
           "sentence": "Ich wähle den schweren Weg der Tugend.",
-          "sentence_translation": "Я выбираю трудный путь добродетели."
+          "sentence_translation": "Я выбираю трудный путь добродетели.",
+          "answer_forms": [
+            "выбирать",
+            "выбираю"
+          ]
         },
         {
           "german": "rechtschaffen",
           "russian": "праведный",
           "transcription": "[РЕХТ-ша-фен]",
           "sentence": "Ich will rechtschaffen leben und handeln.",
-          "sentence_translation": "Я хочу жить и действовать праведно."
+          "sentence_translation": "Я хочу жить и действовать праведно.",
+          "answer_forms": [
+            "праведный",
+            "праведным"
+          ]
         },
         {
           "german": "das Prinzip",
           "russian": "принцип",
           "transcription": "[дас прин-ЦИП]",
           "sentence": "Meine Prinzipien sind wichtiger als meine Ehe.",
-          "sentence_translation": "Мои принципы важнее моего брака."
+          "sentence_translation": "Мои принципы важнее моего брака.",
+          "answer_forms": [
+            "принцип",
+            "принципы"
+          ]
         },
         {
           "german": "edel",
           "russian": "благородный",
           "transcription": "[Э-дель]",
           "sentence": "Ich strebe nach edlen Taten.",
-          "sentence_translation": "Я стремлюсь к благородным поступкам."
+          "sentence_translation": "Я стремлюсь к благородным поступкам.",
+          "answer_forms": [
+            "благородный",
+            "благородным"
+          ]
         },
         {
           "german": "die Tugend",
           "russian": "добродетель",
           "transcription": "[ди ТУ-генд]",
           "sentence": "Die Tugend wird mein Leitstern sein.",
-          "sentence_translation": "Добродетель будет моей путеводной звездой."
+          "sentence_translation": "Добродетель будет моей путеводной звездой.",
+          "answer_forms": [
+            "добродетель"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -356,49 +491,73 @@
           "russian": "борьба",
           "transcription": "[дер КАМПФ]",
           "sentence": "Der Kampf für das Recht beginnt jetzt.",
-          "sentence_translation": "Борьба за право начинается сейчас."
+          "sentence_translation": "Борьба за право начинается сейчас.",
+          "answer_forms": [
+            "борьба"
+          ]
         },
         {
           "german": "das Recht",
           "russian": "право",
           "transcription": "[дас РЕХТ]",
           "sentence": "Das Recht muss über das Unrecht siegen.",
-          "sentence_translation": "Право должно победить неправду."
+          "sentence_translation": "Право должно победить неправду.",
+          "answer_forms": [
+            "право"
+          ]
         },
         {
           "german": "die Güte",
           "russian": "доброта",
           "transcription": "[ди ГЮ-те]",
           "sentence": "Mit Güte will ich das Böse besiegen.",
-          "sentence_translation": "Добротой я хочу победить зло."
+          "sentence_translation": "Добротой я хочу победить зло.",
+          "answer_forms": [
+            "доброта",
+            "добротой"
+          ]
         },
         {
           "german": "strafen",
           "russian": "наказывать",
           "transcription": "[ШТРА-фен]",
           "sentence": "Die Schuldigen müssen bestraft werden.",
-          "sentence_translation": "Виновные должны быть наказаны."
+          "sentence_translation": "Виновные должны быть наказаны.",
+          "answer_forms": [
+            "наказывать"
+          ]
         },
         {
           "german": "richten",
           "russian": "судить",
           "transcription": "[РИХ-тен]",
           "sentence": "Gerecht will ich über die Verbrecher richten.",
-          "sentence_translation": "Справедливо я хочу судить преступников."
+          "sentence_translation": "Справедливо я хочу судить преступников.",
+          "answer_forms": [
+            "судить",
+            "сужу"
+          ]
         },
         {
           "german": "beschützen",
           "russian": "защищать",
           "transcription": "[бе-ШЮ-цен]",
           "sentence": "Die Unschuldigen will ich beschützen.",
-          "sentence_translation": "Невинных я хочу защитить."
+          "sentence_translation": "Невинных я хочу защитить.",
+          "answer_forms": [
+            "защищать"
+          ]
         },
         {
           "german": "eingreifen",
           "russian": "вмешиваться",
           "transcription": "[АЙН-грай-фен]",
           "sentence": "Ich greife ein, um das Schlimmste zu verhindern.",
-          "sentence_translation": "Я вмешиваюсь, чтобы предотвратить худшее."
+          "sentence_translation": "Я вмешиваюсь, чтобы предотвратить худшее.",
+          "answer_forms": [
+            "вмешиваться",
+            "вмешиваюсь"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -420,56 +579,83 @@
           "russian": "правление",
           "transcription": "[ди ХЕР-шафт]",
           "sentence": "Die Herrschaft fällt nun in meine Hände.",
-          "sentence_translation": "Правление теперь переходит в мои руки."
+          "sentence_translation": "Правление теперь переходит в мои руки.",
+          "answer_forms": [
+            "правление"
+          ]
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
           "sentence": "Mit Weisheit will ich das Land führen.",
-          "sentence_translation": "С мудростью я хочу вести страну."
+          "sentence_translation": "С мудростью я хочу вести страну.",
+          "answer_forms": [
+            "мудрость",
+            "мудростью"
+          ]
         },
         {
           "german": "der Neuanfang",
           "russian": "новое начало",
           "transcription": "[дер НОЙ-ан-фанг]",
           "sentence": "Ein Neuanfang für das Königreich beginnt.",
-          "sentence_translation": "Новое начало для королевства начинается."
+          "sentence_translation": "Новое начало для королевства начинается.",
+          "answer_forms": [
+            "новое начало"
+          ]
         },
         {
           "german": "lenken",
           "russian": "направлять",
           "transcription": "[ЛЕН-кен]",
           "sentence": "Ich lenke das Land in eine bessere Zukunft.",
-          "sentence_translation": "Я направляю страну в лучшее будущее."
+          "sentence_translation": "Я направляю страну в лучшее будущее.",
+          "answer_forms": [
+            "направлять"
+          ]
         },
         {
           "german": "aufbauen",
           "russian": "строить",
           "transcription": "[АУФ-бау-ен]",
           "sentence": "Ich baue auf, was zerstört wurde.",
-          "sentence_translation": "Я строю то, что было разрушено."
+          "sentence_translation": "Я строю то, что было разрушено.",
+          "answer_forms": [
+            "строить"
+          ]
         },
         {
           "german": "erneuern",
           "russian": "обновлять",
           "transcription": "[ер-НОЙ-ерн]",
           "sentence": "Das Reich will ich erneuern und heilen.",
-          "sentence_translation": "Королевство я хочу обновить и исцелить."
+          "sentence_translation": "Королевство я хочу обновить и исцелить.",
+          "answer_forms": [
+            "обновлять",
+            "обновлю"
+          ]
         },
         {
           "german": "versöhnen",
           "russian": "примирять",
           "transcription": "[фер-ЗЁ-нен]",
           "sentence": "Ich will die Getrennten versöhnen.",
-          "sentence_translation": "Я хочу примирить разделённых."
+          "sentence_translation": "Я хочу примирить разделённых.",
+          "answer_forms": [
+            "примирять",
+            "примирю"
+          ]
         },
         {
           "german": "der Friede",
           "russian": "мир",
           "transcription": "[дер ФРИ-де]",
           "sentence": "Der Friede soll wieder ins Land kommen.",
-          "sentence_translation": "Мир должен вернуться в страну."
+          "sentence_translation": "Мир должен вернуться в страну.",
+          "answer_forms": [
+            "мир"
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/cordelia.json
+++ b/data/characters/cordelia.json
@@ -21,56 +21,82 @@
           "russian": "правда",
           "transcription": "[ди ВАР-хайт]",
           "sentence": "Die Wahrheit war vor meinen Augen verborgen.",
-          "sentence_translation": "Правда была скрыта от моих глаз."
+          "sentence_translation": "Правда была скрыта от моих глаз.",
+          "answer_forms": [
+            "правда"
+          ]
         },
         {
           "german": "die Zeremonie",
           "russian": "церемония",
           "transcription": "[ди це-ре-мо-НИ]",
           "sentence": "Die Zeremonie beginnt im prächtigen Thronsaal.",
-          "sentence_translation": "Церемония начинается в великолепном тронном зале."
+          "sentence_translation": "Церемония начинается в великолепном тронном зале.",
+          "answer_forms": [
+            "церемония"
+          ]
         },
         {
           "german": "verkünden",
           "russian": "провозглашать",
           "transcription": "[фер-КЮН-ден]",
           "sentence": "Ich verkünde nur die Wahrheit meines Herzens.",
-          "sentence_translation": "Я провозглашаю только правду моего сердца."
+          "sentence_translation": "Я провозглашаю только правду моего сердца.",
+          "answer_forms": [
+            "провозглашать",
+            "провозгласи"
+          ]
         },
         {
           "german": "die Macht",
           "russian": "власть",
           "transcription": "[ди МАХТ]",
           "sentence": "Die Macht bedeutet nichts ohne wahre Liebe.",
-          "sentence_translation": "Власть ничего не значит без истинной любви."
+          "sentence_translation": "Власть ничего не значит без истинной любви.",
+          "answer_forms": [
+            "власть"
+          ]
         },
         {
           "german": "gehorchen",
           "russian": "повиноваться",
           "transcription": "[ге-ХОР-хен]",
           "sentence": "Ich kann der Lüge nicht gehorchen.",
-          "sentence_translation": "Я не могу повиноваться лжи."
+          "sentence_translation": "Я не могу повиноваться лжи.",
+          "answer_forms": [
+            "повиноваться"
+          ]
         },
         {
           "german": "die Pflicht",
           "russian": "долг",
           "transcription": "[ди ПФЛИХТ]",
           "sentence": "Meine Pflicht ist es, ehrlich zu sein.",
-          "sentence_translation": "Мой долг - быть честной."
+          "sentence_translation": "Мой долг - быть честной.",
+          "answer_forms": [
+            "долг"
+          ]
         },
         {
           "german": "feierlich",
           "russian": "торжественный",
           "transcription": "[ФАЙ-ер-лих]",
           "sentence": "Dieser feierliche Moment wird zur Tragödie.",
-          "sentence_translation": "Этот торжественный момент становится трагедией."
+          "sentence_translation": "Этот торжественный момент становится трагедией.",
+          "answer_forms": [
+            "торжественный",
+            "торжественная"
+          ]
         },
         {
           "german": "die Treue",
           "russian": "верность",
           "transcription": "[ди ТРОЙ-е]",
           "sentence": "Meine Treue gilt der Wahrheit und der echten Liebe.",
-          "sentence_translation": "Моя верность принадлежит правде и истинной любви."
+          "sentence_translation": "Моя верность принадлежит правде и истинной любви.",
+          "answer_forms": [
+            "верность"
+          ]
         }
       ]
     },
@@ -92,56 +118,84 @@
           "russian": "изгонять",
           "transcription": "[фер-ШТО-сен]",
           "sentence": "Der König verstößt mich aus seinem Herzen.",
-          "sentence_translation": "Король изгоняет меня из своего сердца."
+          "sentence_translation": "Король изгоняет меня из своего сердца.",
+          "answer_forms": [
+            "изгонять",
+            "изгоняет"
+          ]
         },
         {
           "german": "verlassen",
           "russian": "покидать",
           "transcription": "[фер-ЛА-сен]",
           "sentence": "Schweren Herzens verlasse ich mein Vaterland.",
-          "sentence_translation": "С тяжёлым сердцем я покидаю родину."
+          "sentence_translation": "С тяжёлым сердцем я покидаю родину.",
+          "answer_forms": [
+            "покидать",
+            "покидаю"
+          ]
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
           "sentence": "Sein Zorn ist grenzenlos und blind.",
-          "sentence_translation": "Его гнев безграничен и слеп."
+          "sentence_translation": "Его гнев безграничен и слеп.",
+          "answer_forms": [
+            "гнев"
+          ]
         },
         {
           "german": "die Strafe",
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
           "sentence": "Diese Strafe ist der Preis für meine Ehrlichkeit.",
-          "sentence_translation": "Это наказание - цена моей честности."
+          "sentence_translation": "Это наказание - цена моей честности.",
+          "answer_forms": [
+            "наказание"
+          ]
         },
         {
           "german": "fremd",
           "russian": "чужой",
           "transcription": "[ФРЕМД]",
           "sentence": "Ich bin jetzt fremd in meinem eigenen Land.",
-          "sentence_translation": "Я теперь чужая в своей собственной стране."
+          "sentence_translation": "Я теперь чужая в своей собственной стране.",
+          "answer_forms": [
+            "чужой"
+          ]
         },
         {
           "german": "die Mitgift",
           "russian": "приданое",
           "transcription": "[ди МИТ-гифт]",
           "sentence": "Ohne Mitgift bin ich reicher an Ehre.",
-          "sentence_translation": "Без приданого я богаче честью."
+          "sentence_translation": "Без приданого я богаче честью.",
+          "answer_forms": [
+            "приданое",
+            "приданого"
+          ]
         },
         {
           "german": "aufnehmen",
           "russian": "принимать",
           "transcription": "[АУФ-не-мен]",
           "sentence": "Der König von Frankreich nimmt mich liebevoll auf.",
-          "sentence_translation": "Король Франции принимает меня с любовью."
+          "sentence_translation": "Король Франции принимает меня с любовью.",
+          "answer_forms": [
+            "принимать",
+            "принимает"
+          ]
         },
         {
           "german": "die Hoffnung",
           "russian": "надежда",
           "transcription": "[ди ХОФ-нунг]",
           "sentence": "Die Hoffnung auf Versöhnung stirbt nie in meinem Herzen.",
-          "sentence_translation": "Надежда на примирение никогда не умирает в моём сердце."
+          "sentence_translation": "Надежда на примирение никогда не умирает в моём сердце.",
+          "answer_forms": [
+            "надежда"
+          ]
         }
       ]
     },
@@ -163,56 +217,84 @@
           "russian": "забота",
           "transcription": "[ди ЗОР-ге]",
           "sentence": "Die Sorge um meinen Vater lässt mich nicht schlafen.",
-          "sentence_translation": "Забота об отце не даёт мне спать."
+          "sentence_translation": "Забота об отце не даёт мне спать.",
+          "answer_forms": [
+            "забота"
+          ]
         },
         {
           "german": "die Einsamkeit",
           "russian": "одиночество",
           "transcription": "[ди АЙН-зам-кайт]",
           "sentence": "In der Einsamkeit denke ich an ihn.",
-          "sentence_translation": "В одиночестве я думаю о нём."
+          "sentence_translation": "В одиночестве я думаю о нём.",
+          "answer_forms": [
+            "одиночество"
+          ]
         },
         {
           "german": "die Nachricht",
           "russian": "известие",
           "transcription": "[ди НАХ-рихт]",
           "sentence": "Schreckliche Nachrichten erreichen mich aus England.",
-          "sentence_translation": "Ужасные известия доходят до меня из Англии."
+          "sentence_translation": "Ужасные известия доходят до меня из Англии.",
+          "answer_forms": [
+            "известие",
+            "известия"
+          ]
         },
         {
           "german": "die Angst",
           "russian": "страх",
           "transcription": "[ди АНГСТ]",
           "sentence": "Die Angst um meinen Vater wächst täglich.",
-          "sentence_translation": "Страх за отца растёт с каждым днём."
+          "sentence_translation": "Страх за отца растёт с каждым днём.",
+          "answer_forms": [
+            "страх"
+          ]
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
           "sentence": "Er muss furchtbar leiden ohne mich.",
-          "sentence_translation": "Он должно быть ужасно страдает без меня."
+          "sentence_translation": "Он должно быть ужасно страдает без меня.",
+          "answer_forms": [
+            "страдать",
+            "страдает"
+          ]
         },
         {
           "german": "beschützen",
           "russian": "защищать",
           "transcription": "[бе-ШЮ-цен]",
           "sentence": "Ich kann ihn aus der Ferne nicht beschützen.",
-          "sentence_translation": "Я не могу защитить его издалека."
+          "sentence_translation": "Я не могу защитить его издалека.",
+          "answer_forms": [
+            "защищать",
+            "защитить"
+          ]
         },
         {
           "german": "die Sehnsucht",
           "russian": "тоска",
           "transcription": "[ди ЗЕН-зухт]",
           "sentence": "Die Sehnsucht nach Versöhnung erfüllt mein Herz.",
-          "sentence_translation": "Тоска по примирению наполняет моё сердце."
+          "sentence_translation": "Тоска по примирению наполняет моё сердце.",
+          "answer_forms": [
+            "тоска"
+          ]
         },
         {
           "german": "beten",
           "russian": "молиться",
           "transcription": "[БЕ-тен]",
           "sentence": "Jeden Tag bete ich für seine Sicherheit.",
-          "sentence_translation": "Каждый день я молюсь за его безопасность."
+          "sentence_translation": "Каждый день я молюсь за его безопасность.",
+          "answer_forms": [
+            "молиться",
+            "молюсь"
+          ]
         }
       ]
     },
@@ -234,56 +316,85 @@
           "russian": "возвращаться",
           "transcription": "[цу-РЮК-ке-рен]",
           "sentence": "Mit einer Armee kehre ich zurück, meinen Vater zu retten.",
-          "sentence_translation": "С армией я возвращаюсь спасти моего отца."
+          "sentence_translation": "С армией я возвращаюсь спасти моего отца.",
+          "answer_forms": [
+            "возвращаться",
+            "возвращаюсь"
+          ]
         },
         {
           "german": "der Kampf",
           "russian": "борьба",
           "transcription": "[дер КАМПФ]",
           "sentence": "Dieser Kampf ist für die Ehre meines Vaters.",
-          "sentence_translation": "Эта борьба за честь моего отца."
+          "sentence_translation": "Эта борьба за честь моего отца.",
+          "answer_forms": [
+            "борьба"
+          ]
         },
         {
           "german": "retten",
           "russian": "спасать",
           "transcription": "[РЕ-тен]",
           "sentence": "Ich muss meinen Vater vor seinen grausamen Töchtern retten.",
-          "sentence_translation": "Я должна спасти отца от его жестоких дочерей."
+          "sentence_translation": "Я должна спасти отца от его жестоких дочерей.",
+          "answer_forms": [
+            "спасать",
+            "спасти"
+          ]
         },
         {
           "german": "die Schlacht",
           "russian": "битва",
           "transcription": "[ди ШЛАХТ]",
           "sentence": "Diese Schlacht entscheidet über das Schicksal des Königreichs.",
-          "sentence_translation": "Эта битва решает судьбу королевства."
+          "sentence_translation": "Эта битва решает судьбу королевства.",
+          "answer_forms": [
+            "битва"
+          ]
         },
         {
           "german": "mutig",
           "russian": "храбрый",
           "transcription": "[МУ-тиг]",
           "sentence": "Sei mutig, mein Herz, für die gerechte Sache.",
-          "sentence_translation": "Будь храбрым, моё сердце, ради правого дела."
+          "sentence_translation": "Будь храбрым, моё сердце, ради правого дела.",
+          "answer_forms": [
+            "храбрый",
+            "храброй"
+          ]
         },
         {
           "german": "die Gerechtigkeit",
           "russian": "справедливость",
           "transcription": "[ди ге-РЕХ-тиг-кайт]",
           "sentence": "Die Gerechtigkeit führt meine Klinge.",
-          "sentence_translation": "Справедливость ведёт мой клинок."
+          "sentence_translation": "Справедливость ведёт мой клинок.",
+          "answer_forms": [
+            "справедливость"
+          ]
         },
         {
           "german": "siegen",
           "russian": "побеждать",
           "transcription": "[ЗИ-ген]",
           "sentence": "Die Liebe wird über den Hass siegen.",
-          "sentence_translation": "Любовь победит ненависть."
+          "sentence_translation": "Любовь победит ненависть.",
+          "answer_forms": [
+            "побеждать",
+            "победить"
+          ]
         },
         {
           "german": "die Armee",
           "russian": "армия",
           "transcription": "[ди ар-МЭ]",
           "sentence": "Diese Armee kämpft für Gerechtigkeit und Liebe.",
-          "sentence_translation": "Эта армия сражается за справедливость и любовь."
+          "sentence_translation": "Эта армия сражается за справедливость и любовь.",
+          "answer_forms": [
+            "армия",
+            "армией"
+          ]
         }
       ]
     },
@@ -305,56 +416,85 @@
           "russian": "прощать",
           "transcription": "[фер-ЦАЙ-ен]",
           "sentence": "Ich verzeihe dir alles, mein lieber Vater.",
-          "sentence_translation": "Я прощаю тебе всё, мой дорогой отец."
+          "sentence_translation": "Я прощаю тебе всё, мой дорогой отец.",
+          "answer_forms": [
+            "прощать",
+            "Прости"
+          ]
         },
         {
           "german": "die Tränen",
           "russian": "слёзы",
           "transcription": "[ди ТРЕ-нен]",
           "sentence": "Unsere Tränen waschen den Schmerz fort.",
-          "sentence_translation": "Наши слёзы смывают боль."
+          "sentence_translation": "Наши слёзы смывают боль.",
+          "answer_forms": [
+            "слёзы"
+          ]
         },
         {
           "german": "umarmen",
           "russian": "обнимать",
           "transcription": "[ум-АР-мен]",
           "sentence": "Lass mich dich umarmen und deine Tränen trocknen.",
-          "sentence_translation": "Позволь мне обнять тебя и вытереть твои слёзы."
+          "sentence_translation": "Позволь мне обнять тебя и вытереть твои слёзы.",
+          "answer_forms": [
+            "обнимать",
+            "обнимаю"
+          ]
         },
         {
           "german": "erkennen",
           "russian": "узнавать",
           "transcription": "[ер-КЕН-нен]",
           "sentence": "Erkennst du mich, dein Kind Cordelia?",
-          "sentence_translation": "Узнаёшь ли ты меня, твоё дитя Корделия?"
+          "sentence_translation": "Узнаёшь ли ты меня, твоё дитя Корделия?",
+          "answer_forms": [
+            "узнавать",
+            "узнаёшь"
+          ]
         },
         {
           "german": "heilen",
           "russian": "исцелять",
           "transcription": "[ХАЙ-лен]",
           "sentence": "Meine Liebe wird deine Wunden heilen.",
-          "sentence_translation": "Моя любовь исцелит твои раны."
+          "sentence_translation": "Моя любовь исцелит твои раны.",
+          "answer_forms": [
+            "исцелять",
+            "исцелить"
+          ]
         },
         {
           "german": "die Reue",
           "russian": "раскаяние",
           "transcription": "[ди РОЙ-е]",
           "sentence": "Deine Reue ist nicht nötig, nur deine Liebe.",
-          "sentence_translation": "Твоё раскаяние не нужно, только твоя любовь."
+          "sentence_translation": "Твоё раскаяние не нужно, только твоя любовь.",
+          "answer_forms": [
+            "раскаяние"
+          ]
         },
         {
           "german": "sanft",
           "russian": "нежный",
           "transcription": "[ЗАНФТ]",
           "sentence": "Sei sanft zu dir selbst, lieber Vater.",
-          "sentence_translation": "Будь нежен к себе, дорогой отец."
+          "sentence_translation": "Будь нежен к себе, дорогой отец.",
+          "answer_forms": [
+            "нежный",
+            "нежно"
+          ]
         },
         {
           "german": "die Vergebung",
           "russian": "прощение",
           "transcription": "[ди фер-ГЕ-бунг]",
           "sentence": "Die Vergebung ist der Schlüssel zum Frieden.",
-          "sentence_translation": "Прощение - ключ к покою."
+          "sentence_translation": "Прощение - ключ к покою.",
+          "answer_forms": [
+            "прощение"
+          ]
         }
       ]
     },
@@ -376,56 +516,85 @@
           "russian": "пленный",
           "transcription": "[ге-ФАН-ген]",
           "sentence": "Obwohl gefangen, bin ich frei in meinem Herzen.",
-          "sentence_translation": "Хотя я в плену, в сердце я свободна."
+          "sentence_translation": "Хотя я в плену, в сердце я свободна.",
+          "answer_forms": [
+            "пленный",
+            "пленников"
+          ]
         },
         {
           "german": "das Gefängnis",
           "russian": "тюрьма",
           "transcription": "[дас ге-ФЭНГ-нис]",
           "sentence": "Dieses Gefängnis kann meine Liebe nicht einsperren.",
-          "sentence_translation": "Эта тюрьма не может запереть мою любовь."
+          "sentence_translation": "Эта тюрьма не может запереть мою любовь.",
+          "answer_forms": [
+            "тюрьма",
+            "тюрьму"
+          ]
         },
         {
           "german": "die Würde",
           "russian": "достоинство",
           "transcription": "[ди ВЮР-де]",
           "sentence": "Mit Würde trage ich mein Schicksal.",
-          "sentence_translation": "С достоинством я несу свою судьбу."
+          "sentence_translation": "С достоинством я несу свою судьбу.",
+          "answer_forms": [
+            "достоинство",
+            "достоинством"
+          ]
         },
         {
           "german": "trösten",
           "russian": "утешать",
           "transcription": "[ТРЁС-тен]",
           "sentence": "Lass mich dich trösten in dieser dunklen Stunde.",
-          "sentence_translation": "Позволь мне утешить тебя в этот тёмный час."
+          "sentence_translation": "Позволь мне утешить тебя в этот тёмный час.",
+          "answer_forms": [
+            "утешать",
+            "утешаю"
+          ]
         },
         {
           "german": "tapfer",
           "russian": "отважный",
           "transcription": "[ТАП-фер]",
           "sentence": "Ich bleibe tapfer für dich, Vater.",
-          "sentence_translation": "Я остаюсь отважной ради тебя, отец."
+          "sentence_translation": "Я остаюсь отважной ради тебя, отец.",
+          "answer_forms": [
+            "отважный",
+            "отважной"
+          ]
         },
         {
           "german": "die Demut",
           "russian": "смирение",
           "transcription": "[ди ДЕ-мут]",
           "sentence": "In der Demut finden wir wahre Größe.",
-          "sentence_translation": "В смирении мы находим истинное величие."
+          "sentence_translation": "В смирении мы находим истинное величие.",
+          "answer_forms": [
+            "смирение"
+          ]
         },
         {
           "german": "das Schicksal",
           "russian": "судьба",
           "transcription": "[дас ШИК-заль]",
           "sentence": "Unser Schicksal ist miteinander verwoben.",
-          "sentence_translation": "Наши судьбы переплетены."
+          "sentence_translation": "Наши судьбы переплетены.",
+          "answer_forms": [
+            "судьба"
+          ]
         },
         {
           "german": "die Ehre",
           "russian": "честь",
           "transcription": "[ди Э-ре]",
           "sentence": "Unsere Ehre bleibt unbefleckt.",
-          "sentence_translation": "Наша честь остаётся незапятнанной."
+          "sentence_translation": "Наша честь остаётся незапятнанной.",
+          "answer_forms": [
+            "честь"
+          ]
         }
       ]
     },
@@ -447,56 +616,82 @@
           "russian": "смерть",
           "transcription": "[дер ТОД]",
           "sentence": "Der Tod trennt uns nur für kurze Zeit.",
-          "sentence_translation": "Смерть разлучает нас лишь ненадолго."
+          "sentence_translation": "Смерть разлучает нас лишь ненадолго.",
+          "answer_forms": [
+            "смерть"
+          ]
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
           "sentence": "Wenn ich sterben muss, sterbe ich mit reinem Herzen.",
-          "sentence_translation": "Если я должна умереть, я умру с чистым сердцем."
+          "sentence_translation": "Если я должна умереть, я умру с чистым сердцем.",
+          "answer_forms": [
+            "умирать",
+            "умираю"
+          ]
         },
         {
           "german": "das Opfer",
           "russian": "жертва",
           "transcription": "[дас ОП-фер]",
           "sentence": "Ich bin das Opfer der Wahrheit und Liebe.",
-          "sentence_translation": "Я жертва правды и любви."
+          "sentence_translation": "Я жертва правды и любви.",
+          "answer_forms": [
+            "жертва"
+          ]
         },
         {
           "german": "die Seele",
           "russian": "душа",
           "transcription": "[ди ЗЕ-ле]",
           "sentence": "Meine Seele ist rein vor Gott.",
-          "sentence_translation": "Моя душа чиста перед Богом."
+          "sentence_translation": "Моя душа чиста перед Богом.",
+          "answer_forms": [
+            "душа"
+          ]
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЕН-де]",
           "sentence": "Dies ist nicht das Ende, nur ein Übergang.",
-          "sentence_translation": "Это не конец, только переход."
+          "sentence_translation": "Это не конец, только переход.",
+          "answer_forms": [
+            "конец"
+          ]
         },
         {
           "german": "ewig",
           "russian": "вечный",
           "transcription": "[Э-виг]",
           "sentence": "Unsere Liebe ist ewig, Vater.",
-          "sentence_translation": "Наша любовь вечна, отец."
+          "sentence_translation": "Наша любовь вечна, отец.",
+          "answer_forms": [
+            "вечный",
+            "вечна"
+          ]
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
           "sentence": "Unser Abschied ist nur vorübergehend.",
-          "sentence_translation": "Наше прощание лишь временно."
+          "sentence_translation": "Наше прощание лишь временно.",
+          "answer_forms": [
+            "прощание"
+          ]
         },
         {
           "german": "die Erlösung",
           "russian": "спасение",
           "transcription": "[ди ер-ЛЁ-зунг]",
           "sentence": "Im Tod finde ich Erlösung und Frieden.",
-          "sentence_translation": "В смерти я нахожу спасение и покой."
+          "sentence_translation": "В смерти я нахожу спасение и покой.",
+          "answer_forms": [
+            "спасение"
+          ]
         }
       ]
     }

--- a/data/characters/cornwall.json
+++ b/data/characters/cornwall.json
@@ -15,56 +15,83 @@
           "russian": "честолюбие",
           "transcription": "[дер ЭР-гайц]",
           "sentence": "Mein Ehrgeiz kennt keine Grenzen mehr.",
-          "sentence_translation": "Моё честолюбие не знает больше границ."
+          "sentence_translation": "Моё честолюбие не знает больше границ.",
+          "answer_forms": [
+            "честолюбие"
+          ]
         },
         {
           "german": "die Gier",
           "russian": "жадность",
           "transcription": "[ди ГИР]",
           "sentence": "Die Gier nach Macht verzehrt meine Seele.",
-          "sentence_translation": "Жадность к власти пожирает мою душу."
+          "sentence_translation": "Жадность к власти пожирает мою душу.",
+          "answer_forms": [
+            "жадность"
+          ]
         },
         {
           "german": "streben",
           "russian": "стремиться",
           "transcription": "[ШТРЕ-бен]",
           "sentence": "Ich strebe nach absoluter Kontrolle.",
-          "sentence_translation": "Я стремлюсь к абсолютному контролю."
+          "sentence_translation": "Я стремлюсь к абсолютному контролю.",
+          "answer_forms": [
+            "стремиться",
+            "стремлюсь"
+          ]
         },
         {
           "german": "verlangen",
           "russian": "желать",
           "transcription": "[фер-ЛАН-ген]",
           "sentence": "Ich verlange mehr als mir zusteht.",
-          "sentence_translation": "Я желаю больше, чем мне положено."
+          "sentence_translation": "Я желаю больше, чем мне положено.",
+          "answer_forms": [
+            "желать",
+            "желаю"
+          ]
         },
         {
           "german": "begehren",
           "russian": "вожделеть",
           "transcription": "[бе-ГЕ-рен]",
           "sentence": "Ich begehre die Krone für mich selbst.",
-          "sentence_translation": "Я вожделею корону для себя."
+          "sentence_translation": "Я вожделею корону для себя.",
+          "answer_forms": [
+            "вожделеть"
+          ]
         },
         {
           "german": "gierig",
           "russian": "жадный",
           "transcription": "[ГИ-риг]",
           "sentence": "Gierig greife ich nach jedem Stück Macht.",
-          "sentence_translation": "Жадно я хватаюсь за каждый кусок власти."
+          "sentence_translation": "Жадно я хватаюсь за каждый кусок власти.",
+          "answer_forms": [
+            "жадный"
+          ]
         },
         {
           "german": "die Herrschsucht",
           "russian": "властолюбие",
           "transcription": "[ди ХЕР-зухт]",
           "sentence": "Die Herrschsucht bestimmt all meine Taten.",
-          "sentence_translation": "Властолюбие определяет все мои поступки."
+          "sentence_translation": "Властолюбие определяет все мои поступки.",
+          "answer_forms": [
+            "властолюбие"
+          ]
         },
         {
           "german": "ergreifen",
           "russian": "захватывать",
           "transcription": "[ер-ГРАЙ-фен]",
           "sentence": "Ich ergreife jede Gelegenheit zur Macht.",
-          "sentence_translation": "Я захватываю каждую возможность власти."
+          "sentence_translation": "Я захватываю каждую возможность власти.",
+          "answer_forms": [
+            "захватывать",
+            "захватить"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -86,49 +113,74 @@
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
           "sentence": "Die Grausamkeit meiner Frau gefällt mir.",
-          "sentence_translation": "Жестокость моей жены мне нравится."
+          "sentence_translation": "Жестокость моей жены мне нравится.",
+          "answer_forms": [
+            "жестокость"
+          ]
         },
         {
           "german": "die Bosheit",
           "russian": "злоба",
           "transcription": "[ди БОС-хайт]",
           "sentence": "Unsere Bosheit macht uns zum perfekten Paar.",
-          "sentence_translation": "Наша злоба делает нас идеальной парой."
+          "sentence_translation": "Наша злоба делает нас идеальной парой.",
+          "answer_forms": [
+            "злоба"
+          ]
         },
         {
           "german": "billigen",
           "russian": "одобрять",
           "transcription": "[БИ-ли-ген]",
           "sentence": "Ich billige alle ihre grausamen Pläne.",
-          "sentence_translation": "Я одобряю все её жестокие планы."
+          "sentence_translation": "Я одобряю все её жестокие планы.",
+          "answer_forms": [
+            "одобрять",
+            "одобряю"
+          ]
         },
         {
           "german": "unterstützen",
           "russian": "поддерживать",
           "transcription": "[ун-тер-ШТЮ-цен]",
           "sentence": "Ich unterstütze ihre Unmenschlichkeit.",
-          "sentence_translation": "Я поддерживаю её бесчеловечность."
+          "sentence_translation": "Я поддерживаю её бесчеловечность.",
+          "answer_forms": [
+            "поддерживать",
+            "поддерживаю"
+          ]
         },
         {
           "german": "anstacheln",
           "russian": "подстрекать",
           "transcription": "[АН-шта-хельн]",
           "sentence": "Ich stachle sie zu größerer Grausamkeit an.",
-          "sentence_translation": "Я подстрекаю её к большей жестокости."
+          "sentence_translation": "Я подстрекаю её к большей жестокости.",
+          "answer_forms": [
+            "подстрекать",
+            "подстрекаю"
+          ]
         },
         {
           "german": "ermutigen",
           "russian": "поощрять",
           "transcription": "[ер-МУ-ти-ген]",
           "sentence": "Ich ermutige ihre dunkelsten Impulse.",
-          "sentence_translation": "Я поощряю её самые тёмные импульсы."
+          "sentence_translation": "Я поощряю её самые тёмные импульсы.",
+          "answer_forms": [
+            "поощрять",
+            "поощряю"
+          ]
         },
         {
           "german": "die Härte",
           "russian": "суровость",
           "transcription": "[ди ХЕР-те]",
           "sentence": "Mit eiserner Härte regieren wir zusammen.",
-          "sentence_translation": "С железной суровостью мы правим вместе."
+          "sentence_translation": "С железной суровостью мы правим вместе.",
+          "answer_forms": [
+            "суровость"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -150,56 +202,83 @@
           "russian": "тирания",
           "transcription": "[ди тю-ра-НАЙ]",
           "sentence": "Meine Tyrannei erstickt jeden Widerstand.",
-          "sentence_translation": "Моя тирания душит любое сопротивление."
+          "sentence_translation": "Моя тирания душит любое сопротивление.",
+          "answer_forms": [
+            "тирания"
+          ]
         },
         {
           "german": "die Unterdrückung",
           "russian": "угнетение",
           "transcription": "[ди ун-тер-ДРЮ-кунг]",
           "sentence": "Die Unterdrückung ist mein Herrschaftsmittel.",
-          "sentence_translation": "Угнетение - моё средство правления."
+          "sentence_translation": "Угнетение - моё средство правления.",
+          "answer_forms": [
+            "угнетение"
+          ]
         },
         {
           "german": "die Furcht",
           "russian": "страх",
           "transcription": "[ди ФУРХТ]",
           "sentence": "Durch Furcht halte ich alle unter Kontrolle.",
-          "sentence_translation": "Страхом я держу всех под контролем."
+          "sentence_translation": "Страхом я держу всех под контролем.",
+          "answer_forms": [
+            "страх"
+          ]
         },
         {
           "german": "unterdrücken",
           "russian": "подавлять",
           "transcription": "[ун-тер-ДРЮ-кен]",
           "sentence": "Ich unterdrücke jeden freien Gedanken.",
-          "sentence_translation": "Я подавляю любую свободную мысль."
+          "sentence_translation": "Я подавляю любую свободную мысль.",
+          "answer_forms": [
+            "подавлять",
+            "подавляю"
+          ]
         },
         {
           "german": "knechten",
           "russian": "порабощать",
           "transcription": "[КНЕХ-тен]",
           "sentence": "Ich knechte alle, die mir unterstehen.",
-          "sentence_translation": "Я порабощаю всех, кто мне подчинён."
+          "sentence_translation": "Я порабощаю всех, кто мне подчинён.",
+          "answer_forms": [
+            "порабощать"
+          ]
         },
         {
           "german": "zwingen",
           "russian": "принуждать",
           "transcription": "[ЦВИН-ген]",
           "sentence": "Ich zwinge alle zu absolutem Gehorsam.",
-          "sentence_translation": "Я принуждаю всех к абсолютному послушанию."
+          "sentence_translation": "Я принуждаю всех к абсолютному послушанию.",
+          "answer_forms": [
+            "принуждать",
+            "принуждаю"
+          ]
         },
         {
           "german": "die Willkür",
           "russian": "произвол",
           "transcription": "[ди ВИЛЬ-кюр]",
           "sentence": "Meine Willkür ist das einzige Gesetz.",
-          "sentence_translation": "Мой произвол - единственный закон."
+          "sentence_translation": "Мой произвол - единственный закон.",
+          "answer_forms": [
+            "произвол"
+          ]
         },
         {
           "german": "brutal",
           "russian": "брутальный",
           "transcription": "[бру-ТАЛЬ]",
           "sentence": "Brutal zerschlage ich jeden Widerstand.",
-          "sentence_translation": "Брутально я сокрушаю любое сопротивление."
+          "sentence_translation": "Брутально я сокрушаю любое сопротивление.",
+          "answer_forms": [
+            "брутальный",
+            "брутально"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -221,49 +300,74 @@
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
           "sentence": "Die Strafe für Widerspruch ist hart.",
-          "sentence_translation": "Наказание за возражение сурово."
+          "sentence_translation": "Наказание за возражение сурово.",
+          "answer_forms": [
+            "наказание"
+          ]
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
           "sentence": "Mein Zorn kennt keine Barmherzigkeit.",
-          "sentence_translation": "Мой гнев не знает милосердия."
+          "sentence_translation": "Мой гнев не знает милосердия.",
+          "answer_forms": [
+            "гнев"
+          ]
         },
         {
           "german": "bestrafen",
           "russian": "карать",
           "transcription": "[бе-ШТРА-фен]",
           "sentence": "Ich bestrafe Kent für seine Frechheit.",
-          "sentence_translation": "Я караю Кента за его дерзость."
+          "sentence_translation": "Я караю Кента за его дерзость.",
+          "answer_forms": [
+            "карать",
+            "караю"
+          ]
         },
         {
           "german": "züchtigen",
           "russian": "наказывать",
           "transcription": "[ЦЮХ-ти-ген]",
           "sentence": "Öffentlich züchtige ich die Widerspenstigen.",
-          "sentence_translation": "Публично я наказываю непокорных."
+          "sentence_translation": "Публично я наказываю непокорных.",
+          "answer_forms": [
+            "наказывать",
+            "наказываю"
+          ]
         },
         {
           "german": "demütigen",
           "russian": "унижать",
           "transcription": "[де-МЮ-ти-ген]",
           "sentence": "Ich demütige ihn vor aller Augen.",
-          "sentence_translation": "Я унижаю его на глазах у всех."
+          "sentence_translation": "Я унижаю его на глазах у всех.",
+          "answer_forms": [
+            "унижать",
+            "унижаю"
+          ]
         },
         {
           "german": "erniedrigen",
           "russian": "унижать",
           "transcription": "[ер-НИД-ри-ген]",
           "sentence": "Ich erniedrige den treuen Diener.",
-          "sentence_translation": "Я унижаю верного слугу."
+          "sentence_translation": "Я унижаю верного слугу.",
+          "answer_forms": [
+            "унижать",
+            "унижаю"
+          ]
         },
         {
           "german": "quälen",
           "russian": "мучить",
           "transcription": "[КВЕ-лен]",
           "sentence": "Es bereitet mir Freude, ihn zu quälen.",
-          "sentence_translation": "Мне доставляет радость мучить его."
+          "sentence_translation": "Мне доставляет радость мучить его.",
+          "answer_forms": [
+            "мучить"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -285,56 +389,83 @@
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
           "sentence": "Die Folter ist mein liebstes Werkzeug.",
-          "sentence_translation": "Пытка - мой любимый инструмент."
+          "sentence_translation": "Пытка - мой любимый инструмент.",
+          "answer_forms": [
+            "пытка"
+          ]
         },
         {
           "german": "der Sadismus",
           "russian": "садизм",
           "transcription": "[дер за-ДИС-мус]",
           "sentence": "Mein Sadismus kennt keine Grenzen.",
-          "sentence_translation": "Мой садизм не знает границ."
+          "sentence_translation": "Мой садизм не знает границ.",
+          "answer_forms": [
+            "садизм"
+          ]
         },
         {
           "german": "das Blut",
           "russian": "кровь",
           "transcription": "[дас БЛУТ]",
           "sentence": "Das Blut des Grafen befleckt meine Hände.",
-          "sentence_translation": "Кровь графа пятнает мои руки."
+          "sentence_translation": "Кровь графа пятнает мои руки.",
+          "answer_forms": [
+            "кровь"
+          ]
         },
         {
           "german": "foltern",
           "russian": "пытать",
           "transcription": "[ФОЛЬ-терн]",
           "sentence": "Mit Lust foltere ich den alten Mann.",
-          "sentence_translation": "С наслаждением я пытаю старика."
+          "sentence_translation": "С наслаждением я пытаю старика.",
+          "answer_forms": [
+            "пытать"
+          ]
         },
         {
           "german": "verstümmeln",
           "russian": "калечить",
           "transcription": "[фер-ШТЮМ-мельн]",
           "sentence": "Ich verstümmle ihn ohne Erbarmen.",
-          "sentence_translation": "Я калечу его без милосердия."
+          "sentence_translation": "Я калечу его без милосердия.",
+          "answer_forms": [
+            "калечить",
+            "калечу"
+          ]
         },
         {
           "german": "blenden",
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
           "sentence": "Eigenhändig blende ich Gloucester.",
-          "sentence_translation": "Собственноручно я ослепляю Глостера."
+          "sentence_translation": "Собственноручно я ослепляю Глостера.",
+          "answer_forms": [
+            "ослеплять",
+            "ослепляю"
+          ]
         },
         {
           "german": "ausstechen",
           "russian": "выкалывать",
           "transcription": "[АУС-ште-хен]",
           "sentence": "Seine Augen steche ich mit Freude aus.",
-          "sentence_translation": "Его глаза я выкалываю с радостью."
+          "sentence_translation": "Его глаза я выкалываю с радостью.",
+          "answer_forms": [
+            "выкалывать",
+            "выкалываю"
+          ]
         },
         {
           "german": "die Qual",
           "russian": "мука",
           "transcription": "[ди КВАЛЬ]",
           "sentence": "Seine Qual bereitet mir Vergnügen.",
-          "sentence_translation": "Его мука доставляет мне удовольствие."
+          "sentence_translation": "Его мука доставляет мне удовольствие.",
+          "answer_forms": [
+            "мука"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -356,49 +487,74 @@
           "russian": "рана",
           "transcription": "[ди ВУН-де]",
           "sentence": "Die Wunde brennt wie Feuer in meinem Leib.",
-          "sentence_translation": "Рана горит как огонь в моём теле."
+          "sentence_translation": "Рана горит как огонь в моём теле.",
+          "answer_forms": [
+            "рана"
+          ]
         },
         {
           "german": "der Schmerz",
           "russian": "боль",
           "transcription": "[дер ШМЕРЦ]",
           "sentence": "Der Schmerz durchbohrt meinen Körper.",
-          "sentence_translation": "Боль пронзает моё тело."
+          "sentence_translation": "Боль пронзает моё тело.",
+          "answer_forms": [
+            "боль"
+          ]
         },
         {
           "german": "die Überraschung",
           "russian": "удивление",
           "transcription": "[ди ю-бер-РА-шунг]",
           "sentence": "Die Überraschung des Angriffs schockiert mich.",
-          "sentence_translation": "Неожиданность нападения шокирует меня."
+          "sentence_translation": "Неожиданность нападения шокирует меня.",
+          "answer_forms": [
+            "удивление"
+          ]
         },
         {
           "german": "bluten",
           "russian": "кровоточить",
           "transcription": "[БЛУ-тен]",
           "sentence": "Ich blute wie ein geschlachtetes Schwein.",
-          "sentence_translation": "Я кровоточу как зарезанная свинья."
+          "sentence_translation": "Я кровоточу как зарезанная свинья.",
+          "answer_forms": [
+            "кровоточить",
+            "кровоточу"
+          ]
         },
         {
           "german": "verwundet",
           "russian": "раненый",
           "transcription": "[фер-ВУН-дет]",
           "sentence": "Schwer verwundet sinke ich zu Boden.",
-          "sentence_translation": "Тяжело раненый я падаю на землю."
+          "sentence_translation": "Тяжело раненый я падаю на землю.",
+          "answer_forms": [
+            "раненый",
+            "ранен"
+          ]
         },
         {
           "german": "schwächen",
           "russian": "ослаблять",
           "transcription": "[ШВЕ-хен]",
           "sentence": "Die Verletzung schwächt meinen starken Körper.",
-          "sentence_translation": "Ранение ослабляет моё сильное тело."
+          "sentence_translation": "Ранение ослабляет моё сильное тело.",
+          "answer_forms": [
+            "ослаблять",
+            "ослабляет"
+          ]
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
           "sentence": "Zum ersten Mal leide ich selbst.",
-          "sentence_translation": "Впервые я сам страдаю."
+          "sentence_translation": "Впервые я сам страдаю.",
+          "answer_forms": [
+            "страдать",
+            "страдаю"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -420,56 +576,84 @@
           "russian": "смерть",
           "transcription": "[дер ТОД]",
           "sentence": "Der Tod kommt für mich zu früh.",
-          "sentence_translation": "Смерть приходит ко мне слишком рано."
+          "sentence_translation": "Смерть приходит ко мне слишком рано.",
+          "answer_forms": [
+            "смерть"
+          ]
         },
         {
           "german": "die Vergeltung",
           "russian": "возмездие",
           "transcription": "[ди фер-ГЕЛЬ-тунг]",
           "sentence": "Die Vergeltung ereilt mich unerwartet.",
-          "sentence_translation": "Возмездие настигает меня неожиданно."
+          "sentence_translation": "Возмездие настигает меня неожиданно.",
+          "answer_forms": [
+            "возмездие"
+          ]
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЕН-де]",
           "sentence": "Mein Ende kommt durch eines Dieners Hand.",
-          "sentence_translation": "Мой конец приходит от руки слуги."
+          "sentence_translation": "Мой конец приходит от руки слуги.",
+          "answer_forms": [
+            "конец"
+          ]
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
           "sentence": "Ich sterbe ohne Reue für meine Taten.",
-          "sentence_translation": "Я умираю без раскаяния за свои дела."
+          "sentence_translation": "Я умираю без раскаяния за свои дела.",
+          "answer_forms": [
+            "умирать",
+            "умираю"
+          ]
         },
         {
           "german": "verenden",
           "russian": "издыхать",
           "transcription": "[фер-ЕН-ден]",
           "sentence": "Wie ein Tier verende ich elend.",
-          "sentence_translation": "Как зверь я издыхаю жалко."
+          "sentence_translation": "Как зверь я издыхаю жалко.",
+          "answer_forms": [
+            "издыхать",
+            "издыхаю"
+          ]
         },
         {
           "german": "verfluchen",
           "russian": "проклинать",
           "transcription": "[фер-ФЛУ-хен]",
           "sentence": "Sterbend verfluche ich meine Mörder.",
-          "sentence_translation": "Умирая, я проклинаю своих убийц."
+          "sentence_translation": "Умирая, я проклинаю своих убийц.",
+          "answer_forms": [
+            "проклинать",
+            "проклинаю"
+          ]
         },
         {
           "german": "röcheln",
           "russian": "хрипеть",
           "transcription": "[РЁ-хельн]",
           "sentence": "Röchelnd hauche ich mein Leben aus.",
-          "sentence_translation": "Хрипя, я испускаю дух."
+          "sentence_translation": "Хрипя, я испускаю дух.",
+          "answer_forms": [
+            "хрипеть",
+            "хриплю"
+          ]
         },
         {
           "german": "die Strafe",
           "russian": "кара",
           "transcription": "[ди ШТРА-фе]",
           "sentence": "Dies ist die gerechte Strafe für meine Grausamkeit.",
-          "sentence_translation": "Это справедливая кара за мою жестокость."
+          "sentence_translation": "Это справедливая кара за мою жестокость.",
+          "answer_forms": [
+            "кара"
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/edgar.json
+++ b/data/characters/edgar.json
@@ -21,56 +21,85 @@
           "russian": "знать",
           "transcription": "[дер А-дель]",
           "sentence": "Der Adel erwartet von mir ehrenhaftes Verhalten.",
-          "sentence_translation": "Знать ожидает от меня достойного поведения."
+          "sentence_translation": "Знать ожидает от меня достойного поведения.",
+          "answer_forms": [
+            "знать",
+            "знати"
+          ]
         },
         {
           "german": "der Erbe",
           "russian": "наследник",
           "transcription": "[дер ЕР-бе]",
           "sentence": "Als rechtmäßiger Erbe habe ich Pflichten.",
-          "sentence_translation": "Как законный наследник, у меня есть обязанности."
+          "sentence_translation": "Как законный наследник, у меня есть обязанности.",
+          "answer_forms": [
+            "наследник"
+          ]
         },
         {
           "german": "das Königreich",
           "russian": "королевство",
           "transcription": "[дас КЁ-ниг-райх]",
           "sentence": "Ich diene dem Königreich mit Ehre.",
-          "sentence_translation": "Я служу королевству с честью."
+          "sentence_translation": "Я служу королевству с честью.",
+          "answer_forms": [
+            "королевство",
+            "королевству"
+          ]
         },
         {
           "german": "vertrauen",
           "russian": "доверять",
           "transcription": "[фер-ТРАУ-ен]",
           "sentence": "Mein Vater vertraut mir vollkommen.",
-          "sentence_translation": "Мой отец полностью мне доверяет."
+          "sentence_translation": "Мой отец полностью мне доверяет.",
+          "answer_forms": [
+            "доверять",
+            "доверяет"
+          ]
         },
         {
           "german": "die Ehre",
           "russian": "честь",
           "transcription": "[ди Э-ре]",
           "sentence": "Die Ehre der Familie liegt in meinen Händen.",
-          "sentence_translation": "Честь семьи в моих руках."
+          "sentence_translation": "Честь семьи в моих руках.",
+          "answer_forms": [
+            "честь"
+          ]
         },
         {
           "german": "legitim",
           "russian": "законный",
           "transcription": "[ле-ги-ТИМ]",
           "sentence": "Ich bin der legitime Sohn des Grafen.",
-          "sentence_translation": "Я законный сын графа."
+          "sentence_translation": "Я законный сын графа.",
+          "answer_forms": [
+            "законный"
+          ]
         },
         {
           "german": "der Graf",
           "russian": "граф",
           "transcription": "[дер ГРАФ]",
           "sentence": "Mein Vater, der Graf, ist ein edler Mann.",
-          "sentence_translation": "Мой отец, граф, благородный человек."
+          "sentence_translation": "Мой отец, граф, благородный человек.",
+          "answer_forms": [
+            "граф",
+            "графа"
+          ]
         },
         {
           "german": "ahnungslos",
           "russian": "ничего не подозревающий",
           "transcription": "[А-нунгс-лос]",
           "sentence": "Ahnungslos vertraue ich meinem Bruder.",
-          "sentence_translation": "Ничего не подозревая, я доверяю брату."
+          "sentence_translation": "Ничего не подозревая, я доверяю брату.",
+          "answer_forms": [
+            "ничего не подозревающий",
+            "ничего не подозревая"
+          ]
         }
       ]
     },
@@ -92,56 +121,82 @@
           "russian": "бежать",
           "transcription": "[ФЛИ-ен]",
           "sentence": "Ich muss vor falschen Anschuldigungen fliehen.",
-          "sentence_translation": "Я должен бежать от ложных обвинений."
+          "sentence_translation": "Я должен бежать от ложных обвинений.",
+          "answer_forms": [
+            "бежать"
+          ]
         },
         {
           "german": "der Verrat",
           "russian": "предательство",
           "transcription": "[дер фер-РАТ]",
           "sentence": "Der Verrat meines Bruders zerstört mein Leben.",
-          "sentence_translation": "Предательство моего брата разрушает мою жизнь."
+          "sentence_translation": "Предательство моего брата разрушает мою жизнь.",
+          "answer_forms": [
+            "предательство"
+          ]
         },
         {
           "german": "die Gefahr",
           "russian": "опасность",
           "transcription": "[ди ге-ФАР]",
           "sentence": "Die Gefahr lauert überall um mich herum.",
-          "sentence_translation": "Опасность подстерегает меня повсюду."
+          "sentence_translation": "Опасность подстерегает меня повсюду.",
+          "answer_forms": [
+            "опасность"
+          ]
         },
         {
           "german": "verfolgen",
           "russian": "преследовать",
           "transcription": "[фер-ФОЛЬ-ген]",
           "sentence": "Die Soldaten verfolgen mich wie einen Verbrecher.",
-          "sentence_translation": "Солдаты преследуют меня как преступника."
+          "sentence_translation": "Солдаты преследуют меня как преступника.",
+          "answer_forms": [
+            "преследовать",
+            "преследуют"
+          ]
         },
         {
           "german": "verstecken",
           "russian": "прятаться",
           "transcription": "[фер-ШТЕ-кен]",
           "sentence": "Ich muss mich in den Wäldern verstecken.",
-          "sentence_translation": "Я должен прятаться в лесах."
+          "sentence_translation": "Я должен прятаться в лесах.",
+          "answer_forms": [
+            "прятаться",
+            "прячусь"
+          ]
         },
         {
           "german": "die Intrige",
           "russian": "интрига",
           "transcription": "[ди ин-ТРИ-ге]",
           "sentence": "Edmunds Intrige hat mich zum Geächteten gemacht.",
-          "sentence_translation": "Интрига Эдмунда сделала меня изгоем."
+          "sentence_translation": "Интрига Эдмунда сделала меня изгоем.",
+          "answer_forms": [
+            "интрига"
+          ]
         },
         {
           "german": "der Betrug",
           "russian": "обман",
           "transcription": "[дер бе-ТРУГ]",
           "sentence": "Dieser Betrug wird eines Tages aufgedeckt.",
-          "sentence_translation": "Этот обман однажды раскроется."
+          "sentence_translation": "Этот обман однажды раскроется.",
+          "answer_forms": [
+            "обман"
+          ]
         },
         {
           "german": "verbannen",
           "russian": "изгнать",
           "transcription": "[фер-БАН-нен]",
           "sentence": "Mein Vater will mich aus dem Land verbannen.",
-          "sentence_translation": "Мой отец хочет изгнать меня из страны."
+          "sentence_translation": "Мой отец хочет изгнать меня из страны.",
+          "answer_forms": [
+            "изгнать"
+          ]
         }
       ]
     },
@@ -163,56 +218,82 @@
           "russian": "безумие",
           "transcription": "[дер ВАН-зин]",
           "sentence": "Ich spiele den Wahnsinn, um zu überleben.",
-          "sentence_translation": "Я играю безумие, чтобы выжить."
+          "sentence_translation": "Я играю безумие, чтобы выжить.",
+          "answer_forms": [
+            "безумие"
+          ]
         },
         {
           "german": "der Bettler",
           "russian": "нищий",
           "transcription": "[дер БЕТ-лер]",
           "sentence": "Als Bettler bin ich unsichtbar für meine Feinde.",
-          "sentence_translation": "Как нищий, я невидим для врагов."
+          "sentence_translation": "Как нищий, я невидим для врагов.",
+          "answer_forms": [
+            "нищий"
+          ]
         },
         {
           "german": "die Verkleidung",
           "russian": "маскировка",
           "transcription": "[ди фер-КЛАЙ-дунг]",
           "sentence": "Diese Verkleidung ist meine einzige Rettung.",
-          "sentence_translation": "Эта маскировка - моё единственное спасение."
+          "sentence_translation": "Эта маскировка - моё единственное спасение.",
+          "answer_forms": [
+            "маскировка"
+          ]
         },
         {
           "german": "nackt",
           "russian": "голый",
           "transcription": "[НАКТ]",
           "sentence": "Fast nackt wandere ich durch die Wildnis.",
-          "sentence_translation": "Почти голый, я брожу по дикой местности."
+          "sentence_translation": "Почти голый, я брожу по дикой местности.",
+          "answer_forms": [
+            "голый"
+          ]
         },
         {
           "german": "murmeln",
           "russian": "бормотать",
           "transcription": "[МУР-мельн]",
           "sentence": "Ich murmle Unsinn, um verrückt zu wirken.",
-          "sentence_translation": "Я бормочу чепуху, чтобы казаться сумасшедшим."
+          "sentence_translation": "Я бормочу чепуху, чтобы казаться сумасшедшим.",
+          "answer_forms": [
+            "бормотать",
+            "бормочу"
+          ]
         },
         {
           "german": "zittern",
           "russian": "дрожать",
           "transcription": "[ЦИ-терн]",
           "sentence": "Vor Kälte und Angst zittere ich ständig.",
-          "sentence_translation": "От холода и страха я постоянно дрожу."
+          "sentence_translation": "От холода и страха я постоянно дрожу.",
+          "answer_forms": [
+            "дрожать",
+            "дрожу"
+          ]
         },
         {
           "german": "das Elend",
           "russian": "нищета",
           "transcription": "[дас Э-ленд]",
           "sentence": "Im Elend lerne ich die wahre Natur des Menschen.",
-          "sentence_translation": "В нищете я познаю истинную природу человека."
+          "sentence_translation": "В нищете я познаю истинную природу человека.",
+          "answer_forms": [
+            "нищета"
+          ]
         },
         {
           "german": "wahnsinnig",
           "russian": "безумный",
           "transcription": "[ВАН-зи-ниг]",
           "sentence": "Ich gebe vor, wahnsinnig zu sein.",
-          "sentence_translation": "Я притворяюсь безумным."
+          "sentence_translation": "Я притворяюсь безумным.",
+          "answer_forms": [
+            "безумный"
+          ]
         }
       ]
     },
@@ -234,56 +315,85 @@
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
           "sentence": "Der Sturm tobt über unseren Köpfen.",
-          "sentence_translation": "Буря бушует над нашими головами."
+          "sentence_translation": "Буря бушует над нашими головами.",
+          "answer_forms": [
+            "буря"
+          ]
         },
         {
           "german": "frieren",
           "russian": "мёрзнуть",
           "transcription": "[ФРИ-рен]",
           "sentence": "Wir frieren gemeinsam in dieser kalten Nacht.",
-          "sentence_translation": "Мы мёрзнем вместе в эту холодную ночь."
+          "sentence_translation": "Мы мёрзнем вместе в эту холодную ночь.",
+          "answer_forms": [
+            "мёрзнуть",
+            "мёрзнем"
+          ]
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
           "sentence": "Der König leidet mehr als ich jemals gelitten habe.",
-          "sentence_translation": "Король страдает больше, чем я когда-либо страдал."
+          "sentence_translation": "Король страдает больше, чем я когда-либо страдал.",
+          "answer_forms": [
+            "страдать",
+            "страдает"
+          ]
         },
         {
           "german": "die Hütte",
           "russian": "хижина",
           "transcription": "[ди ХЮ-те]",
           "sentence": "In dieser armseligen Hütte finden wir Zuflucht.",
-          "sentence_translation": "В этой жалкой хижине мы находим убежище."
+          "sentence_translation": "В этой жалкой хижине мы находим убежище.",
+          "answer_forms": [
+            "хижина",
+            "хижине"
+          ]
         },
         {
           "german": "beschützen",
           "russian": "защищать",
           "transcription": "[бе-ШЮ-цен]",
           "sentence": "Heimlich beschütze ich den wahnsinnigen König.",
-          "sentence_translation": "Тайно я защищаю безумного короля."
+          "sentence_translation": "Тайно я защищаю безумного короля.",
+          "answer_forms": [
+            "защищать",
+            "защищаю"
+          ]
         },
         {
           "german": "begleiten",
           "russian": "сопровождать",
           "transcription": "[бе-ГЛАЙ-тен]",
           "sentence": "Als Tom begleite ich Lear durch seine dunkelste Stunde.",
-          "sentence_translation": "Как Том, я сопровождаю Лира в его самый тёмный час."
+          "sentence_translation": "Как Том, я сопровождаю Лира в его самый тёмный час.",
+          "answer_forms": [
+            "сопровождать",
+            "сопровождаю"
+          ]
         },
         {
           "german": "der Donner",
           "russian": "гром",
           "transcription": "[дер ДО-нер]",
           "sentence": "Der Donner übertönt unsere Schreie.",
-          "sentence_translation": "Гром заглушает наши крики."
+          "sentence_translation": "Гром заглушает наши крики.",
+          "answer_forms": [
+            "гром"
+          ]
         },
         {
           "german": "der Blitz",
           "russian": "молния",
           "transcription": "[дер БЛИЦ]",
           "sentence": "Die Blitze erhellen unser Elend.",
-          "sentence_translation": "Молнии освещают нашу нищету."
+          "sentence_translation": "Молнии освещают нашу нищету.",
+          "answer_forms": [
+            "молния"
+          ]
         }
       ]
     },
@@ -305,56 +415,85 @@
           "russian": "слепой",
           "transcription": "[БЛИНД]",
           "sentence": "Mein blinder Vater erkennt mich nicht.",
-          "sentence_translation": "Мой слепой отец не узнаёт меня."
+          "sentence_translation": "Мой слепой отец не узнаёт меня.",
+          "answer_forms": [
+            "слепой"
+          ]
         },
         {
           "german": "führen",
           "russian": "вести",
           "transcription": "[ФЮ-рен]",
           "sentence": "Ich führe ihn sicher durch die Dunkelheit.",
-          "sentence_translation": "Я веду его безопасно сквозь тьму."
+          "sentence_translation": "Я веду его безопасно сквозь тьму.",
+          "answer_forms": [
+            "вести",
+            "веду"
+          ]
         },
         {
           "german": "die Klippe",
           "russian": "утёс",
           "transcription": "[ди КЛИ-пе]",
           "sentence": "Er glaubt, wir stehen am Rand der Klippe.",
-          "sentence_translation": "Он думает, мы стоим на краю утёса."
+          "sentence_translation": "Он думает, мы стоим на краю утёса.",
+          "answer_forms": [
+            "утёс",
+            "утёса"
+          ]
         },
         {
           "german": "täuschen",
           "russian": "обманывать",
           "transcription": "[ТОЙ-шен]",
           "sentence": "Ich täusche ihn, um sein Leben zu retten.",
-          "sentence_translation": "Я обманываю его, чтобы спасти его жизнь."
+          "sentence_translation": "Я обманываю его, чтобы спасти его жизнь.",
+          "answer_forms": [
+            "обманывать",
+            "обманываю"
+          ]
         },
         {
           "german": "retten",
           "russian": "спасать",
           "transcription": "[РЕ-тен]",
           "sentence": "Mit List will ich meinen Vater retten.",
-          "sentence_translation": "Хитростью я хочу спасти отца."
+          "sentence_translation": "Хитростью я хочу спасти отца.",
+          "answer_forms": [
+            "спасать",
+            "спасти"
+          ]
         },
         {
           "german": "die List",
           "russian": "хитрость",
           "transcription": "[ди ЛИСТ]",
           "sentence": "Meine List bewahrt ihn vor dem Selbstmord.",
-          "sentence_translation": "Моя хитрость спасает его от самоубийства."
+          "sentence_translation": "Моя хитрость спасает его от самоубийства.",
+          "answer_forms": [
+            "хитрость"
+          ]
         },
         {
           "german": "trösten",
           "russian": "утешать",
           "transcription": "[ТРЁС-тен]",
           "sentence": "Als Fremder tröste ich meinen eigenen Vater.",
-          "sentence_translation": "Как чужой, я утешаю собственного отца."
+          "sentence_translation": "Как чужой, я утешаю собственного отца.",
+          "answer_forms": [
+            "утешать",
+            "утешаю"
+          ]
         },
         {
           "german": "die Verzweiflung",
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
           "sentence": "Seine Verzweiflung bricht mir das Herz.",
-          "sentence_translation": "Его отчаяние разбивает мне сердце."
+          "sentence_translation": "Его отчаяние разбивает мне сердце.",
+          "answer_forms": [
+            "отчаяние"
+          ]
         }
       ]
     },
@@ -376,56 +515,82 @@
           "russian": "бой",
           "transcription": "[дер КАМПФ]",
           "sentence": "Der Kampf gegen meinen Bruder ist unvermeidlich.",
-          "sentence_translation": "Бой с моим братом неизбежен."
+          "sentence_translation": "Бой с моим братом неизбежен.",
+          "answer_forms": [
+            "бой"
+          ]
         },
         {
           "german": "das Duell",
           "russian": "дуэль",
           "transcription": "[дас ду-ЭЛЬ]",
           "sentence": "In diesem Duell kämpfe ich für die Gerechtigkeit.",
-          "sentence_translation": "В этой дуэли я сражаюсь за справедливость."
+          "sentence_translation": "В этой дуэли я сражаюсь за справедливость.",
+          "answer_forms": [
+            "дуэль"
+          ]
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
           "sentence": "Nicht Rache, sondern Gerechtigkeit leitet meine Klinge.",
-          "sentence_translation": "Не месть, а справедливость ведёт мой клинок."
+          "sentence_translation": "Не месть, а справедливость ведёт мой клинок.",
+          "answer_forms": [
+            "месть"
+          ]
         },
         {
           "german": "enthüllen",
           "russian": "разоблачать",
           "transcription": "[энт-ХЮ-лен]",
           "sentence": "Ich enthülle meine wahre Identität.",
-          "sentence_translation": "Я разоблачаю свою истинную личность."
+          "sentence_translation": "Я разоблачаю свою истинную личность.",
+          "answer_forms": [
+            "разоблачать",
+            "разоблачаю"
+          ]
         },
         {
           "german": "siegen",
           "russian": "побеждать",
           "transcription": "[ЗИ-ген]",
           "sentence": "Die Wahrheit wird über die Lüge siegen.",
-          "sentence_translation": "Правда победит ложь."
+          "sentence_translation": "Правда победит ложь.",
+          "answer_forms": [
+            "побеждать",
+            "победить"
+          ]
         },
         {
           "german": "die Gerechtigkeit",
           "russian": "справедливость",
           "transcription": "[ди ге-РЕХ-тиг-кайт]",
           "sentence": "Die Gerechtigkeit fordert diesen Kampf.",
-          "sentence_translation": "Справедливость требует этого боя."
+          "sentence_translation": "Справедливость требует этого боя.",
+          "answer_forms": [
+            "справедливость"
+          ]
         },
         {
           "german": "das Schwert",
           "russian": "меч",
           "transcription": "[дас ШВЕРТ]",
           "sentence": "Mein Schwert ist die Waffe der Wahrheit.",
-          "sentence_translation": "Мой меч - оружие правды."
+          "sentence_translation": "Мой меч - оружие правды.",
+          "answer_forms": [
+            "меч"
+          ]
         },
         {
           "german": "der Bruder",
           "russian": "брат",
           "transcription": "[дер БРУ-дер]",
           "sentence": "Mein Bruder muss für seine Verbrechen büßen.",
-          "sentence_translation": "Мой брат должен поплатиться за свои преступления."
+          "sentence_translation": "Мой брат должен поплатиться за свои преступления.",
+          "answer_forms": [
+            "брат"
+          ]
         }
       ]
     },
@@ -447,56 +612,84 @@
           "russian": "выживать",
           "transcription": "[ю-бер-ЛЕ-бен]",
           "sentence": "Ich habe alle Prüfungen überlebt.",
-          "sentence_translation": "Я пережил все испытания."
+          "sentence_translation": "Я пережил все испытания.",
+          "answer_forms": [
+            "выживать",
+            "выжил"
+          ]
         },
         {
           "german": "erben",
           "russian": "наследовать",
           "transcription": "[ЭР-бен]",
           "sentence": "Nun erbe ich Titel und Verantwortung.",
-          "sentence_translation": "Теперь я наследую титул и ответственность."
+          "sentence_translation": "Теперь я наследую титул и ответственность.",
+          "answer_forms": [
+            "наследовать",
+            "наследую"
+          ]
         },
         {
           "german": "die Zukunft",
           "russian": "будущее",
           "transcription": "[ди ЦУ-кунфт]",
           "sentence": "Die Zukunft des Königreichs liegt in unseren Händen.",
-          "sentence_translation": "Будущее королевства в наших руках."
+          "sentence_translation": "Будущее королевства в наших руках.",
+          "answer_forms": [
+            "будущее"
+          ]
         },
         {
           "german": "regieren",
           "russian": "править",
           "transcription": "[ре-ГИ-рен]",
           "sentence": "Mit Weisheit werde ich regieren.",
-          "sentence_translation": "С мудростью я буду править."
+          "sentence_translation": "С мудростью я буду править.",
+          "answer_forms": [
+            "править"
+          ]
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
           "sentence": "Durch Leiden habe ich Weisheit erlangt.",
-          "sentence_translation": "Через страдания я обрёл мудрость."
+          "sentence_translation": "Через страдания я обрёл мудрость.",
+          "answer_forms": [
+            "мудрость",
+            "мудростью"
+          ]
         },
         {
           "german": "die Ordnung",
           "russian": "порядок",
           "transcription": "[ди ОРД-нунг]",
           "sentence": "Neue Ordnung muss aus dem Chaos entstehen.",
-          "sentence_translation": "Новый порядок должен возникнуть из хаоса."
+          "sentence_translation": "Новый порядок должен возникнуть из хаоса.",
+          "answer_forms": [
+            "порядок"
+          ]
         },
         {
           "german": "die Verantwortung",
           "russian": "ответственность",
           "transcription": "[ди фер-АНТ-вор-тунг]",
           "sentence": "Die Verantwortung für alle wiegt schwer.",
-          "sentence_translation": "Ответственность за всех тяжела."
+          "sentence_translation": "Ответственность за всех тяжела.",
+          "answer_forms": [
+            "ответственность"
+          ]
         },
         {
           "german": "neu",
           "russian": "новый",
           "transcription": "[НОЙ]",
           "sentence": "Eine neue Ära beginnt für unser Land.",
-          "sentence_translation": "Новая эра начинается для нашей страны."
+          "sentence_translation": "Новая эра начинается для нашей страны.",
+          "answer_forms": [
+            "новый",
+            "новая"
+          ]
         }
       ]
     }

--- a/data/characters/edmund.json
+++ b/data/characters/edmund.json
@@ -21,56 +21,83 @@
           "russian": "бастард",
           "transcription": "[дер БАС-тард]",
           "sentence": "Als Bastard habe ich keine Rechte.",
-          "sentence_translation": "Как бастард я не имею прав."
+          "sentence_translation": "Как бастард я не имею прав.",
+          "answer_forms": [
+            "бастард"
+          ]
         },
         {
           "german": "der Neid",
           "russian": "зависть",
           "transcription": "[дер НАЙД]",
           "sentence": "Der Neid auf Edgar verzehrt mich.",
-          "sentence_translation": "Зависть к Эдгару пожирает меня."
+          "sentence_translation": "Зависть к Эдгару пожирает меня.",
+          "answer_forms": [
+            "зависть"
+          ]
         },
         {
           "german": "die Ambition",
           "russian": "амбиция",
           "transcription": "[ди ам-би-ЦИ-он]",
           "sentence": "Meine Ambition kennt keine Grenzen.",
-          "sentence_translation": "Моя амбиция не знает границ."
+          "sentence_translation": "Моя амбиция не знает границ.",
+          "answer_forms": [
+            "амбиция"
+          ]
         },
         {
           "german": "benachteiligt",
           "russian": "обделённый",
           "transcription": "[бе-НАХ-тай-лигт]",
           "sentence": "Ich bin von Geburt an benachteiligt.",
-          "sentence_translation": "Я обделён с рождения."
+          "sentence_translation": "Я обделён с рождения.",
+          "answer_forms": [
+            "обделённый",
+            "обделён"
+          ]
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
           "sentence": "Die Rache an der Gesellschaft ist mein Ziel.",
-          "sentence_translation": "Месть обществу - моя цель."
+          "sentence_translation": "Месть обществу - моя цель.",
+          "answer_forms": [
+            "месть"
+          ]
         },
         {
           "german": "aufsteigen",
           "russian": "возвышаться",
           "transcription": "[АУФ-штай-ген]",
           "sentence": "Ich will über alle aufsteigen.",
-          "sentence_translation": "Я хочу возвыситься над всеми."
+          "sentence_translation": "Я хочу возвыситься над всеми.",
+          "answer_forms": [
+            "возвышаться",
+            "возвышусь"
+          ]
         },
         {
           "german": "unehelich",
           "russian": "внебрачный",
           "transcription": "[УН-э-е-лих]",
           "sentence": "Meine uneheliche Geburt ist mein Fluch.",
-          "sentence_translation": "Моё внебрачное рождение - мой проклятие."
+          "sentence_translation": "Моё внебрачное рождение - мой проклятие.",
+          "answer_forms": [
+            "внебрачный",
+            "внебрачное"
+          ]
         },
         {
           "german": "die Natur",
           "russian": "природа",
           "transcription": "[ди на-ТУР]",
           "sentence": "Die Natur ist meine Göttin, nicht das Gesetz.",
-          "sentence_translation": "Природа - моя богиня, не закон."
+          "sentence_translation": "Природа - моя богиня, не закон.",
+          "answer_forms": [
+            "природа"
+          ]
         }
       ]
     },
@@ -92,56 +119,85 @@
           "russian": "подделывать",
           "transcription": "[ФЕЛЬ-шен]",
           "sentence": "Ich fälsche Edgars Brief perfekt.",
-          "sentence_translation": "Я идеально подделываю письмо Эдгара."
+          "sentence_translation": "Я идеально подделываю письмо Эдгара.",
+          "answer_forms": [
+            "подделывать",
+            "подделываю"
+          ]
         },
         {
           "german": "intrigieren",
           "russian": "интриговать",
           "transcription": "[ин-три-ГИ-рен]",
           "sentence": "Ich intrigiere gegen meinen Bruder.",
-          "sentence_translation": "Я интригую против брата."
+          "sentence_translation": "Я интригую против брата.",
+          "answer_forms": [
+            "интриговать",
+            "интригую"
+          ]
         },
         {
           "german": "beschuldigen",
           "russian": "обвинять",
           "transcription": "[бе-ШУЛЬ-ди-ген]",
           "sentence": "Ich beschuldige Edgar des Verrats.",
-          "sentence_translation": "Я обвиняю Эдгара в предательстве."
+          "sentence_translation": "Я обвиняю Эдгара в предательстве.",
+          "answer_forms": [
+            "обвинять",
+            "обвиняю"
+          ]
         },
         {
           "german": "der Plan",
           "russian": "план",
           "transcription": "[дер ПЛАН]",
           "sentence": "Mein Plan wird perfekt ausgeführt.",
-          "sentence_translation": "Мой план выполняется идеально."
+          "sentence_translation": "Мой план выполняется идеально.",
+          "answer_forms": [
+            "план"
+          ]
         },
         {
           "german": "manipulieren",
           "russian": "манипулировать",
           "transcription": "[ма-ни-пу-ЛИ-рен]",
           "sentence": "Ich manipuliere meinen Vater geschickt.",
-          "sentence_translation": "Я ловко манипулирую отцом."
+          "sentence_translation": "Я ловко манипулирую отцом.",
+          "answer_forms": [
+            "манипулировать",
+            "манипулирую"
+          ]
         },
         {
           "german": "der Brief",
           "russian": "письмо",
           "transcription": "[дер БРИФ]",
           "sentence": "Der gefälschte Brief ist mein Beweis.",
-          "sentence_translation": "Поддельное письмо - моё доказательство."
+          "sentence_translation": "Поддельное письмо - моё доказательство.",
+          "answer_forms": [
+            "письмо"
+          ]
         },
         {
           "german": "lügen",
           "russian": "лгать",
           "transcription": "[ЛЮ-ген]",
           "sentence": "Ich lüge ohne mit der Wimper zu zucken.",
-          "sentence_translation": "Я лгу не моргнув глазом."
+          "sentence_translation": "Я лгу не моргнув глазом.",
+          "answer_forms": [
+            "лгать",
+            "лгу"
+          ]
         },
         {
           "german": "die Täuschung",
           "russian": "обман",
           "transcription": "[ди ТОЙ-шунг]",
           "sentence": "Die Täuschung ist vollkommen.",
-          "sentence_translation": "Обман совершенен."
+          "sentence_translation": "Обман совершенен.",
+          "answer_forms": [
+            "обман"
+          ]
         }
       ]
     },
@@ -163,56 +219,85 @@
           "russian": "изгонять",
           "transcription": "[фер-ТРАЙ-бен]",
           "sentence": "Ich vertreibe Edgar aus seinem Erbe.",
-          "sentence_translation": "Я изгоняю Эдгара из его наследства."
+          "sentence_translation": "Я изгоняю Эдгара из его наследства.",
+          "answer_forms": [
+            "изгонять",
+            "изгнал"
+          ]
         },
         {
           "german": "triumphieren",
           "russian": "торжествовать",
           "transcription": "[три-ум-ФИ-рен]",
           "sentence": "Ich triumphiere über meinen Bruder.",
-          "sentence_translation": "Я торжествую над братом."
+          "sentence_translation": "Я торжествую над братом.",
+          "answer_forms": [
+            "торжествовать",
+            "торжествую"
+          ]
         },
         {
           "german": "erben",
           "russian": "наследовать",
           "transcription": "[ЭР-бен]",
           "sentence": "Nun erbe ich alles, was Edgar zustand.",
-          "sentence_translation": "Теперь я наследую всё, что полагалось Эдгару."
+          "sentence_translation": "Теперь я наследую всё, что полагалось Эдгару.",
+          "answer_forms": [
+            "наследовать",
+            "наследую"
+          ]
         },
         {
           "german": "der Erfolg",
           "russian": "успех",
           "transcription": "[дер эр-ФОЛЬГ]",
           "sentence": "Mein Erfolg ist vollkommen.",
-          "sentence_translation": "Мой успех полный."
+          "sentence_translation": "Мой успех полный.",
+          "answer_forms": [
+            "успех"
+          ]
         },
         {
           "german": "gewinnen",
           "russian": "выигрывать",
           "transcription": "[ге-ВИН-нен]",
           "sentence": "Ich gewinne alles durch List.",
-          "sentence_translation": "Я выигрываю всё хитростью."
+          "sentence_translation": "Я выигрываю всё хитростью.",
+          "answer_forms": [
+            "выигрывать",
+            "выиграл"
+          ]
         },
         {
           "german": "die Belohnung",
           "russian": "награда",
           "transcription": "[ди бе-ЛО-нунг]",
           "sentence": "Die Belohnung für meine Intrige ist groß.",
-          "sentence_translation": "Награда за мою интригу велика."
+          "sentence_translation": "Награда за мою интригу велика.",
+          "answer_forms": [
+            "награда"
+          ]
         },
         {
           "german": "verdrängen",
           "russian": "вытеснять",
           "transcription": "[фер-ДРЕН-ген]",
           "sentence": "Ich verdränge den rechtmäßigen Erben.",
-          "sentence_translation": "Я вытесняю законного наследника."
+          "sentence_translation": "Я вытесняю законного наследника.",
+          "answer_forms": [
+            "вытеснять",
+            "вытеснил"
+          ]
         },
         {
           "german": "der Sieg",
           "russian": "победа",
           "transcription": "[дер ЗИГ]",
           "sentence": "Der Sieg über Edgar ist süß.",
-          "sentence_translation": "Победа над Эдгаром сладка."
+          "sentence_translation": "Победа над Эдгаром сладка.",
+          "answer_forms": [
+            "победа"
+          ]
         }
       ]
     },
@@ -234,56 +319,84 @@
           "russian": "объединяться",
           "transcription": "[фер-БЮН-ден]",
           "sentence": "Ich verbünde mich mit den bösen Schwestern.",
-          "sentence_translation": "Я объединяюсь со злыми сёстрами."
+          "sentence_translation": "Я объединяюсь со злыми сёстрами.",
+          "answer_forms": [
+            "объединяться",
+            "объединяюсь"
+          ]
         },
         {
           "german": "die Macht",
           "russian": "власть",
           "transcription": "[ди МАХТ]",
           "sentence": "Die Macht über das Königreich ist nah.",
-          "sentence_translation": "Власть над королевством близка."
+          "sentence_translation": "Власть над королевством близка.",
+          "answer_forms": [
+            "власть"
+          ]
         },
         {
           "german": "erobern",
           "russian": "завоёвывать",
           "transcription": "[эр-О-берн]",
           "sentence": "Wir erobern das Reich gemeinsam.",
-          "sentence_translation": "Мы завоёвываем королевство вместе."
+          "sentence_translation": "Мы завоёвываем королевство вместе.",
+          "answer_forms": [
+            "завоёвывать",
+            "завоёвываем"
+          ]
         },
         {
           "german": "das Bündnis",
           "russian": "союз",
           "transcription": "[дас БЮНД-нис]",
           "sentence": "Unser Bündnis ist stark und grausam.",
-          "sentence_translation": "Наш союз силён и жесток."
+          "sentence_translation": "Наш союз силён и жесток.",
+          "answer_forms": [
+            "союз"
+          ]
         },
         {
           "german": "verführen",
           "russian": "соблазнять",
           "transcription": "[фер-ФЮ-рен]",
           "sentence": "Ich verführe beide Schwestern gleichzeitig.",
-          "sentence_translation": "Я соблазняю обеих сестёр одновременно."
+          "sentence_translation": "Я соблазняю обеих сестёр одновременно.",
+          "answer_forms": [
+            "соблазнять",
+            "соблазняю"
+          ]
         },
         {
           "german": "die Eroberung",
           "russian": "завоевание",
           "transcription": "[ди эр-О-бе-рунг]",
           "sentence": "Die Eroberung des Throns ist mein Ziel.",
-          "sentence_translation": "Завоевание трона - моя цель."
+          "sentence_translation": "Завоевание трона - моя цель.",
+          "answer_forms": [
+            "завоевание"
+          ]
         },
         {
           "german": "beherrschen",
           "russian": "господствовать",
           "transcription": "[бе-ХЕР-шен]",
           "sentence": "Ich beherrsche das Spiel der Macht.",
-          "sentence_translation": "Я господствую в игре власти."
+          "sentence_translation": "Я господствую в игре власти.",
+          "answer_forms": [
+            "господствовать",
+            "господствую"
+          ]
         },
         {
           "german": "die Allianz",
           "russian": "альянс",
           "transcription": "[ди а-ли-АНЦС]",
           "sentence": "Unsere Allianz wird alle Feinde vernichten.",
-          "sentence_translation": "Наш альянс уничтожит всех врагов."
+          "sentence_translation": "Наш альянс уничтожит всех врагов.",
+          "answer_forms": [
+            "альянс"
+          ]
         }
       ]
     },
@@ -305,56 +418,86 @@
           "russian": "предавать",
           "transcription": "[фер-РА-тен]",
           "sentence": "Ich verrate meinen eigenen Vater.",
-          "sentence_translation": "Я предаю собственного отца."
+          "sentence_translation": "Я предаю собственного отца.",
+          "answer_forms": [
+            "предавать",
+            "предаю"
+          ]
         },
         {
           "german": "blenden",
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
           "sentence": "Sie blenden ihn auf meinen Hinweis.",
-          "sentence_translation": "Они ослепляют его по моей наводке."
+          "sentence_translation": "Они ослепляют его по моей наводке.",
+          "answer_forms": [
+            "ослеплять",
+            "ослепят"
+          ]
         },
         {
           "german": "die Grausamkeit",
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
           "sentence": "Meine Grausamkeit kennt keine Grenzen.",
-          "sentence_translation": "Моя жестокость не знает границ."
+          "sentence_translation": "Моя жестокость не знает границ.",
+          "answer_forms": [
+            "жестокость"
+          ]
         },
         {
           "german": "denunzieren",
           "russian": "доносить",
           "transcription": "[де-нун-ЦИ-рен]",
           "sentence": "Ich denunziere meinen Vater als Verräter.",
-          "sentence_translation": "Я доношу на отца как на предателя."
+          "sentence_translation": "Я доношу на отца как на предателя.",
+          "answer_forms": [
+            "доносить",
+            "доношу"
+          ]
         },
         {
           "german": "ausliefern",
           "russian": "выдавать",
           "transcription": "[АУС-ли-ферн]",
           "sentence": "Ich liefere ihn seinen Feinden aus.",
-          "sentence_translation": "Я выдаю его врагам."
+          "sentence_translation": "Я выдаю его врагам.",
+          "answer_forms": [
+            "выдавать",
+            "выдаю"
+          ]
         },
         {
           "german": "die Folter",
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
           "sentence": "Die Folter meines Vaters stört mich nicht.",
-          "sentence_translation": "Пытка моего отца меня не тревожит."
+          "sentence_translation": "Пытка моего отца меня не тревожит.",
+          "answer_forms": [
+            "пытка"
+          ]
         },
         {
           "german": "opfern",
           "russian": "жертвовать",
           "transcription": "[ОП-ферн]",
           "sentence": "Ich opfere ihn für meine Ambitionen.",
-          "sentence_translation": "Я жертвую им ради своих амбиций."
+          "sentence_translation": "Я жертвую им ради своих амбиций.",
+          "answer_forms": [
+            "жертвовать",
+            "жертвую"
+          ]
         },
         {
           "german": "erbarmungslos",
           "russian": "беспощадный",
           "transcription": "[эр-БАР-мунгс-лос]",
           "sentence": "Erbarmungslos verfolge ich mein Ziel.",
-          "sentence_translation": "Беспощадно я преследую свою цель."
+          "sentence_translation": "Беспощадно я преследую свою цель.",
+          "answer_forms": [
+            "беспощадный",
+            "беспощадно"
+          ]
         }
       ]
     },
@@ -376,56 +519,84 @@
           "russian": "любовная связь",
           "transcription": "[ди ЛИБ-шафт]",
           "sentence": "Meine Liebschaft mit beiden Schwestern ist gefährlich.",
-          "sentence_translation": "Моя любовная связь с обеими сёстрами опасна."
+          "sentence_translation": "Моя любовная связь с обеими сёстрами опасна.",
+          "answer_forms": [
+            "любовная связь"
+          ]
         },
         {
           "german": "die Rivalität",
           "russian": "соперничество",
           "transcription": "[ди ри-ва-ли-ТЕТ]",
           "sentence": "Ihre Rivalität spielt mir in die Hände.",
-          "sentence_translation": "Их соперничество играет мне на руку."
+          "sentence_translation": "Их соперничество играет мне на руку.",
+          "answer_forms": [
+            "соперничество"
+          ]
         },
         {
           "german": "spielen",
           "russian": "играть",
           "transcription": "[ШПИ-лен]",
           "sentence": "Ich spiele mit ihren Gefühlen.",
-          "sentence_translation": "Я играю с их чувствами."
+          "sentence_translation": "Я играю с их чувствами.",
+          "answer_forms": [
+            "играть",
+            "играю"
+          ]
         },
         {
           "german": "verlocken",
           "russian": "завлекать",
           "transcription": "[фер-ЛО-кен]",
           "sentence": "Ich verlocke sie mit falschen Versprechen.",
-          "sentence_translation": "Я завлекаю их ложными обещаниями."
+          "sentence_translation": "Я завлекаю их ложными обещаниями.",
+          "answer_forms": [
+            "завлекать",
+            "завлекаю"
+          ]
         },
         {
           "german": "die Lust",
           "russian": "похоть",
           "transcription": "[ди ЛУСТ]",
           "sentence": "Ihre Lust macht sie blind.",
-          "sentence_translation": "Их похоть делает их слепыми."
+          "sentence_translation": "Их похоть делает их слепыми.",
+          "answer_forms": [
+            "похоть"
+          ]
         },
         {
           "german": "ausnutzen",
           "russian": "использовать",
           "transcription": "[АУС-нут-цен]",
           "sentence": "Ich nutze ihre Leidenschaft aus.",
-          "sentence_translation": "Я использую их страсть."
+          "sentence_translation": "Я использую их страсть.",
+          "answer_forms": [
+            "использовать",
+            "использую"
+          ]
         },
         {
           "german": "jonglieren",
           "russian": "жонглировать",
           "transcription": "[жон-ГЛИ-рен]",
           "sentence": "Ich jongliere mit zwei gefährlichen Frauen.",
-          "sentence_translation": "Я жонглирую двумя опасными женщинами."
+          "sentence_translation": "Я жонглирую двумя опасными женщинами.",
+          "answer_forms": [
+            "жонглировать",
+            "жонглирую"
+          ]
         },
         {
           "german": "die Affäre",
           "russian": "интрига",
           "transcription": "[ди а-ФЕ-ре]",
           "sentence": "Diese Affäre wird tödlich enden.",
-          "sentence_translation": "Эта интрига закончится смертью."
+          "sentence_translation": "Эта интрига закончится смертью.",
+          "answer_forms": [
+            "интрига"
+          ]
         }
       ]
     },
@@ -447,56 +618,84 @@
           "russian": "дуэль",
           "transcription": "[дас ду-ЭЛЬ]",
           "sentence": "Das Duell mit Edgar ist mein Ende.",
-          "sentence_translation": "Дуэль с Эдгаром - мой конец."
+          "sentence_translation": "Дуэль с Эдгаром - мой конец.",
+          "answer_forms": [
+            "дуэль"
+          ]
         },
         {
           "german": "fallen",
           "russian": "падать",
           "transcription": "[ФАЛ-лен]",
           "sentence": "Ich falle von seinem gerechten Schwert.",
-          "sentence_translation": "Я падаю от его справедливого меча."
+          "sentence_translation": "Я падаю от его справедливого меча.",
+          "answer_forms": [
+            "падать",
+            "падаю"
+          ]
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
           "sentence": "Am Ende bereue ich meine Taten.",
-          "sentence_translation": "В конце я сожалею о своих делах."
+          "sentence_translation": "В конце я сожалею о своих делах.",
+          "answer_forms": [
+            "сожалеть",
+            "сожалею"
+          ]
         },
         {
           "german": "die Niederlage",
           "russian": "поражение",
           "transcription": "[ди НИ-дер-ла-ге]",
           "sentence": "Die Niederlage ist vollkommen.",
-          "sentence_translation": "Поражение полное."
+          "sentence_translation": "Поражение полное.",
+          "answer_forms": [
+            "поражение"
+          ]
         },
         {
           "german": "verlieren",
           "russian": "проигрывать",
           "transcription": "[фер-ЛИ-рен]",
           "sentence": "Ich verliere alles, was ich gewann.",
-          "sentence_translation": "Я проигрываю всё, что выиграл."
+          "sentence_translation": "Я проигрываю всё, что выиграл.",
+          "answer_forms": [
+            "проигрывать",
+            "проигрываю"
+          ]
         },
         {
           "german": "der Untergang",
           "russian": "падение",
           "transcription": "[дер УН-тер-ганг]",
           "sentence": "Mein Untergang ist gerecht.",
-          "sentence_translation": "Моё падение справедливо."
+          "sentence_translation": "Моё падение справедливо.",
+          "answer_forms": [
+            "падение"
+          ]
         },
         {
           "german": "gestehen",
           "russian": "признаваться",
           "transcription": "[ге-ШТЕ-ен]",
           "sentence": "Ich gestehe alle meine Verbrechen.",
-          "sentence_translation": "Я признаюсь во всех преступлениях."
+          "sentence_translation": "Я признаюсь во всех преступлениях.",
+          "answer_forms": [
+            "признаваться",
+            "признаюсь"
+          ]
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЭН-де]",
           "sentence": "Das Ende kommt schnell und gerecht.",
-          "sentence_translation": "Конец приходит быстро и справедливо."
+          "sentence_translation": "Конец приходит быстро и справедливо.",
+          "answer_forms": [
+            "конец"
+          ]
         }
       ]
     }

--- a/data/characters/fool.json
+++ b/data/characters/fool.json
@@ -15,56 +15,82 @@
           "russian": "шут",
           "transcription": "[дер НАР]",
           "sentence": "Als Narr sage ich die Wahrheit durch Scherze.",
-          "sentence_translation": "Как шут я говорю правду через шутки."
+          "sentence_translation": "Как шут я говорю правду через шутки.",
+          "answer_forms": [
+            "шут"
+          ]
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
           "sentence": "Hinter meinen Späßen verbirgt sich Weisheit.",
-          "sentence_translation": "За моими шутками скрывается мудрость."
+          "sentence_translation": "За моими шутками скрывается мудрость.",
+          "answer_forms": [
+            "мудрость"
+          ]
         },
         {
           "german": "die Trauer",
           "russian": "печаль",
           "transcription": "[ди ТРАУ-ер]",
           "sentence": "Die Trauer um Корделия macht mich stumm.",
-          "sentence_translation": "Печаль о Корделии делает меня немым."
+          "sentence_translation": "Печаль о Корделии делает меня немым.",
+          "answer_forms": [
+            "печаль"
+          ]
         },
         {
           "german": "scherzen",
           "russian": "шутить",
           "transcription": "[ШЕР-цен]",
           "sentence": "Ich scherze, um den Schmerz zu verbergen.",
-          "sentence_translation": "Я шучу, чтобы скрыть боль."
+          "sentence_translation": "Я шучу, чтобы скрыть боль.",
+          "answer_forms": [
+            "шутить",
+            "шучу"
+          ]
         },
         {
           "german": "der Spaß",
           "russian": "забава",
           "transcription": "[дер ШПАС]",
           "sentence": "Der Spaß ist meine Maske vor der Welt.",
-          "sentence_translation": "Забава - моя маска перед миром."
+          "sentence_translation": "Забава - моя маска перед миром.",
+          "answer_forms": [
+            "забава"
+          ]
         },
         {
           "german": "klug",
           "russian": "умный",
           "transcription": "[КЛУГ]",
           "sentence": "Ich bin klüger als alle bei Hofe.",
-          "sentence_translation": "Я умнее всех при дворе."
+          "sentence_translation": "Я умнее всех при дворе.",
+          "answer_forms": [
+            "умный"
+          ]
         },
         {
           "german": "vermissen",
           "russian": "скучать",
           "transcription": "[фер-МИ-сен]",
           "sentence": "Ich vermisse die süße Корделия sehr.",
-          "sentence_translation": "Я очень скучаю по милой Корделии."
+          "sentence_translation": "Я очень скучаю по милой Корделии.",
+          "answer_forms": [
+            "скучать",
+            "скучаю"
+          ]
         },
         {
           "german": "der Witz",
           "russian": "остроумие",
           "transcription": "[дер ВИТЦ]",
           "sentence": "Mein Witz ist scharf wie ein Schwert.",
-          "sentence_translation": "Моё остроумие остро как меч."
+          "sentence_translation": "Моё остроумие остро как меч.",
+          "answer_forms": [
+            "остроумие"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -86,49 +112,75 @@
           "russian": "правда",
           "transcription": "[ди ВАР-хайт]",
           "sentence": "Die Wahrheit verpacke ich in lustige Lieder.",
-          "sentence_translation": "Правду я заворачиваю в весёлые песни."
+          "sentence_translation": "Правду я заворачиваю в весёлые песни.",
+          "answer_forms": [
+            "правда"
+          ]
         },
         {
           "german": "der Scherz",
           "russian": "шутка",
           "transcription": "[дер ШЕРЦ]",
           "sentence": "Jeder Scherz enthält eine bittere Lehre.",
-          "sentence_translation": "Каждая шутка содержит горький урок."
+          "sentence_translation": "Каждая шутка содержит горький урок.",
+          "answer_forms": [
+            "шутка",
+            "шутку"
+          ]
         },
         {
           "german": "die Warnung",
           "russian": "предупреждение",
           "transcription": "[ди ВАР-нунг]",
           "sentence": "Meine Warnung kommt als Rätsel verkleidet.",
-          "sentence_translation": "Моё предупреждение приходит замаскированным под загадку."
+          "sentence_translation": "Моё предупреждение приходит замаскированным под загадку.",
+          "answer_forms": [
+            "предупреждение"
+          ]
         },
         {
           "german": "bitter",
           "russian": "горький",
           "transcription": "[БИ-тер]",
           "sentence": "Die Wahrheit schmeckt bitter wie Galle.",
-          "sentence_translation": "Правда горька как желчь."
+          "sentence_translation": "Правда горька как желчь.",
+          "answer_forms": [
+            "горький",
+            "горькая"
+          ]
         },
         {
           "german": "spotten",
           "russian": "насмехаться",
           "transcription": "[ШПО-тен]",
           "sentence": "Ich spotte über die Torheit der Mächtigen.",
-          "sentence_translation": "Я насмехаюсь над глупостью сильных."
+          "sentence_translation": "Я насмехаюсь над глупостью сильных.",
+          "answer_forms": [
+            "насмехаться",
+            "насмехаюсь"
+          ]
         },
         {
           "german": "necken",
           "russian": "дразнить",
           "transcription": "[НЕ-кен]",
           "sentence": "Ich necke den König mit der Wahrheit.",
-          "sentence_translation": "Я дразню короля правдой."
+          "sentence_translation": "Я дразню короля правдой.",
+          "answer_forms": [
+            "дразнить",
+            "дражню"
+          ]
         },
         {
           "german": "enthüllen",
           "russian": "раскрывать",
           "transcription": "[энт-ХЮ-лен]",
           "sentence": "Spielerisch enthülle ich seine Fehler.",
-          "sentence_translation": "Играючи я раскрываю его ошибки."
+          "sentence_translation": "Играючи я раскрываю его ошибки.",
+          "answer_forms": [
+            "раскрывать",
+            "раскрываю"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -150,56 +202,85 @@
           "russian": "пророчество",
           "transcription": "[ди про-фе-ЦАЙ-унг]",
           "sentence": "Meine Prophezeiung wird wahr werden.",
-          "sentence_translation": "Моё пророчество сбудется."
+          "sentence_translation": "Моё пророчество сбудется.",
+          "answer_forms": [
+            "пророчество"
+          ]
         },
         {
           "german": "das Rätsel",
           "russian": "загадка",
           "transcription": "[дас РЕТ-зель]",
           "sentence": "In Rätseln spreche ich von der Zukunft.",
-          "sentence_translation": "В загадках я говорю о будущем."
+          "sentence_translation": "В загадках я говорю о будущем.",
+          "answer_forms": [
+            "загадка",
+            "загадке"
+          ]
         },
         {
           "german": "die Vorahnung",
           "russian": "предчувствие",
           "transcription": "[ди ФОР-а-нунг]",
           "sentence": "Eine dunkle Vorahnung erfüllt mein Herz.",
-          "sentence_translation": "Тёмное предчувствие наполняет моё сердце."
+          "sentence_translation": "Тёмное предчувствие наполняет моё сердце.",
+          "answer_forms": [
+            "предчувствие"
+          ]
         },
         {
           "german": "vorhersagen",
           "russian": "предсказывать",
           "transcription": "[ФОР-хер-за-ген]",
           "sentence": "Ich sage das kommende Unheil vorher.",
-          "sentence_translation": "Я предсказываю грядущую беду."
+          "sentence_translation": "Я предсказываю грядущую беду.",
+          "answer_forms": [
+            "предсказывать",
+            "предсказываю"
+          ]
         },
         {
           "german": "deuten",
           "russian": "толковать",
           "transcription": "[ДОЙ-тен]",
           "sentence": "Die Zeichen deute ich besser als alle.",
-          "sentence_translation": "Знаки я толкую лучше всех."
+          "sentence_translation": "Знаки я толкую лучше всех.",
+          "answer_forms": [
+            "толковать",
+            "толкую"
+          ]
         },
         {
           "german": "ahnen",
           "russian": "предчувствовать",
           "transcription": "[А-нен]",
           "sentence": "Ich ahne das schlimme Ende voraus.",
-          "sentence_translation": "Я предчувствую плохой конец."
+          "sentence_translation": "Я предчувствую плохой конец.",
+          "answer_forms": [
+            "предчувствовать",
+            "предчувствую"
+          ]
         },
         {
           "german": "das Omen",
           "russian": "знамение",
           "transcription": "[дас О-мен]",
           "sentence": "Jedes Omen zeigt auf Untergang.",
-          "sentence_translation": "Каждое знамение указывает на гибель."
+          "sentence_translation": "Каждое знамение указывает на гибель.",
+          "answer_forms": [
+            "знамение"
+          ]
         },
         {
           "german": "rätselhaft",
           "russian": "загадочный",
           "transcription": "[РЕТ-зель-хафт]",
           "sentence": "Meine Worte bleiben rätselhaft und wahr.",
-          "sentence_translation": "Мои слова остаются загадочными и правдивыми."
+          "sentence_translation": "Мои слова остаются загадочными и правдивыми.",
+          "answer_forms": [
+            "загадочный",
+            "загадочны"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -221,49 +302,76 @@
           "russian": "безумие",
           "transcription": "[дер ВАН-зин]",
           "sentence": "Im Wahnsinn finden wir uns als Brüder.",
-          "sentence_translation": "В безумии мы находим друг друга как братья."
+          "sentence_translation": "В безумии мы находим друг друга как братья.",
+          "answer_forms": [
+            "безумие",
+            "безумии"
+          ]
         },
         {
           "german": "die Freundschaft",
           "russian": "дружба",
           "transcription": "[ди ФРОЙНД-шафт]",
           "sentence": "Unsere Freundschaft überdauert den Sturm.",
-          "sentence_translation": "Наша дружба переживёт бурю."
+          "sentence_translation": "Наша дружба переживёт бурю.",
+          "answer_forms": [
+            "дружба"
+          ]
         },
         {
           "german": "begleiten",
           "russian": "сопровождать",
           "transcription": "[бе-ГЛАЙ-тен]",
           "sentence": "Treu begleite ich meinen verrückten König.",
-          "sentence_translation": "Верно я сопровождаю своего безумного короля."
+          "sentence_translation": "Верно я сопровождаю своего безумного короля.",
+          "answer_forms": [
+            "сопровождать",
+            "сопровождаю"
+          ]
         },
         {
           "german": "frieren",
           "russian": "мёрзнуть",
           "transcription": "[ФРИ-рен]",
           "sentence": "Wir frieren gemeinsam in der kalten Nacht.",
-          "sentence_translation": "Мы мёрзнем вместе в холодную ночь."
+          "sentence_translation": "Мы мёрзнем вместе в холодную ночь.",
+          "answer_forms": [
+            "мёрзнуть",
+            "мёрзнем"
+          ]
         },
         {
           "german": "singen",
           "russian": "петь",
           "transcription": "[ЗИН-ген]",
           "sentence": "Ich singe, um seine Angst zu lindern.",
-          "sentence_translation": "Я пою, чтобы облегчить его страх."
+          "sentence_translation": "Я пою, чтобы облегчить его страх.",
+          "answer_forms": [
+            "петь",
+            "пою"
+          ]
         },
         {
           "german": "zittern",
           "russian": "дрожать",
           "transcription": "[ЦИ-терн]",
           "sentence": "Vor Kälte zittern wir wie Espenlaub.",
-          "sentence_translation": "От холода мы дрожим как осиновый лист."
+          "sentence_translation": "От холода мы дрожим как осиновый лист.",
+          "answer_forms": [
+            "дрожать",
+            "дрожим"
+          ]
         },
         {
           "german": "treu",
           "russian": "верный",
           "transcription": "[ТРОЙ]",
           "sentence": "Ich bleibe treu, wenn alle anderen fliehen.",
-          "sentence_translation": "Я остаюсь верным, когда все остальные бегут."
+          "sentence_translation": "Я остаюсь верным, когда все остальные бегут.",
+          "answer_forms": [
+            "верный",
+            "верным"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -285,56 +393,85 @@
           "russian": "песня",
           "transcription": "[дас ЛИД]",
           "sentence": "Mein Lied erzählt von vergangenen Tagen.",
-          "sentence_translation": "Моя песня рассказывает о прошлых днях."
+          "sentence_translation": "Моя песня рассказывает о прошлых днях.",
+          "answer_forms": [
+            "песня",
+            "песню"
+          ]
         },
         {
           "german": "der Trost",
           "russian": "утешение",
           "transcription": "[дер ТРОСТ]",
           "sentence": "Mit Liedern bringe ich kleinen Trost.",
-          "sentence_translation": "Песнями я приношу малое утешение."
+          "sentence_translation": "Песнями я приношу малое утешение.",
+          "answer_forms": [
+            "утешение"
+          ]
         },
         {
           "german": "die Ironie",
           "russian": "ирония",
           "transcription": "[ди и-ро-НИ]",
           "sentence": "Die Ironie ist meine letzte Waffe.",
-          "sentence_translation": "Ирония - моё последнее оружие."
+          "sentence_translation": "Ирония - моё последнее оружие.",
+          "answer_forms": [
+            "ирония"
+          ]
         },
         {
           "german": "summen",
           "russian": "напевать",
           "transcription": "[ЗУ-мен]",
           "sentence": "Leise summe ich alte Melodien.",
-          "sentence_translation": "Тихо я напеваю старые мелодии."
+          "sentence_translation": "Тихо я напеваю старые мелодии.",
+          "answer_forms": [
+            "напевать",
+            "напеваю"
+          ]
         },
         {
           "german": "die Melodie",
           "russian": "мелодия",
           "transcription": "[ди ме-ло-ДИ]",
           "sentence": "Die Melodie erinnert an bessere Zeiten.",
-          "sentence_translation": "Мелодия напоминает о лучших временах."
+          "sentence_translation": "Мелодия напоминает о лучших временах.",
+          "answer_forms": [
+            "мелодия",
+            "мелодии"
+          ]
         },
         {
           "german": "pfeifen",
           "russian": "свистеть",
           "transcription": "[ПФАЙ-фен]",
           "sentence": "Ich pfeife gegen die Dunkelheit an.",
-          "sentence_translation": "Я свищу против темноты."
+          "sentence_translation": "Я свищу против темноты.",
+          "answer_forms": [
+            "свистеть",
+            "свищу"
+          ]
         },
         {
           "german": "der Reim",
           "russian": "рифма",
           "transcription": "[дер РАЙМ]",
           "sentence": "Jeder Reim verbirgt eine tiefe Wahrheit.",
-          "sentence_translation": "Каждая рифма скрывает глубокую правду."
+          "sentence_translation": "Каждая рифма скрывает глубокую правду.",
+          "answer_forms": [
+            "рифма"
+          ]
         },
         {
           "german": "klingen",
           "russian": "звучать",
           "transcription": "[КЛИН-ген]",
           "sentence": "Meine Worte klingen lustig, doch sind traurig.",
-          "sentence_translation": "Мои слова звучат весело, но печальны."
+          "sentence_translation": "Мои слова звучат весело, но печальны.",
+          "answer_forms": [
+            "звучать",
+            "звучат"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -356,49 +493,74 @@
           "russian": "философия",
           "transcription": "[ди фи-ло-зо-ФИ]",
           "sentence": "Meine Philosophie ist einfach: Alles ist Narretei.",
-          "sentence_translation": "Моя философия проста: всё - глупость."
+          "sentence_translation": "Моя философия проста: всё - глупость.",
+          "answer_forms": [
+            "философия"
+          ]
         },
         {
           "german": "das Schicksal",
           "russian": "судьба",
           "transcription": "[дас ШИК-заль]",
           "sentence": "Das Schicksal macht Narren aus uns allen.",
-          "sentence_translation": "Судьба делает дураков из всех нас."
+          "sentence_translation": "Судьба делает дураков из всех нас.",
+          "answer_forms": [
+            "судьба"
+          ]
         },
         {
           "german": "die Vergänglichkeit",
           "russian": "бренность",
           "transcription": "[ди фер-ГЕНГ-лих-кайт]",
           "sentence": "Die Vergänglichkeit der Macht ist offenbar.",
-          "sentence_translation": "Бренность власти очевидна."
+          "sentence_translation": "Бренность власти очевидна.",
+          "answer_forms": [
+            "бренность"
+          ]
         },
         {
           "german": "nachdenken",
           "russian": "размышлять",
           "transcription": "[НАХ-ден-кен]",
           "sentence": "Ich denke nach über des Lebens Sinn.",
-          "sentence_translation": "Я размышляю о смысле жизни."
+          "sentence_translation": "Я размышляю о смысле жизни.",
+          "answer_forms": [
+            "размышлять",
+            "размышляю"
+          ]
         },
         {
           "german": "erkennen",
           "russian": "познавать",
           "transcription": "[ер-КЕН-нен]",
           "sentence": "Ich erkenne die Wahrheit hinter dem Schein.",
-          "sentence_translation": "Я познаю правду за видимостью."
+          "sentence_translation": "Я познаю правду за видимостью.",
+          "answer_forms": [
+            "познавать",
+            "познаю"
+          ]
         },
         {
           "german": "der Sinn",
           "russian": "смысл",
           "transcription": "[дер ЗИН]",
           "sentence": "Der Sinn des Lebens ist ein schlechter Witz.",
-          "sentence_translation": "Смысл жизни - плохая шутка."
+          "sentence_translation": "Смысл жизни - плохая шутка.",
+          "answer_forms": [
+            "смысл",
+            "смысле"
+          ]
         },
         {
           "german": "vergänglich",
           "russian": "преходящий",
           "transcription": "[фер-ГЕНГ-лих]",
           "sentence": "Alles ist vergänglich, nur die Torheit bleibt.",
-          "sentence_translation": "Всё преходяще, только глупость остаётся."
+          "sentence_translation": "Всё преходяще, только глупость остаётся.",
+          "answer_forms": [
+            "преходящий",
+            "преходяще"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -420,56 +582,85 @@
           "russian": "исчезать",
           "transcription": "[фер-ШВИН-ден]",
           "sentence": "Ich verschwinde wie ein Traum im Morgen.",
-          "sentence_translation": "Я исчезаю как сон поутру."
+          "sentence_translation": "Я исчезаю как сон поутру.",
+          "answer_forms": [
+            "исчезать",
+            "исчезнуть"
+          ]
         },
         {
           "german": "das Geheimnis",
           "russian": "тайна",
           "transcription": "[дас ге-ХАЙМ-нис]",
           "sentence": "Mein Verschwinden bleibt ein ewiges Geheimnis.",
-          "sentence_translation": "Моё исчезновение остаётся вечной тайной."
+          "sentence_translation": "Моё исчезновение остаётся вечной тайной.",
+          "answer_forms": [
+            "тайна"
+          ]
         },
         {
           "german": "die Leere",
           "russian": "пустота",
           "transcription": "[ди ЛЕ-ре]",
           "sentence": "Ich hinterlasse nur Leere und Erinnerung.",
-          "sentence_translation": "Я оставляю только пустоту и воспоминание."
+          "sentence_translation": "Я оставляю только пустоту и воспоминание.",
+          "answer_forms": [
+            "пустота",
+            "пустоту"
+          ]
         },
         {
           "german": "sich auflösen",
           "russian": "растворяться",
           "transcription": "[зих АУФ-лё-зен]",
           "sentence": "Ich löse mich auf wie Nebel im Wind.",
-          "sentence_translation": "Я растворяюсь как туман на ветру."
+          "sentence_translation": "Я растворяюсь как туман на ветру.",
+          "answer_forms": [
+            "растворяться",
+            "растворяюсь"
+          ]
         },
         {
           "german": "spurlos",
           "russian": "бесследно",
           "transcription": "[ШПУР-лос]",
           "sentence": "Spurlos gehe ich aus dieser Welt.",
-          "sentence_translation": "Бесследно я ухожу из этого мира."
+          "sentence_translation": "Бесследно я ухожу из этого мира.",
+          "answer_forms": [
+            "бесследно"
+          ]
         },
         {
           "german": "der Nebel",
           "russian": "туман",
           "transcription": "[дер НЕ-бель]",
           "sentence": "Im Nebel verliere ich mich für immer.",
-          "sentence_translation": "В тумане я теряюсь навсегда."
+          "sentence_translation": "В тумане я теряюсь навсегда.",
+          "answer_forms": [
+            "туман"
+          ]
         },
         {
           "german": "rätselhaft",
           "russian": "загадочный",
           "transcription": "[РЕТ-зель-хафт]",
           "sentence": "Mein Ende bleibt rätselhaft und stumm.",
-          "sentence_translation": "Мой конец остаётся загадочным и немым."
+          "sentence_translation": "Мой конец остаётся загадочным и немым.",
+          "answer_forms": [
+            "загадочный",
+            "загадочен"
+          ]
         },
         {
           "german": "fortgehen",
           "russian": "уходить",
           "transcription": "[ФОРТ-ге-ен]",
           "sentence": "Ich gehe fort, wenn keiner es bemerkt.",
-          "sentence_translation": "Я ухожу, когда никто не замечает."
+          "sentence_translation": "Я ухожу, когда никто не замечает.",
+          "answer_forms": [
+            "уходить",
+            "ухожу"
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/gloucester.json
+++ b/data/characters/gloucester.json
@@ -15,56 +15,83 @@
           "russian": "знать",
           "transcription": "[дер А-дель]",
           "sentence": "Als Adel diene ich meinem König treu.",
-          "sentence_translation": "Как знать я верно служу своему королю."
+          "sentence_translation": "Как знать я верно служу своему королю.",
+          "answer_forms": [
+            "знать"
+          ]
         },
         {
           "german": "dienen",
           "russian": "служить",
           "transcription": "[ДИ-нен]",
           "sentence": "Ich diene dem König seit vielen Jahren.",
-          "sentence_translation": "Я служу королю много лет."
+          "sentence_translation": "Я служу королю много лет.",
+          "answer_forms": [
+            "служить",
+            "служу"
+          ]
         },
         {
           "german": "vertrauen",
           "russian": "доверять",
           "transcription": "[фер-ТРАУ-ен]",
           "sentence": "Ich vertraue beiden Söhnen gleich.",
-          "sentence_translation": "Я доверяю обоим сыновьям одинаково."
+          "sentence_translation": "Я доверяю обоим сыновьям одинаково.",
+          "answer_forms": [
+            "доверять",
+            "доверяю"
+          ]
         },
         {
           "german": "der Graf",
           "russian": "граф",
           "transcription": "[дер ГРАФ]",
           "sentence": "Als Graf habe ich große Verantwortung.",
-          "sentence_translation": "Как граф я несу большую ответственность."
+          "sentence_translation": "Как граф я несу большую ответственность.",
+          "answer_forms": [
+            "граф"
+          ]
         },
         {
           "german": "die Ehre",
           "russian": "честь",
           "transcription": "[ди Э-ре]",
           "sentence": "Meine Ehre ist mein höchstes Gut.",
-          "sentence_translation": "Моя честь - моё высшее благо."
+          "sentence_translation": "Моя честь - моё высшее благо.",
+          "answer_forms": [
+            "честь"
+          ]
         },
         {
           "german": "rechtschaffen",
           "russian": "праведный",
           "transcription": "[РЕХТ-ша-фен]",
           "sentence": "Ich bin ein rechtschaffener Mann.",
-          "sentence_translation": "Я праведный человек."
+          "sentence_translation": "Я праведный человек.",
+          "answer_forms": [
+            "праведный"
+          ]
         },
         {
           "german": "die Pflicht",
           "russian": "долг",
           "transcription": "[ди ПФЛИХТ]",
           "sentence": "Meine Pflicht ruft mich zum König.",
-          "sentence_translation": "Мой долг зовёт меня к королю."
+          "sentence_translation": "Мой долг зовёт меня к королю.",
+          "answer_forms": [
+            "долг"
+          ]
         },
         {
           "german": "achten",
           "russian": "уважать",
           "transcription": "[АХ-тен]",
           "sentence": "Ich achte beide Söhne, Edgar und Edmund.",
-          "sentence_translation": "Я уважаю обоих сыновей, Эдгара и Эдмунда."
+          "sentence_translation": "Я уважаю обоих сыновей, Эдгара и Эдмунда.",
+          "answer_forms": [
+            "уважать",
+            "уважаю"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -86,56 +113,84 @@
           "russian": "письмо",
           "transcription": "[дер БРИФ]",
           "sentence": "Dieser Brief beweist Edgars Verrat.",
-          "sentence_translation": "Это письмо доказывает предательство Эдгара."
+          "sentence_translation": "Это письмо доказывает предательство Эдгара.",
+          "answer_forms": [
+            "письмо"
+          ]
         },
         {
           "german": "glauben",
           "russian": "верить",
           "transcription": "[ГЛАУ-бен]",
           "sentence": "Ich glaube Edmunds Lügen sofort.",
-          "sentence_translation": "Я сразу верю лжи Эдмунда."
+          "sentence_translation": "Я сразу верю лжи Эдмунда.",
+          "answer_forms": [
+            "верить",
+            "верю"
+          ]
         },
         {
           "german": "täuschen",
           "russian": "обманывать",
           "transcription": "[ТОЙ-шен]",
           "sentence": "Edmund täuscht mich mit falschen Beweisen.",
-          "sentence_translation": "Эдмунд обманывает меня ложными доказательствами."
+          "sentence_translation": "Эдмунд обманывает меня ложными доказательствами.",
+          "answer_forms": [
+            "обманывать"
+          ]
         },
         {
           "german": "der Betrug",
           "russian": "обман",
           "transcription": "[дер бе-ТРУГ]",
           "sentence": "Ich erkenne den Betrug nicht.",
-          "sentence_translation": "Я не распознаю обман."
+          "sentence_translation": "Я не распознаю обман.",
+          "answer_forms": [
+            "обман"
+          ]
         },
         {
           "german": "arglos",
           "russian": "простодушный",
           "transcription": "[АРГ-лос]",
           "sentence": "Ich bin zu arglos für solche Intrigen.",
-          "sentence_translation": "Я слишком простодушен для таких интриг."
+          "sentence_translation": "Я слишком простодушен для таких интриг.",
+          "answer_forms": [
+            "простодушный",
+            "простодушен"
+          ]
         },
         {
           "german": "verdächtigen",
           "russian": "подозревать",
           "transcription": "[фер-ДЕХ-ти-ген]",
           "sentence": "Ich verdächtige meinen guten Sohn Edgar.",
-          "sentence_translation": "Я подозреваю моего доброго сына Эдгара."
+          "sentence_translation": "Я подозреваю моего доброго сына Эдгара.",
+          "answer_forms": [
+            "подозревать",
+            "подозреваю"
+          ]
         },
         {
           "german": "leichtgläubig",
           "russian": "легковерный",
           "transcription": "[ЛАЙХТ-глой-биг]",
           "sentence": "Ich bin zu leichtgläubig für diese Welt.",
-          "sentence_translation": "Я слишком легковерен для этого мира."
+          "sentence_translation": "Я слишком легковерен для этого мира.",
+          "answer_forms": [
+            "легковерный",
+            "легковерен"
+          ]
         },
         {
           "german": "die Falle",
           "russian": "ловушка",
           "transcription": "[ди ФА-ле]",
           "sentence": "Ich tappe blind in Edmunds Falle.",
-          "sentence_translation": "Я слепо попадаю в ловушку Эдмунда."
+          "sentence_translation": "Я слепо попадаю в ловушку Эдмунда.",
+          "answer_forms": [
+            "ловушка"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -157,49 +212,74 @@
           "russian": "изгонять",
           "transcription": "[фер-ШТО-сен]",
           "sentence": "Ich verstoße meinen unschuldigen Sohn.",
-          "sentence_translation": "Я изгоняю своего невинного сына."
+          "sentence_translation": "Я изгоняю своего невинного сына.",
+          "answer_forms": [
+            "изгонять",
+            "изгоняю"
+          ]
         },
         {
           "german": "verfluchen",
           "russian": "проклинать",
           "transcription": "[фер-ФЛУ-хен]",
           "sentence": "Im Zorn verfluche ich Edgar.",
-          "sentence_translation": "В гневе я проклинаю Эдгара."
+          "sentence_translation": "В гневе я проклинаю Эдгара.",
+          "answer_forms": [
+            "проклинать",
+            "проклинаю"
+          ]
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
           "sentence": "Später werde ich diese Tat bitter bereuen.",
-          "sentence_translation": "Позже я горько пожалею об этом поступке."
+          "sentence_translation": "Позже я горько пожалею об этом поступке.",
+          "answer_forms": [
+            "сожалеть"
+          ]
         },
         {
           "german": "der Irrtum",
           "russian": "заблуждение",
           "transcription": "[дер ИР-тум]",
           "sentence": "Mein Irrtum zerstört meine Familie.",
-          "sentence_translation": "Моё заблуждение разрушает мою семью."
+          "sentence_translation": "Моё заблуждение разрушает мою семью.",
+          "answer_forms": [
+            "заблуждение"
+          ]
         },
         {
           "german": "blind",
           "russian": "слепой",
           "transcription": "[БЛИНД]",
           "sentence": "Ich bin blind für die Wahrheit.",
-          "sentence_translation": "Я слеп к правде."
+          "sentence_translation": "Я слеп к правде.",
+          "answer_forms": [
+            "слепой",
+            "слеп"
+          ]
         },
         {
           "german": "jagen",
           "russian": "гнать",
           "transcription": "[Я-ген]",
           "sentence": "Ich jage meinen Sohn fort wie einen Verbrecher.",
-          "sentence_translation": "Я гоню сына прочь как преступника."
+          "sentence_translation": "Я гоню сына прочь как преступника.",
+          "answer_forms": [
+            "гнать",
+            "гоню"
+          ]
         },
         {
           "german": "die Ungerechtigkeit",
           "russian": "несправедливость",
           "transcription": "[ди УН-ге-рех-тиг-кайт]",
           "sentence": "Ich begehe große Ungerechtigkeit.",
-          "sentence_translation": "Я совершаю большую несправедливость."
+          "sentence_translation": "Я совершаю большую несправедливость.",
+          "answer_forms": [
+            "несправедливость"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -221,56 +301,83 @@
           "russian": "помогать",
           "transcription": "[ХЕЛЬ-фен]",
           "sentence": "Heimlich helfe ich dem verstoßenen König.",
-          "sentence_translation": "Тайно я помогаю изгнанному королю."
+          "sentence_translation": "Тайно я помогаю изгнанному королю.",
+          "answer_forms": [
+            "помогать"
+          ]
         },
         {
           "german": "das Mitleid",
           "russian": "сострадание",
           "transcription": "[дас МИТ-лайд]",
           "sentence": "Mitleid erfüllt mein Herz für Lear.",
-          "sentence_translation": "Сострадание наполняет моё сердце к Лиру."
+          "sentence_translation": "Сострадание наполняет моё сердце к Лиру.",
+          "answer_forms": [
+            "сострадание"
+          ]
         },
         {
           "german": "riskieren",
           "russian": "рисковать",
           "transcription": "[рис-КИ-рен]",
           "sentence": "Ich riskiere alles für den alten König.",
-          "sentence_translation": "Я рискую всем ради старого короля."
+          "sentence_translation": "Я рискую всем ради старого короля.",
+          "answer_forms": [
+            "рисковать",
+            "рискую"
+          ]
         },
         {
           "german": "die Gefahr",
           "russian": "опасность",
           "transcription": "[ди ге-ФАР]",
           "sentence": "Die Gefahr der Entdeckung ist groß.",
-          "sentence_translation": "Опасность разоблачения велика."
+          "sentence_translation": "Опасность разоблачения велика.",
+          "answer_forms": [
+            "опасность"
+          ]
         },
         {
           "german": "heimlich",
           "russian": "тайно",
           "transcription": "[ХАЙМ-лих]",
           "sentence": "Ich handle heimlich gegen die neuen Herrscher.",
-          "sentence_translation": "Я действую тайно против новых правителей."
+          "sentence_translation": "Я действую тайно против новых правителей.",
+          "answer_forms": [
+            "тайно"
+          ]
         },
         {
           "german": "schützen",
           "russian": "защищать",
           "transcription": "[ШЮ-цен]",
           "sentence": "Ich will den wahnsinnigen König schützen.",
-          "sentence_translation": "Я хочу защитить безумного короля."
+          "sentence_translation": "Я хочу защитить безумного короля.",
+          "answer_forms": [
+            "защищать",
+            "защитить"
+          ]
         },
         {
           "german": "der Verrat",
           "russian": "измена",
           "transcription": "[дер фер-РАТ]",
           "sentence": "Meine Hilfe gilt als Verrat.",
-          "sentence_translation": "Моя помощь считается изменой."
+          "sentence_translation": "Моя помощь считается изменой.",
+          "answer_forms": [
+            "измена"
+          ]
         },
         {
           "german": "wagen",
           "russian": "осмеливаться",
           "transcription": "[ВА-ген]",
           "sentence": "Ich wage es, gegen die Töchter zu handeln.",
-          "sentence_translation": "Я осмеливаюсь действовать против дочерей."
+          "sentence_translation": "Я осмеливаюсь действовать против дочерей.",
+          "answer_forms": [
+            "осмеливаться",
+            "осмеливаюсь"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -292,49 +399,73 @@
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
           "sentence": "Sie blenden mich für meinen Verrat.",
-          "sentence_translation": "Они ослепляют меня за мою измену."
+          "sentence_translation": "Они ослепляют меня за мою измену.",
+          "answer_forms": [
+            "ослеплять",
+            "ослепляют"
+          ]
         },
         {
           "german": "die Folter",
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
           "sentence": "Die Folter ist grausam und erbarmungslos.",
-          "sentence_translation": "Пытка жестока и беспощадна."
+          "sentence_translation": "Пытка жестока и беспощадна.",
+          "answer_forms": [
+            "пытка"
+          ]
         },
         {
           "german": "der Schmerz",
           "russian": "боль",
           "transcription": "[дер ШМЕРЦ]",
           "sentence": "Der Schmerz durchbohrt meine Seele.",
-          "sentence_translation": "Боль пронзает мою душу."
+          "sentence_translation": "Боль пронзает мою душу.",
+          "answer_forms": [
+            "боль"
+          ]
         },
         {
           "german": "die Dunkelheit",
           "russian": "темнота",
           "transcription": "[ди ДУН-кель-хайт]",
           "sentence": "Ewige Dunkelheit umgibt mich nun.",
-          "sentence_translation": "Вечная темнота окружает меня теперь."
+          "sentence_translation": "Вечная темнота окружает меня теперь.",
+          "answer_forms": [
+            "темнота"
+          ]
         },
         {
           "german": "schreien",
           "russian": "кричать",
           "transcription": "[ШРАЙ-ен]",
           "sentence": "Ich schreie vor unerträglichem Schmerz.",
-          "sentence_translation": "Я кричу от невыносимой боли."
+          "sentence_translation": "Я кричу от невыносимой боли.",
+          "answer_forms": [
+            "кричать",
+            "кричу"
+          ]
         },
         {
           "german": "erblinden",
           "russian": "слепнуть",
           "transcription": "[ер-БЛИН-ден]",
           "sentence": "Ich erblinde durch ihre Grausamkeit.",
-          "sentence_translation": "Я слепну от их жестокости."
+          "sentence_translation": "Я слепну от их жестокости.",
+          "answer_forms": [
+            "слепнуть",
+            "слепну"
+          ]
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
           "sentence": "Dies ist ihre Rache für meine Treue.",
-          "sentence_translation": "Это их месть за мою верность."
+          "sentence_translation": "Это их месть за мою верность.",
+          "answer_forms": [
+            "месть"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -356,56 +487,84 @@
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
           "sentence": "Die Verzweiflung treibt mich zum Abgrund.",
-          "sentence_translation": "Отчаяние гонит меня к пропасти."
+          "sentence_translation": "Отчаяние гонит меня к пропасти.",
+          "answer_forms": [
+            "отчаяние"
+          ]
         },
         {
           "german": "springen",
           "russian": "прыгать",
           "transcription": "[ШПРИН-ген]",
           "sentence": "Ich will von den Klippen springen.",
-          "sentence_translation": "Я хочу прыгнуть со скал."
+          "sentence_translation": "Я хочу прыгнуть со скал.",
+          "answer_forms": [
+            "прыгать",
+            "прыгнуть"
+          ]
         },
         {
           "german": "die Täuschung",
           "russian": "обман",
           "transcription": "[ди ТОЙ-шунг]",
           "sentence": "Edgars liebevolle Täuschung rettet mich.",
-          "sentence_translation": "Любящий обман Эдгара спасает меня."
+          "sentence_translation": "Любящий обман Эдгара спасает меня.",
+          "answer_forms": [
+            "обман"
+          ]
         },
         {
           "german": "der Abgrund",
           "russian": "пропасть",
           "transcription": "[дер АБ-грунд]",
           "sentence": "Der Abgrund ruft nach mir.",
-          "sentence_translation": "Пропасть зовёт меня."
+          "sentence_translation": "Пропасть зовёт меня.",
+          "answer_forms": [
+            "пропасть"
+          ]
         },
         {
           "german": "aufgeben",
           "russian": "сдаваться",
           "transcription": "[АУФ-ге-бен]",
           "sentence": "Ich will das Leben aufgeben.",
-          "sentence_translation": "Я хочу отказаться от жизни."
+          "sentence_translation": "Я хочу отказаться от жизни.",
+          "answer_forms": [
+            "сдаваться",
+            "сдаться"
+          ]
         },
         {
           "german": "die Hoffnungslosigkeit",
           "russian": "безнадёжность",
           "transcription": "[ди ХОФ-нунгс-ло-зиг-кайт]",
           "sentence": "Die Hoffnungslosigkeit erdrückt mich.",
-          "sentence_translation": "Безнадёжность давит меня."
+          "sentence_translation": "Безнадёжность давит меня.",
+          "answer_forms": [
+            "безнадёжность"
+          ]
         },
         {
           "german": "stürzen",
           "russian": "падать",
           "transcription": "[ШТЮР-цен]",
           "sentence": "Ich glaube, von hohen Klippen zu stürzen.",
-          "sentence_translation": "Я верю, что падаю с высоких скал."
+          "sentence_translation": "Я верю, что падаю с высоких скал.",
+          "answer_forms": [
+            "падать",
+            "падаю"
+          ]
         },
         {
           "german": "erlösen",
           "russian": "избавлять",
           "transcription": "[ер-ЛЁ-зен]",
           "sentence": "Der Tod soll mich von der Schuld erlösen.",
-          "sentence_translation": "Смерть должна избавить меня от вины."
+          "sentence_translation": "Смерть должна избавить меня от вины.",
+          "answer_forms": [
+            "избавлять",
+            "избавить"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -427,56 +586,84 @@
           "russian": "узнавать",
           "transcription": "[ер-КЕН-нен]",
           "sentence": "Endlich erkenne ich meinen treuen Edgar.",
-          "sentence_translation": "Наконец я узнаю моего верного Эдгара."
+          "sentence_translation": "Наконец я узнаю моего верного Эдгара.",
+          "answer_forms": [
+            "узнавать",
+            "узнаю"
+          ]
         },
         {
           "german": "vergeben",
           "russian": "прощать",
           "transcription": "[фер-ГЕ-бен]",
           "sentence": "Edgar vergibt mir meine Blindheit.",
-          "sentence_translation": "Эдгар прощает мне мою слепоту."
+          "sentence_translation": "Эдгар прощает мне мою слепоту.",
+          "answer_forms": [
+            "прощать",
+            "прощает"
+          ]
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
           "sentence": "Ich sterbe vor Freude und Kummer.",
-          "sentence_translation": "Я умираю от радости и горя."
+          "sentence_translation": "Я умираю от радости и горя.",
+          "answer_forms": [
+            "умирать",
+            "умираю"
+          ]
         },
         {
           "german": "die Erkenntnis",
           "russian": "осознание",
           "transcription": "[ди ер-КЕНТ-нис]",
           "sentence": "Die späte Erkenntnis bricht mein Herz.",
-          "sentence_translation": "Позднее осознание разбивает моё сердце."
+          "sentence_translation": "Позднее осознание разбивает моё сердце.",
+          "answer_forms": [
+            "осознание"
+          ]
         },
         {
           "german": "die Reue",
           "russian": "раскаяние",
           "transcription": "[ди РОЙ-е]",
           "sentence": "Die Reue überwältigt meine Seele.",
-          "sentence_translation": "Раскаяние переполняет мою душу."
+          "sentence_translation": "Раскаяние переполняет мою душу.",
+          "answer_forms": [
+            "раскаяние"
+          ]
         },
         {
           "german": "umarmen",
           "russian": "обнимать",
           "transcription": "[ум-АР-мен]",
           "sentence": "Ein letztes Mal umarme ich meinen Sohn.",
-          "sentence_translation": "В последний раз я обнимаю сына."
+          "sentence_translation": "В последний раз я обнимаю сына.",
+          "answer_forms": [
+            "обнимать",
+            "обнимаю"
+          ]
         },
         {
           "german": "die Versöhnung",
           "russian": "примирение",
           "transcription": "[ди фер-ЗЁ-нунг]",
           "sentence": "Die Versöhnung kommt zu spät.",
-          "sentence_translation": "Примирение приходит слишком поздно."
+          "sentence_translation": "Примирение приходит слишком поздно.",
+          "answer_forms": [
+            "примирение"
+          ]
         },
         {
           "german": "das Herz",
           "russian": "сердце",
           "transcription": "[дас ХЕРЦ]",
           "sentence": "Mein Herz zerbricht vor Glück und Leid.",
-          "sentence_translation": "Моё сердце разрывается от счастья и горя."
+          "sentence_translation": "Моё сердце разрывается от счастья и горя.",
+          "answer_forms": [
+            "сердце"
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/goneril.json
+++ b/data/characters/goneril.json
@@ -21,56 +21,84 @@
           "russian": "ложь",
           "transcription": "[ди ЛЮ-ге]",
           "sentence": "Die Lüge klingt süßer als die Wahrheit.",
-          "sentence_translation": "Ложь звучит слаще правды."
+          "sentence_translation": "Ложь звучит слаще правды.",
+          "answer_forms": [
+            "ложь"
+          ]
         },
         {
           "german": "schwören",
           "russian": "клясться",
           "transcription": "[ШВЁ-рен]",
           "sentence": "Ich schwöre, dass ich Euch mehr liebe als mein Leben.",
-          "sentence_translation": "Я клянусь, что люблю вас больше жизни."
+          "sentence_translation": "Я клянусь, что люблю вас больше жизни.",
+          "answer_forms": [
+            "клясться",
+            "клянусь"
+          ]
         },
         {
           "german": "das Erbe",
           "russian": "наследство",
           "transcription": "[дас ЕР-бе]",
           "sentence": "Das Erbe ist endlich mein.",
-          "sentence_translation": "Наследство наконец моё."
+          "sentence_translation": "Наследство наконец моё.",
+          "answer_forms": [
+            "наследство"
+          ]
         },
         {
           "german": "heucheln",
           "russian": "лицемерить",
           "transcription": "[ХОЙ-хельн]",
           "sentence": "Ich muss vor meinem Vater heucheln.",
-          "sentence_translation": "Я должна лицемерить перед отцом."
+          "sentence_translation": "Я должна лицемерить перед отцом.",
+          "answer_forms": [
+            "лицемерить",
+            "лицемерю"
+          ]
         },
         {
           "german": "die Gier",
           "russian": "жадность",
           "transcription": "[ди ГИР]",
           "sentence": "Die Gier nach Macht treibt mich an.",
-          "sentence_translation": "Жадность к власти движет мной."
+          "sentence_translation": "Жадность к власти движет мной.",
+          "answer_forms": [
+            "жадность"
+          ]
         },
         {
           "german": "täuschen",
           "russian": "обманывать",
           "transcription": "[ТОЙ-шен]",
           "sentence": "Ich täusche meinen alten Vater leicht.",
-          "sentence_translation": "Я легко обманываю старого отца."
+          "sentence_translation": "Я легко обманываю старого отца.",
+          "answer_forms": [
+            "обманывать",
+            "обманываю"
+          ]
         },
         {
           "german": "schmeicheln",
           "russian": "льстить",
           "transcription": "[ШМАЙ-хельн]",
           "sentence": "Mit süßen Worten schmeichle ich ihm.",
-          "sentence_translation": "Сладкими словами я льщу ему."
+          "sentence_translation": "Сладкими словами я льщу ему.",
+          "answer_forms": [
+            "льстить",
+            "льщу"
+          ]
         },
         {
           "german": "das Vermögen",
           "russian": "состояние",
           "transcription": "[дас фер-МЁ-ген]",
           "sentence": "Sein ganzes Vermögen wird mir gehören.",
-          "sentence_translation": "Всё его состояние будет моим."
+          "sentence_translation": "Всё его состояние будет моим.",
+          "answer_forms": [
+            "состояние"
+          ]
         }
       ]
     },
@@ -92,56 +120,82 @@
           "russian": "власть",
           "transcription": "[ди МАХТ]",
           "sentence": "Die Macht über das halbe Königreich ist mein.",
-          "sentence_translation": "Власть над половиной королевства моя."
+          "sentence_translation": "Власть над половиной королевства моя.",
+          "answer_forms": [
+            "власть"
+          ]
         },
         {
           "german": "herrschen",
           "russian": "править",
           "transcription": "[ХЕР-шен]",
           "sentence": "Jetzt herrsche ich über meine Länder.",
-          "sentence_translation": "Теперь я правлю своими землями."
+          "sentence_translation": "Теперь я правлю своими землями.",
+          "answer_forms": [
+            "править"
+          ]
         },
         {
           "german": "befehlen",
           "russian": "приказывать",
           "transcription": "[бе-ФЕ-лен]",
           "sentence": "Ich befehle, und alle gehorchen mir.",
-          "sentence_translation": "Я приказываю, и все подчиняются мне."
+          "sentence_translation": "Я приказываю, и все подчиняются мне.",
+          "answer_forms": [
+            "приказывать"
+          ]
         },
         {
           "german": "der Thron",
           "russian": "трон",
           "transcription": "[дер ТРОН]",
           "sentence": "Der Thron meines Vaters wird bald leer sein.",
-          "sentence_translation": "Трон моего отца скоро опустеет."
+          "sentence_translation": "Трон моего отца скоро опустеет.",
+          "answer_forms": [
+            "трон"
+          ]
         },
         {
           "german": "erobern",
           "russian": "завоёвывать",
           "transcription": "[ер-О-берн]",
           "sentence": "Ich erobere, was mir zusteht.",
-          "sentence_translation": "Я завоёвываю то, что мне положено."
+          "sentence_translation": "Я завоёвываю то, что мне положено.",
+          "answer_forms": [
+            "завоёвывать",
+            "завоёвываю"
+          ]
         },
         {
           "german": "die Herrschaft",
           "russian": "господство",
           "transcription": "[ди ХЕР-шафт]",
           "sentence": "Die Herrschaft über alle ist mein Ziel.",
-          "sentence_translation": "Господство над всеми - моя цель."
+          "sentence_translation": "Господство над всеми - моя цель.",
+          "answer_forms": [
+            "господство"
+          ]
         },
         {
           "german": "regieren",
           "russian": "управлять",
           "transcription": "[ре-ГИ-рен]",
           "sentence": "Ich werde mit eiserner Hand regieren.",
-          "sentence_translation": "Я буду управлять железной рукой."
+          "sentence_translation": "Я буду управлять железной рукой.",
+          "answer_forms": [
+            "управлять"
+          ]
         },
         {
           "german": "unterwerfen",
           "russian": "подчинять",
           "transcription": "[ун-тер-ВЕР-фен]",
           "sentence": "Alle müssen sich mir unterwerfen.",
-          "sentence_translation": "Все должны мне подчиниться."
+          "sentence_translation": "Все должны мне подчиниться.",
+          "answer_forms": [
+            "подчинять",
+            "подчиниться"
+          ]
         }
       ]
     },
@@ -163,56 +217,86 @@
           "russian": "унижать",
           "transcription": "[де-МЮ-ти-ген]",
           "sentence": "Ich demütige meinen alten Vater ohne Mitleid.",
-          "sentence_translation": "Я унижаю старого отца без жалости."
+          "sentence_translation": "Я унижаю старого отца без жалости.",
+          "answer_forms": [
+            "унижать",
+            "унизить"
+          ]
         },
         {
           "german": "grausam",
           "russian": "жестокий",
           "transcription": "[ГРАУ-зам]",
           "sentence": "Ich bin grausam zu dem, der mir alles gab.",
-          "sentence_translation": "Я жестока к тому, кто дал мне всё."
+          "sentence_translation": "Я жестока к тому, кто дал мне всё.",
+          "answer_forms": [
+            "жестокий",
+            "жестока"
+          ]
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
           "sentence": "Die Rache für Jahre der Unterwerfung.",
-          "sentence_translation": "Месть за годы подчинения."
+          "sentence_translation": "Месть за годы подчинения.",
+          "answer_forms": [
+            "месть"
+          ]
         },
         {
           "german": "vertreiben",
           "russian": "изгонять",
           "transcription": "[фер-ТРАЙ-бен]",
           "sentence": "Ich vertreibe ihn aus meinem Haus.",
-          "sentence_translation": "Я изгоняю его из моего дома."
+          "sentence_translation": "Я изгоняю его из моего дома.",
+          "answer_forms": [
+            "изгонять",
+            "изгоняю"
+          ]
         },
         {
           "german": "verachten",
           "russian": "презирать",
           "transcription": "[фер-АХ-тен]",
           "sentence": "Ich verachte seine Schwäche und sein Alter.",
-          "sentence_translation": "Я презираю его слабость и старость."
+          "sentence_translation": "Я презираю его слабость и старость.",
+          "answer_forms": [
+            "презирать",
+            "презираю"
+          ]
         },
         {
           "german": "verweigern",
           "russian": "отказывать",
           "transcription": "[фер-ВАЙ-герн]",
           "sentence": "Ich verweigere ihm jeden Komfort.",
-          "sentence_translation": "Я отказываю ему в любом комфорте."
+          "sentence_translation": "Я отказываю ему в любом комфорте.",
+          "answer_forms": [
+            "отказывать",
+            "отказываю"
+          ]
         },
         {
           "german": "quälen",
           "russian": "мучить",
           "transcription": "[КВЕ-лен]",
           "sentence": "Es macht mir Freude, ihn zu quälen.",
-          "sentence_translation": "Мне доставляет радость мучить его."
+          "sentence_translation": "Мне доставляет радость мучить его.",
+          "answer_forms": [
+            "мучить"
+          ]
         },
         {
           "german": "beschränken",
           "russian": "ограничивать",
           "transcription": "[бе-ШРЕН-кен]",
           "sentence": "Ich beschränke seine Dienerschaft auf null.",
-          "sentence_translation": "Я ограничиваю его свиту до нуля."
+          "sentence_translation": "Я ограничиваю его свиту до нуля.",
+          "answer_forms": [
+            "ограничивать",
+            "ограничиваю"
+          ]
         }
       ]
     },
@@ -234,49 +318,76 @@
           "russian": "отвергать",
           "transcription": "[фер-ШТО-сен]",
           "sentence": "Ich verstoße meinen Vater in die Nacht.",
-          "sentence_translation": "Я отвергаю отца в ночь."
+          "sentence_translation": "Я отвергаю отца в ночь.",
+          "answer_forms": [
+            "отвергать",
+            "отвергла"
+          ]
         },
         {
           "german": "der Sturm",
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
           "sentence": "Der Sturm soll sein neues Zuhause sein.",
-          "sentence_translation": "Буря пусть будет его новым домом."
+          "sentence_translation": "Буря пусть будет его новым домом.",
+          "answer_forms": [
+            "буря",
+            "бурю"
+          ]
         },
         {
           "german": "gnadenlos",
           "russian": "безжалостный",
           "transcription": "[ГНА-ден-лос]",
           "sentence": "Ich bin gnadenlos wie der Winter.",
-          "sentence_translation": "Я безжалостна как зима."
+          "sentence_translation": "Я безжалостна как зима.",
+          "answer_forms": [
+            "безжалостный",
+            "безжалостность"
+          ]
         },
         {
           "german": "verschließen",
           "russian": "запирать",
           "transcription": "[фер-ШЛИ-сен]",
           "sentence": "Ich verschließe meine Türen vor ihm.",
-          "sentence_translation": "Я запираю двери перед ним."
+          "sentence_translation": "Я запираю двери перед ним.",
+          "answer_forms": [
+            "запирать",
+            "запираю"
+          ]
         },
         {
           "german": "die Kälte",
           "russian": "холод",
           "transcription": "[ди КЕЛ-те]",
           "sentence": "Die Kälte meines Herzens übertrifft den Winter.",
-          "sentence_translation": "Холод моего сердца превосходит зиму."
+          "sentence_translation": "Холод моего сердца превосходит зиму.",
+          "answer_forms": [
+            "холод"
+          ]
         },
         {
           "german": "erbarmungslos",
           "russian": "беспощадный",
           "transcription": "[ер-БАР-мунгс-лос]",
           "sentence": "Erbarmungslos werfe ich ihn hinaus.",
-          "sentence_translation": "Беспощадно я выбрасываю его."
+          "sentence_translation": "Беспощадно я выбрасываю его.",
+          "answer_forms": [
+            "беспощадный",
+            "беспощадна"
+          ]
         },
         {
           "german": "verhärten",
           "russian": "ожесточаться",
           "transcription": "[фер-ХЕР-тен]",
           "sentence": "Mein Herz verhärtet sich gegen alle Bitten.",
-          "sentence_translation": "Моё сердце ожесточается против всех просьб."
+          "sentence_translation": "Моё сердце ожесточается против всех просьб.",
+          "answer_forms": [
+            "ожесточаться",
+            "ожесточилось"
+          ]
         }
       ]
     },
@@ -298,56 +409,85 @@
           "russian": "ссориться",
           "transcription": "[ШТРАЙ-тен]",
           "sentence": "Ich streite mit meinem schwachen Mann.",
-          "sentence_translation": "Я ссорюсь со своим слабым мужем."
+          "sentence_translation": "Я ссорюсь со своим слабым мужем.",
+          "answer_forms": [
+            "ссориться",
+            "ссоримся"
+          ]
         },
         {
           "german": "verraten",
           "russian": "предавать",
           "transcription": "[фер-РА-тен]",
           "sentence": "Ich verrate meinen Mann für Edmund.",
-          "sentence_translation": "Я предаю мужа ради Эдмунда."
+          "sentence_translation": "Я предаю мужа ради Эдмунда.",
+          "answer_forms": [
+            "предавать",
+            "предаю"
+          ]
         },
         {
           "german": "die Zwietracht",
           "russian": "раздор",
           "transcription": "[ди ЦВИ-трахт]",
           "sentence": "Die Zwietracht zerstört unsere Ehe.",
-          "sentence_translation": "Раздор разрушает наш брак."
+          "sentence_translation": "Раздор разрушает наш брак.",
+          "answer_forms": [
+            "раздор"
+          ]
         },
         {
           "german": "hassen",
           "russian": "ненавидеть",
           "transcription": "[ХА-сен]",
           "sentence": "Ich hasse seine Schwäche und Güte.",
-          "sentence_translation": "Я ненавижу его слабость и доброту."
+          "sentence_translation": "Я ненавижу его слабость и доброту.",
+          "answer_forms": [
+            "ненавидеть",
+            "ненавижу"
+          ]
         },
         {
           "german": "betrügen",
           "russian": "изменять",
           "transcription": "[бе-ТРЮ-ген]",
           "sentence": "Ich betrüge ihn mit Edmund.",
-          "sentence_translation": "Я изменяю ему с Эдмундом."
+          "sentence_translation": "Я изменяю ему с Эдмундом.",
+          "answer_forms": [
+            "изменять",
+            "изменяю"
+          ]
         },
         {
           "german": "die Verachtung",
           "russian": "презрение",
           "transcription": "[ди фер-АХ-тунг]",
           "sentence": "Meine Verachtung für ihn wächst täglich.",
-          "sentence_translation": "Моё презрение к нему растёт ежедневно."
+          "sentence_translation": "Моё презрение к нему растёт ежедневно.",
+          "answer_forms": [
+            "презрение"
+          ]
         },
         {
           "german": "zerstören",
           "russian": "разрушать",
           "transcription": "[цер-ШТЁ-рен]",
           "sentence": "Ich zerstöre alles, was uns verband.",
-          "sentence_translation": "Я разрушаю всё, что нас связывало."
+          "sentence_translation": "Я разрушаю всё, что нас связывало.",
+          "answer_forms": [
+            "разрушать",
+            "разрушаю"
+          ]
         },
         {
           "german": "die Leidenschaft",
           "russian": "страсть",
           "transcription": "[ди ЛАЙ-ден-шафт]",
           "sentence": "Meine Leidenschaft gilt nur Edmund.",
-          "sentence_translation": "Моя страсть принадлежит только Эдмунду."
+          "sentence_translation": "Моя страсть принадлежит только Эдмунду.",
+          "answer_forms": [
+            "страсть"
+          ]
         }
       ]
     },
@@ -369,56 +509,84 @@
           "russian": "ревность",
           "transcription": "[ди АЙ-фер-зухт]",
           "sentence": "Die Eifersucht verzehrt mich von innen.",
-          "sentence_translation": "Ревность пожирает меня изнутри."
+          "sentence_translation": "Ревность пожирает меня изнутри.",
+          "answer_forms": [
+            "ревность"
+          ]
         },
         {
           "german": "rivalisieren",
           "russian": "соперничать",
           "transcription": "[ри-ва-ли-ЗИ-рен]",
           "sentence": "Ich rivalisiere mit meiner Schwester um Edmund.",
-          "sentence_translation": "Я соперничаю с сестрой за Эдмунда."
+          "sentence_translation": "Я соперничаю с сестрой за Эдмунда.",
+          "answer_forms": [
+            "соперничать",
+            "соперничаем"
+          ]
         },
         {
           "german": "kämpfen",
           "russian": "бороться",
           "transcription": "[КЕМП-фен]",
           "sentence": "Ich kämpfe um das, was ich begehre.",
-          "sentence_translation": "Я борюсь за то, чего желаю."
+          "sentence_translation": "Я борюсь за то, чего желаю.",
+          "answer_forms": [
+            "бороться",
+            "борюсь"
+          ]
         },
         {
           "german": "begehren",
           "russian": "желать",
           "transcription": "[бе-ГЕ-рен]",
           "sentence": "Ich begehre Edmund mehr als mein Leben.",
-          "sentence_translation": "Я желаю Эдмунда больше жизни."
+          "sentence_translation": "Я желаю Эдмунда больше жизни.",
+          "answer_forms": [
+            "желать",
+            "желаю"
+          ]
         },
         {
           "german": "beseitigen",
           "russian": "устранять",
           "transcription": "[бе-ЗАЙ-ти-ген]",
           "sentence": "Ich muss meine Schwester beseitigen.",
-          "sentence_translation": "Я должна устранить свою сестру."
+          "sentence_translation": "Я должна устранить свою сестру.",
+          "answer_forms": [
+            "устранять",
+            "устраню"
+          ]
         },
         {
           "german": "das Gift",
           "russian": "яд",
           "transcription": "[дас ГИФТ]",
           "sentence": "Das Gift ist bereit für meine Schwester.",
-          "sentence_translation": "Яд готов для моей сестры."
+          "sentence_translation": "Яд готов для моей сестры.",
+          "answer_forms": [
+            "яд"
+          ]
         },
         {
           "german": "die Intrige",
           "russian": "интрига",
           "transcription": "[ди ин-ТРИ-ге]",
           "sentence": "Meine Intrige wird sie vernichten.",
-          "sentence_translation": "Моя интрига уничтожит её."
+          "sentence_translation": "Моя интрига уничтожит её.",
+          "answer_forms": [
+            "интрига"
+          ]
         },
         {
           "german": "morden",
           "russian": "убивать",
           "transcription": "[МОР-ден]",
           "sentence": "Ich bin bereit zu morden für meine Lust.",
-          "sentence_translation": "Я готова убивать ради своей страсти."
+          "sentence_translation": "Я готова убивать ради своей страсти.",
+          "answer_forms": [
+            "убивать"
+          ]
         }
       ]
     },
@@ -440,56 +608,84 @@
           "russian": "отравлять",
           "transcription": "[фер-ГИФ-тен]",
           "sentence": "Ich vergifte erst meine Schwester, dann mich selbst.",
-          "sentence_translation": "Я отравляю сначала сестру, потом себя."
+          "sentence_translation": "Я отравляю сначала сестру, потом себя.",
+          "answer_forms": [
+            "отравлять",
+            "отравила"
+          ]
         },
         {
           "german": "die Verzweiflung",
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
           "sentence": "Die Verzweiflung führt mich zum Tod.",
-          "sentence_translation": "Отчаяние ведёт меня к смерти."
+          "sentence_translation": "Отчаяние ведёт меня к смерти.",
+          "answer_forms": [
+            "отчаяние"
+          ]
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
           "sentence": "Ich sterbe durch meine eigene Hand.",
-          "sentence_translation": "Я умираю от своей собственной руки."
+          "sentence_translation": "Я умираю от своей собственной руки.",
+          "answer_forms": [
+            "умирать",
+            "умру"
+          ]
         },
         {
           "german": "die Schuld",
           "russian": "вина",
           "transcription": "[ди ШУЛЬД]",
           "sentence": "Die Schuld erdrückt mich am Ende.",
-          "sentence_translation": "Вина давит меня в конце."
+          "sentence_translation": "Вина давит меня в конце.",
+          "answer_forms": [
+            "вина"
+          ]
         },
         {
           "german": "vernichten",
           "russian": "уничтожать",
           "transcription": "[фер-НИХ-тен]",
           "sentence": "Ich vernichte mich selbst durch meine Bosheit.",
-          "sentence_translation": "Я уничтожаю себя своим злом."
+          "sentence_translation": "Я уничтожаю себя своим злом.",
+          "answer_forms": [
+            "уничтожать",
+            "уничтожу"
+          ]
         },
         {
           "german": "das Verderben",
           "russian": "погибель",
           "transcription": "[дас фер-ДЕР-бен]",
           "sentence": "Das Verderben holt mich ein.",
-          "sentence_translation": "Погибель настигает меня."
+          "sentence_translation": "Погибель настигает меня.",
+          "answer_forms": [
+            "погибель"
+          ]
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
           "sentence": "Zu spät bereue ich meine Taten.",
-          "sentence_translation": "Слишком поздно я сожалею о своих делах."
+          "sentence_translation": "Слишком поздно я сожалею о своих делах.",
+          "answer_forms": [
+            "сожалеть",
+            "сожалею"
+          ]
         },
         {
           "german": "die Hölle",
           "russian": "ад",
           "transcription": "[ди ХЁ-ле]",
           "sentence": "Die Hölle wartet auf meine schwarze Seele.",
-          "sentence_translation": "Ад ждёт мою чёрную душу."
+          "sentence_translation": "Ад ждёт мою чёрную душу.",
+          "answer_forms": [
+            "ад"
+          ]
         }
       ]
     }

--- a/data/characters/kent.json
+++ b/data/characters/kent.json
@@ -15,56 +15,82 @@
           "russian": "верность",
           "transcription": "[ди ТРОЙ-е]",
           "sentence": "Die Treue zu meinem König ist unerschütterlich.",
-          "sentence_translation": "Верность моему королю непоколебима."
+          "sentence_translation": "Верность моему королю непоколебима.",
+          "answer_forms": [
+            "верность"
+          ]
         },
         {
           "german": "der Mut",
           "russian": "мужество",
           "transcription": "[дер МУТ]",
           "sentence": "Der Mut fordert mich, die Wahrheit zu sagen.",
-          "sentence_translation": "Мужество требует от меня говорить правду."
+          "sentence_translation": "Мужество требует от меня говорить правду.",
+          "answer_forms": [
+            "мужество"
+          ]
         },
         {
           "german": "widersprechen",
           "russian": "возражать",
           "transcription": "[ВИ-дер-шпре-хен]",
           "sentence": "Ich widerspreche dem König für seine eigene Ehre.",
-          "sentence_translation": "Я возражаю королю ради его же чести."
+          "sentence_translation": "Я возражаю королю ради его же чести.",
+          "answer_forms": [
+            "возражать"
+          ]
         },
         {
           "german": "verteidigen",
           "russian": "защищать",
           "transcription": "[фер-ТАЙ-ди-ген]",
           "sentence": "Ich verteidige Корделия gegen Ungerechtigkeit.",
-          "sentence_translation": "Я защищаю Корделию от несправедливости."
+          "sentence_translation": "Я защищаю Корделию от несправедливости.",
+          "answer_forms": [
+            "защищать"
+          ]
         },
         {
           "german": "aufrichtig",
           "russian": "искренний",
           "transcription": "[АУФ-рих-тиг]",
           "sentence": "Ich bin aufrichtig, auch wenn es gefährlich ist.",
-          "sentence_translation": "Я искренен, даже если это опасно."
+          "sentence_translation": "Я искренен, даже если это опасно.",
+          "answer_forms": [
+            "искренний",
+            "искренен"
+          ]
         },
         {
           "german": "der Diener",
           "russian": "слуга",
           "transcription": "[дер ДИ-нер]",
           "sentence": "Als treuer Diener spreche ich offen.",
-          "sentence_translation": "Как верный слуга, я говорю открыто."
+          "sentence_translation": "Как верный слуга, я говорю открыто.",
+          "answer_forms": [
+            "слуга"
+          ]
         },
         {
           "german": "warnen",
           "russian": "предупреждать",
           "transcription": "[ВАР-нен]",
           "sentence": "Ich warne den König vor seinem Fehler.",
-          "sentence_translation": "Я предупреждаю короля об его ошибке."
+          "sentence_translation": "Я предупреждаю короля об его ошибке.",
+          "answer_forms": [
+            "предупреждать"
+          ]
         },
         {
           "german": "gerecht",
           "russian": "справедливый",
           "transcription": "[ге-РЕХТ]",
           "sentence": "Ich kämpfe für das, was gerecht ist.",
-          "sentence_translation": "Я борюсь за то, что справедливо."
+          "sentence_translation": "Я борюсь за то, что справедливо.",
+          "answer_forms": [
+            "справедливый",
+            "справедливо"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -86,49 +112,71 @@
           "russian": "изгнание",
           "transcription": "[ди фер-БА-нунг]",
           "sentence": "Die Verbannung ist der Preis für meine Ehrlichkeit.",
-          "sentence_translation": "Изгнание - цена моей честности."
+          "sentence_translation": "Изгнание - цена моей честности.",
+          "answer_forms": [
+            "изгнание"
+          ]
         },
         {
           "german": "die Ungerechtigkeit",
           "russian": "несправедливость",
           "transcription": "[ди УН-ге-рех-тиг-кайт]",
           "sentence": "Diese Ungerechtigkeit werde ich nicht akzeptieren.",
-          "sentence_translation": "Эту несправедливость я не приму."
+          "sentence_translation": "Эту несправедливость я не приму.",
+          "answer_forms": [
+            "несправедливость"
+          ]
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
           "sentence": "Der Zorn des Königs trifft mich ungerecht.",
-          "sentence_translation": "Гнев короля поражает меня несправедливо."
+          "sentence_translation": "Гнев короля поражает меня несправедливо.",
+          "answer_forms": [
+            "гнев"
+          ]
         },
         {
           "german": "verbannt",
           "russian": "изгнанный",
           "transcription": "[фер-БАНТ]",
           "sentence": "Verbannt aus dem Land, das ich liebe.",
-          "sentence_translation": "Изгнан из страны, которую люблю."
+          "sentence_translation": "Изгнан из страны, которую люблю.",
+          "answer_forms": [
+            "изгнанный",
+            "изгнан"
+          ]
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
           "sentence": "Der Abschied vom Hof schmerzt mich tief.",
-          "sentence_translation": "Прощание с двором глубоко ранит меня."
+          "sentence_translation": "Прощание с двором глубоко ранит меня.",
+          "answer_forms": [
+            "прощание"
+          ]
         },
         {
           "german": "die Strafe",
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
           "sentence": "Diese Strafe nehme ich mit Würde an.",
-          "sentence_translation": "Это наказание я принимаю с достоинством."
+          "sentence_translation": "Это наказание я принимаю с достоинством.",
+          "answer_forms": [
+            "наказание"
+          ]
         },
         {
           "german": "zurückkehren",
           "russian": "возвращаться",
           "transcription": "[цу-РЮК-ке-рен]",
           "sentence": "Ich schwöre, verkleidet zurückzukehren.",
-          "sentence_translation": "Я клянусь вернуться переодетым."
+          "sentence_translation": "Я клянусь вернуться переодетым.",
+          "answer_forms": [
+            "возвращаться"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -150,56 +198,87 @@
           "russian": "переодевание",
           "transcription": "[ди фер-КЛАЙ-дунг]",
           "sentence": "In Verkleidung diene ich meinem König weiter.",
-          "sentence_translation": "В переодевании я продолжаю служить королю."
+          "sentence_translation": "В переодевании я продолжаю служить королю.",
+          "answer_forms": [
+            "переодевание",
+            "переодевании"
+          ]
         },
         {
           "german": "die List",
           "russian": "хитрость",
           "transcription": "[ди ЛИСТ]",
           "sentence": "Mit List kehre ich an den Hof zurück.",
-          "sentence_translation": "Хитростью я возвращаюсь ко двору."
+          "sentence_translation": "Хитростью я возвращаюсь ко двору.",
+          "answer_forms": [
+            "хитрость",
+            "хитростью"
+          ]
         },
         {
           "german": "unerkannt",
           "russian": "неузнанный",
           "transcription": "[УН-ер-кант]",
           "sentence": "Unerkannt bleibe ich an seiner Seite.",
-          "sentence_translation": "Неузнанным я остаюсь рядом с ним."
+          "sentence_translation": "Неузнанным я остаюсь рядом с ним.",
+          "answer_forms": [
+            "неузнанный"
+          ]
         },
         {
           "german": "vorgeben",
           "russian": "притворяться",
           "transcription": "[ФОР-ге-бен]",
           "sentence": "Ich gebe vor, ein einfacher Mann zu sein.",
-          "sentence_translation": "Я притворяюсь простым человеком."
+          "sentence_translation": "Я притворяюсь простым человеком.",
+          "answer_forms": [
+            "притворяться",
+            "притворяюсь"
+          ]
         },
         {
           "german": "verstellen",
           "russian": "изменять",
           "transcription": "[фер-ШТЕ-лен]",
           "sentence": "Ich verstelle meine Stimme und Haltung.",
-          "sentence_translation": "Я изменяю свой голос и осанку."
+          "sentence_translation": "Я изменяю свой голос и осанку.",
+          "answer_forms": [
+            "изменять",
+            "изменяю"
+          ]
         },
         {
           "german": "der Bart",
           "russian": "борода",
           "transcription": "[дер БАРТ]",
           "sentence": "Mit falschem Bart bin ich nicht zu erkennen.",
-          "sentence_translation": "С фальшивой бородой меня не узнать."
+          "sentence_translation": "С фальшивой бородой меня не узнать.",
+          "answer_forms": [
+            "борода",
+            "бородой"
+          ]
         },
         {
           "german": "anheuern",
           "russian": "наниматься",
           "transcription": "[АН-хой-ерн]",
           "sentence": "Als Кай heuere ich beim König an.",
-          "sentence_translation": "Как Кай я нанимаюсь к королю."
+          "sentence_translation": "Как Кай я нанимаюсь к королю.",
+          "answer_forms": [
+            "наниматься",
+            "нанимаюсь"
+          ]
         },
         {
           "german": "treu",
           "russian": "верный",
           "transcription": "[ТРОЙ]",
           "sentence": "Treu bleibe ich trotz der Verkleidung.",
-          "sentence_translation": "Верным остаюсь несмотря на переодевание."
+          "sentence_translation": "Верным остаюсь несмотря на переодевание.",
+          "answer_forms": [
+            "верный",
+            "верным"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -221,49 +300,74 @@
           "russian": "служба",
           "transcription": "[дер ДИНСТ]",
           "sentence": "Mein Dienst geht über die Verbannung hinaus.",
-          "sentence_translation": "Моя служба идёт дальше изгнания."
+          "sentence_translation": "Моя служба идёт дальше изгнания.",
+          "answer_forms": [
+            "служба"
+          ]
         },
         {
           "german": "der Schutz",
           "russian": "защита",
           "transcription": "[дер ШУТЦ]",
           "sentence": "Ich biete Schutz, ohne erkannt zu werden.",
-          "sentence_translation": "Я предоставляю защиту, не будучи узнанным."
+          "sentence_translation": "Я предоставляю защиту, не будучи узнанным.",
+          "answer_forms": [
+            "защита"
+          ]
         },
         {
           "german": "die Gefahr",
           "russian": "опасность",
           "transcription": "[ди ге-ФАР]",
           "sentence": "Trotz Gefahr bleibe ich beim König.",
-          "sentence_translation": "Несмотря на опасность, я остаюсь с королём."
+          "sentence_translation": "Несмотря на опасность, я остаюсь с королём.",
+          "answer_forms": [
+            "опасность"
+          ]
         },
         {
           "german": "bewachen",
           "russian": "охранять",
           "transcription": "[бе-ВА-хен]",
           "sentence": "Heimlich bewache ich meinen alten Herrn.",
-          "sentence_translation": "Тайно я охраняю своего старого господина."
+          "sentence_translation": "Тайно я охраняю своего старого господина.",
+          "answer_forms": [
+            "охранять",
+            "охраняю"
+          ]
         },
         {
           "german": "kämpfen",
           "russian": "сражаться",
           "transcription": "[КЕМП-фен]",
           "sentence": "Ich kämpfe gegen alle seine Feinde.",
-          "sentence_translation": "Я сражаюсь против всех его врагов."
+          "sentence_translation": "Я сражаюсь против всех его врагов.",
+          "answer_forms": [
+            "сражаться",
+            "сражаюсь"
+          ]
         },
         {
           "german": "raten",
           "russian": "советовать",
           "transcription": "[РА-тен]",
           "sentence": "Als Кай rate ich ihm zur Vorsicht.",
-          "sentence_translation": "Как Кай я советую ему осторожность."
+          "sentence_translation": "Как Кай я советую ему осторожность.",
+          "answer_forms": [
+            "советовать",
+            "советую"
+          ]
         },
         {
           "german": "die Wache",
           "russian": "стража",
           "transcription": "[ди ВА-хе]",
           "sentence": "Ich halte Wache über seinen Schlaf.",
-          "sentence_translation": "Я держу стражу над его сном."
+          "sentence_translation": "Я держу стражу над его сном.",
+          "answer_forms": [
+            "стража",
+            "стражу"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -285,56 +389,85 @@
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
           "sentence": "Diese Strafe erdulde ich für meinen König.",
-          "sentence_translation": "Это наказание я терплю ради короля."
+          "sentence_translation": "Это наказание я терплю ради короля.",
+          "answer_forms": [
+            "наказание"
+          ]
         },
         {
           "german": "die Demütigung",
           "russian": "унижение",
           "transcription": "[ди де-МЮ-ти-гунг]",
           "sentence": "Die Demütigung macht mich nur stärker.",
-          "sentence_translation": "Унижение делает меня только сильнее."
+          "sentence_translation": "Унижение делает меня только сильнее.",
+          "answer_forms": [
+            "унижение"
+          ]
         },
         {
           "german": "die Standhaftigkeit",
           "russian": "стойкость",
           "transcription": "[ди ШТАНД-хаф-тиг-кайт]",
           "sentence": "Mit Standhaftigkeit ertrage ich die Schmach.",
-          "sentence_translation": "Со стойкостью я переношу позор."
+          "sentence_translation": "Со стойкостью я переношу позор.",
+          "answer_forms": [
+            "стойкость",
+            "стойкостью"
+          ]
         },
         {
           "german": "fesseln",
           "russian": "сковывать",
           "transcription": "[ФЕ-сельн]",
           "sentence": "Sie fesseln mich wie einen gemeinen Dieb.",
-          "sentence_translation": "Они сковывают меня как обычного вора."
+          "sentence_translation": "Они сковывают меня как обычного вора.",
+          "answer_forms": [
+            "сковывать",
+            "сковывают"
+          ]
         },
         {
           "german": "erdulden",
           "russian": "терпеть",
           "transcription": "[ер-ДУЛЬ-ден]",
           "sentence": "Ich erdulde die Schande ohne Klage.",
-          "sentence_translation": "Я терплю позор без жалоб."
+          "sentence_translation": "Я терплю позор без жалоб.",
+          "answer_forms": [
+            "терпеть",
+            "терплю"
+          ]
         },
         {
           "german": "der Stock",
           "russian": "колодка",
           "transcription": "[дер ШТОК]",
           "sentence": "Im Stock sitze ich die ganze Nacht.",
-          "sentence_translation": "В колодке я сижу всю ночь."
+          "sentence_translation": "В колодке я сижу всю ночь.",
+          "answer_forms": [
+            "колодка",
+            "колодки"
+          ]
         },
         {
           "german": "ausharren",
           "russian": "выдерживать",
           "transcription": "[АУС-ха-рен]",
           "sentence": "Ich harre aus bis zur Befreiung.",
-          "sentence_translation": "Я выдерживаю до освобождения."
+          "sentence_translation": "Я выдерживаю до освобождения.",
+          "answer_forms": [
+            "выдерживать",
+            "выдерживаю"
+          ]
         },
         {
           "german": "die Schande",
           "russian": "позор",
           "transcription": "[ди ШАН-де]",
           "sentence": "Diese Schande ist Cornwall's, nicht meine.",
-          "sentence_translation": "Этот позор Корнуолла, не мой."
+          "sentence_translation": "Этот позор Корнуолла, не мой.",
+          "answer_forms": [
+            "позор"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -356,49 +489,72 @@
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
           "sentence": "Im Sturm bleibe ich bei meinem König.",
-          "sentence_translation": "В буре я остаюсь с моим королём."
+          "sentence_translation": "В буре я остаюсь с моим королём.",
+          "answer_forms": [
+            "буря"
+          ]
         },
         {
           "german": "der Beistand",
           "russian": "поддержка",
           "transcription": "[дер БАЙ-штанд]",
           "sentence": "Mein Beistand ist alles, was ich bieten kann.",
-          "sentence_translation": "Моя поддержка - всё, что я могу предложить."
+          "sentence_translation": "Моя поддержка - всё, что я могу предложить.",
+          "answer_forms": [
+            "поддержка"
+          ]
         },
         {
           "german": "begleiten",
           "russian": "сопровождать",
           "transcription": "[бе-ГЛАЙ-тен]",
           "sentence": "Ich begleite ihn durch Wind und Regen.",
-          "sentence_translation": "Я сопровождаю его сквозь ветер и дождь."
+          "sentence_translation": "Я сопровождаю его сквозь ветер и дождь.",
+          "answer_forms": [
+            "сопровождать",
+            "сопровождаю"
+          ]
         },
         {
           "german": "trösten",
           "russian": "утешать",
           "transcription": "[ТРЁС-тен]",
           "sentence": "Mit Worten tröste ich den wahnsinnigen König.",
-          "sentence_translation": "Словами я утешаю безумного короля."
+          "sentence_translation": "Словами я утешаю безумного короля.",
+          "answer_forms": [
+            "утешать"
+          ]
         },
         {
           "german": "die Zuflucht",
           "russian": "убежище",
           "transcription": "[ди ЦУ-флухт]",
           "sentence": "Ich suche Zuflucht für uns beide.",
-          "sentence_translation": "Я ищу убежище для нас обоих."
+          "sentence_translation": "Я ищу убежище для нас обоих.",
+          "answer_forms": [
+            "убежище"
+          ]
         },
         {
           "german": "durchhalten",
           "russian": "выдерживать",
           "transcription": "[ДУРХ-халь-тен]",
           "sentence": "Gemeinsam werden wir durchhalten.",
-          "sentence_translation": "Вместе мы выдержим."
+          "sentence_translation": "Вместе мы выдержим.",
+          "answer_forms": [
+            "выдерживать",
+            "выдержать"
+          ]
         },
         {
           "german": "die Kälte",
           "russian": "холод",
           "transcription": "[ди КЕЛ-те]",
           "sentence": "Die Kälte dringt in unsere Knochen.",
-          "sentence_translation": "Холод проникает в наши кости."
+          "sentence_translation": "Холод проникает в наши кости.",
+          "answer_forms": [
+            "холод"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -420,56 +576,83 @@
           "russian": "смерть",
           "transcription": "[дер ТОД]",
           "sentence": "Bis zum Tod bleibe ich an seiner Seite.",
-          "sentence_translation": "До смерти я остаюсь рядом с ним."
+          "sentence_translation": "До смерти я остаюсь рядом с ним.",
+          "answer_forms": [
+            "смерть"
+          ]
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
           "sentence": "Der Abschied von meinem König bricht mein Herz.",
-          "sentence_translation": "Прощание с моим королём разбивает моё сердце."
+          "sentence_translation": "Прощание с моим королём разбивает моё сердце.",
+          "answer_forms": [
+            "прощание"
+          ]
         },
         {
           "german": "ewig",
           "russian": "вечный",
           "transcription": "[Э-виг]",
           "sentence": "Meine Treue ist ewig, über den Tod hinaus.",
-          "sentence_translation": "Моя верность вечна, за пределами смерти."
+          "sentence_translation": "Моя верность вечна, за пределами смерти.",
+          "answer_forms": [
+            "вечный",
+            "вечная"
+          ]
         },
         {
           "german": "weinen",
           "russian": "плакать",
           "transcription": "[ВАЙ-нен]",
           "sentence": "Ich weine um meinen gefallenen König.",
-          "sentence_translation": "Я плачу о моём павшем короле."
+          "sentence_translation": "Я плачу о моём павшем короле.",
+          "answer_forms": [
+            "плакать",
+            "плачу"
+          ]
         },
         {
           "german": "die Erschöpfung",
           "russian": "истощение",
           "transcription": "[ди ер-ШЁП-фунг]",
           "sentence": "Die Erschöpfung überwältigt meinen alten Körper.",
-          "sentence_translation": "Истощение одолевает моё старое тело."
+          "sentence_translation": "Истощение одолевает моё старое тело.",
+          "answer_forms": [
+            "истощение"
+          ]
         },
         {
           "german": "aufgeben",
           "russian": "сдаваться",
           "transcription": "[АУФ-ге-бен]",
           "sentence": "Ich gebe auf, nachdem mein Herr gestorben ist.",
-          "sentence_translation": "Я сдаюсь после смерти моего господина."
+          "sentence_translation": "Я сдаюсь после смерти моего господина.",
+          "answer_forms": [
+            "сдаваться",
+            "сдаться"
+          ]
         },
         {
           "german": "die Trauer",
           "russian": "скорбь",
           "transcription": "[ди ТРАУ-ер]",
           "sentence": "Die Trauer ist zu schwer zu ertragen.",
-          "sentence_translation": "Скорбь слишком тяжела, чтобы вынести."
+          "sentence_translation": "Скорбь слишком тяжела, чтобы вынести.",
+          "answer_forms": [
+            "скорбь"
+          ]
         },
         {
           "german": "folgen",
           "russian": "следовать",
           "transcription": "[ФОЛЬ-ген]",
           "sentence": "Bald folge ich meinem König ins Jenseits.",
-          "sentence_translation": "Скоро я последую за королём в иной мир."
+          "sentence_translation": "Скоро я последую за королём в иной мир.",
+          "answer_forms": [
+            "следовать"
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/king_lear.json
+++ b/data/characters/king_lear.json
@@ -21,56 +21,83 @@
           "russian": "трон",
           "transcription": "[дер ТРОН]",
           "sentence": "Vom Thron herab verkünde ich meinen Willen.",
-          "sentence_translation": "С трона я провозглашаю свою волю."
+          "sentence_translation": "С трона я провозглашаю свою волю.",
+          "answer_forms": [
+            "трон",
+            "троне"
+          ]
         },
         {
           "german": "das Königreich",
           "russian": "королевство",
           "transcription": "[дас КЁ-ниг-райх]",
           "sentence": "Mein Königreich teile ich unter meinen Töchtern.",
-          "sentence_translation": "Моё королевство я делю между дочерьми."
+          "sentence_translation": "Моё королевство я делю между дочерьми.",
+          "answer_forms": [
+            "королевство"
+          ]
         },
         {
           "german": "die Macht",
           "russian": "власть",
           "transcription": "[ди МАХТ]",
           "sentence": "Die Macht gebe ich an jene, die mich am meisten liebt.",
-          "sentence_translation": "Власть я отдаю той, кто любит меня больше всех."
+          "sentence_translation": "Власть я отдаю той, кто любит меня больше всех.",
+          "answer_forms": [
+            "власть"
+          ]
         },
         {
           "german": "herrschen",
           "russian": "править",
           "transcription": "[ХЕР-шен]",
           "sentence": "Ich habe lange genug geherrscht.",
-          "sentence_translation": "Я правил достаточно долго."
+          "sentence_translation": "Я правил достаточно долго.",
+          "answer_forms": [
+            "править"
+          ]
         },
         {
           "german": "verkünden",
           "russian": "провозглашать",
           "transcription": "[фер-КЮН-ден]",
           "sentence": "Ich verkünde die Teilung meines Reiches.",
-          "sentence_translation": "Я провозглашаю раздел моего королевства."
+          "sentence_translation": "Я провозглашаю раздел моего королевства.",
+          "answer_forms": [
+            "провозглашать",
+            "провозглашаю"
+          ]
         },
         {
           "german": "die Krone",
           "russian": "корона",
           "transcription": "[ди КРО-не]",
           "sentence": "Diese Krone ist schwer geworden für mein altes Haupt.",
-          "sentence_translation": "Эта корона стала тяжела для моей старой головы."
+          "sentence_translation": "Эта корона стала тяжела для моей старой головы.",
+          "answer_forms": [
+            "корона"
+          ]
         },
         {
           "german": "die Zeremonie",
           "russian": "церемония",
           "transcription": "[ди це-ре-мо-НИ]",
           "sentence": "Die Zeremonie der Teilung beginnt jetzt.",
-          "sentence_translation": "Церемония раздела начинается сейчас."
+          "sentence_translation": "Церемония раздела начинается сейчас.",
+          "answer_forms": [
+            "церемония",
+            "церемонию"
+          ]
         },
         {
           "german": "prächtig",
           "russian": "великолепный",
           "transcription": "[ПРЕХ-тиг]",
           "sentence": "Ein prächtiger Tag für eine verhängnisvolle Entscheidung.",
-          "sentence_translation": "Великолепный день для рокового решения."
+          "sentence_translation": "Великолепный день для рокового решения.",
+          "answer_forms": [
+            "великолепный"
+          ]
         }
       ]
     },
@@ -92,56 +119,85 @@
           "russian": "унижать",
           "transcription": "[де-МЮ-ти-ген]",
           "sentence": "Meine eigene Tochter will mich demütigen!",
-          "sentence_translation": "Моя собственная дочь хочет меня унизить!"
+          "sentence_translation": "Моя собственная дочь хочет меня унизить!",
+          "answer_forms": [
+            "унижать",
+            "унизить"
+          ]
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
           "sentence": "Mein Zorn brennt wie Feuer in meiner Brust!",
-          "sentence_translation": "Мой гнев горит как огонь в моей груди!"
+          "sentence_translation": "Мой гнев горит как огонь в моей груди!",
+          "answer_forms": [
+            "гнев"
+          ]
         },
         {
           "german": "die Undankbarkeit",
           "russian": "неблагодарность",
           "transcription": "[ди УН-данк-бар-кайт]",
           "sentence": "Die Undankbarkeit ist schärfer als der Zahn einer Schlange!",
-          "sentence_translation": "Неблагодарность острее змеиного зуба!"
+          "sentence_translation": "Неблагодарность острее змеиного зуба!",
+          "answer_forms": [
+            "неблагодарность",
+            "неблагодарности"
+          ]
         },
         {
           "german": "verfluchen",
           "russian": "проклинать",
           "transcription": "[фер-ФЛУ-хен]",
           "sentence": "Ich verfluche dich bei allen Sternen!",
-          "sentence_translation": "Я проклинаю тебя всеми звёздами!"
+          "sentence_translation": "Я проклинаю тебя всеми звёздами!",
+          "answer_forms": [
+            "проклинать",
+            "проклинаю"
+          ]
         },
         {
           "german": "vertreiben",
           "russian": "изгонять",
           "transcription": "[фер-ТРАЙ-бен]",
           "sentence": "Aus meinem eigenen Haus will sie mich vertreiben!",
-          "sentence_translation": "Из моего собственного дома она хочет меня изгнать!"
+          "sentence_translation": "Из моего собственного дома она хочет меня изгнать!",
+          "answer_forms": [
+            "изгонять",
+            "изгнать"
+          ]
         },
         {
           "german": "die Kränkung",
           "russian": "обида",
           "transcription": "[ди КРЭН-кунг]",
           "sentence": "Diese Kränkung werde ich nicht vergessen!",
-          "sentence_translation": "Эту обиду я не забуду!"
+          "sentence_translation": "Эту обиду я не забуду!",
+          "answer_forms": [
+            "обида"
+          ]
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
           "sentence": "Sie wird ihre Grausamkeit bereuen!",
-          "sentence_translation": "Она пожалеет о своей жестокости!"
+          "sentence_translation": "Она пожалеет о своей жестокости!",
+          "answer_forms": [
+            "сожалеть"
+          ]
         },
         {
           "german": "der Fluch",
           "russian": "проклятие",
           "transcription": "[дер ФЛУХ]",
           "sentence": "Mein Fluch soll über dich kommen!",
-          "sentence_translation": "Моё проклятие падёт на тебя!"
+          "sentence_translation": "Моё проклятие падёт на тебя!",
+          "answer_forms": [
+            "проклятие",
+            "проклятием"
+          ]
         }
       ]
     },
@@ -163,56 +219,84 @@
           "russian": "покидать",
           "transcription": "[фер-ЛА-сен]",
           "sentence": "Auch Regan will mich verlassen und verstoßen!",
-          "sentence_translation": "И Регана хочет меня покинуть и отвергнуть!"
+          "sentence_translation": "И Регана хочет меня покинуть и отвергнуть!",
+          "answer_forms": [
+            "покидать"
+          ]
         },
         {
           "german": "verstoßen",
           "russian": "отвергать",
           "transcription": "[фер-ШТО-сен]",
           "sentence": "Meine Töchter verstoßen mich wie einen Bettler!",
-          "sentence_translation": "Мои дочери отвергают меня как нищего!"
+          "sentence_translation": "Мои дочери отвергают меня как нищего!",
+          "answer_forms": [
+            "отвергать",
+            "отвергнуть"
+          ]
         },
         {
           "german": "die Grausamkeit",
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
           "sentence": "Ihre Grausamkeit übertrifft die ihrer Schwester!",
-          "sentence_translation": "Её жестокость превосходит жестокость сестры!"
+          "sentence_translation": "Её жестокость превосходит жестокость сестры!",
+          "answer_forms": [
+            "жестокость"
+          ]
         },
         {
           "german": "die Verzweiflung",
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
           "sentence": "Die Verzweiflung packt mein altes Herz!",
-          "sentence_translation": "Отчаяние охватывает моё старое сердце!"
+          "sentence_translation": "Отчаяние охватывает моё старое сердце!",
+          "answer_forms": [
+            "отчаяние"
+          ]
         },
         {
           "german": "betteln",
           "russian": "просить",
           "transcription": "[БЕ-тельн]",
           "sentence": "Muss ich um Unterkunft betteln bei meinen eigenen Kindern?",
-          "sentence_translation": "Должен ли я просить крова у собственных детей?"
+          "sentence_translation": "Должен ли я просить крова у собственных детей?",
+          "answer_forms": [
+            "просить",
+            "прошу"
+          ]
         },
         {
           "german": "die Einsamkeit",
           "russian": "одиночество",
           "transcription": "[ди АЙН-зам-кайт]",
           "sentence": "Die Einsamkeit umgibt mich wie ein kalter Mantel.",
-          "sentence_translation": "Одиночество окружает меня как холодный плащ."
+          "sentence_translation": "Одиночество окружает меня как холодный плащ.",
+          "answer_forms": [
+            "одиночество"
+          ]
         },
         {
           "german": "die Träne",
           "russian": "слеза",
           "transcription": "[ди ТРЭ-не]",
           "sentence": "Keine Träne will ich für diese Undankbaren vergießen!",
-          "sentence_translation": "Ни одной слезы я не пролью за этих неблагодарных!"
+          "sentence_translation": "Ни одной слезы я не пролью за этих неблагодарных!",
+          "answer_forms": [
+            "слеза",
+            "слезы"
+          ]
         },
         {
           "german": "die Not",
           "russian": "нужда",
           "transcription": "[ди НОТ]",
           "sentence": "In meiner Not erkennen sie mich nicht als Vater.",
-          "sentence_translation": "В моей нужде они не признают меня отцом."
+          "sentence_translation": "В моей нужде они не признают меня отцом.",
+          "answer_forms": [
+            "нужда",
+            "нужде"
+          ]
         }
       ]
     },
@@ -234,56 +318,82 @@
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
           "sentence": "Der Sturm in meinem Kopf ist schlimmer als draußen!",
-          "sentence_translation": "Буря в моей голове хуже, чем снаружи!"
+          "sentence_translation": "Буря в моей голове хуже, чем снаружи!",
+          "answer_forms": [
+            "буря"
+          ]
         },
         {
           "german": "der Wahnsinn",
           "russian": "безумие",
           "transcription": "[дер ВАН-зин]",
           "sentence": "Der Wahnsinn ist gnädiger als die Vernunft!",
-          "sentence_translation": "Безумие милосерднее разума!"
+          "sentence_translation": "Безумие милосерднее разума!",
+          "answer_forms": [
+            "безумие"
+          ]
         },
         {
           "german": "toben",
           "russian": "бушевать",
           "transcription": "[ТО-бен]",
           "sentence": "Lasst die Winde toben und die Blitze fallen!",
-          "sentence_translation": "Пусть ветры бушуют и молнии падают!"
+          "sentence_translation": "Пусть ветры бушуют и молнии падают!",
+          "answer_forms": [
+            "бушевать",
+            "бушуют"
+          ]
         },
         {
           "german": "der Donner",
           "russian": "гром",
           "transcription": "[дер ДО-нер]",
           "sentence": "Der Donner ist die Stimme der Götter!",
-          "sentence_translation": "Гром - это голос богов!"
+          "sentence_translation": "Гром - это голос богов!",
+          "answer_forms": [
+            "гром"
+          ]
         },
         {
           "german": "der Blitz",
           "russian": "молния",
           "transcription": "[дер БЛИЦ]",
           "sentence": "Die Blitze sollen meine weißen Haare verbrennen!",
-          "sentence_translation": "Пусть молнии сожгут мои седые волосы!"
+          "sentence_translation": "Пусть молнии сожгут мои седые волосы!",
+          "answer_forms": [
+            "молния"
+          ]
         },
         {
           "german": "schreien",
           "russian": "кричать",
           "transcription": "[ШРАЙ-ен]",
           "sentence": "Ich schreie in den Wind meine Wut hinaus!",
-          "sentence_translation": "Я кричу в ветер свою ярость!"
+          "sentence_translation": "Я кричу в ветер свою ярость!",
+          "answer_forms": [
+            "кричать",
+            "кричу"
+          ]
         },
         {
           "german": "nackt",
           "russian": "голый",
           "transcription": "[НАКТ]",
           "sentence": "Nackt kam ich auf die Welt, nackt gehe ich!",
-          "sentence_translation": "Голым я пришёл в мир, голым и уйду!"
+          "sentence_translation": "Голым я пришёл в мир, голым и уйду!",
+          "answer_forms": [
+            "голый"
+          ]
         },
         {
           "german": "das Chaos",
           "russian": "хаос",
           "transcription": "[дас ХА-ос]",
           "sentence": "Das Chaos in der Natur spiegelt meine Seele!",
-          "sentence_translation": "Хаос в природе отражает мою душу!"
+          "sentence_translation": "Хаос в природе отражает мою душу!",
+          "answer_forms": [
+            "хаос"
+          ]
         }
       ]
     },
@@ -305,56 +415,85 @@
           "russian": "нищета",
           "transcription": "[дас Э-ленд]",
           "sentence": "Im Elend erkenne ich die Wahrheit der Welt.",
-          "sentence_translation": "В нищете я познаю истину мира."
+          "sentence_translation": "В нищете я познаю истину мира.",
+          "answer_forms": [
+            "нищета",
+            "нищету"
+          ]
         },
         {
           "german": "der Bettler",
           "russian": "нищий",
           "transcription": "[дер БЕТ-лер]",
           "sentence": "Dieser Bettler ist glücklicher als ich, der König!",
-          "sentence_translation": "Этот нищий счастливее меня, короля!"
+          "sentence_translation": "Этот нищий счастливее меня, короля!",
+          "answer_forms": [
+            "нищий"
+          ]
         },
         {
           "german": "arm",
           "russian": "бедный",
           "transcription": "[АРМ]",
           "sentence": "Die Armen leiden mehr als Könige jemals wissen.",
-          "sentence_translation": "Бедные страдают больше, чем короли когда-либо узнают."
+          "sentence_translation": "Бедные страдают больше, чем короли когда-либо узнают.",
+          "answer_forms": [
+            "бедный",
+            "бедны"
+          ]
         },
         {
           "german": "frieren",
           "russian": "мёрзнуть",
           "transcription": "[ФРИ-рен]",
           "sentence": "Wir alle frieren in dieser kalten Welt.",
-          "sentence_translation": "Мы все мёрзнем в этом холодном мире."
+          "sentence_translation": "Мы все мёрзнем в этом холодном мире.",
+          "answer_forms": [
+            "мёрзнуть",
+            "мёрзнем"
+          ]
         },
         {
           "german": "die Hütte",
           "russian": "хижина",
           "transcription": "[ди ХЮ-те]",
           "sentence": "Diese Hütte ist ein Palast für die Verlassenen.",
-          "sentence_translation": "Эта хижина - дворец для покинутых."
+          "sentence_translation": "Эта хижина - дворец для покинутых.",
+          "answer_forms": [
+            "хижина",
+            "хижине"
+          ]
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
           "sentence": "Wer nicht gelitten hat, kennt das Leben nicht.",
-          "sentence_translation": "Кто не страдал, не знает жизни."
+          "sentence_translation": "Кто не страдал, не знает жизни.",
+          "answer_forms": [
+            "страдать",
+            "страдают"
+          ]
         },
         {
           "german": "der Narr",
           "russian": "шут",
           "transcription": "[дер НАР]",
           "sentence": "Mein Narr ist weiser als ich je war.",
-          "sentence_translation": "Мой шут мудрее, чем я когда-либо был."
+          "sentence_translation": "Мой шут мудрее, чем я когда-либо был.",
+          "answer_forms": [
+            "шут"
+          ]
         },
         {
           "german": "die Erkenntnis",
           "russian": "познание",
           "transcription": "[ди ер-КЕНТ-нис]",
           "sentence": "Die Erkenntnis kommt durch Schmerz und Verlust.",
-          "sentence_translation": "Познание приходит через боль и утрату."
+          "sentence_translation": "Познание приходит через боль и утрату.",
+          "answer_forms": [
+            "познание"
+          ]
         }
       ]
     },
@@ -376,56 +515,85 @@
           "russian": "узнавать",
           "transcription": "[эр-КЕ-нен]",
           "sentence": "Ich erkenne dich, meine treue Cordelia!",
-          "sentence_translation": "Я узнаю тебя, моя верная Корделия!"
+          "sentence_translation": "Я узнаю тебя, моя верная Корделия!",
+          "answer_forms": [
+            "узнавать",
+            "узнаю"
+          ]
         },
         {
           "german": "verstehen",
           "russian": "понимать",
           "transcription": "[фер-ШТЕ-ен]",
           "sentence": "Jetzt verstehe ich, wer mich wirklich liebte.",
-          "sentence_translation": "Теперь я понимаю, кто действительно меня любил."
+          "sentence_translation": "Теперь я понимаю, кто действительно меня любил.",
+          "answer_forms": [
+            "понимать",
+            "понимаю"
+          ]
         },
         {
           "german": "die Wahrheit",
           "russian": "правда",
           "transcription": "[ди ВАР-хайт]",
           "sentence": "Die Wahrheit war immer in deinen Worten, Kind.",
-          "sentence_translation": "Правда всегда была в твоих словах, дитя."
+          "sentence_translation": "Правда всегда была в твоих словах, дитя.",
+          "answer_forms": [
+            "правда",
+            "правду"
+          ]
         },
         {
           "german": "die Reue",
           "russian": "раскаяние",
           "transcription": "[ди РОЙ-е]",
           "sentence": "Die Reue brennt heißer als alle Feuer der Hölle.",
-          "sentence_translation": "Раскаяние жжёт горячее всех адских огней."
+          "sentence_translation": "Раскаяние жжёт горячее всех адских огней.",
+          "answer_forms": [
+            "раскаяние"
+          ]
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
           "sentence": "Die Weisheit kommt zu spät zu mir.",
-          "sentence_translation": "Мудрость приходит ко мне слишком поздно."
+          "sentence_translation": "Мудрость приходит ко мне слишком поздно.",
+          "answer_forms": [
+            "мудрость"
+          ]
         },
         {
           "german": "vergeben",
           "russian": "прощать",
           "transcription": "[фер-ГЕ-бен]",
           "sentence": "Kannst du einem törichten alten Mann vergeben?",
-          "sentence_translation": "Можешь ли ты простить глупого старика?"
+          "sentence_translation": "Можешь ли ты простить глупого старика?",
+          "answer_forms": [
+            "прощать",
+            "простить"
+          ]
         },
         {
           "german": "die Einsicht",
           "russian": "прозрение",
           "transcription": "[ди АЙН-зихт]",
           "sentence": "Die Einsicht verbrennt meine Seele.",
-          "sentence_translation": "Прозрение сжигает мою душу."
+          "sentence_translation": "Прозрение сжигает мою душу.",
+          "answer_forms": [
+            "прозрение"
+          ]
         },
         {
           "german": "schuldig",
           "russian": "виновный",
           "transcription": "[ШУЛЬ-диг]",
           "sentence": "Ich bin schuldig vor meiner Tochter.",
-          "sentence_translation": "Я виновен перед своей дочерью."
+          "sentence_translation": "Я виновен перед своей дочерью.",
+          "answer_forms": [
+            "виновный",
+            "виновен"
+          ]
         }
       ]
     },
@@ -447,56 +615,83 @@
           "russian": "прощать",
           "transcription": "[фер-ЦАЙ-ен]",
           "sentence": "Verzeih mir, ich bin nur ein törichter alter Mann.",
-          "sentence_translation": "Прости меня, я всего лишь глупый старик."
+          "sentence_translation": "Прости меня, я всего лишь глупый старик.",
+          "answer_forms": [
+            "прощать"
+          ]
         },
         {
           "german": "der Tod",
           "russian": "смерть",
           "transcription": "[дер ТОД]",
           "sentence": "Der Tod ist gnädiger als das Leben ohne dich.",
-          "sentence_translation": "Смерть милосерднее жизни без тебя."
+          "sentence_translation": "Смерть милосерднее жизни без тебя.",
+          "answer_forms": [
+            "смерть"
+          ]
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
           "sentence": "Lass mich an deiner Seite sterben, Cordelia.",
-          "sentence_translation": "Позволь мне умереть рядом с тобой, Корделия."
+          "sentence_translation": "Позволь мне умереть рядом с тобой, Корделия.",
+          "answer_forms": [
+            "умирать",
+            "умереть"
+          ]
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЕН-де]",
           "sentence": "Das Ende kommt, aber mit dir bin ich nicht allein.",
-          "sentence_translation": "Конец приходит, но с тобой я не одинок."
+          "sentence_translation": "Конец приходит, но с тобой я не одинок.",
+          "answer_forms": [
+            "конец",
+            "концом"
+          ]
         },
         {
           "german": "das Herz",
           "russian": "сердце",
           "transcription": "[дас ХЕРЦ]",
           "sentence": "Mein Herz bricht vor Schmerz und Liebe.",
-          "sentence_translation": "Моё сердце разбивается от боли и любви."
+          "sentence_translation": "Моё сердце разбивается от боли и любви.",
+          "answer_forms": [
+            "сердце"
+          ]
         },
         {
           "german": "die Trauer",
           "russian": "скорбь",
           "transcription": "[ди ТРАУ-ер]",
           "sentence": "Die Trauer überwältigt meine Seele.",
-          "sentence_translation": "Скорбь переполняет мою душу."
+          "sentence_translation": "Скорбь переполняет мою душу.",
+          "answer_forms": [
+            "скорбь"
+          ]
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
           "sentence": "Das ist unser letzter Abschied, mein Kind.",
-          "sentence_translation": "Это наше последнее прощание, дитя моё."
+          "sentence_translation": "Это наше последнее прощание, дитя моё.",
+          "answer_forms": [
+            "прощание"
+          ]
         },
         {
           "german": "ewig",
           "russian": "вечный",
           "transcription": "[Э-виг]",
           "sentence": "Unsere Liebe wird ewig dauern, mein Kind.",
-          "sentence_translation": "Наша любовь будет вечной, дитя моё."
+          "sentence_translation": "Наша любовь будет вечной, дитя моё.",
+          "answer_forms": [
+            "вечный",
+            "вечна"
+          ]
         }
       ]
     }

--- a/data/characters/oswald.json
+++ b/data/characters/oswald.json
@@ -15,56 +15,83 @@
           "russian": "слуга",
           "transcription": "[дер ДИ-нер]",
           "sentence": "Als Diener gehorche ich meiner Herrin blind.",
-          "sentence_translation": "Как слуга я слепо подчиняюсь своей госпоже."
+          "sentence_translation": "Как слуга я слепо подчиняюсь своей госпоже.",
+          "answer_forms": [
+            "слуга"
+          ]
         },
         {
           "german": "der Gehorsam",
           "russian": "послушание",
           "transcription": "[дер ге-ХОР-зам]",
           "sentence": "Mein Gehorsam kennt keine Fragen.",
-          "sentence_translation": "Моё послушание не знает вопросов."
+          "sentence_translation": "Моё послушание не знает вопросов.",
+          "answer_forms": [
+            "послушание"
+          ]
         },
         {
           "german": "die Ergebenheit",
           "russian": "преданность",
           "transcription": "[ди ер-ГЕ-бен-хайт]",
           "sentence": "Meine Ergebenheit gilt nur Lady Goneril.",
-          "sentence_translation": "Моя преданность принадлежит только леди Гонерилье."
+          "sentence_translation": "Моя преданность принадлежит только леди Гонерилье.",
+          "answer_forms": [
+            "преданность"
+          ]
         },
         {
           "german": "dienen",
           "russian": "служить",
           "transcription": "[ДИ-нен]",
           "sentence": "Ich diene ohne Gewissen oder Ehre.",
-          "sentence_translation": "Я служу без совести и чести."
+          "sentence_translation": "Я служу без совести и чести.",
+          "answer_forms": [
+            "служить",
+            "служу"
+          ]
         },
         {
           "german": "der Verwalter",
           "russian": "управляющий",
           "transcription": "[дер фер-ВАЛЬ-тер]",
           "sentence": "Als Verwalter kontrolliere ich den Haushalt.",
-          "sentence_translation": "Как управляющий я контролирую дом."
+          "sentence_translation": "Как управляющий я контролирую дом.",
+          "answer_forms": [
+            "управляющий"
+          ]
         },
         {
           "german": "ergeben",
           "russian": "покорный",
           "transcription": "[ер-ГЕ-бен]",
           "sentence": "Ergeben folge ich jedem Befehl.",
-          "sentence_translation": "Покорно я следую каждому приказу."
+          "sentence_translation": "Покорно я следую каждому приказу.",
+          "answer_forms": [
+            "покорный"
+          ]
         },
         {
           "german": "unterwürfig",
           "russian": "раболепный",
           "transcription": "[УН-тер-вюр-фиг]",
           "sentence": "Unterwürfig krieche ich vor meiner Herrin.",
-          "sentence_translation": "Раболепно я пресмыкаюсь перед госпожой."
+          "sentence_translation": "Раболепно я пресмыкаюсь перед госпожой.",
+          "answer_forms": [
+            "раболепный",
+            "раболепно"
+          ]
         },
         {
           "german": "befolgen",
           "russian": "исполнять",
           "transcription": "[бе-ФОЛЬ-ген]",
           "sentence": "Jeden Befehl befolge ich sofort.",
-          "sentence_translation": "Каждый приказ я исполняю немедленно."
+          "sentence_translation": "Каждый приказ я исполняю немедленно.",
+          "answer_forms": [
+            "исполнять",
+            "исполняю"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -86,49 +113,74 @@
           "russian": "гонец",
           "transcription": "[дер БО-те]",
           "sentence": "Als Bote überbringe ich böse Nachrichten.",
-          "sentence_translation": "Как гонец я приношу дурные вести."
+          "sentence_translation": "Как гонец я приношу дурные вести.",
+          "answer_forms": [
+            "гонец"
+          ]
         },
         {
           "german": "der Auftrag",
           "russian": "поручение",
           "transcription": "[дер АУФ-траг]",
           "sentence": "Jeden Auftrag erfülle ich gewissenhaft.",
-          "sentence_translation": "Каждое поручение я выполняю добросовестно."
+          "sentence_translation": "Каждое поручение я выполняю добросовестно.",
+          "answer_forms": [
+            "поручение"
+          ]
         },
         {
           "german": "die Eile",
           "russian": "спешка",
           "transcription": "[ди АЙ-ле]",
           "sentence": "In großer Eile renne ich hin und her.",
-          "sentence_translation": "В большой спешке я бегаю туда-сюда."
+          "sentence_translation": "В большой спешке я бегаю туда-сюда.",
+          "answer_forms": [
+            "спешка",
+            "спешке"
+          ]
         },
         {
           "german": "überbringen",
           "russian": "передавать",
           "transcription": "[ю-бер-БРИН-ген]",
           "sentence": "Ich überbringe Befehle an alle Diener.",
-          "sentence_translation": "Я передаю приказы всем слугам."
+          "sentence_translation": "Я передаю приказы всем слугам.",
+          "answer_forms": [
+            "передавать",
+            "передаю"
+          ]
         },
         {
           "german": "hasten",
           "russian": "спешить",
           "transcription": "[ХАС-тен]",
           "sentence": "Ich haste von einem Ort zum anderen.",
-          "sentence_translation": "Я спешу с места на место."
+          "sentence_translation": "Я спешу с места на место.",
+          "answer_forms": [
+            "спешить",
+            "спешу"
+          ]
         },
         {
           "german": "die Botschaft",
           "russian": "послание",
           "transcription": "[ди БОТ-шафт]",
           "sentence": "Die Botschaft meiner Herrin ist grausam.",
-          "sentence_translation": "Послание моей госпожи жестоко."
+          "sentence_translation": "Послание моей госпожи жестоко.",
+          "answer_forms": [
+            "послание"
+          ]
         },
         {
           "german": "eilen",
           "russian": "торопиться",
           "transcription": "[АЙ-лен]",
           "sentence": "Ich eile, um ihre Wünsche zu erfüllen.",
-          "sentence_translation": "Я тороплюсь исполнить её желания."
+          "sentence_translation": "Я тороплюсь исполнить её желания.",
+          "answer_forms": [
+            "торопиться",
+            "тороплюсь"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -150,56 +202,86 @@
           "russian": "оскорбление",
           "transcription": "[ди бе-ЛАЙ-ди-гунг]",
           "sentence": "Jede Beleidigung spreche ich mit Genuss aus.",
-          "sentence_translation": "Каждое оскорбление я произношу с наслаждением."
+          "sentence_translation": "Каждое оскорбление я произношу с наслаждением.",
+          "answer_forms": [
+            "оскорбление"
+          ]
         },
         {
           "german": "die Respektlosigkeit",
           "russian": "неуважение",
           "transcription": "[ди рес-ПЕКТ-ло-зиг-кайт]",
           "sentence": "Meine Respektlosigkeit kennt keine Grenzen.",
-          "sentence_translation": "Моё неуважение не знает границ."
+          "sentence_translation": "Моё неуважение не знает границ.",
+          "answer_forms": [
+            "неуважение"
+          ]
         },
         {
           "german": "die Feigheit",
           "russian": "трусость",
           "transcription": "[ди ФАЙГ-хайт]",
           "sentence": "Aus Feigheit greife ich nur Schwache an.",
-          "sentence_translation": "Из трусости я нападаю только на слабых."
+          "sentence_translation": "Из трусости я нападаю только на слабых.",
+          "answer_forms": [
+            "трусость",
+            "трусости"
+          ]
         },
         {
           "german": "beleidigen",
           "russian": "оскорблять",
           "transcription": "[бе-ЛАЙ-ди-ген]",
           "sentence": "Ich beleidige den alten König ohne Scham.",
-          "sentence_translation": "Я оскорбляю старого короля без стыда."
+          "sentence_translation": "Я оскорбляю старого короля без стыда.",
+          "answer_forms": [
+            "оскорблять",
+            "оскорбляю"
+          ]
         },
         {
           "german": "verhöhnen",
           "russian": "высмеивать",
           "transcription": "[фер-ХЁ-нен]",
           "sentence": "Ich verhöhne seine königliche Würde.",
-          "sentence_translation": "Я высмеиваю его королевское достоинство."
+          "sentence_translation": "Я высмеиваю его королевское достоинство.",
+          "answer_forms": [
+            "высмеивать",
+            "высмеиваю"
+          ]
         },
         {
           "german": "frech",
           "russian": "дерзкий",
           "transcription": "[ФРЕХ]",
           "sentence": "Frech widerspreche ich dem alten Mann.",
-          "sentence_translation": "Дерзко я возражаю старику."
+          "sentence_translation": "Дерзко я возражаю старику.",
+          "answer_forms": [
+            "дерзкий",
+            "дерзко"
+          ]
         },
         {
           "german": "missachten",
           "russian": "пренебрегать",
           "transcription": "[МИС-ах-тен]",
           "sentence": "Ich missachte seinen früheren Rang.",
-          "sentence_translation": "Я пренебрегаю его прежним рангом."
+          "sentence_translation": "Я пренебрегаю его прежним рангом.",
+          "answer_forms": [
+            "пренебрегать",
+            "пренебрегаю"
+          ]
         },
         {
           "german": "feige",
           "russian": "трусливый",
           "transcription": "[ФАЙ-ге]",
           "sentence": "Feige verstecke ich mich hinter meiner Herrin.",
-          "sentence_translation": "Трусливо я прячусь за своей госпожой."
+          "sentence_translation": "Трусливо я прячусь за своей госпожой.",
+          "answer_forms": [
+            "трусливый",
+            "трусливо"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -221,49 +303,75 @@
           "russian": "шпион",
           "transcription": "[дер шпи-ОН]",
           "sentence": "Als Spion lausche ich an jeder Tür.",
-          "sentence_translation": "Как шпион я подслушиваю у каждой двери."
+          "sentence_translation": "Как шпион я подслушиваю у каждой двери.",
+          "answer_forms": [
+            "шпион"
+          ]
         },
         {
           "german": "der Verrat",
           "russian": "предательство",
           "transcription": "[дер фер-РАТ]",
           "sentence": "Der Verrat ist mein tägliches Geschäft.",
-          "sentence_translation": "Предательство - моё ежедневное дело."
+          "sentence_translation": "Предательство - моё ежедневное дело.",
+          "answer_forms": [
+            "предательство"
+          ]
         },
         {
           "german": "die Heimlichkeit",
           "russian": "скрытность",
           "transcription": "[ди ХАЙМ-лих-кайт]",
           "sentence": "In Heimlichkeit sammle ich Informationen.",
-          "sentence_translation": "В скрытности я собираю информацию."
+          "sentence_translation": "В скрытности я собираю информацию.",
+          "answer_forms": [
+            "скрытность",
+            "скрытности"
+          ]
         },
         {
           "german": "spionieren",
           "russian": "шпионить",
           "transcription": "[шпи-о-НИ-рен]",
           "sentence": "Ich spioniere für meine böse Herrin.",
-          "sentence_translation": "Я шпионю для моей злой госпожи."
+          "sentence_translation": "Я шпионю для моей злой госпожи.",
+          "answer_forms": [
+            "шпионить",
+            "шпионю"
+          ]
         },
         {
           "german": "lauschen",
           "russian": "подслушивать",
           "transcription": "[ЛАУ-шен]",
           "sentence": "Heimlich lausche ich allen Gesprächen.",
-          "sentence_translation": "Тайно я подслушиваю все разговоры."
+          "sentence_translation": "Тайно я подслушиваю все разговоры.",
+          "answer_forms": [
+            "подслушивать",
+            "подслушиваю"
+          ]
         },
         {
           "german": "verraten",
           "russian": "выдавать",
           "transcription": "[фер-РА-тен]",
           "sentence": "Ich verrate jeden an meine Herrin.",
-          "sentence_translation": "Я выдаю каждого своей госпоже."
+          "sentence_translation": "Я выдаю каждого своей госпоже.",
+          "answer_forms": [
+            "выдавать",
+            "выдаю"
+          ]
         },
         {
           "german": "schnüffeln",
           "russian": "вынюхивать",
           "transcription": "[ШНЮФ-фельн]",
           "sentence": "Überall schnüffle ich nach Geheimnissen.",
-          "sentence_translation": "Везде я вынюхиваю секреты."
+          "sentence_translation": "Везде я вынюхиваю секреты.",
+          "answer_forms": [
+            "вынюхивать",
+            "вынюхиваю"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -285,56 +393,85 @@
           "russian": "интрига",
           "transcription": "[ди ин-ТРИ-ге]",
           "sentence": "Jede Intrige spinne ich mit Freude.",
-          "sentence_translation": "Каждую интригу я плету с радостью."
+          "sentence_translation": "Каждую интригу я плету с радостью.",
+          "answer_forms": [
+            "интрига"
+          ]
         },
         {
           "german": "der Plan",
           "russian": "план",
           "transcription": "[дер ПЛАН]",
           "sentence": "Mein hinterhältiger Plan wird funktionieren.",
-          "sentence_translation": "Мой коварный план сработает."
+          "sentence_translation": "Мой коварный план сработает.",
+          "answer_forms": [
+            "план"
+          ]
         },
         {
           "german": "die Hinterlist",
           "russian": "коварство",
           "transcription": "[ди ХИН-тер-лист]",
           "sentence": "Mit Hinterlist verfolge ich meine Ziele.",
-          "sentence_translation": "С коварством я преследую свои цели."
+          "sentence_translation": "С коварством я преследую свои цели.",
+          "answer_forms": [
+            "коварство",
+            "коварством"
+          ]
         },
         {
           "german": "schmieden",
           "russian": "ковать",
           "transcription": "[ШМИ-ден]",
           "sentence": "Ich schmiede Pläne gegen alle Feinde.",
-          "sentence_translation": "Я кую планы против всех врагов."
+          "sentence_translation": "Я кую планы против всех врагов.",
+          "answer_forms": [
+            "ковать",
+            "кую"
+          ]
         },
         {
           "german": "hintergehen",
           "russian": "обманывать",
           "transcription": "[ХИН-тер-ге-ен]",
           "sentence": "Ich hintergehe jeden, der mir traut.",
-          "sentence_translation": "Я обманываю каждого, кто мне доверяет."
+          "sentence_translation": "Я обманываю каждого, кто мне доверяет.",
+          "answer_forms": [
+            "обманывать",
+            "обманываю"
+          ]
         },
         {
           "german": "tückisch",
           "russian": "коварный",
           "transcription": "[ТЮ-киш]",
           "sentence": "Tückisch plane ich meinen nächsten Schritt.",
-          "sentence_translation": "Коварно я планирую свой следующий шаг."
+          "sentence_translation": "Коварно я планирую свой следующий шаг.",
+          "answer_forms": [
+            "коварный",
+            "коварно"
+          ]
         },
         {
           "german": "verschlagen",
           "russian": "хитрый",
           "transcription": "[фер-ШЛАГ-ен]",
           "sentence": "Verschlagen verberge ich meine wahren Absichten.",
-          "sentence_translation": "Хитро я скрываю свои истинные намерения."
+          "sentence_translation": "Хитро я скрываю свои истинные намерения.",
+          "answer_forms": [
+            "хитрый",
+            "хитро"
+          ]
         },
         {
           "german": "die Falle",
           "russian": "ловушка",
           "transcription": "[ди ФА-ле]",
           "sentence": "Ich stelle Fallen für die Ahnungslosen.",
-          "sentence_translation": "Я ставлю ловушки для ничего не подозревающих."
+          "sentence_translation": "Я ставлю ловушки для ничего не подозревающих.",
+          "answer_forms": [
+            "ловушка"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -356,49 +493,74 @@
           "russian": "преследование",
           "transcription": "[ди фер-ФОЛЬ-гунг]",
           "sentence": "Die Verfolgung des blinden Grafen beginnt.",
-          "sentence_translation": "Преследование слепого графа начинается."
+          "sentence_translation": "Преследование слепого графа начинается.",
+          "answer_forms": [
+            "преследование"
+          ]
         },
         {
           "german": "die Jagd",
           "russian": "охота",
           "transcription": "[ди ЯГДТ]",
           "sentence": "Die Jagd auf Gloucester macht mir Spaß.",
-          "sentence_translation": "Охота на Глостера доставляет мне удовольствие."
+          "sentence_translation": "Охота на Глостера доставляет мне удовольствие.",
+          "answer_forms": [
+            "охота"
+          ]
         },
         {
           "german": "verfolgen",
           "russian": "преследовать",
           "transcription": "[фер-ФОЛЬ-ген]",
           "sentence": "Gnadenlos verfolge ich den alten Mann.",
-          "sentence_translation": "Безжалостно я преследую старика."
+          "sentence_translation": "Безжалостно я преследую старика.",
+          "answer_forms": [
+            "преследовать",
+            "преследую"
+          ]
         },
         {
           "german": "jagen",
           "russian": "гнаться",
           "transcription": "[Я-ген]",
           "sentence": "Wie ein Hund jage ich meine Beute.",
-          "sentence_translation": "Как собака я гонюсь за добычей."
+          "sentence_translation": "Как собака я гонюсь за добычей.",
+          "answer_forms": [
+            "гнаться",
+            "гонюсь"
+          ]
         },
         {
           "german": "aufspüren",
           "russian": "выслеживать",
           "transcription": "[АУФ-шпю-рен]",
           "sentence": "Ich spüre den Flüchtling überall auf.",
-          "sentence_translation": "Я выслеживаю беглеца повсюду."
+          "sentence_translation": "Я выслеживаю беглеца повсюду.",
+          "answer_forms": [
+            "выслеживать",
+            "выслеживаю"
+          ]
         },
         {
           "german": "hetzen",
           "russian": "травить",
           "transcription": "[ХЕ-цен]",
           "sentence": "Ich hetze ihn bis zum Ende.",
-          "sentence_translation": "Я травлю его до конца."
+          "sentence_translation": "Я травлю его до конца.",
+          "answer_forms": [
+            "травить",
+            "травлю"
+          ]
         },
         {
           "german": "die Beute",
           "russian": "добыча",
           "transcription": "[ди БОЙ-те]",
           "sentence": "Der Graf ist meine leichte Beute.",
-          "sentence_translation": "Граф - моя лёгкая добыча."
+          "sentence_translation": "Граф - моя лёгкая добыча.",
+          "answer_forms": [
+            "добыча"
+          ]
         }
       ],
       "theatrical_scene": {
@@ -420,56 +582,85 @@
           "russian": "смерть",
           "transcription": "[дер ТОД]",
           "sentence": "Der Tod ereilt mich durch Эдгars Hand.",
-          "sentence_translation": "Смерть настигает меня от руки Эдгара."
+          "sentence_translation": "Смерть настигает меня от руки Эдгара.",
+          "answer_forms": [
+            "смерть"
+          ]
         },
         {
           "german": "die Feigheit",
           "russian": "трусость",
           "transcription": "[ди ФАЙГ-хайт]",
           "sentence": "Meine Feigheit führt zu meinem Ende.",
-          "sentence_translation": "Моя трусость приводит к моему концу."
+          "sentence_translation": "Моя трусость приводит к моему концу.",
+          "answer_forms": [
+            "трусость"
+          ]
         },
         {
           "german": "die Niederlage",
           "russian": "поражение",
           "transcription": "[ди НИ-дер-ла-ге]",
           "sentence": "Die Niederlage ist mein letztes Schicksal.",
-          "sentence_translation": "Поражение - моя последняя судьба."
+          "sentence_translation": "Поражение - моя последняя судьба.",
+          "answer_forms": [
+            "поражение"
+          ]
         },
         {
           "german": "fallen",
           "russian": "падать",
           "transcription": "[ФА-лен]",
           "sentence": "Ich falle wie der Feigling, der ich bin.",
-          "sentence_translation": "Я падаю как трус, которым являюсь."
+          "sentence_translation": "Я падаю как трус, которым являюсь.",
+          "answer_forms": [
+            "падать",
+            "падаю"
+          ]
         },
         {
           "german": "unterliegen",
           "russian": "проигрывать",
           "transcription": "[ун-тер-ЛИ-ген]",
           "sentence": "Ich unterliege dem edlen Edgar.",
-          "sentence_translation": "Я проигрываю благородному Эдгару."
+          "sentence_translation": "Я проигрываю благородному Эдгару.",
+          "answer_forms": [
+            "проигрывать",
+            "проигрываю"
+          ]
         },
         {
           "german": "wimmern",
           "russian": "хныкать",
           "transcription": "[ВИМ-мерн]",
           "sentence": "Wimmernd bitte ich um Gnade.",
-          "sentence_translation": "Хныкая, я прошу о пощаде."
+          "sentence_translation": "Хныкая, я прошу о пощаде.",
+          "answer_forms": [
+            "хныкать",
+            "хныкаю"
+          ]
         },
         {
           "german": "betteln",
           "russian": "умолять",
           "transcription": "[БЕ-тельн]",
           "sentence": "Um mein Leben bettle ich vergeblich.",
-          "sentence_translation": "О жизни я умоляю напрасно."
+          "sentence_translation": "О жизни я умоляю напрасно.",
+          "answer_forms": [
+            "умолять",
+            "умоляю"
+          ]
         },
         {
           "german": "erbärmlich",
           "russian": "жалкий",
           "transcription": "[ер-БЕРМ-лих]",
           "sentence": "Erbärmlich ende ich wie ich gelebt habe.",
-          "sentence_translation": "Жалко я заканчиваю, как и жил."
+          "sentence_translation": "Жалко я заканчиваю, как и жил.",
+          "answer_forms": [
+            "жалкий",
+            "жалко"
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/regan.json
+++ b/data/characters/regan.json
@@ -21,56 +21,85 @@
           "russian": "притворяться",
           "transcription": "[ФОР-той-шен]",
           "sentence": "Ich täusche Liebe vor, die nie existierte.",
-          "sentence_translation": "Я притворяюсь в любви, которой никогда не было."
+          "sentence_translation": "Я притворяюсь в любви, которой никогда не было.",
+          "answer_forms": [
+            "притворяться",
+            "притворяюсь"
+          ]
         },
         {
           "german": "übertreffen",
           "russian": "превосходить",
           "transcription": "[ю-бер-ТРЕ-фен]",
           "sentence": "Ich will meine Schwester in der Lüge übertreffen.",
-          "sentence_translation": "Я хочу превзойти сестру во лжи."
+          "sentence_translation": "Я хочу превзойти сестру во лжи.",
+          "answer_forms": [
+            "превосходить",
+            "превзойти"
+          ]
         },
         {
           "german": "wetteifern",
           "russian": "состязаться",
           "transcription": "[ВЕТ-ай-ферн]",
           "sentence": "Wir wetteifern um das größte Erbe.",
-          "sentence_translation": "Мы состязаемся за большее наследство."
+          "sentence_translation": "Мы состязаемся за большее наследство.",
+          "answer_forms": [
+            "состязаться",
+            "состязаемся"
+          ]
         },
         {
           "german": "die Falschheit",
           "russian": "фальшь",
           "transcription": "[ди ФАЛЬШ-хайт]",
           "sentence": "Meine Falschheit kennt keine Grenzen.",
-          "sentence_translation": "Моя фальшь не знает границ."
+          "sentence_translation": "Моя фальшь не знает границ.",
+          "answer_forms": [
+            "фальшь"
+          ]
         },
         {
           "german": "vorspielen",
           "russian": "разыгрывать",
           "transcription": "[ФОР-шпи-лен]",
           "sentence": "Ich spiele ihm Töchterliebe vor.",
-          "sentence_translation": "Я разыгрываю перед ним дочернюю любовь."
+          "sentence_translation": "Я разыгрываю перед ним дочернюю любовь.",
+          "answer_forms": [
+            "разыгрывать",
+            "разыгрываю"
+          ]
         },
         {
           "german": "die List",
           "russian": "хитрость",
           "transcription": "[ди ЛИСТ]",
           "sentence": "Mit List gewinne ich sein Vertrauen.",
-          "sentence_translation": "Хитростью я завоёвываю его доверие."
+          "sentence_translation": "Хитростью я завоёвываю его доверие.",
+          "answer_forms": [
+            "хитрость"
+          ]
         },
         {
           "german": "erschleichen",
           "russian": "выманивать",
           "transcription": "[ер-ШЛАЙ-хен]",
           "sentence": "Ich erschleiche mir sein Königreich.",
-          "sentence_translation": "Я выманиваю его королевство."
+          "sentence_translation": "Я выманиваю его королевство.",
+          "answer_forms": [
+            "выманивать",
+            "выманиваю"
+          ]
         },
         {
           "german": "die Habgier",
           "russian": "алчность",
           "transcription": "[ди ХАБ-гир]",
           "sentence": "Die Habgier treibt meine süßen Worte.",
-          "sentence_translation": "Алчность движет моими сладкими словами."
+          "sentence_translation": "Алчность движет моими сладкими словами.",
+          "answer_forms": [
+            "алчность"
+          ]
         }
       ]
     },
@@ -92,49 +121,74 @@
           "russian": "союз",
           "transcription": "[дас БЮНД-нис]",
           "sentence": "Ein Bündnis mit Goneril gegen unseren Vater.",
-          "sentence_translation": "Союз с Гонерильей против нашего отца."
+          "sentence_translation": "Союз с Гонерильей против нашего отца.",
+          "answer_forms": [
+            "союз"
+          ]
         },
         {
           "german": "teilen",
           "russian": "делить",
           "transcription": "[ТАЙ-лен]",
           "sentence": "Wir teilen das Reich zwischen uns.",
-          "sentence_translation": "Мы делим королевство между собой."
+          "sentence_translation": "Мы делим королевство между собой.",
+          "answer_forms": [
+            "делить",
+            "делим"
+          ]
         },
         {
           "german": "planen",
           "russian": "планировать",
           "transcription": "[ПЛА-нен]",
           "sentence": "Wir planen den Untergang des alten Königs.",
-          "sentence_translation": "Мы планируем падение старого короля."
+          "sentence_translation": "Мы планируем падение старого короля.",
+          "answer_forms": [
+            "планировать",
+            "планируем"
+          ]
         },
         {
           "german": "verschwören",
           "russian": "заговорить",
           "transcription": "[фер-ШВЁ-рен]",
           "sentence": "Wir verschwören uns gegen ihn.",
-          "sentence_translation": "Мы составляем заговор против него."
+          "sentence_translation": "Мы составляем заговор против него.",
+          "answer_forms": [
+            "заговорить",
+            "составляем заговор"
+          ]
         },
         {
           "german": "die Absprache",
           "russian": "сговор",
           "transcription": "[ди АБ-шпра-хе]",
           "sentence": "Unsere Absprache ist perfekt.",
-          "sentence_translation": "Наш сговор совершенен."
+          "sentence_translation": "Наш сговор совершенен.",
+          "answer_forms": [
+            "сговор"
+          ]
         },
         {
           "german": "vereinbaren",
           "russian": "договариваться",
           "transcription": "[фер-АЙН-ба-рен]",
           "sentence": "Wir vereinbaren gemeinsame Grausamkeit.",
-          "sentence_translation": "Мы договариваемся о совместной жестокости."
+          "sentence_translation": "Мы договариваемся о совместной жестокости.",
+          "answer_forms": [
+            "договариваться",
+            "договариваемся"
+          ]
         },
         {
           "german": "die Strategie",
           "russian": "стратегия",
           "transcription": "[ди штра-те-ГИ]",
           "sentence": "Unsere Strategie wird ihn brechen.",
-          "sentence_translation": "Наша стратегия сломает его."
+          "sentence_translation": "Наша стратегия сломает его.",
+          "answer_forms": [
+            "стратегия"
+          ]
         }
       ]
     },
@@ -156,56 +210,83 @@
           "russian": "пытать",
           "transcription": "[ФОЛЬ-терн]",
           "sentence": "Ich foltere ihn mit kalten Worten.",
-          "sentence_translation": "Я пытаю его холодными словами."
+          "sentence_translation": "Я пытаю его холодными словами.",
+          "answer_forms": [
+            "пытать"
+          ]
         },
         {
           "german": "erniedrigen",
           "russian": "унижать",
           "transcription": "[ер-НИД-ри-ген]",
           "sentence": "Ich erniedrige den einst mächtigen König.",
-          "sentence_translation": "Я унижаю некогда могущественного короля."
+          "sentence_translation": "Я унижаю некогда могущественного короля.",
+          "answer_forms": [
+            "унижать"
+          ]
         },
         {
           "german": "verhöhnen",
           "russian": "насмехаться",
           "transcription": "[фер-ХЁ-нен]",
           "sentence": "Ich verhöhne seine väterliche Liebe.",
-          "sentence_translation": "Я насмехаюсь над его отцовской любовью."
+          "sentence_translation": "Я насмехаюсь над его отцовской любовью.",
+          "answer_forms": [
+            "насмехаться",
+            "насмехаюсь"
+          ]
         },
         {
           "german": "die Bosheit",
           "russian": "злоба",
           "transcription": "[ди БОС-хайт]",
           "sentence": "Meine Bosheit kennt kein Erbarmen.",
-          "sentence_translation": "Моя злоба не знает милосердия."
+          "sentence_translation": "Моя злоба не знает милосердия.",
+          "answer_forms": [
+            "злоба"
+          ]
         },
         {
           "german": "misshandeln",
           "russian": "жестоко обращаться",
           "transcription": "[МИС-хан-дельн]",
           "sentence": "Ich misshandle den alten Mann.",
-          "sentence_translation": "Я жестоко обращаюсь со стариком."
+          "sentence_translation": "Я жестоко обращаюсь со стариком.",
+          "answer_forms": [
+            "жестоко обращаться",
+            "жестоко обращаюсь"
+          ]
         },
         {
           "german": "die Härte",
           "russian": "жёсткость",
           "transcription": "[ди ХЕР-те]",
           "sentence": "Mit eiserner Härte stoße ich ihn fort.",
-          "sentence_translation": "С железной жёсткостью я отталкиваю его."
+          "sentence_translation": "С железной жёсткостью я отталкиваю его.",
+          "answer_forms": [
+            "жёсткость"
+          ]
         },
         {
           "german": "abweisen",
           "russian": "отвергать",
           "transcription": "[АБ-вай-зен]",
           "sentence": "Ich weise alle seine Bitten ab.",
-          "sentence_translation": "Я отвергаю все его просьбы."
+          "sentence_translation": "Я отвергаю все его просьбы.",
+          "answer_forms": [
+            "отвергать",
+            "отвергаю"
+          ]
         },
         {
           "german": "die Grausamkeit",
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
           "sentence": "Meine Grausamkeit übertrifft die meiner Schwester.",
-          "sentence_translation": "Моя жестокость превосходит жестокость сестры."
+          "sentence_translation": "Моя жестокость превосходит жестокость сестры.",
+          "answer_forms": [
+            "жестокость"
+          ]
         }
       ]
     },
@@ -227,56 +308,85 @@
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
           "sentence": "Wir blenden den treuen Grafen Gloucester.",
-          "sentence_translation": "Мы ослепляем верного графа Глостера."
+          "sentence_translation": "Мы ослепляем верного графа Глостера.",
+          "answer_forms": [
+            "ослеплять",
+            "ослепить"
+          ]
         },
         {
           "german": "der Sadismus",
           "russian": "садизм",
           "transcription": "[дер за-ДИС-мус]",
           "sentence": "Mein Sadismus findet Befriedigung.",
-          "sentence_translation": "Мой садизм находит удовлетворение."
+          "sentence_translation": "Мой садизм находит удовлетворение.",
+          "answer_forms": [
+            "садизм"
+          ]
         },
         {
           "german": "genießen",
           "russian": "наслаждаться",
           "transcription": "[ге-НИ-сен]",
           "sentence": "Ich genieße jeden Schrei des Schmerzes.",
-          "sentence_translation": "Я наслаждаюсь каждым криком боли."
+          "sentence_translation": "Я наслаждаюсь каждым криком боли.",
+          "answer_forms": [
+            "наслаждаться",
+            "наслаждаюсь"
+          ]
         },
         {
           "german": "ausstechen",
           "russian": "выкалывать",
           "transcription": "[АУС-ште-хен]",
           "sentence": "Stecht ihm beide Augen aus!",
-          "sentence_translation": "Выколите ему оба глаза!"
+          "sentence_translation": "Выколите ему оба глаза!",
+          "answer_forms": [
+            "выкалывать",
+            "Выколите"
+          ]
         },
         {
           "german": "die Folter",
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
           "sentence": "Die Folter ist meine Unterhaltung.",
-          "sentence_translation": "Пытка - моё развлечение."
+          "sentence_translation": "Пытка - моё развлечение.",
+          "answer_forms": [
+            "пытка"
+          ]
         },
         {
           "german": "erbarmungslos",
           "russian": "беспощадный",
           "transcription": "[ер-БАР-мунгс-лос]",
           "sentence": "Ich bin erbarmungslos in meiner Rache.",
-          "sentence_translation": "Я беспощадна в своей мести."
+          "sentence_translation": "Я беспощадна в своей мести.",
+          "answer_forms": [
+            "беспощадный",
+            "беспощадна"
+          ]
         },
         {
           "german": "die Brutalität",
           "russian": "брутальность",
           "transcription": "[ди бру-та-ли-ТЕТ]",
           "sentence": "Meine Brutalität erschreckt sogar Cornwall.",
-          "sentence_translation": "Моя брутальность пугает даже Корнуолла."
+          "sentence_translation": "Моя брутальность пугает даже Корнуолла.",
+          "answer_forms": [
+            "брутальность"
+          ]
         },
         {
           "german": "zertreten",
           "russian": "растаптывать",
           "transcription": "[цер-ТРЕ-тен]",
           "sentence": "Ich zertrete seine Augen unter meinem Fuß.",
-          "sentence_translation": "Я растаптываю его глаза под ногой."
+          "sentence_translation": "Я растаптываю его глаза под ногой.",
+          "answer_forms": [
+            "растаптывать",
+            "растаптываю"
+          ]
         }
       ]
     },
@@ -298,49 +408,74 @@
           "russian": "вдова",
           "transcription": "[ди ВИТ-ве]",
           "sentence": "Als Witwe bin ich endlich frei.",
-          "sentence_translation": "Как вдова я наконец свободна."
+          "sentence_translation": "Как вдова я наконец свободна.",
+          "answer_forms": [
+            "вдова"
+          ]
         },
         {
           "german": "begehren",
           "russian": "вожделеть",
           "transcription": "[бе-ГЕ-рен]",
           "sentence": "Ich begehre Edmund mit brennender Lust.",
-          "sentence_translation": "Я вожделею Эдмунда с пылающей страстью."
+          "sentence_translation": "Я вожделею Эдмунда с пылающей страстью.",
+          "answer_forms": [
+            "вожделеть",
+            "вожделею"
+          ]
         },
         {
           "german": "verführen",
           "russian": "соблазнять",
           "transcription": "[фер-ФЮ-рен]",
           "sentence": "Ich will Edmund verführen und besitzen.",
-          "sentence_translation": "Я хочу соблазнить и завладеть Эдмундом."
+          "sentence_translation": "Я хочу соблазнить и завладеть Эдмундом.",
+          "answer_forms": [
+            "соблазнять",
+            "соблазнить"
+          ]
         },
         {
           "german": "die Begierde",
           "russian": "вожделение",
           "transcription": "[ди бе-ГИР-де]",
           "sentence": "Meine Begierde brennt wie Feuer.",
-          "sentence_translation": "Моё вожделение горит как огонь."
+          "sentence_translation": "Моё вожделение горит как огонь.",
+          "answer_forms": [
+            "вожделение"
+          ]
         },
         {
           "german": "locken",
           "russian": "заманивать",
           "transcription": "[ЛО-кен]",
           "sentence": "Ich locke ihn mit Versprechungen.",
-          "sentence_translation": "Я заманиваю его обещаниями."
+          "sentence_translation": "Я заманиваю его обещаниями.",
+          "answer_forms": [
+            "заманивать",
+            "заманиваю"
+          ]
         },
         {
           "german": "die Lust",
           "russian": "похоть",
           "transcription": "[ди ЛУСТ]",
           "sentence": "Die Lust macht mich blind für Gefahr.",
-          "sentence_translation": "Похоть делает меня слепой к опасности."
+          "sentence_translation": "Похоть делает меня слепой к опасности.",
+          "answer_forms": [
+            "похоть"
+          ]
         },
         {
           "german": "werben",
           "russian": "добиваться",
           "transcription": "[ВЕР-бен]",
           "sentence": "Ich werbe schamlos um seine Gunst.",
-          "sentence_translation": "Я бесстыдно добиваюсь его благосклонности."
+          "sentence_translation": "Я бесстыдно добиваюсь его благосклонности.",
+          "answer_forms": [
+            "добиваться",
+            "добиваюсь"
+          ]
         }
       ]
     },
@@ -362,49 +497,76 @@
           "russian": "соревноваться",
           "transcription": "[ВЕТ-кемп-фен]",
           "sentence": "Wir wettkämpfen um Edmunds Liebe.",
-          "sentence_translation": "Мы соревнуемся за любовь Эдмунда."
+          "sentence_translation": "Мы соревнуемся за любовь Эдмунда.",
+          "answer_forms": [
+            "соревноваться",
+            "соревнуемся"
+          ]
         },
         {
           "german": "hassen",
           "russian": "ненавидеть",
           "transcription": "[ХА-сен]",
           "sentence": "Ich hasse meine Schwester mehr als je zuvor.",
-          "sentence_translation": "Я ненавижу сестру больше, чем когда-либо."
+          "sentence_translation": "Я ненавижу сестру больше, чем когда-либо.",
+          "answer_forms": [
+            "ненавидеть",
+            "ненавижу"
+          ]
         },
         {
           "german": "bedrohen",
           "russian": "угрожать",
           "transcription": "[бе-ДРО-ен]",
           "sentence": "Ich bedrohe sie mit dem Tod.",
-          "sentence_translation": "Я угрожаю ей смертью."
+          "sentence_translation": "Я угрожаю ей смертью.",
+          "answer_forms": [
+            "угрожать",
+            "угрожаю"
+          ]
         },
         {
           "german": "die Rivalität",
           "russian": "соперничество",
           "transcription": "[ди ри-ва-ли-ТЕТ]",
           "sentence": "Unsere Rivalität wird tödlich enden.",
-          "sentence_translation": "Наше соперничество закончится смертью."
+          "sentence_translation": "Наше соперничество закончится смертью.",
+          "answer_forms": [
+            "соперничество"
+          ]
         },
         {
           "german": "bekämpfen",
           "russian": "бороться",
           "transcription": "[бе-КЕМП-фен]",
           "sentence": "Ich bekämpfe sie mit allen Mitteln.",
-          "sentence_translation": "Я борюсь с ней всеми средствами."
+          "sentence_translation": "Я борюсь с ней всеми средствами.",
+          "answer_forms": [
+            "бороться",
+            "борюсь"
+          ]
         },
         {
           "german": "misstrauen",
           "russian": "не доверять",
           "transcription": "[МИС-трау-ен]",
           "sentence": "Ich misstraue jedem ihrer Worte.",
-          "sentence_translation": "Я не доверяю ни одному её слову."
+          "sentence_translation": "Я не доверяю ни одному её слову.",
+          "answer_forms": [
+            "не доверять",
+            "не доверяю"
+          ]
         },
         {
           "german": "argwöhnen",
           "russian": "подозревать",
           "transcription": "[АРГ-вё-нен]",
           "sentence": "Ich argwöhne Gift in meinem Wein.",
-          "sentence_translation": "Я подозреваю яд в моём вине."
+          "sentence_translation": "Я подозреваю яд в моём вине.",
+          "answer_forms": [
+            "подозревать",
+            "подозреваю"
+          ]
         }
       ]
     },
@@ -426,56 +588,86 @@
           "russian": "отравленный",
           "transcription": "[фер-ГИФ-тет]",
           "sentence": "Ich bin von meiner eigenen Schwester vergiftet.",
-          "sentence_translation": "Я отравлена собственной сестрой."
+          "sentence_translation": "Я отравлена собственной сестрой.",
+          "answer_forms": [
+            "отравленный",
+            "отравлена"
+          ]
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
           "sentence": "Ich leide furchtbare Qualen.",
-          "sentence_translation": "Я страдаю от ужасных мук."
+          "sentence_translation": "Я страдаю от ужасных мук.",
+          "answer_forms": [
+            "страдать",
+            "страдаю"
+          ]
         },
         {
           "german": "verenden",
           "russian": "издыхать",
           "transcription": "[фер-ЕН-ден]",
           "sentence": "Wie ein Tier verende ich elend.",
-          "sentence_translation": "Как зверь я издыхаю жалко."
+          "sentence_translation": "Как зверь я издыхаю жалко.",
+          "answer_forms": [
+            "издыхать",
+            "издыхаю"
+          ]
         },
         {
           "german": "die Qual",
           "russian": "мучение",
           "transcription": "[ди КВАЛЬ]",
           "sentence": "Die Qual des Giftes zerreißt mich.",
-          "sentence_translation": "Мучение от яда разрывает меня."
+          "sentence_translation": "Мучение от яда разрывает меня.",
+          "answer_forms": [
+            "мучение"
+          ]
         },
         {
           "german": "verwünschen",
           "russian": "проклинать",
           "transcription": "[фер-ВЮН-шен]",
           "sentence": "Ich verwünsche meine Schwester mit letzter Kraft.",
-          "sentence_translation": "Я проклинаю сестру последними силами."
+          "sentence_translation": "Я проклинаю сестру последними силами.",
+          "answer_forms": [
+            "проклинать",
+            "проклинаю"
+          ]
         },
         {
           "german": "das Verhängnis",
           "russian": "рок",
           "transcription": "[дас фер-ХЕНГ-нис]",
           "sentence": "Das Verhängnis ereilt mich gerecht.",
-          "sentence_translation": "Рок настигает меня справедливо."
+          "sentence_translation": "Рок настигает меня справедливо.",
+          "answer_forms": [
+            "рок"
+          ]
         },
         {
           "german": "büßen",
           "russian": "расплачиваться",
           "transcription": "[БЮ-сен]",
           "sentence": "Ich büße für all meine Grausamkeiten.",
-          "sentence_translation": "Я расплачиваюсь за все свои жестокости."
+          "sentence_translation": "Я расплачиваюсь за все свои жестокости.",
+          "answer_forms": [
+            "расплачиваться",
+            "расплачиваюсь"
+          ]
         },
         {
           "german": "verflucht",
           "russian": "проклятый",
           "transcription": "[фер-ФЛУХТ]",
           "sentence": "Verflucht sei unser böses Blut!",
-          "sentence_translation": "Проклята наша злая кровь!"
+          "sentence_translation": "Проклята наша злая кровь!",
+          "answer_forms": [
+            "проклятый",
+            "проклята"
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add `answer_forms` lists to every character vocabulary entry so exercises can map hints to answers without hard-coded logic
- refactor the HTML journey exercise generation to consume the new forms list, format answers consistently, and validate that all blanks resolve without UNKNOWN markers

## Testing
- python - <<'PY'
import json, os
from generators.html_lira import LiraHTMLGenerator

gen = LiraHTMLGenerator(config={})
root = 'data/characters'
for filename in sorted(os.listdir(root)):
    if not filename.endswith('.json'):
        continue
    path = os.path.join(root, filename)
    character = gen.load_character(path)
    try:
        gen._generate_exercises(character)
    except Exception as exc:
        raise SystemExit(f'Error in {filename}: {exc}')
print('All exercises generated successfully')
PY

------
https://chatgpt.com/codex/tasks/task_e_68cd40bdd0a0832096966ef1b0681f81