### PR TITLE
Add vocabulary training generator and interactive pages

### DIFF
--- a/generators/__init__.py
+++ b/generators/__init__.py
@@ -1,5 +1,6 @@
 """Generators package"""
 from .html_lira import LiraHTMLGenerator
 from .index_gen import IndexGenerator
+from .training_gen import TrainingPageGenerator
 
-__all__ = ['LiraHTMLGenerator', 'IndexGenerator']
+__all__ = ['LiraHTMLGenerator', 'IndexGenerator', 'TrainingPageGenerator']

--- a/generators/index_gen.py
+++ b/generators/index_gen.py
@@ -7,7 +7,7 @@ from .base import BaseGenerator
 class IndexGenerator(BaseGenerator):
     """Generate index page with all character journeys"""
 
-    def generate(self, character_files):
+    def generate(self, character_files, review_items=None):
         """Generate index page with character grid"""
         role_descriptions = {
             "king_lear": "Трагический король",
@@ -50,7 +50,8 @@ class IndexGenerator(BaseGenerator):
                 }
             )
 
-        review_items = self._get_review_items()
+        if review_items is None:
+            review_items = self.get_review_items()
 
         return self.render_template(
             "index.html",
@@ -60,6 +61,10 @@ class IndexGenerator(BaseGenerator):
             vocabulary_total=vocabulary_total,
             review_items=review_items,
         )
+
+    def get_review_items(self, limit=6):
+        """Public helper to provide review items for other generators."""
+        return self._get_review_items(limit=limit)
 
     def _get_review_items(self, limit=6):
         """Return a curated list of vocabulary items for spaced repetition."""

--- a/generators/training_gen.py
+++ b/generators/training_gen.py
@@ -1,0 +1,194 @@
+"""Training page generator for vocabulary items."""
+
+import random
+import re
+from typing import Dict, List, Optional
+
+from .base import BaseGenerator
+
+
+class TrainingPageGenerator(BaseGenerator):
+    """Generate interactive training pages for vocabulary words."""
+
+    def __init__(self, config, vocabulary_data: Optional[Dict] = None):
+        super().__init__(config)
+        self._data = vocabulary_data or {}
+        self._words: List[Dict] = list(self._data.get("words", []))
+        self._categories: Dict[str, Dict] = self._data.get("categories", {})
+
+    def find_word(self, word_id: str) -> Optional[Dict]:
+        """Return a word entry by its identifier."""
+        for word in self._words:
+            if word.get("id") == word_id:
+                return word
+        return None
+
+    def generate_word_page(self, word: Dict) -> str:
+        """Render HTML page for a given vocabulary word."""
+        category_info = self._categories.get(word.get("category")) or {}
+        translations = self._normalize_translation(word)
+        quiz = self._build_quiz(word)
+        match_game = self._build_match_game(word, category_info)
+        typing_task = self._build_typing_task(word)
+        related_words = self._related_words(word)
+
+        return self.render_template(
+            "trainings/word.html",
+            word=word,
+            category=category_info,
+            translations=translations,
+            quiz=quiz,
+            match_game=match_game,
+            typing_task=typing_task,
+            related_words=related_words,
+            learning_stats=self._data.get("learning_stats"),
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers for exercises
+    # ------------------------------------------------------------------
+    def _build_quiz(self, word: Dict) -> Dict:
+        """Build a deterministic multiple-choice quiz for translation."""
+        correct = self._extract_translation(word)
+        word_label = word.get("word", "")
+        article = word.get("article")
+
+        if article:
+            prompt_word = f"{article} {word_label}".strip()
+        else:
+            prompt_word = word_label
+
+        question = f"Как перевести «{prompt_word}» на русский язык?"
+
+        # Gather alternative translations for distractors
+        alternatives = []
+        seen = {correct}
+        for other in self._words:
+            if other is word:
+                continue
+            translation = self._extract_translation(other)
+            if not translation or translation in seen:
+                continue
+            alternatives.append(translation)
+            seen.add(translation)
+
+        rng = random.Random(word.get("id") or prompt_word)
+        rng.shuffle(alternatives)
+        distractors = alternatives[:3]
+
+        options = [
+            {"label": correct, "is_correct": True}
+        ]
+        options.extend({"label": opt, "is_correct": False} for opt in distractors)
+        rng.shuffle(options)
+
+        return {"question": question, "options": options, "has_quiz": bool(correct)}
+
+    def _build_match_game(self, word: Dict, category_info: Dict) -> Dict:
+        """Build drag-and-drop pairs for grammatical information."""
+        targets = []
+
+        mapping = [
+            ("article", "Артикль", word.get("article")),
+            ("gender", "Род", word.get("gender")),
+            ("plural", "Множественное число", word.get("plural")),
+            ("level", "Уровень", word.get("level")),
+            (
+                "category",
+                "Тематика",
+                category_info.get("name") or word.get("category"),
+            ),
+            ("phonetic", "Произношение", word.get("phonetic")),
+        ]
+
+        for key, label, value in mapping:
+            if value:
+                targets.append({"key": key, "label": label, "value": value})
+
+        tokens = [
+            {"key": target["key"], "label": target["value"]}
+            for target in targets
+        ]
+
+        rng = random.Random((word.get("id") or word.get("word")) + "-match")
+        rng.shuffle(tokens)
+
+        return {"targets": targets, "tokens": tokens, "has_game": bool(targets)}
+
+    def _build_typing_task(self, word: Dict) -> Dict:
+        """Create a short typing exercise based on the example sentence."""
+        example = word.get("example") or {}
+        german_sentence = None
+        if isinstance(example, dict):
+            german_sentence = example.get("de")
+        elif isinstance(example, str):
+            german_sentence = example
+
+        base_word = word.get("word", "")
+        if german_sentence and base_word:
+            pattern = re.compile(re.escape(base_word), re.IGNORECASE)
+            if pattern.search(german_sentence):
+                prompt_sentence = pattern.sub("_____", german_sentence, count=1)
+            else:
+                prompt_sentence = german_sentence
+        else:
+            prompt_sentence = None
+
+        hint = None
+        if word.get("article"):
+            hint = f"Попробуй с артиклем: {word['article']} {base_word}".strip()
+
+        return {
+            "prompt": prompt_sentence,
+            "answer": base_word,
+            "hint": hint,
+        }
+
+    def _related_words(self, word: Dict, limit: int = 3) -> List[Dict]:
+        """Return related words from the same category."""
+        category = word.get("category")
+        if not category:
+            return []
+
+        related = [
+            other
+            for other in self._words
+            if other is not word and other.get("category") == category
+        ]
+        related.sort(key=lambda item: item.get("id") or item.get("word", ""))
+
+        result = []
+        for entry in related[:limit]:
+            translations = self._normalize_translation(entry)
+            result.append(
+                {
+                    "id": entry.get("id"),
+                    "article": entry.get("article"),
+                    "word": entry.get("word"),
+                    "translation_ru": translations.get("ru"),
+                    "translation_en": translations.get("en"),
+                }
+            )
+        return result
+
+    @staticmethod
+    def _extract_translation(word: Dict) -> Optional[str]:
+        """Extract Russian translation if available."""
+        translation = word.get("translation")
+        if isinstance(translation, dict):
+            return translation.get("ru") or translation.get("en")
+        return translation
+
+    @staticmethod
+    def _normalize_translation(word: Dict) -> Dict[str, Optional[str]]:
+        """Return RU and EN translations as a simple mapping."""
+        translation = word.get("translation")
+        if isinstance(translation, dict):
+            return {
+                "ru": translation.get("ru"),
+                "en": translation.get("en"),
+            }
+        return {"ru": translation, "en": None}
+
+
+__all__ = ["TrainingPageGenerator"]

--- a/output/static/css/training.css
+++ b/output/static/css/training.css
@@ -1,0 +1,436 @@
+:root {
+    --bg-color: #0f172a;
+    --card-bg: rgba(15, 23, 42, 0.7);
+    --accent: #38bdf8;
+    --accent-soft: rgba(56, 189, 248, 0.2);
+    --text-color: #e2e8f0;
+    --muted: #94a3b8;
+    --success: #34d399;
+    --error: #f87171;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: var(--text-color);
+    background: radial-gradient(circle at top left, #1d4ed8, #0f172a 55%);
+}
+
+.training-container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 4rem;
+}
+
+.training-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 0.8));
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 24px;
+    padding: 2rem;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 20px 50px rgba(15, 23, 42, 0.6);
+}
+
+.training-header::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.25), transparent 50%);
+    pointer-events: none;
+}
+
+.back-link {
+    align-self: flex-start;
+    color: var(--muted);
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.12);
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.back-link:hover {
+    background: rgba(148, 163, 184, 0.22);
+    color: #fff;
+    transform: translateY(-1px);
+}
+
+.word-title {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.word-emoji {
+    font-size: 2.75rem;
+    filter: drop-shadow(0 10px 20px rgba(15, 23, 42, 0.5));
+}
+
+.word-article {
+    margin: 0;
+    font-weight: 600;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.word-title h1 {
+    margin: 0.25rem 0;
+    font-size: 2.8rem;
+    line-height: 1.1;
+}
+
+.word-translation {
+    margin: 0;
+    color: #f8fafc;
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.word-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.18);
+    color: var(--text-color);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.tag-accent {
+    background: rgba(56, 189, 248, 0.15);
+    color: #bae6fd;
+}
+
+main {
+    margin-top: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.training-section {
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 24px;
+    padding: 2rem;
+    box-shadow: 0 14px 40px rgba(8, 47, 73, 0.35);
+}
+
+.training-section h2 {
+    margin-top: 0;
+    font-size: 1.75rem;
+}
+
+.section-header p {
+    margin-top: 0.25rem;
+    color: var(--muted);
+}
+
+.overview-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.info-card {
+    padding: 1.25rem;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.info-card h3 {
+    margin-top: 0;
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+}
+
+.info-card p {
+    margin: 0.5rem 0 0;
+    line-height: 1.5;
+}
+
+.example {
+    font-weight: 600;
+    color: #e0f2fe;
+}
+
+.example-translation {
+    color: var(--muted);
+    margin-top: 0.35rem;
+}
+
+.quiz {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.quiz-question {
+    font-size: 1.2rem;
+    margin: 0;
+}
+
+.quiz-options {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.quiz-option {
+    padding: 0.85rem 1rem;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(15, 23, 42, 0.6);
+    color: var(--text-color);
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border 0.2s ease, transform 0.2s ease, background 0.2s ease;
+}
+
+.quiz-option:hover,
+.quiz-option:focus {
+    border-color: rgba(56, 189, 248, 0.6);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.quiz-option[data-state="correct"] {
+    border-color: rgba(52, 211, 153, 0.8);
+    background: rgba(52, 211, 153, 0.15);
+}
+
+.quiz-option[data-state="incorrect"] {
+    border-color: rgba(248, 113, 113, 0.7);
+    background: rgba(248, 113, 113, 0.12);
+}
+
+.feedback {
+    min-height: 1.25rem;
+    font-weight: 600;
+}
+
+.feedback.success {
+    color: var(--success);
+}
+
+.feedback.error {
+    color: var(--error);
+}
+
+.match-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 240px);
+}
+
+.match-targets {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.match-target {
+    padding: 1rem;
+    border-radius: 16px;
+    border: 1px dashed rgba(148, 163, 184, 0.3);
+    background: rgba(15, 23, 42, 0.5);
+}
+
+.match-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+}
+
+.match-dropzone {
+    min-height: 2.5rem;
+    margin-top: 0.75rem;
+    border-radius: 12px;
+    background: rgba(15, 23, 42, 0.8);
+    border: 1px dashed rgba(148, 163, 184, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem;
+    transition: border 0.2s ease, background 0.2s ease;
+}
+
+.match-dropzone[data-filled="true"] {
+    border-style: solid;
+    border-color: rgba(56, 189, 248, 0.6);
+    background: rgba(56, 189, 248, 0.15);
+}
+
+.match-dropzone[data-active="true"] {
+    border-color: rgba(56, 189, 248, 0.9);
+    background: rgba(56, 189, 248, 0.18);
+}
+
+.match-tokens {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.match-token {
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    background: rgba(15, 23, 42, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    font-weight: 600;
+    cursor: grab;
+    transition: transform 0.2s ease, border 0.2s ease;
+}
+
+.match-token:active {
+    cursor: grabbing;
+    transform: scale(1.02);
+}
+
+.match-token[data-state="placed"] {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.typing-task {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.typing-prompt {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.typing-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: var(--muted);
+}
+
+.typing-input {
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(15, 23, 42, 0.7);
+    color: var(--text-color);
+    font-size: 1rem;
+}
+
+.typing-input:focus {
+    outline: none;
+    border-color: rgba(56, 189, 248, 0.6);
+}
+
+.typing-actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.typing-actions button {
+    padding: 0.65rem 1.25rem;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(56, 189, 248, 0.15);
+    color: #e0f2fe;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.typing-actions button:hover,
+.typing-actions button:focus {
+    outline: none;
+    transform: translateY(-1px);
+    background: rgba(56, 189, 248, 0.25);
+}
+
+.related-grid {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.related-card {
+    padding: 1.25rem;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.related-card h3 {
+    margin-top: 0;
+}
+
+.related-card p {
+    color: var(--muted);
+}
+
+.related-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.75rem;
+    color: var(--accent);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.related-link::after {
+    content: '↗';
+    transition: transform 0.2s ease;
+}
+
+.related-link:hover::after {
+    transform: translateX(3px);
+}
+
+@media (max-width: 720px) {
+    .training-container {
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    .word-title {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .word-title h1 {
+        font-size: 2.2rem;
+    }
+
+    .match-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/output/static/js/training.js
+++ b/output/static/js/training.js
@@ -1,0 +1,152 @@
+(function () {
+    "use strict";
+
+    document.addEventListener("DOMContentLoaded", () => {
+        initQuiz();
+        initMatchGame();
+        initTypingTask();
+    });
+
+    function initQuiz() {
+        const quiz = document.querySelector('[data-component="quiz"]');
+        if (!quiz) return;
+
+        const options = Array.from(quiz.querySelectorAll('.quiz-option'));
+        const feedback = quiz.querySelector('[data-role="quiz-feedback"]');
+        let solved = false;
+
+        options.forEach(option => {
+            option.addEventListener('click', () => {
+                if (solved) return;
+
+                const isCorrect = option.dataset.correct === 'true';
+                options.forEach(btn => btn.removeAttribute('data-state'));
+
+                if (isCorrect) {
+                    option.dataset.state = 'correct';
+                    setFeedback(feedback, 'Отлично! Это правильный перевод.', true);
+                    solved = true;
+                } else {
+                    option.dataset.state = 'incorrect';
+                    setFeedback(feedback, 'Попробуйте ещё раз. Подумайте о примере.', false);
+                }
+            });
+        });
+    }
+
+    function initMatchGame() {
+        const match = document.querySelector('[data-component="match"]');
+        if (!match) return;
+
+        const tokens = Array.from(match.querySelectorAll('.match-token'));
+        const dropzones = Array.from(match.querySelectorAll('.match-dropzone'));
+        const feedback = match.querySelector('[data-role="match-feedback"]');
+        let placedCount = 0;
+
+        tokens.forEach(token => {
+            token.addEventListener('dragstart', event => {
+                if (token.dataset.state === 'placed') {
+                    event.preventDefault();
+                    return;
+                }
+                event.dataTransfer.effectAllowed = 'move';
+                event.dataTransfer.setData('text/plain', token.dataset.key);
+                token.classList.add('dragging');
+            });
+
+            token.addEventListener('dragend', () => {
+                token.classList.remove('dragging');
+            });
+        });
+
+        dropzones.forEach(zone => {
+            zone.addEventListener('dragover', event => {
+                event.preventDefault();
+                zone.dataset.active = 'true';
+            });
+
+            zone.addEventListener('dragleave', () => {
+                zone.dataset.active = 'false';
+            });
+
+            zone.addEventListener('drop', event => {
+                event.preventDefault();
+                const key = event.dataTransfer.getData('text/plain');
+                zone.dataset.active = 'false';
+
+                const draggedToken = tokens.find(token => token.classList.contains('dragging'));
+                if (!draggedToken) return;
+
+                if (zone.dataset.key === key) {
+                    zone.textContent = draggedToken.textContent;
+                    zone.dataset.filled = 'true';
+                    draggedToken.dataset.state = 'placed';
+                    draggedToken.setAttribute('draggable', 'false');
+                    draggedToken.classList.remove('dragging');
+                    draggedToken.classList.add('matched');
+                    setFeedback(feedback, 'Есть совпадение! Так держать.', true);
+                    placedCount += 1;
+
+                    if (placedCount === dropzones.length) {
+                        setFeedback(feedback, 'Карточка собрана полностью! 🎉', true);
+                    }
+                } else {
+                    setFeedback(feedback, 'Это другое свойство. Попробуйте ещё.', false);
+                }
+            });
+        });
+    }
+
+    function initTypingTask() {
+        const typing = document.querySelector('[data-component="typing"]');
+        if (!typing) return;
+
+        const input = typing.querySelector('.typing-input');
+        const checkButton = typing.querySelector('.typing-check');
+        const hintButton = typing.querySelector('.typing-hint');
+        const feedback = typing.querySelector('[data-role="typing-feedback"]');
+        const correctAnswer = (typing.dataset.answer || '').trim();
+
+        if (!input || !checkButton) return;
+
+        const handleCheck = () => {
+            const userAnswer = (input.value || '').trim().toUpperCase();
+            if (!userAnswer) {
+                setFeedback(feedback, 'Введите слово, прежде чем проверять ответ.', false);
+                return;
+            }
+
+            if (userAnswer === correctAnswer) {
+                setFeedback(feedback, 'Правильно! Слово закреплено.', true);
+                input.setAttribute('disabled', 'disabled');
+                checkButton.setAttribute('disabled', 'disabled');
+            } else {
+                setFeedback(feedback, 'Пока нет. Обрати внимание на артикль и пример.', false);
+            }
+        };
+
+        checkButton.addEventListener('click', handleCheck);
+        input.addEventListener('keydown', event => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                handleCheck();
+            }
+        });
+
+        if (hintButton) {
+            hintButton.addEventListener('click', () => {
+                const hint = hintButton.dataset.hint;
+                if (hint) {
+                    setFeedback(feedback, hint, true);
+                }
+            });
+        }
+    }
+
+    function setFeedback(element, message, isSuccess) {
+        if (!element) return;
+        element.textContent = message;
+        element.classList.remove('success', 'error');
+        element.classList.add(isSuccess ? 'success' : 'error');
+    }
+})();

--- a/output/trainings/w001.html
+++ b/output/trainings/w001.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Тренировка: das Reich</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../static/css/training.css">
+</head>
+<body>
+    <div class="training-container" data-word-id="w001">
+        <header class="training-header">
+            <a class="back-link" href="../index.html">← На главную</a>
+            <div class="word-title">
+                <div class="word-emoji" aria-hidden="true">👑</div>
+                <div>
+                    <p class="word-article">das</p>
+                    <h1>Reich</h1>
+                    
+                    <p class="word-translation">Королевство/Империя</p>
+                    
+                </div>
+            </div>
+            <div class="word-tags">
+                <span class="tag">Уровень A2</span>
+                <span class="tag">Neutrum</span>
+                
+                <span class="tag tag-accent">👑 Royal Vocabulary</span>
+                
+                <span class="tag">[райх]</span>
+            </div>
+        </header>
+
+        <main>
+            <section class="training-section">
+                <h2>Быстрый обзор</h2>
+                <div class="overview-grid">
+                    <article class="info-card">
+                        <h3>Значение</h3>
+                        <p>
+                            
+                                <strong>RU:</strong> Королевство/Империя<br>
+                                <strong>EN:</strong> Kingdom/Empire
+                            
+                        </p>
+                    </article>
+                    <article class="info-card">
+                        <h3>Пример</h3>
+                        
+                        <p class="example">Wir teilen unser Reich unter den Töchtern auf.</p>
+                        <p class="example-translation">Мы делим наше королевство между дочерьми.</p>
+                        
+                    </article>
+                    
+                    <article class="info-card stats">
+                        <h3>Прогресс словаря</h3>
+                        <p>Всего слов: 10</p>
+                        <p>Изучено: 0 • В процессе: 0</p>
+                    </article>
+                    
+                </div>
+            </section>
+
+            
+            <section class="training-section" aria-labelledby="quiz-title">
+                <div class="section-header">
+                    <h2 id="quiz-title">Викторина</h2>
+                    <p>Выберите правильный ответ из предложенных вариантов.</p>
+                </div>
+                <div class="quiz" data-component="quiz">
+                    <p class="quiz-question">Как перевести «das Reich» на русский язык?</p>
+                    <div class="quiz-options">
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Власть</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Предательство</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Примирение</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="true">Королевство/Империя</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="quiz-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            
+            <section class="training-section" aria-labelledby="match-title">
+                <div class="section-header">
+                    <h2 id="match-title">Собери карточку</h2>
+                    <p>Перетащите характеристики в подходящие поля.</p>
+                </div>
+                <div class="match-game" data-component="match">
+                    <div class="match-grid">
+                        <ul class="match-targets">
+                            
+                            <li class="match-target">
+                                <span class="match-label">Артикль</span>
+                                <div class="match-dropzone" data-key="article" aria-label="Артикль"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Род</span>
+                                <div class="match-dropzone" data-key="gender" aria-label="Род"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Уровень</span>
+                                <div class="match-dropzone" data-key="level" aria-label="Уровень"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Тематика</span>
+                                <div class="match-dropzone" data-key="category" aria-label="Тематика"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Произношение</span>
+                                <div class="match-dropzone" data-key="phonetic" aria-label="Произношение"></div>
+                            </li>
+                            
+                        </ul>
+                        <div class="match-tokens" aria-label="Характеристики для перетаскивания">
+                            
+                            <div class="match-token" draggable="true" data-key="gender">Neutrum</div>
+                            
+                            <div class="match-token" draggable="true" data-key="level">A2</div>
+                            
+                            <div class="match-token" draggable="true" data-key="category">Royal Vocabulary</div>
+                            
+                            <div class="match-token" draggable="true" data-key="article">das</div>
+                            
+                            <div class="match-token" draggable="true" data-key="phonetic">[райх]</div>
+                            
+                        </div>
+                    </div>
+                    <div class="feedback" data-role="match-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            <section class="training-section" aria-labelledby="typing-title">
+                <div class="section-header">
+                    <h2 id="typing-title">Письменная практика</h2>
+                    <p>Восстановите слово по примеру предложения.</p>
+                </div>
+                <div class="typing-task" data-component="typing" data-answer="REICH">
+                    
+                    <p class="typing-prompt">Wir teilen unser _____ unter den Töchtern auf.</p>
+                    
+                    <label class="typing-label">
+                        Ваш ответ
+                        <input type="text" class="typing-input" placeholder="Введите слово">
+                    </label>
+                    <div class="typing-actions">
+                        <button type="button" class="typing-check">Проверить</button>
+                        
+                        <button type="button" class="typing-hint" data-hint="Попробуй с артиклем: das Reich">Подсказка</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="typing-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+
+            
+            <section class="training-section" aria-labelledby="related-title">
+                <h2 id="related-title">Соседние слова</h2>
+                <div class="related-grid">
+                    
+                    <article class="related-card">
+                        <h3>die Macht</h3>
+                        
+                        <p>Власть</p>
+                        
+                        <a href="w002.html" class="related-link">Тренироваться →</a>
+                    </article>
+                    
+                    <article class="related-card">
+                        <h3>die Krone</h3>
+                        
+                        <p>Корона</p>
+                        
+                        <a href="w008.html" class="related-link">Тренироваться →</a>
+                    </article>
+                    
+                </div>
+            </section>
+            
+        </main>
+    </div>
+    <script src="../static/js/training.js"></script>
+</body>
+</html>

--- a/output/trainings/w002.html
+++ b/output/trainings/w002.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Тренировка: die Macht</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../static/css/training.css">
+</head>
+<body>
+    <div class="training-container" data-word-id="w002">
+        <header class="training-header">
+            <a class="back-link" href="../index.html">← На главную</a>
+            <div class="word-title">
+                <div class="word-emoji" aria-hidden="true">⚡</div>
+                <div>
+                    <p class="word-article">die</p>
+                    <h1>Macht</h1>
+                    
+                    <p class="word-translation">Власть</p>
+                    
+                </div>
+            </div>
+            <div class="word-tags">
+                <span class="tag">Уровень A2</span>
+                <span class="tag">Femininum</span>
+                
+                <span class="tag tag-accent">👑 Royal Vocabulary</span>
+                
+                <span class="tag">[махт]</span>
+            </div>
+        </header>
+
+        <main>
+            <section class="training-section">
+                <h2>Быстрый обзор</h2>
+                <div class="overview-grid">
+                    <article class="info-card">
+                        <h3>Значение</h3>
+                        <p>
+                            
+                                <strong>RU:</strong> Власть<br>
+                                <strong>EN:</strong> Power
+                            
+                        </p>
+                    </article>
+                    <article class="info-card">
+                        <h3>Пример</h3>
+                        
+                        <p class="example">Die Macht des Königs ist groß.</p>
+                        <p class="example-translation">Власть короля велика.</p>
+                        
+                    </article>
+                    
+                    <article class="info-card stats">
+                        <h3>Прогресс словаря</h3>
+                        <p>Всего слов: 10</p>
+                        <p>Изучено: 0 • В процессе: 0</p>
+                    </article>
+                    
+                </div>
+            </section>
+
+            
+            <section class="training-section" aria-labelledby="quiz-title">
+                <div class="section-header">
+                    <h2 id="quiz-title">Викторина</h2>
+                    <p>Выберите правильный ответ из предложенных вариантов.</p>
+                </div>
+                <div class="quiz" data-component="quiz">
+                    <p class="quiz-question">Как перевести «die Macht» на русский язык?</p>
+                    <div class="quiz-options">
+                        
+                        <button class="quiz-option" type="button" data-correct="true">Власть</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Королевство/Империя</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Отчаяние</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Корона</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="quiz-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            
+            <section class="training-section" aria-labelledby="match-title">
+                <div class="section-header">
+                    <h2 id="match-title">Собери карточку</h2>
+                    <p>Перетащите характеристики в подходящие поля.</p>
+                </div>
+                <div class="match-game" data-component="match">
+                    <div class="match-grid">
+                        <ul class="match-targets">
+                            
+                            <li class="match-target">
+                                <span class="match-label">Артикль</span>
+                                <div class="match-dropzone" data-key="article" aria-label="Артикль"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Род</span>
+                                <div class="match-dropzone" data-key="gender" aria-label="Род"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Уровень</span>
+                                <div class="match-dropzone" data-key="level" aria-label="Уровень"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Тематика</span>
+                                <div class="match-dropzone" data-key="category" aria-label="Тематика"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Произношение</span>
+                                <div class="match-dropzone" data-key="phonetic" aria-label="Произношение"></div>
+                            </li>
+                            
+                        </ul>
+                        <div class="match-tokens" aria-label="Характеристики для перетаскивания">
+                            
+                            <div class="match-token" draggable="true" data-key="article">die</div>
+                            
+                            <div class="match-token" draggable="true" data-key="gender">Femininum</div>
+                            
+                            <div class="match-token" draggable="true" data-key="phonetic">[махт]</div>
+                            
+                            <div class="match-token" draggable="true" data-key="level">A2</div>
+                            
+                            <div class="match-token" draggable="true" data-key="category">Royal Vocabulary</div>
+                            
+                        </div>
+                    </div>
+                    <div class="feedback" data-role="match-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            <section class="training-section" aria-labelledby="typing-title">
+                <div class="section-header">
+                    <h2 id="typing-title">Письменная практика</h2>
+                    <p>Восстановите слово по примеру предложения.</p>
+                </div>
+                <div class="typing-task" data-component="typing" data-answer="MACHT">
+                    
+                    <p class="typing-prompt">Die _____ des Königs ist groß.</p>
+                    
+                    <label class="typing-label">
+                        Ваш ответ
+                        <input type="text" class="typing-input" placeholder="Введите слово">
+                    </label>
+                    <div class="typing-actions">
+                        <button type="button" class="typing-check">Проверить</button>
+                        
+                        <button type="button" class="typing-hint" data-hint="Попробуй с артиклем: die Macht">Подсказка</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="typing-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+
+            
+            <section class="training-section" aria-labelledby="related-title">
+                <h2 id="related-title">Соседние слова</h2>
+                <div class="related-grid">
+                    
+                    <article class="related-card">
+                        <h3>das Reich</h3>
+                        
+                        <p>Королевство/Империя</p>
+                        
+                        <a href="w001.html" class="related-link">Тренироваться →</a>
+                    </article>
+                    
+                    <article class="related-card">
+                        <h3>die Krone</h3>
+                        
+                        <p>Корона</p>
+                        
+                        <a href="w008.html" class="related-link">Тренироваться →</a>
+                    </article>
+                    
+                </div>
+            </section>
+            
+        </main>
+    </div>
+    <script src="../static/js/training.js"></script>
+</body>
+</html>

--- a/output/trainings/w003.html
+++ b/output/trainings/w003.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Тренировка: die Tochter</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../static/css/training.css">
+</head>
+<body>
+    <div class="training-container" data-word-id="w003">
+        <header class="training-header">
+            <a class="back-link" href="../index.html">← На главную</a>
+            <div class="word-title">
+                <div class="word-emoji" aria-hidden="true">👸</div>
+                <div>
+                    <p class="word-article">die</p>
+                    <h1>Tochter</h1>
+                    
+                    <p class="word-translation">Дочь</p>
+                    
+                </div>
+            </div>
+            <div class="word-tags">
+                <span class="tag">Уровень A1</span>
+                <span class="tag">Femininum</span>
+                
+                <span class="tag tag-accent">👨‍👩‍👧 Family Relations</span>
+                
+                <span class="tag">[ТОХ-тер]</span>
+            </div>
+        </header>
+
+        <main>
+            <section class="training-section">
+                <h2>Быстрый обзор</h2>
+                <div class="overview-grid">
+                    <article class="info-card">
+                        <h3>Значение</h3>
+                        <p>
+                            
+                                <strong>RU:</strong> Дочь<br>
+                                <strong>EN:</strong> Daughter
+                            
+                        </p>
+                    </article>
+                    <article class="info-card">
+                        <h3>Пример</h3>
+                        
+                        <p class="example">Meine drei Töchter sind sehr unterschiedlich.</p>
+                        <p class="example-translation">Мои три дочери очень разные.</p>
+                        
+                    </article>
+                    
+                    <article class="info-card stats">
+                        <h3>Прогресс словаря</h3>
+                        <p>Всего слов: 10</p>
+                        <p>Изучено: 0 • В процессе: 0</p>
+                    </article>
+                    
+                </div>
+            </section>
+
+            
+            <section class="training-section" aria-labelledby="quiz-title">
+                <div class="section-header">
+                    <h2 id="quiz-title">Викторина</h2>
+                    <p>Выберите правильный ответ из предложенных вариантов.</p>
+                </div>
+                <div class="quiz" data-component="quiz">
+                    <p class="quiz-question">Как перевести «die Tochter» на русский язык?</p>
+                    <div class="quiz-options">
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Примирение</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Предательство</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="true">Дочь</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Королевство/Империя</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="quiz-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            
+            <section class="training-section" aria-labelledby="match-title">
+                <div class="section-header">
+                    <h2 id="match-title">Собери карточку</h2>
+                    <p>Перетащите характеристики в подходящие поля.</p>
+                </div>
+                <div class="match-game" data-component="match">
+                    <div class="match-grid">
+                        <ul class="match-targets">
+                            
+                            <li class="match-target">
+                                <span class="match-label">Артикль</span>
+                                <div class="match-dropzone" data-key="article" aria-label="Артикль"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Род</span>
+                                <div class="match-dropzone" data-key="gender" aria-label="Род"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Множественное число</span>
+                                <div class="match-dropzone" data-key="plural" aria-label="Множественное число"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Уровень</span>
+                                <div class="match-dropzone" data-key="level" aria-label="Уровень"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Тематика</span>
+                                <div class="match-dropzone" data-key="category" aria-label="Тематика"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Произношение</span>
+                                <div class="match-dropzone" data-key="phonetic" aria-label="Произношение"></div>
+                            </li>
+                            
+                        </ul>
+                        <div class="match-tokens" aria-label="Характеристики для перетаскивания">
+                            
+                            <div class="match-token" draggable="true" data-key="level">A1</div>
+                            
+                            <div class="match-token" draggable="true" data-key="article">die</div>
+                            
+                            <div class="match-token" draggable="true" data-key="gender">Femininum</div>
+                            
+                            <div class="match-token" draggable="true" data-key="plural">Töchter</div>
+                            
+                            <div class="match-token" draggable="true" data-key="phonetic">[ТОХ-тер]</div>
+                            
+                            <div class="match-token" draggable="true" data-key="category">Family Relations</div>
+                            
+                        </div>
+                    </div>
+                    <div class="feedback" data-role="match-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            <section class="training-section" aria-labelledby="typing-title">
+                <div class="section-header">
+                    <h2 id="typing-title">Письменная практика</h2>
+                    <p>Восстановите слово по примеру предложения.</p>
+                </div>
+                <div class="typing-task" data-component="typing" data-answer="TOCHTER">
+                    
+                    <p class="typing-prompt">Meine drei Töchter sind sehr unterschiedlich.</p>
+                    
+                    <label class="typing-label">
+                        Ваш ответ
+                        <input type="text" class="typing-input" placeholder="Введите слово">
+                    </label>
+                    <div class="typing-actions">
+                        <button type="button" class="typing-check">Проверить</button>
+                        
+                        <button type="button" class="typing-hint" data-hint="Попробуй с артиклем: die Tochter">Подсказка</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="typing-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+
+            
+        </main>
+    </div>
+    <script src="../static/js/training.js"></script>
+</body>
+</html>

--- a/output/trainings/w005.html
+++ b/output/trainings/w005.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Тренировка: der Sturm</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../static/css/training.css">
+</head>
+<body>
+    <div class="training-container" data-word-id="w005">
+        <header class="training-header">
+            <a class="back-link" href="../index.html">← На главную</a>
+            <div class="word-title">
+                <div class="word-emoji" aria-hidden="true">⛈️</div>
+                <div>
+                    <p class="word-article">der</p>
+                    <h1>Sturm</h1>
+                    
+                    <p class="word-translation">Буря</p>
+                    
+                </div>
+            </div>
+            <div class="word-tags">
+                <span class="tag">Уровень A2</span>
+                <span class="tag">Maskulinum</span>
+                
+                <span class="tag tag-accent">⚡ Nature &amp; Weather</span>
+                
+                <span class="tag">[штурм]</span>
+            </div>
+        </header>
+
+        <main>
+            <section class="training-section">
+                <h2>Быстрый обзор</h2>
+                <div class="overview-grid">
+                    <article class="info-card">
+                        <h3>Значение</h3>
+                        <p>
+                            
+                                <strong>RU:</strong> Буря<br>
+                                <strong>EN:</strong> Storm
+                            
+                        </p>
+                    </article>
+                    <article class="info-card">
+                        <h3>Пример</h3>
+                        
+                        <p class="example">Der König tobt im Sturm.</p>
+                        <p class="example-translation">Король бушует в буре.</p>
+                        
+                    </article>
+                    
+                    <article class="info-card stats">
+                        <h3>Прогресс словаря</h3>
+                        <p>Всего слов: 10</p>
+                        <p>Изучено: 0 • В процессе: 0</p>
+                    </article>
+                    
+                </div>
+            </section>
+
+            
+            <section class="training-section" aria-labelledby="quiz-title">
+                <div class="section-header">
+                    <h2 id="quiz-title">Викторина</h2>
+                    <p>Выберите правильный ответ из предложенных вариантов.</p>
+                </div>
+                <div class="quiz" data-component="quiz">
+                    <p class="quiz-question">Как перевести «der Sturm» на русский язык?</p>
+                    <div class="quiz-options">
+                        
+                        <button class="quiz-option" type="button" data-correct="true">Буря</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Замок</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Власть</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Королевство/Империя</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="quiz-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            
+            <section class="training-section" aria-labelledby="match-title">
+                <div class="section-header">
+                    <h2 id="match-title">Собери карточку</h2>
+                    <p>Перетащите характеристики в подходящие поля.</p>
+                </div>
+                <div class="match-game" data-component="match">
+                    <div class="match-grid">
+                        <ul class="match-targets">
+                            
+                            <li class="match-target">
+                                <span class="match-label">Артикль</span>
+                                <div class="match-dropzone" data-key="article" aria-label="Артикль"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Род</span>
+                                <div class="match-dropzone" data-key="gender" aria-label="Род"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Уровень</span>
+                                <div class="match-dropzone" data-key="level" aria-label="Уровень"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Тематика</span>
+                                <div class="match-dropzone" data-key="category" aria-label="Тематика"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Произношение</span>
+                                <div class="match-dropzone" data-key="phonetic" aria-label="Произношение"></div>
+                            </li>
+                            
+                        </ul>
+                        <div class="match-tokens" aria-label="Характеристики для перетаскивания">
+                            
+                            <div class="match-token" draggable="true" data-key="gender">Maskulinum</div>
+                            
+                            <div class="match-token" draggable="true" data-key="article">der</div>
+                            
+                            <div class="match-token" draggable="true" data-key="phonetic">[штурм]</div>
+                            
+                            <div class="match-token" draggable="true" data-key="level">A2</div>
+                            
+                            <div class="match-token" draggable="true" data-key="category">Nature &amp; Weather</div>
+                            
+                        </div>
+                    </div>
+                    <div class="feedback" data-role="match-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            <section class="training-section" aria-labelledby="typing-title">
+                <div class="section-header">
+                    <h2 id="typing-title">Письменная практика</h2>
+                    <p>Восстановите слово по примеру предложения.</p>
+                </div>
+                <div class="typing-task" data-component="typing" data-answer="STURM">
+                    
+                    <p class="typing-prompt">Der König tobt im _____.</p>
+                    
+                    <label class="typing-label">
+                        Ваш ответ
+                        <input type="text" class="typing-input" placeholder="Введите слово">
+                    </label>
+                    <div class="typing-actions">
+                        <button type="button" class="typing-check">Проверить</button>
+                        
+                        <button type="button" class="typing-hint" data-hint="Попробуй с артиклем: der Sturm">Подсказка</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="typing-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+
+            
+        </main>
+    </div>
+    <script src="../static/js/training.js"></script>
+</body>
+</html>

--- a/output/trainings/w008.html
+++ b/output/trainings/w008.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Тренировка: die Krone</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../static/css/training.css">
+</head>
+<body>
+    <div class="training-container" data-word-id="w008">
+        <header class="training-header">
+            <a class="back-link" href="../index.html">← На главную</a>
+            <div class="word-title">
+                <div class="word-emoji" aria-hidden="true">👑</div>
+                <div>
+                    <p class="word-article">die</p>
+                    <h1>Krone</h1>
+                    
+                    <p class="word-translation">Корона</p>
+                    
+                </div>
+            </div>
+            <div class="word-tags">
+                <span class="tag">Уровень A2</span>
+                <span class="tag">Femininum</span>
+                
+                <span class="tag tag-accent">👑 Royal Vocabulary</span>
+                
+                <span class="tag">[КРО-не]</span>
+            </div>
+        </header>
+
+        <main>
+            <section class="training-section">
+                <h2>Быстрый обзор</h2>
+                <div class="overview-grid">
+                    <article class="info-card">
+                        <h3>Значение</h3>
+                        <p>
+                            
+                                <strong>RU:</strong> Корона<br>
+                                <strong>EN:</strong> Crown
+                            
+                        </p>
+                    </article>
+                    <article class="info-card">
+                        <h3>Пример</h3>
+                        
+                        <p class="example">Die schwere Krone drückt auf sein Haupt.</p>
+                        <p class="example-translation">Тяжелая корона давит на его голову.</p>
+                        
+                    </article>
+                    
+                    <article class="info-card stats">
+                        <h3>Прогресс словаря</h3>
+                        <p>Всего слов: 10</p>
+                        <p>Изучено: 0 • В процессе: 0</p>
+                    </article>
+                    
+                </div>
+            </section>
+
+            
+            <section class="training-section" aria-labelledby="quiz-title">
+                <div class="section-header">
+                    <h2 id="quiz-title">Викторина</h2>
+                    <p>Выберите правильный ответ из предложенных вариантов.</p>
+                </div>
+                <div class="quiz" data-component="quiz">
+                    <p class="quiz-question">Как перевести «die Krone» на русский язык?</p>
+                    <div class="quiz-options">
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Безумие</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="true">Корона</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Буря</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Замок</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="quiz-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            
+            <section class="training-section" aria-labelledby="match-title">
+                <div class="section-header">
+                    <h2 id="match-title">Собери карточку</h2>
+                    <p>Перетащите характеристики в подходящие поля.</p>
+                </div>
+                <div class="match-game" data-component="match">
+                    <div class="match-grid">
+                        <ul class="match-targets">
+                            
+                            <li class="match-target">
+                                <span class="match-label">Артикль</span>
+                                <div class="match-dropzone" data-key="article" aria-label="Артикль"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Род</span>
+                                <div class="match-dropzone" data-key="gender" aria-label="Род"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Уровень</span>
+                                <div class="match-dropzone" data-key="level" aria-label="Уровень"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Тематика</span>
+                                <div class="match-dropzone" data-key="category" aria-label="Тематика"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Произношение</span>
+                                <div class="match-dropzone" data-key="phonetic" aria-label="Произношение"></div>
+                            </li>
+                            
+                        </ul>
+                        <div class="match-tokens" aria-label="Характеристики для перетаскивания">
+                            
+                            <div class="match-token" draggable="true" data-key="phonetic">[КРО-не]</div>
+                            
+                            <div class="match-token" draggable="true" data-key="gender">Femininum</div>
+                            
+                            <div class="match-token" draggable="true" data-key="article">die</div>
+                            
+                            <div class="match-token" draggable="true" data-key="level">A2</div>
+                            
+                            <div class="match-token" draggable="true" data-key="category">Royal Vocabulary</div>
+                            
+                        </div>
+                    </div>
+                    <div class="feedback" data-role="match-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            <section class="training-section" aria-labelledby="typing-title">
+                <div class="section-header">
+                    <h2 id="typing-title">Письменная практика</h2>
+                    <p>Восстановите слово по примеру предложения.</p>
+                </div>
+                <div class="typing-task" data-component="typing" data-answer="KRONE">
+                    
+                    <p class="typing-prompt">Die schwere _____ drückt auf sein Haupt.</p>
+                    
+                    <label class="typing-label">
+                        Ваш ответ
+                        <input type="text" class="typing-input" placeholder="Введите слово">
+                    </label>
+                    <div class="typing-actions">
+                        <button type="button" class="typing-check">Проверить</button>
+                        
+                        <button type="button" class="typing-hint" data-hint="Попробуй с артиклем: die Krone">Подсказка</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="typing-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+
+            
+            <section class="training-section" aria-labelledby="related-title">
+                <h2 id="related-title">Соседние слова</h2>
+                <div class="related-grid">
+                    
+                    <article class="related-card">
+                        <h3>das Reich</h3>
+                        
+                        <p>Королевство/Империя</p>
+                        
+                        <a href="w001.html" class="related-link">Тренироваться →</a>
+                    </article>
+                    
+                    <article class="related-card">
+                        <h3>die Macht</h3>
+                        
+                        <p>Власть</p>
+                        
+                        <a href="w002.html" class="related-link">Тренироваться →</a>
+                    </article>
+                    
+                </div>
+            </section>
+            
+        </main>
+    </div>
+    <script src="../static/js/training.js"></script>
+</body>
+</html>

--- a/output/trainings/w009.html
+++ b/output/trainings/w009.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Тренировка: das Schloss</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../static/css/training.css">
+</head>
+<body>
+    <div class="training-container" data-word-id="w009">
+        <header class="training-header">
+            <a class="back-link" href="../index.html">← На главную</a>
+            <div class="word-title">
+                <div class="word-emoji" aria-hidden="true">🏰</div>
+                <div>
+                    <p class="word-article">das</p>
+                    <h1>Schloss</h1>
+                    
+                    <p class="word-translation">Замок</p>
+                    
+                </div>
+            </div>
+            <div class="word-tags">
+                <span class="tag">Уровень A2</span>
+                <span class="tag">Neutrum</span>
+                
+                <span class="tag tag-accent">🏰 Places &amp; Locations</span>
+                
+                <span class="tag">[шлос]</span>
+            </div>
+        </header>
+
+        <main>
+            <section class="training-section">
+                <h2>Быстрый обзор</h2>
+                <div class="overview-grid">
+                    <article class="info-card">
+                        <h3>Значение</h3>
+                        <p>
+                            
+                                <strong>RU:</strong> Замок<br>
+                                <strong>EN:</strong> Castle
+                            
+                        </p>
+                    </article>
+                    <article class="info-card">
+                        <h3>Пример</h3>
+                        
+                        <p class="example">Im Schloss herrscht große Unruhe.</p>
+                        <p class="example-translation">В замке царит большое волнение.</p>
+                        
+                    </article>
+                    
+                    <article class="info-card stats">
+                        <h3>Прогресс словаря</h3>
+                        <p>Всего слов: 10</p>
+                        <p>Изучено: 0 • В процессе: 0</p>
+                    </article>
+                    
+                </div>
+            </section>
+
+            
+            <section class="training-section" aria-labelledby="quiz-title">
+                <div class="section-header">
+                    <h2 id="quiz-title">Викторина</h2>
+                    <p>Выберите правильный ответ из предложенных вариантов.</p>
+                </div>
+                <div class="quiz" data-component="quiz">
+                    <p class="quiz-question">Как перевести «das Schloss» на русский язык?</p>
+                    <div class="quiz-options">
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Корона</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Примирение</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="false">Королевство/Империя</button>
+                        
+                        <button class="quiz-option" type="button" data-correct="true">Замок</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="quiz-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            
+            <section class="training-section" aria-labelledby="match-title">
+                <div class="section-header">
+                    <h2 id="match-title">Собери карточку</h2>
+                    <p>Перетащите характеристики в подходящие поля.</p>
+                </div>
+                <div class="match-game" data-component="match">
+                    <div class="match-grid">
+                        <ul class="match-targets">
+                            
+                            <li class="match-target">
+                                <span class="match-label">Артикль</span>
+                                <div class="match-dropzone" data-key="article" aria-label="Артикль"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Род</span>
+                                <div class="match-dropzone" data-key="gender" aria-label="Род"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Множественное число</span>
+                                <div class="match-dropzone" data-key="plural" aria-label="Множественное число"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Уровень</span>
+                                <div class="match-dropzone" data-key="level" aria-label="Уровень"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Тематика</span>
+                                <div class="match-dropzone" data-key="category" aria-label="Тематика"></div>
+                            </li>
+                            
+                            <li class="match-target">
+                                <span class="match-label">Произношение</span>
+                                <div class="match-dropzone" data-key="phonetic" aria-label="Произношение"></div>
+                            </li>
+                            
+                        </ul>
+                        <div class="match-tokens" aria-label="Характеристики для перетаскивания">
+                            
+                            <div class="match-token" draggable="true" data-key="gender">Neutrum</div>
+                            
+                            <div class="match-token" draggable="true" data-key="category">Places &amp; Locations</div>
+                            
+                            <div class="match-token" draggable="true" data-key="phonetic">[шлос]</div>
+                            
+                            <div class="match-token" draggable="true" data-key="plural">Schlösser</div>
+                            
+                            <div class="match-token" draggable="true" data-key="article">das</div>
+                            
+                            <div class="match-token" draggable="true" data-key="level">A2</div>
+                            
+                        </div>
+                    </div>
+                    <div class="feedback" data-role="match-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            
+
+            <section class="training-section" aria-labelledby="typing-title">
+                <div class="section-header">
+                    <h2 id="typing-title">Письменная практика</h2>
+                    <p>Восстановите слово по примеру предложения.</p>
+                </div>
+                <div class="typing-task" data-component="typing" data-answer="SCHLOSS">
+                    
+                    <p class="typing-prompt">Im _____ herrscht große Unruhe.</p>
+                    
+                    <label class="typing-label">
+                        Ваш ответ
+                        <input type="text" class="typing-input" placeholder="Введите слово">
+                    </label>
+                    <div class="typing-actions">
+                        <button type="button" class="typing-check">Проверить</button>
+                        
+                        <button type="button" class="typing-hint" data-hint="Попробуй с артиклем: das Schloss">Подсказка</button>
+                        
+                    </div>
+                    <div class="feedback" data-role="typing-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+
+            
+        </main>
+    </div>
+    <script src="../static/js/training.js"></script>
+</body>
+</html>

--- a/static/css/training.css
+++ b/static/css/training.css
@@ -1,0 +1,436 @@
+:root {
+    --bg-color: #0f172a;
+    --card-bg: rgba(15, 23, 42, 0.7);
+    --accent: #38bdf8;
+    --accent-soft: rgba(56, 189, 248, 0.2);
+    --text-color: #e2e8f0;
+    --muted: #94a3b8;
+    --success: #34d399;
+    --error: #f87171;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: var(--text-color);
+    background: radial-gradient(circle at top left, #1d4ed8, #0f172a 55%);
+}
+
+.training-container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 4rem;
+}
+
+.training-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 0.8));
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 24px;
+    padding: 2rem;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 20px 50px rgba(15, 23, 42, 0.6);
+}
+
+.training-header::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.25), transparent 50%);
+    pointer-events: none;
+}
+
+.back-link {
+    align-self: flex-start;
+    color: var(--muted);
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.12);
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.back-link:hover {
+    background: rgba(148, 163, 184, 0.22);
+    color: #fff;
+    transform: translateY(-1px);
+}
+
+.word-title {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.word-emoji {
+    font-size: 2.75rem;
+    filter: drop-shadow(0 10px 20px rgba(15, 23, 42, 0.5));
+}
+
+.word-article {
+    margin: 0;
+    font-weight: 600;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.word-title h1 {
+    margin: 0.25rem 0;
+    font-size: 2.8rem;
+    line-height: 1.1;
+}
+
+.word-translation {
+    margin: 0;
+    color: #f8fafc;
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.word-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.18);
+    color: var(--text-color);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.tag-accent {
+    background: rgba(56, 189, 248, 0.15);
+    color: #bae6fd;
+}
+
+main {
+    margin-top: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.training-section {
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 24px;
+    padding: 2rem;
+    box-shadow: 0 14px 40px rgba(8, 47, 73, 0.35);
+}
+
+.training-section h2 {
+    margin-top: 0;
+    font-size: 1.75rem;
+}
+
+.section-header p {
+    margin-top: 0.25rem;
+    color: var(--muted);
+}
+
+.overview-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.info-card {
+    padding: 1.25rem;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.info-card h3 {
+    margin-top: 0;
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+}
+
+.info-card p {
+    margin: 0.5rem 0 0;
+    line-height: 1.5;
+}
+
+.example {
+    font-weight: 600;
+    color: #e0f2fe;
+}
+
+.example-translation {
+    color: var(--muted);
+    margin-top: 0.35rem;
+}
+
+.quiz {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.quiz-question {
+    font-size: 1.2rem;
+    margin: 0;
+}
+
+.quiz-options {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.quiz-option {
+    padding: 0.85rem 1rem;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(15, 23, 42, 0.6);
+    color: var(--text-color);
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border 0.2s ease, transform 0.2s ease, background 0.2s ease;
+}
+
+.quiz-option:hover,
+.quiz-option:focus {
+    border-color: rgba(56, 189, 248, 0.6);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.quiz-option[data-state="correct"] {
+    border-color: rgba(52, 211, 153, 0.8);
+    background: rgba(52, 211, 153, 0.15);
+}
+
+.quiz-option[data-state="incorrect"] {
+    border-color: rgba(248, 113, 113, 0.7);
+    background: rgba(248, 113, 113, 0.12);
+}
+
+.feedback {
+    min-height: 1.25rem;
+    font-weight: 600;
+}
+
+.feedback.success {
+    color: var(--success);
+}
+
+.feedback.error {
+    color: var(--error);
+}
+
+.match-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 240px);
+}
+
+.match-targets {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.match-target {
+    padding: 1rem;
+    border-radius: 16px;
+    border: 1px dashed rgba(148, 163, 184, 0.3);
+    background: rgba(15, 23, 42, 0.5);
+}
+
+.match-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+}
+
+.match-dropzone {
+    min-height: 2.5rem;
+    margin-top: 0.75rem;
+    border-radius: 12px;
+    background: rgba(15, 23, 42, 0.8);
+    border: 1px dashed rgba(148, 163, 184, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem;
+    transition: border 0.2s ease, background 0.2s ease;
+}
+
+.match-dropzone[data-filled="true"] {
+    border-style: solid;
+    border-color: rgba(56, 189, 248, 0.6);
+    background: rgba(56, 189, 248, 0.15);
+}
+
+.match-dropzone[data-active="true"] {
+    border-color: rgba(56, 189, 248, 0.9);
+    background: rgba(56, 189, 248, 0.18);
+}
+
+.match-tokens {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.match-token {
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    background: rgba(15, 23, 42, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    font-weight: 600;
+    cursor: grab;
+    transition: transform 0.2s ease, border 0.2s ease;
+}
+
+.match-token:active {
+    cursor: grabbing;
+    transform: scale(1.02);
+}
+
+.match-token[data-state="placed"] {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.typing-task {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.typing-prompt {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.typing-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: var(--muted);
+}
+
+.typing-input {
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(15, 23, 42, 0.7);
+    color: var(--text-color);
+    font-size: 1rem;
+}
+
+.typing-input:focus {
+    outline: none;
+    border-color: rgba(56, 189, 248, 0.6);
+}
+
+.typing-actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.typing-actions button {
+    padding: 0.65rem 1.25rem;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(56, 189, 248, 0.15);
+    color: #e0f2fe;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.typing-actions button:hover,
+.typing-actions button:focus {
+    outline: none;
+    transform: translateY(-1px);
+    background: rgba(56, 189, 248, 0.25);
+}
+
+.related-grid {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.related-card {
+    padding: 1.25rem;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.related-card h3 {
+    margin-top: 0;
+}
+
+.related-card p {
+    color: var(--muted);
+}
+
+.related-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.75rem;
+    color: var(--accent);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.related-link::after {
+    content: '↗';
+    transition: transform 0.2s ease;
+}
+
+.related-link:hover::after {
+    transform: translateX(3px);
+}
+
+@media (max-width: 720px) {
+    .training-container {
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    .word-title {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .word-title h1 {
+        font-size: 2.2rem;
+    }
+
+    .match-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/static/js/training.js
+++ b/static/js/training.js
@@ -1,0 +1,152 @@
+(function () {
+    "use strict";
+
+    document.addEventListener("DOMContentLoaded", () => {
+        initQuiz();
+        initMatchGame();
+        initTypingTask();
+    });
+
+    function initQuiz() {
+        const quiz = document.querySelector('[data-component="quiz"]');
+        if (!quiz) return;
+
+        const options = Array.from(quiz.querySelectorAll('.quiz-option'));
+        const feedback = quiz.querySelector('[data-role="quiz-feedback"]');
+        let solved = false;
+
+        options.forEach(option => {
+            option.addEventListener('click', () => {
+                if (solved) return;
+
+                const isCorrect = option.dataset.correct === 'true';
+                options.forEach(btn => btn.removeAttribute('data-state'));
+
+                if (isCorrect) {
+                    option.dataset.state = 'correct';
+                    setFeedback(feedback, 'Отлично! Это правильный перевод.', true);
+                    solved = true;
+                } else {
+                    option.dataset.state = 'incorrect';
+                    setFeedback(feedback, 'Попробуйте ещё раз. Подумайте о примере.', false);
+                }
+            });
+        });
+    }
+
+    function initMatchGame() {
+        const match = document.querySelector('[data-component="match"]');
+        if (!match) return;
+
+        const tokens = Array.from(match.querySelectorAll('.match-token'));
+        const dropzones = Array.from(match.querySelectorAll('.match-dropzone'));
+        const feedback = match.querySelector('[data-role="match-feedback"]');
+        let placedCount = 0;
+
+        tokens.forEach(token => {
+            token.addEventListener('dragstart', event => {
+                if (token.dataset.state === 'placed') {
+                    event.preventDefault();
+                    return;
+                }
+                event.dataTransfer.effectAllowed = 'move';
+                event.dataTransfer.setData('text/plain', token.dataset.key);
+                token.classList.add('dragging');
+            });
+
+            token.addEventListener('dragend', () => {
+                token.classList.remove('dragging');
+            });
+        });
+
+        dropzones.forEach(zone => {
+            zone.addEventListener('dragover', event => {
+                event.preventDefault();
+                zone.dataset.active = 'true';
+            });
+
+            zone.addEventListener('dragleave', () => {
+                zone.dataset.active = 'false';
+            });
+
+            zone.addEventListener('drop', event => {
+                event.preventDefault();
+                const key = event.dataTransfer.getData('text/plain');
+                zone.dataset.active = 'false';
+
+                const draggedToken = tokens.find(token => token.classList.contains('dragging'));
+                if (!draggedToken) return;
+
+                if (zone.dataset.key === key) {
+                    zone.textContent = draggedToken.textContent;
+                    zone.dataset.filled = 'true';
+                    draggedToken.dataset.state = 'placed';
+                    draggedToken.setAttribute('draggable', 'false');
+                    draggedToken.classList.remove('dragging');
+                    draggedToken.classList.add('matched');
+                    setFeedback(feedback, 'Есть совпадение! Так держать.', true);
+                    placedCount += 1;
+
+                    if (placedCount === dropzones.length) {
+                        setFeedback(feedback, 'Карточка собрана полностью! 🎉', true);
+                    }
+                } else {
+                    setFeedback(feedback, 'Это другое свойство. Попробуйте ещё.', false);
+                }
+            });
+        });
+    }
+
+    function initTypingTask() {
+        const typing = document.querySelector('[data-component="typing"]');
+        if (!typing) return;
+
+        const input = typing.querySelector('.typing-input');
+        const checkButton = typing.querySelector('.typing-check');
+        const hintButton = typing.querySelector('.typing-hint');
+        const feedback = typing.querySelector('[data-role="typing-feedback"]');
+        const correctAnswer = (typing.dataset.answer || '').trim();
+
+        if (!input || !checkButton) return;
+
+        const handleCheck = () => {
+            const userAnswer = (input.value || '').trim().toUpperCase();
+            if (!userAnswer) {
+                setFeedback(feedback, 'Введите слово, прежде чем проверять ответ.', false);
+                return;
+            }
+
+            if (userAnswer === correctAnswer) {
+                setFeedback(feedback, 'Правильно! Слово закреплено.', true);
+                input.setAttribute('disabled', 'disabled');
+                checkButton.setAttribute('disabled', 'disabled');
+            } else {
+                setFeedback(feedback, 'Пока нет. Обрати внимание на артикль и пример.', false);
+            }
+        };
+
+        checkButton.addEventListener('click', handleCheck);
+        input.addEventListener('keydown', event => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                handleCheck();
+            }
+        });
+
+        if (hintButton) {
+            hintButton.addEventListener('click', () => {
+                const hint = hintButton.dataset.hint;
+                if (hint) {
+                    setFeedback(feedback, hint, true);
+                }
+            });
+        }
+    }
+
+    function setFeedback(element, message, isSuccess) {
+        if (!element) return;
+        element.textContent = message;
+        element.classList.remove('success', 'error');
+        element.classList.add(isSuccess ? 'success' : 'error');
+    }
+})();

--- a/templates/trainings/word.html
+++ b/templates/trainings/word.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Тренировка: {{ word.article }} {{ word.word }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../static/css/training.css">
+</head>
+<body>
+    <div class="training-container" data-word-id="{{ word.id }}">
+        <header class="training-header">
+            <a class="back-link" href="../index.html">← На главную</a>
+            <div class="word-title">
+                <div class="word-emoji" aria-hidden="true">{{ word.emoji or "📘" }}</div>
+                <div>
+                    <p class="word-article">{{ word.article }}</p>
+                    <h1>{{ word.word }}</h1>
+                    {% if translations.ru or translations.en %}
+                    <p class="word-translation">{{ translations.ru or translations.en }}</p>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="word-tags">
+                {% if word.level %}<span class="tag">Уровень {{ word.level }}</span>{% endif %}
+                {% if word.gender %}<span class="tag">{{ word.gender }}</span>{% endif %}
+                {% if category.name %}
+                <span class="tag tag-accent">{{ category.emoji }} {{ category.name }}</span>
+                {% elif word.category %}
+                <span class="tag">Тема: {{ word.category }}</span>
+                {% endif %}
+                {% if word.phonetic %}<span class="tag">{{ word.phonetic }}</span>{% endif %}
+            </div>
+        </header>
+
+        <main>
+            <section class="training-section">
+                <h2>Быстрый обзор</h2>
+                <div class="overview-grid">
+                    <article class="info-card">
+                        <h3>Значение</h3>
+                        <p>
+                            {% if translations.ru or translations.en %}
+                                {% if translations.ru %}<strong>RU:</strong> {{ translations.ru }}<br>{% endif %}
+                                {% if translations.en %}<strong>EN:</strong> {{ translations.en }}{% endif %}
+                            {% else %}
+                                Перевод пока не указан.
+                            {% endif %}
+                        </p>
+                    </article>
+                    <article class="info-card">
+                        <h3>Пример</h3>
+                        {% if word.example %}
+                        <p class="example">{{ word.example.de or word.example }}</p>
+                        <p class="example-translation">{{ word.example.ru or word.example.en }}</p>
+                        {% else %}
+                        <p>Добавьте свой пример использования слова.</p>
+                        {% endif %}
+                    </article>
+                    {% if learning_stats %}
+                    <article class="info-card stats">
+                        <h3>Прогресс словаря</h3>
+                        <p>Всего слов: {{ learning_stats.total_words }}</p>
+                        <p>Изучено: {{ learning_stats.learned }} • В процессе: {{ learning_stats.in_progress }}</p>
+                    </article>
+                    {% endif %}
+                </div>
+            </section>
+
+            {% if quiz.has_quiz %}
+            <section class="training-section" aria-labelledby="quiz-title">
+                <div class="section-header">
+                    <h2 id="quiz-title">Викторина</h2>
+                    <p>Выберите правильный ответ из предложенных вариантов.</p>
+                </div>
+                <div class="quiz" data-component="quiz">
+                    <p class="quiz-question">{{ quiz.question }}</p>
+                    <div class="quiz-options">
+                        {% for option in quiz.options %}
+                        <button class="quiz-option" type="button" data-correct="{{ 'true' if option.is_correct else 'false' }}">{{ option.label }}</button>
+                        {% endfor %}
+                    </div>
+                    <div class="feedback" data-role="quiz-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            {% endif %}
+
+            {% if match_game.has_game %}
+            <section class="training-section" aria-labelledby="match-title">
+                <div class="section-header">
+                    <h2 id="match-title">Собери карточку</h2>
+                    <p>Перетащите характеристики в подходящие поля.</p>
+                </div>
+                <div class="match-game" data-component="match">
+                    <div class="match-grid">
+                        <ul class="match-targets">
+                            {% for target in match_game.targets %}
+                            <li class="match-target">
+                                <span class="match-label">{{ target.label }}</span>
+                                <div class="match-dropzone" data-key="{{ target.key }}" aria-label="{{ target.label }}"></div>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                        <div class="match-tokens" aria-label="Характеристики для перетаскивания">
+                            {% for token in match_game.tokens %}
+                            <div class="match-token" draggable="true" data-key="{{ token.key }}">{{ token.label }}</div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="feedback" data-role="match-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+            {% endif %}
+
+            <section class="training-section" aria-labelledby="typing-title">
+                <div class="section-header">
+                    <h2 id="typing-title">Письменная практика</h2>
+                    <p>Восстановите слово по примеру предложения.</p>
+                </div>
+                <div class="typing-task" data-component="typing" data-answer="{{ typing_task.answer | upper }}">
+                    {% if typing_task.prompt %}
+                    <p class="typing-prompt">{{ typing_task.prompt }}</p>
+                    {% else %}
+                    <p class="typing-prompt">Напишите слово: {{ word.word }}</p>
+                    {% endif %}
+                    <label class="typing-label">
+                        Ваш ответ
+                        <input type="text" class="typing-input" placeholder="Введите слово">
+                    </label>
+                    <div class="typing-actions">
+                        <button type="button" class="typing-check">Проверить</button>
+                        {% if typing_task.hint %}
+                        <button type="button" class="typing-hint" data-hint="{{ typing_task.hint }}">Подсказка</button>
+                        {% endif %}
+                    </div>
+                    <div class="feedback" data-role="typing-feedback" aria-live="polite"></div>
+                </div>
+            </section>
+
+            {% if related_words %}
+            <section class="training-section" aria-labelledby="related-title">
+                <h2 id="related-title">Соседние слова</h2>
+                <div class="related-grid">
+                    {% for related in related_words %}
+                    <article class="related-card">
+                        <h3>{{ related.article }} {{ related.word }}</h3>
+                        {% if related.translation_ru or related.translation_en %}
+                        <p>{{ related.translation_ru or related.translation_en }}</p>
+                        {% endif %}
+                        <a href="{{ related.id }}.html" class="related-link">Тренироваться →</a>
+                    </article>
+                    {% endfor %}
+                </div>
+            </section>
+            {% endif %}
+        </main>
+    </div>
+    <script src="../static/js/training.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a training page generator that prepares quizzes, drag-and-drop games, typing prompts and related vocabulary details from the shared word list
- update the main build pipeline to load vocabulary data, create the trainings output directory and render HTML trainings for the daily review items while reusing the same selection for the index
- introduce a dedicated training template with new CSS/JS assets and regenerate the output trainings so the review cards link to interactive practice pages

## Testing
- python main.py
- pytest *(fails: scripts/test_mobile_navigation.py expects a Windows-only test fixture path)*

------
https://chatgpt.com/codex/tasks/task_e_68cd814d8b948320b7b41d797062dd21