### PR TITLE
Prepare quizzes before generating Lira JS

### DIFF
--- a/generators/html_lira.py
+++ b/generators/html_lira.py
@@ -71,10 +71,10 @@ class LiraHTMLGenerator(BaseGenerator):
             if not phase.get("id"):
                 phase["id"] = f"phase-{index}"
 
+        exercises, quizzes, quizzes_json = self._prepare_exercises(journey_phases)
+
         relations_metadata = self._collect_relations_metadata(journey_phases)
         js = LiraJSGenerator.generate(character)
-
-        exercises, quizzes, quizzes_json = self._prepare_exercises(journey_phases)
         initial_description = journey_phases[0].get("description", "") if journey_phases else ""
         first_phase_title = journey_phases[0].get("title", "") if journey_phases else ""
         initial_progress = self._initial_progress_percentage(len(journey_phases))
@@ -235,6 +235,8 @@ class LiraHTMLGenerator(BaseGenerator):
                         "correct_index": correct_index,
                     }
                 )
+
+            phase["quizzes"] = phase_quizzes
 
             quizzes.append(
                 {

--- a/generators/js_lira.py
+++ b/generators/js_lira.py
@@ -60,10 +60,20 @@ class LiraJSGenerator:
 
             quizzes = []
             for quiz in phase.get('quizzes', []):
+                choices = list(quiz.get('choices', []))
+                correct_index = quiz.get('correct_index')
+                if correct_index is None:
+                    correct_index = quiz.get('correctIndex', 0)
+
+                try:
+                    correct_index = int(correct_index)
+                except (TypeError, ValueError):
+                    correct_index = 0
+
                 quizzes.append({
                     'question': quiz.get('question', ''),
-                    'choices': quiz.get('choices', []),
-                    'correctIndex': quiz.get('correct_index', 0),
+                    'choices': choices,
+                    'correctIndex': correct_index,
                 })
 
             phase_vocabularies[phase_id] = {


### PR DESCRIPTION
## Summary
- run `_prepare_exercises` before generating the Lira journey JavaScript so the character data already includes expanded quizzes
- store the generated quiz list on each phase for both the template and the JS serializer
- normalize quiz serialization in `LiraJSGenerator` by copying choice lists and supporting both `correct_index` and `correctIndex`

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68cd924b5db48320890709ccbf1d006d