### PR TITLE
Add review vocabulary section to index page

### DIFF
--- a/generators/index_gen.py
+++ b/generators/index_gen.py
@@ -1,4 +1,6 @@
 """Index page generator with character cards"""
+import json
+
 from .base import BaseGenerator
 
 
@@ -48,10 +50,94 @@ class IndexGenerator(BaseGenerator):
                 }
             )
 
+        review_items = self._get_review_items()
+
         return self.render_template(
             "index.html",
             cards=cards,
             character_count=len(cards),
             phase_total=phase_total,
             vocabulary_total=vocabulary_total,
+            review_items=review_items,
         )
+
+    def _get_review_items(self, limit=6):
+        """Return a curated list of vocabulary items for spaced repetition."""
+        vocabulary_path = self.config.DATA_DIR / "vocabulary" / "words.json"
+        if not vocabulary_path.exists():
+            return []
+
+        try:
+            with open(vocabulary_path, "r", encoding="utf-8") as f:
+                vocabulary = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"[WARNING] Unable to load vocabulary data: {exc}")
+            return []
+
+        words = vocabulary.get("words", [])
+        if not isinstance(words, list):
+            return []
+
+        pending_words = [word for word in words if not word.get("learned", False)]
+        if not pending_words:
+            pending_words = words
+
+        sorted_words = sorted(pending_words, key=self._review_sort_key)
+        selected_words = sorted_words[:limit]
+
+        review_items = []
+        for word in selected_words:
+            review_items.append(
+                {
+                    "id": self._get_item_id(word),
+                    "emoji": word.get("emoji", "📝"),
+                    "word": self._format_word(word),
+                    "translation": self._extract_translation(word),
+                    "level": word.get("level"),
+                    "category": word.get("category"),
+                    "phonetic": word.get("phonetic"),
+                    "example": self._extract_example(word),
+                    "practice_url": f"trainings/{self._get_item_id(word)}.html",
+                }
+            )
+
+        return review_items
+
+    def _review_sort_key(self, word):
+        """Sort vocabulary by frequency, level and alphabetical order."""
+        frequency_order = {"high": 0, "medium": 1, "low": 2}
+        frequency = word.get("frequency")
+        frequency_rank = 3
+        if isinstance(frequency, str):
+            frequency_rank = frequency_order.get(frequency.lower(), 3)
+
+        level = word.get("level") or "Z"
+        word_value = word.get("word") or ""
+
+        return (frequency_rank, level, word_value)
+
+    def _get_item_id(self, word):
+        """Return stable identifier for vocabulary item."""
+        return word.get("id") or (word.get("word") or "vocab").replace(" ", "_")
+
+    def _format_word(self, word):
+        """Compose article and base word for display."""
+        base = word.get("word", "")
+        article = word.get("article")
+        if article:
+            return f"{article} {base}".strip()
+        return base
+
+    def _extract_translation(self, word):
+        """Extract Russian translation (fallback to English/string)."""
+        translation = word.get("translation")
+        if isinstance(translation, dict):
+            return translation.get("ru") or translation.get("en")
+        return translation
+
+    def _extract_example(self, word):
+        """Return German example sentence if available."""
+        example = word.get("example")
+        if isinstance(example, dict):
+            return example.get("de")
+        return example

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -65,6 +65,152 @@ body {
     letter-spacing: 1px;
 }
 
+.review-section {
+    margin: 0 auto 60px;
+    margin-top: -20px;
+    padding: 36px 40px 40px;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 28px;
+    color: #f7fafc;
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(14px);
+    max-width: 1100px;
+}
+
+.review-header h2 {
+    font-size: 2.2em;
+    font-weight: 800;
+    letter-spacing: -0.5px;
+}
+
+.review-header p {
+    margin-top: 10px;
+    font-size: 1.05em;
+    opacity: 0.85;
+}
+
+.review-grid {
+    margin-top: 30px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 22px;
+}
+
+.review-card {
+    background: rgba(255, 255, 255, 0.95);
+    color: #1a202c;
+    border-radius: 20px;
+    padding: 24px;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.review-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.1), rgba(118, 75, 162, 0.15));
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.review-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 18px 40px rgba(102, 126, 234, 0.25);
+}
+
+.review-card:hover::before {
+    opacity: 1;
+}
+
+.review-card > * {
+    position: relative;
+    z-index: 1;
+}
+
+.review-card-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 18px;
+}
+
+.review-icon {
+    font-size: 48px;
+    filter: drop-shadow(0 8px 15px rgba(102, 126, 234, 0.35));
+}
+
+.review-title {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.review-word {
+    font-size: 1.35em;
+    font-weight: 700;
+    color: #2d3748;
+    letter-spacing: -0.3px;
+}
+
+.review-translation {
+    font-size: 1em;
+    color: #4a5568;
+}
+
+.review-example {
+    font-style: italic;
+    color: #2d3748;
+    background: rgba(102, 126, 234, 0.12);
+    border-left: 4px solid rgba(102, 126, 234, 0.55);
+    padding: 12px 16px;
+    border-radius: 12px;
+    line-height: 1.5;
+}
+
+.review-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.review-tag {
+    background: rgba(102, 126, 234, 0.18);
+    color: #4c51bf;
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 0.85em;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+}
+
+.review-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    align-self: flex-start;
+    padding: 12px 26px;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    text-decoration: none;
+    border-radius: 12px;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    box-shadow: 0 12px 28px rgba(102, 126, 234, 0.35);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.review-link:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 35px rgba(102, 126, 234, 0.45);
+}
+
 .characters-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -241,6 +387,27 @@ body {
         font-size: 2.5em;
     }
 
+    .review-section {
+        margin: 20px 0 40px;
+        padding: 26px 22px 28px;
+    }
+
+    .review-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .review-card {
+        padding: 22px;
+    }
+
+    .review-card-header {
+        gap: 14px;
+    }
+
+    .review-meta {
+        gap: 8px;
+    }
+
     .characters-grid {
         grid-template-columns: 1fr;
     }
@@ -248,5 +415,25 @@ body {
     .stats {
         flex-direction: column;
         gap: 20px;
+    }
+}
+
+@media (max-width: 480px) {
+    .header h1 {
+        font-size: 2.2em;
+    }
+
+    .review-card-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .review-icon {
+        font-size: 42px;
+    }
+
+    .review-link {
+        width: 100%;
+        justify-content: center;
     }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,45 @@
             </div>
         </header>
 
+        {% if review_items %}
+        <section class="review-section">
+            <div class="review-header">
+                <h2>Повторить сегодня</h2>
+                <p>Подборка {{ review_items|length }} слов и выражений, которые стоит освежить.</p>
+            </div>
+            <div class="review-grid">
+                {% for item in review_items %}
+                <article class="review-card" data-word-id="{{ item.id }}">
+                    <div class="review-card-header">
+                        <div class="review-icon">{{ item.emoji }}</div>
+                        <div class="review-title">
+                            <span class="review-word">{{ item.word }}</span>
+                            {% if item.translation %}
+                            <span class="review-translation">{{ item.translation }}</span>
+                            {% endif %}
+                        </div>
+                    </div>
+                    {% if item.example %}
+                    <p class="review-example">«{{ item.example }}»</p>
+                    {% endif %}
+                    <div class="review-meta">
+                        {% if item.level %}
+                        <span class="review-tag">Уровень {{ item.level }}</span>
+                        {% endif %}
+                        {% if item.category %}
+                        <span class="review-tag">Тема: {{ item.category }}</span>
+                        {% endif %}
+                        {% if item.phonetic %}
+                        <span class="review-tag">{{ item.phonetic }}</span>
+                        {% endif %}
+                    </div>
+                    <a href="{{ item.practice_url }}" class="review-link" aria-label="Тренировка слова {{ item.word }}">Тренировка →</a>
+                </article>
+                {% endfor %}
+            </div>
+        </section>
+        {% endif %}
+
         <div class="characters-grid">
             {% for card in cards %}
             <div class="character-card" data-character="{{ card.id }}">


### PR DESCRIPTION
## Summary
- load a daily review list from `data/vocabulary/words.json` in the index generator
- render a "Повторить сегодня" block on the index page with links to practice items
- style the review section and cards with responsive tweaks for mobile devices

## Testing
- pytest *(fails: scripts/test_mobile_navigation.py expects Windows-only path `F:\\AiKlientBank\\KingLearComic`)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4f6f14508320bbf097bb9af982d2