### PR TITLE
Shuffle quiz answers when generating journeys

### DIFF
--- a/generators/html_lira.py
+++ b/generators/html_lira.py
@@ -1,5 +1,6 @@
 """HTML Generator for Lira Journey pages"""
 import json
+import random
 import re
 from pathlib import Path
 
@@ -149,11 +150,28 @@ class LiraHTMLGenerator(BaseGenerator):
 
             phase_quizzes = []
             for quiz in phase.get("quizzes", []):
+                choices = list(quiz.get("choices", []))
+                correct_index = quiz.get("correct_index", 0)
+
+                correct_choice = None
+                if 0 <= correct_index < len(choices):
+                    correct_choice = choices[correct_index]
+
+                random.shuffle(choices)
+
+                if correct_choice is not None and choices:
+                    try:
+                        correct_index = choices.index(correct_choice)
+                    except ValueError:
+                        correct_index = 0
+                else:
+                    correct_index = 0
+
                 phase_quizzes.append(
                     {
                         "question": quiz.get("question", ""),
-                        "choices": quiz.get("choices", []),
-                        "correct_index": quiz.get("correct_index", 0),
+                        "choices": choices,
+                        "correct_index": correct_index,
                     }
                 )
 


### PR DESCRIPTION
## Summary
- shuffle quiz choices when preparing Lira journey quizzes while tracking the original correct answer
- write shuffled choice order and recalculated correct index into both the rendered quiz metadata and JSON map

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68cd875dc6cc8320bfceb83d1e1d62d1