### PR TITLE
Improve journey timeline progress control

### DIFF
--- a/templates/journey.html
+++ b/templates/journey.html
@@ -20,7 +20,7 @@
             <div class="journey-timeline">
                 <svg class="journey-line" width="100%" height="4">
                     <line x1="0" y1="2" x2="100%" y2="2" stroke="#6b5b95" stroke-width="2" opacity="0.3" />
-                    <line x1="0" y1="2" x2="{{ initial_progress }}%" y2="2" stroke="#6b5b95" stroke-width="3" class="progress-line" />
+                    <line x1="0" y1="2" x2="100%" y2="2" stroke="#6b5b95" stroke-width="3" class="progress-line" data-start-progress="{{ initial_progress }}" />
                 </svg>
 
                 <div class="journey-points">


### PR DESCRIPTION
## Summary
- keep the timeline SVG progress line at full length and expose the initial fill percentage via a data attribute
- initialise and update the progress line dash styling in JavaScript based on the saved percentage for consistent growth during navigation

## Testing
- pytest *(fails: missing Jinja2 dependency; unable to install due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd49c832b08320bd579701fdd3b04e