### PR TITLE
Add visual hints and themes to journey vocabulary cards

### DIFF
--- a/generators/js_lira.py
+++ b/generators/js_lira.py
@@ -20,12 +20,20 @@ class LiraJSGenerator:
 
             words = []
             for word in phase.get('vocabulary', []):
+                themes = word.get('themes') or []
+                if isinstance(themes, str):
+                    themes = [themes]
+                elif not isinstance(themes, list):
+                    themes = []
+
                 words.append({
                     'word': word.get('german', ''),
                     'translation': word.get('russian', ''),
                     'transcription': word.get('transcription', ''),
                     'sentence': word.get('sentence', ''),
                     'sentenceTranslation': word.get('sentence_translation', ''),
+                    'visual_hint': word.get('visual_hint', ''),
+                    'themes': themes,
                 })
 
             phase_vocabularies[phase_id] = {
@@ -182,10 +190,25 @@ function displayVocabulary(phaseKey) {
             const card = document.createElement('div');
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
+
+            const visualHintMarkup = item.visual_hint
+                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
+                : '';
+
+            const themesMarkup = Array.isArray(item.themes) && item.themes.length
+                ? `<div class="word-themes">${item.themes.map(theme => `<span class=\"word-theme\">${theme}</span>`).join('')}</div>`
+                : '';
+
             card.innerHTML = `
-                <div class="word-german">${item.word}</div>
-                <div class="word-translation">${item.translation}</div>
-                <div class="word-transcription">${item.transcription}</div>
+                <div class="word-card-header">
+                    ${visualHintMarkup}
+                    <div class="word-meta">
+                        <div class="word-german">${item.word}</div>
+                        <div class="word-translation">${item.translation}</div>
+                        <div class="word-transcription">${item.transcription}</div>
+                    </div>
+                </div>
+                ${themesMarkup}
                 <div class="word-sentence">
                     <div class="sentence-german">"${item.sentence}"</div>
                     <div class="sentence-translation">${item.sentenceTranslation}</div>

--- a/static/css/journey.css
+++ b/static/css/journey.css
@@ -211,9 +211,71 @@ body {
     background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
     border-radius: 15px;
     padding: 20px;
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    text-align: left;
     transition: all 0.3s ease;
     animation: slideIn 0.4s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.word-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(102, 126, 234, 0.1), rgba(118, 75, 162, 0.08));
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+}
+
+.word-card:hover::after {
+    opacity: 1;
+}
+
+.word-card-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.word-visual-hint {
+    width: 56px;
+    height: 56px;
+    border-radius: 16px;
+    background: rgba(102, 126, 234, 0.12);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    box-shadow: inset 0 0 0 1px rgba(102, 126, 234, 0.2);
+    color: #574b90;
+    flex-shrink: 0;
+}
+
+.word-meta {
+    flex: 1;
+}
+
+.word-themes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: -4px;
+}
+
+.word-theme {
+    background: rgba(102, 126, 234, 0.12);
+    color: #4c51bf;
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 0.75em;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    box-shadow: inset 0 0 0 1px rgba(102, 126, 234, 0.25);
 }
 
 .word-card:hover {
@@ -225,25 +287,23 @@ body {
     font-size: 1.4em;
     font-weight: 700;
     color: #667eea;
-    margin-bottom: 8px;
+    margin-bottom: 6px;
 }
 
 .word-translation {
     font-size: 1.1em;
     color: #555;
-    margin-bottom: 5px;
+    margin-bottom: 4px;
 }
 
 .word-transcription {
     font-size: 0.9em;
     color: #888;
     font-style: italic;
-    margin-bottom: 15px;
 }
 
 .word-sentence {
-    margin-top: 15px;
-    padding-top: 15px;
+    padding-top: 16px;
     border-top: 1px solid #e0e0e0;
 }
 
@@ -402,6 +462,21 @@ body {
     
     .word-card {
         padding: 15px;
+        gap: 14px;
+    }
+
+    .word-card-header {
+        gap: 12px;
+    }
+
+    .word-visual-hint {
+        width: 48px;
+        height: 48px;
+        font-size: 1.6rem;
+    }
+
+    .word-theme {
+        font-size: 0.7em;
     }
     
     .phase-navigation {

--- a/tests/test_js_lira_generator.py
+++ b/tests/test_js_lira_generator.py
@@ -25,6 +25,8 @@ class LiraJSGeneratorTests(unittest.TestCase):
                             'transcription': '[энт-ШАЙ-дӯнг]',
                             'sentence': 'Er flüstert: "Das ist Edmunds Weg."\nUnd geht.',
                             'sentence_translation': 'Он шепчет: "Это путь Эдмунда."\nИ уходит.',
+                            'visual_hint': '🎯',
+                            'themes': ['Strategie', 'Täuschung'],
                         }
                     ],
                 }
@@ -61,6 +63,8 @@ class LiraJSGeneratorTests(unittest.TestCase):
             word_payload['sentenceTranslation'],
             word_source['sentence_translation'],
         )
+        self.assertEqual(word_payload['visual_hint'], word_source['visual_hint'])
+        self.assertEqual(word_payload['themes'], word_source['themes'])
 
         # ensure_ascii=False keeps non-latin characters intact in the script output
         self.assertIn('решение', script)


### PR DESCRIPTION
## Summary
- include visual hints and theme data for vocabulary words in the generated journey JavaScript payload
- render emoji hints and topic badges inside journey vocabulary cards and style the new elements for desktop and mobile
- extend generator tests to cover the new vocabulary fields

## Testing
- pytest *(fails: scripts/test_mobile_navigation expects Windows-specific project path)*
- pytest tests/test_js_lira_generator.py


------
https://chatgpt.com/codex/tasks/task_e_68cd4f7c3bd883209f7f9c8781e11589