### PR TITLE
Add vocabulary hints to journey words

### DIFF
--- a/data/vocabulary/vocabulary.json
+++ b/data/vocabulary/vocabulary.json
@@ -66,7 +66,8 @@
       ],
       "collocations": [
         "Ich weise alle seine Bitten ab. — Я отвергаю все его просьбы."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0435",
@@ -98,7 +99,8 @@
       ],
       "collocations": [
         "Ich achte beide Söhne, Edgar und Edmund. — Я уважаю обоих сыновей, Эдгара и Эдмунда."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0436",
@@ -130,7 +132,8 @@
       ],
       "collocations": [
         "Ich ahne das schlimme Ende voraus. — Я предчувствую плохой конец."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0437",
@@ -165,7 +168,8 @@
       ],
       "collocations": [
         "Ahnungslos vertraue ich meinem Bruder. — Ничего не подозревая, я доверяю брату."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0169",
@@ -228,7 +232,8 @@
       ],
       "collocations": [
         "Als Кай heuere ich beim König an. — Как Кай я нанимаюсь к королю."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0439",
@@ -262,7 +267,8 @@
       ],
       "collocations": [
         "Ich klage sie ihrer Unmenschlichkeit an. — Я обвиняю её в бесчеловечности."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0440",
@@ -294,7 +300,8 @@
       ],
       "collocations": [
         "Ich stachle sie zu größerer Grausamkeit an. — Я подстрекаю её к большей жестокости."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0170",
@@ -357,7 +364,8 @@
       ],
       "collocations": [
         "Ich bin zu arglos für solche Intrigen. — Я слишком простодушен для таких интриг."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0442",
@@ -390,7 +398,8 @@
       ],
       "collocations": [
         "Ich argwöhne Gift in meinem Wein. — Я подозреваю яд в моём вине."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0443",
@@ -422,7 +431,8 @@
       ],
       "collocations": [
         "Die Armen leiden mehr als Könige jemals wissen. — Бедные страдают больше, чем короли когда-либо узнают."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0444",
@@ -454,7 +464,8 @@
       ],
       "collocations": [
         "Ich baue auf, was zerstört wurde. — Я строю то, что было разрушено."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0445",
@@ -486,7 +497,8 @@
       ],
       "collocations": [
         "Ich begehre auf gegen das Unrecht. — Я восстаю против несправедливости."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0446",
@@ -526,7 +538,8 @@
       "collocations": [
         "Ich gebe auf, nachdem mein Herr gestorben ist. — Я сдаюсь после смерти моего господина.",
         "Ich will das Leben aufgeben. — Я хочу отказаться от жизни."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0447",
@@ -558,7 +571,8 @@
       ],
       "collocations": [
         "Der König von Frankreich nimmt mich liebevoll auf. — Король Франции принимает меня с любовью."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0448",
@@ -590,7 +604,8 @@
       ],
       "collocations": [
         "Ich bin aufrichtig, auch wenn es gefährlich ist. — Я искренен, даже если это опасно."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0449",
@@ -622,7 +637,8 @@
       ],
       "collocations": [
         "Ich spüre den Flüchtling überall auf. — Я выслеживаю беглеца повсюду."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0450",
@@ -654,7 +670,8 @@
       ],
       "collocations": [
         "Ich will über alle aufsteigen. — Я хочу возвыситься над всеми."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0451",
@@ -687,7 +704,8 @@
       ],
       "collocations": [
         "Ich wache auf aus meinem langen Schlaf. — Я просыпаюсь от долгого сна."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0171",
@@ -786,7 +804,8 @@
       ],
       "collocations": [
         "Ich harre aus bis zur Befreiung. — Я выдерживаю до освобождения."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0453",
@@ -820,7 +839,8 @@
       ],
       "collocations": [
         "Ich liefere ihn seinen Feinden aus. — Я выдаю его врагам."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0454",
@@ -852,7 +872,8 @@
       ],
       "collocations": [
         "Ich nutze ihre Leidenschaft aus. — Я использую их страсть."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0455",
@@ -891,7 +912,8 @@
       "collocations": [
         "Stecht ihm beide Augen aus! — Выколите ему оба глаза!",
         "Seine Augen steche ich mit Freude aus. — Его глаза я выкалываю с радостью."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0456",
@@ -924,7 +946,8 @@
       ],
       "collocations": [
         "Ich bedrohe sie mit dem Tod. — Я угрожаю ей смертью."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0173",
@@ -993,7 +1016,8 @@
       ],
       "collocations": [
         "Jeden Befehl befolge ich sofort. — Каждый приказ я исполняю немедленно."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0174",
@@ -1150,7 +1174,8 @@
         "Als Tom begleite ich Lear durch seine dunkelste Stunde. — Как Том, я сопровождаю Лира в его самый тёмный час.",
         "Ich begleite ihn durch Wind und Regen. — Я сопровождаю его сквозь ветер и дождь.",
         "Treu begleite ich meinen verrückten König. — Верно я сопровождаю своего безумного короля."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0177",
@@ -1288,7 +1313,8 @@
       ],
       "collocations": [
         "Ich bekämpfe sie mit allen Mitteln. — Я борюсь с ней всеми средствами."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0180",
@@ -1419,7 +1445,8 @@
       ],
       "collocations": [
         "Ich bin von Geburt an benachteiligt. — Я обделён с рождения."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0183",
@@ -1502,7 +1529,8 @@
       ],
       "collocations": [
         "Ich beschränke seine Dienerschaft auf null. — Я ограничиваю его свиту до нуля."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0462",
@@ -1536,7 +1564,8 @@
       ],
       "collocations": [
         "Ich beschuldige Edgar des Verrats. — Я обвиняю Эдгара в предательстве."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0184",
@@ -1616,7 +1645,8 @@
       ],
       "collocations": [
         "Ich muss meine Schwester beseitigen. — Я должна устранить свою сестру."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0185",
@@ -1687,7 +1717,8 @@
       ],
       "collocations": [
         "Jeden Tag bete ich für seine Sicherheit. — Каждый день я молюсь за его безопасность."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0186",
@@ -1769,7 +1800,8 @@
       "collocations": [
         "Um mein Leben bettle ich vergeblich. — О жизни я умоляю напрасно.",
         "Muss ich um Unterkunft betteln bei meinen eigenen Kindern? — Должен ли я просить крова у собственных детей?"
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0466",
@@ -1801,7 +1833,8 @@
       ],
       "collocations": [
         "Ihre Grausamkeit beunruhigt mich zunehmend. — Её жестокость всё больше тревожит меня."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0467",
@@ -1833,7 +1866,8 @@
       ],
       "collocations": [
         "Heimlich bewache ich meinen alten Herrn. — Тайно я охраняю своего старого господина."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0187",
@@ -1958,7 +1992,8 @@
       ],
       "collocations": [
         "Ich billige alle ihre grausamen Pläne. — Я одобряю все её жестокие планы."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0190",
@@ -2022,7 +2057,8 @@
       ],
       "collocations": [
         "Die Wahrheit schmeckt bitter wie Galle. — Правда горька как желчь."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0191",
@@ -2144,7 +2180,8 @@
       "collocations": [
         "Mein blinder Vater erkennt mich nicht. — Мой слепой отец не узнаёт меня.",
         "Ich bin blind für die Wahrheit. — Я слеп к правде."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0471",
@@ -2176,7 +2213,8 @@
       ],
       "collocations": [
         "Ich blute wie ein geschlachtetes Schwein. — Я кровоточу как зарезанная свинья."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0193",
@@ -2239,7 +2277,8 @@
       ],
       "collocations": [
         "Brutal zerschlage ich jeden Widerstand. — Брутально я сокрушаю любое сопротивление."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0473",
@@ -2271,7 +2310,8 @@
       ],
       "collocations": [
         "Ich büße für all meine Grausamkeiten. — Я расплачиваюсь за все свои жестокости."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0194",
@@ -2508,7 +2548,8 @@
       "collocations": [
         "Unser Bündnis ist stark und grausam. — Наш союз силён и жесток.",
         "Ein Bündnis mit Goneril gegen unseren Vater. — Союз с Гонерильей против нашего отца."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0006",
@@ -2746,7 +2787,8 @@
       ],
       "collocations": [
         "Mit Entsetzen sehe ich ihr wahres Gesicht. — С ужасом я вижу её истинное лицо."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0011",
@@ -3055,7 +3097,8 @@
       ],
       "collocations": [
         "Das Gift ist bereit für meine Schwester. — Яд готов для моей сестры."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0019",
@@ -3460,7 +3503,8 @@
       ],
       "collocations": [
         "Mein Lied erzählt von vergangenen Tagen. — Моя песня рассказывает о прошлых днях."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0030",
@@ -3529,7 +3573,8 @@
       ],
       "collocations": [
         "Jedes Omen zeigt auf Untergang. — Каждое знамение указывает на гибель."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0031",
@@ -3598,7 +3643,8 @@
       ],
       "collocations": [
         "Meine Prinzipien sind wichtiger als meine Ehe. — Мои принципы важнее моего брака."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0033",
@@ -3699,7 +3745,8 @@
       ],
       "collocations": [
         "In Rätseln spreche ich von der Zukunft. — В загадках я говорю о будущем."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0034",
@@ -3805,7 +3852,8 @@
       ],
       "collocations": [
         "Mein Schweigen macht mich zum Mitschuldigen. — Моё молчание делает меня соучастником."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0036",
@@ -3874,7 +3922,8 @@
       ],
       "collocations": [
         "Ein tiefes Unbehagen erfüllt meine Seele. — Глубокое беспокойство наполняет мою душу."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0037",
@@ -4002,7 +4051,8 @@
       ],
       "collocations": [
         "Das Verderben holt mich ein. — Погибель настигает меня."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0484",
@@ -4034,7 +4084,8 @@
       ],
       "collocations": [
         "Das Verhängnis ereilt mich gerecht. — Рок настигает меня справедливо."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0485",
@@ -4066,7 +4117,8 @@
       ],
       "collocations": [
         "Sein ganzes Vermögen wird mir gehören. — Всё его состояние будет моим."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0040",
@@ -4241,7 +4293,8 @@
         "Meine eigene Tochter will mich demütigen! — Моя собственная дочь хочет меня унизить!",
         "Ich demütige ihn vor aller Augen. — Я унижаю его на глазах у всех.",
         "Ich demütige meinen alten Vater ohne Mitleid. — Я унижаю старого отца без жалости."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0487",
@@ -4273,7 +4326,8 @@
       ],
       "collocations": [
         "Ich denunziere meinen Vater als Verräter. — Я доношу на отца как на предателя."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0488",
@@ -4305,7 +4359,8 @@
       ],
       "collocations": [
         "Der Abgrund ruft nach mir. — Пропасть зовёт меня."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0489",
@@ -4360,7 +4415,8 @@
         "Unser Abschied ist nur vorübergehend. — Наше прощание лишь временно.",
         "Der Abschied vom Hof schmerzt mich tief. — Прощание с двором глубоко ранит меня.",
         "Der Abschied von meinem König bricht mein Herz. — Прощание с моим королём разбивает моё сердце."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0044",
@@ -4437,7 +4493,8 @@
       ],
       "collocations": [
         "Jeden Auftrag erfülle ich gewissenhaft. — Каждое поручение я выполняю добросовестно."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0491",
@@ -4469,7 +4526,8 @@
       ],
       "collocations": [
         "Mit falschem Bart bin ich nicht zu erkennen. — С фальшивой бородой меня не узнать."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0045",
@@ -4570,7 +4628,8 @@
       ],
       "collocations": [
         "Mein Beistand ist alles, was ich bieten kann. — Моя поддержка - всё, что я могу предложить."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0047",
@@ -4652,7 +4711,8 @@
       "collocations": [
         "Dieser Bettler ist glücklicher als ich, der König! — Этот нищий счастливее меня, короля!",
         "Als Bettler bin ich unsichtbar für meine Feinde. — Как нищий, я невидим для врагов."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0048",
@@ -4949,7 +5009,8 @@
       ],
       "collocations": [
         "Mein Dienst geht über die Verbannung hinaus. — Моя служба идёт дальше изгнания."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0055",
@@ -5055,7 +5116,8 @@
       ],
       "collocations": [
         "Mein Ehrgeiz kennt keine Grenzen mehr. — Моё честолюбие не знает больше границ."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0057",
@@ -5124,7 +5186,8 @@
       ],
       "collocations": [
         "Mein Erfolg ist vollkommen. — Мой успех полный."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0058",
@@ -5258,7 +5321,8 @@
       ],
       "collocations": [
         "Der Friede soll wieder ins Land kommen. — Мир должен вернуться в страну."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0061",
@@ -5322,7 +5386,8 @@
       ],
       "collocations": [
         "Mein Gehorsam kennt keine Fragen. — Моё послушание не знает вопросов."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0062",
@@ -5854,7 +5919,8 @@
       ],
       "collocations": [
         "Im Nebel verliere ich mich für immer. — В тумане я теряюсь навсегда."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0500",
@@ -5886,7 +5952,8 @@
       ],
       "collocations": [
         "Der Neid auf Edgar verzehrt mich. — Зависть к Эдгару пожирает меня."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0501",
@@ -5919,7 +5986,8 @@
       ],
       "collocations": [
         "Ein Neuanfang für das Königreich beginnt. — Новое начало для королевства начинается."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0502",
@@ -5959,7 +6027,8 @@
       "collocations": [
         "Mein hinterhältiger Plan wird funktionieren. — Мой коварный план сработает.",
         "Mein Plan wird perfekt ausgeführt. — Мой план выполняется идеально."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0076",
@@ -6023,7 +6092,8 @@
       ],
       "collocations": [
         "Jeder Reim verbirgt eine tiefe Wahrheit. — Каждая рифма скрывает глубокую правду."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0077",
@@ -6094,7 +6164,8 @@
       "collocations": [
         "Mein Sadismus findet Befriedigung. — Мой садизм находит удовлетворение.",
         "Mein Sadismus kennt keine Grenzen. — Мой садизм не знает границ."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0505",
@@ -6126,7 +6197,8 @@
       ],
       "collocations": [
         "Jeder Scherz enthält eine bittere Lehre. — Каждая шутка содержит горький урок."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0078",
@@ -6200,7 +6272,8 @@
       ],
       "collocations": [
         "Ich biete Schutz, ohne erkannt zu werden. — Я предоставляю защиту, не будучи узнанным."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0507",
@@ -6232,7 +6305,8 @@
       ],
       "collocations": [
         "Der Sieg über Edgar ist süß. — Победа над Эдгаром сладка."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0508",
@@ -6264,7 +6338,8 @@
       ],
       "collocations": [
         "Der Sinn des Lebens ist ein schlechter Witz. — Смысл жизни - плохая шутка."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0079",
@@ -6328,7 +6403,8 @@
       ],
       "collocations": [
         "Der Spaß ist meine Maske vor der Welt. — Забава - моя маска перед миром."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0080",
@@ -6392,7 +6468,8 @@
       ],
       "collocations": [
         "Als Spion lausche ich an jeder Tür. — Как шпион я подслушиваю у каждой двери."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0081",
@@ -6456,7 +6533,8 @@
       ],
       "collocations": [
         "Im Stock sitze ich die ganze Nacht. — В колодке я сижу всю ночь."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0082",
@@ -6520,7 +6598,8 @@
       ],
       "collocations": [
         "Der Streit mit meiner Frau eskaliert. — Спор с моей женой обостряется."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0083",
@@ -6703,7 +6782,8 @@
       ],
       "collocations": [
         "Mit Liedern bringe ich kleinen Trost. — Песнями я приношу малое утешение."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0086",
@@ -6767,7 +6847,8 @@
       ],
       "collocations": [
         "Mein Untergang ist gerecht. — Моё падение справедливо."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0087",
@@ -6879,7 +6960,8 @@
       ],
       "collocations": [
         "Als Verwalter kontrolliere ich den Haushalt. — Как управляющий я контролирую дом."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0090",
@@ -6990,7 +7072,8 @@
       ],
       "collocations": [
         "Mein Widerstand gegen das Böse beginnt. — Моё сопротивление злу начинается."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0091",
@@ -7054,7 +7137,8 @@
       ],
       "collocations": [
         "Mein Witz ist scharf wie ein Schwert. — Моё остроумие остро как меч."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0092",
@@ -7138,7 +7222,8 @@
       ],
       "collocations": [
         "Der Zweifel an ihrer Güte wächst in mir. — Сомнение в её доброте растёт во мне."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0519",
@@ -7170,7 +7255,8 @@
       ],
       "collocations": [
         "Die Zeichen deute ich besser als alle. — Знаки я толкую лучше всех."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0520",
@@ -7202,7 +7288,8 @@
       ],
       "collocations": [
         "Unsere Absprache ist perfekt. — Наш сговор совершенен."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0521",
@@ -7235,7 +7322,8 @@
       ],
       "collocations": [
         "Diese Affäre wird tödlich enden. — Эта интрига закончится смертью."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0522",
@@ -7267,7 +7355,8 @@
       ],
       "collocations": [
         "Unsere Allianz wird alle Feinde vernichten. — Наш альянс уничтожит всех врагов."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0523",
@@ -7299,7 +7388,8 @@
       ],
       "collocations": [
         "Meine Ambition kennt keine Grenzen. — Моя амбиция не знает границ."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0093",
@@ -7401,7 +7491,8 @@
       ],
       "collocations": [
         "Diese Armee kämpft für Gerechtigkeit und Liebe. — Эта армия сражается за справедливость и любовь."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0095",
@@ -7497,7 +7588,8 @@
       ],
       "collocations": [
         "Meine Begierde brennt wie Feuer. — Моё вожделение горит как огонь."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0526",
@@ -7529,7 +7621,8 @@
       ],
       "collocations": [
         "Jede Beleidigung spreche ich mit Genuss aus. — Каждое оскорбление я произношу с наслаждением."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0527",
@@ -7561,7 +7654,8 @@
       ],
       "collocations": [
         "Die Belohnung für meine Intrige ist groß. — Награда за мою интригу велика."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0528",
@@ -7593,7 +7687,8 @@
       ],
       "collocations": [
         "Der Graf ist meine leichte Beute. — Граф - моя лёгкая добыча."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0529",
@@ -7633,7 +7728,8 @@
       "collocations": [
         "Meine Bosheit kennt kein Erbarmen. — Моя злоба не знает милосердия.",
         "Unsere Bosheit macht uns zum perfekten Paar. — Наша злоба делает нас идеальной парой."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0530",
@@ -7665,7 +7761,8 @@
       ],
       "collocations": [
         "Die Botschaft meiner Herrin ist grausam. — Послание моей госпожи жестоко."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0531",
@@ -7697,7 +7794,8 @@
       ],
       "collocations": [
         "Meine Brutalität erschreckt sogar Cornwall. — Моя брутальность пугает даже Корнуолла."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0097",
@@ -7761,7 +7859,8 @@
       ],
       "collocations": [
         "In der Demut finden wir wahre Größe. — В смирении мы находим истинное величие."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0533",
@@ -7793,7 +7892,8 @@
       ],
       "collocations": [
         "Die Demütigung macht mich nur stärker. — Унижение делает меня только сильнее."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0098",
@@ -7862,7 +7962,8 @@
       ],
       "collocations": [
         "Die Ehe bindet mich an eine grausame Frau. — Брак связывает меня с жестокой женой."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0099",
@@ -7978,7 +8079,8 @@
       ],
       "collocations": [
         "In großer Eile renne ich hin und her. — В большой спешке я бегаю туда-сюда."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0101",
@@ -8052,7 +8154,8 @@
       ],
       "collocations": [
         "Die Einsicht verbrennt meine Seele. — Прозрение сжигает мою душу."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0102",
@@ -8153,7 +8256,8 @@
       ],
       "collocations": [
         "Meine Ergebenheit gilt nur Lady Goneril. — Моя преданность принадлежит только леди Гонерилье."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0105",
@@ -8302,7 +8406,8 @@
       ],
       "collocations": [
         "Die Eroberung des Throns ist mein Ziel. — Завоевание трона - моя цель."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0539",
@@ -8334,7 +8439,8 @@
       ],
       "collocations": [
         "Die Erschöpfung überwältigt meinen alten Körper. — Истощение одолевает моё старое тело."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0107",
@@ -8406,7 +8512,8 @@
       "collocations": [
         "Ich stelle Fallen für die Ahnungslosen. — Я ставлю ловушки для ничего не подозревающих.",
         "Ich tappe blind in Edmunds Falle. — Я слепо попадаю в ловушку Эдмунда."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0541",
@@ -8438,7 +8545,8 @@
       ],
       "collocations": [
         "Meine Falschheit kennt keine Grenzen. — Моя фальшь не знает границ."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0108",
@@ -8509,7 +8617,8 @@
       "collocations": [
         "Aus Feigheit greife ich nur Schwache an. — Из трусости я нападаю только на слабых.",
         "Meine Feigheit führt zu meinem Ende. — Моя трусость приводит к моему концу."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0109",
@@ -8593,7 +8702,8 @@
         "Die Folter ist meine Unterhaltung. — Пытка - моё развлечение.",
         "Die Folter ist mein liebstes Werkzeug. — Пытка - мой любимый инструмент.",
         "Die Folter ist grausam und erbarmungslos. — Пытка жестока и беспощадна."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0110",
@@ -8753,7 +8863,8 @@
       ],
       "collocations": [
         "Unsere Freundschaft überdauert den Sturm. — Наша дружба переживёт бурю."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0545",
@@ -8786,7 +8897,8 @@
       ],
       "collocations": [
         "Durch Furcht halte ich alle unter Kontrolle. — Страхом я держу всех под контролем."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0114",
@@ -9041,7 +9153,8 @@
         "Meine Grausamkeit kennt keine Grenzen. — Моя жестокость не знает границ.",
         "Meine Grausamkeit übertrifft die meiner Schwester. — Моя жестокость превосходит жестокость сестры.",
         "Die Grausamkeit meiner Frau gefällt mir. — Жестокость моей жены мне нравится."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0119",
@@ -9137,7 +9250,8 @@
       ],
       "collocations": [
         "Mit Güte will ich das Böse besiegen. — Добротой я хочу победить зло."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0548",
@@ -9169,7 +9283,8 @@
       ],
       "collocations": [
         "Die Habgier treibt meine süßen Worte. — Алчность движет моими сладкими словами."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0121",
@@ -9233,7 +9348,8 @@
       ],
       "collocations": [
         "In Heimlichkeit sammle ich Informationen. — В скрытности я собираю информацию."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0550",
@@ -9274,7 +9390,8 @@
       "collocations": [
         "Die Herrschaft fällt nun in meine Hände. — Правление теперь переходит в мои руки.",
         "Die Herrschaft über alle ist mein Ziel. — Господство над всеми - моя цель."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0551",
@@ -9306,7 +9423,8 @@
       ],
       "collocations": [
         "Die Herrschsucht bestimmt all meine Taten. — Властолюбие определяет все мои поступки."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0122",
@@ -9402,7 +9520,8 @@
       ],
       "collocations": [
         "Mit Hinterlist verfolge ich meine Ziele. — С коварством я преследую свои цели."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0124",
@@ -9471,7 +9590,8 @@
       ],
       "collocations": [
         "Die Hoffnungslosigkeit erdrückt mich. — Безнадёжность давит меня."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0554",
@@ -9512,7 +9632,8 @@
       "collocations": [
         "Mit eiserner Härte stoße ich ihn fort. — С железной жёсткостью я отталкиваю его.",
         "Mit eiserner Härte regieren wir zusammen. — С железной суровостью мы правим вместе."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0125",
@@ -9589,7 +9710,8 @@
       "collocations": [
         "Diese Hütte ist ein Palast für die Verlassenen. — Эта хижина - дворец для покинутых.",
         "In dieser armseligen Hütte finden wir Zuflucht. — В этой жалкой хижине мы находим убежище."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0126",
@@ -9669,7 +9791,8 @@
       ],
       "collocations": [
         "Die Ironie ist meine letzte Waffe. — Ирония - моё последнее оружие."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0557",
@@ -9701,7 +9824,8 @@
       ],
       "collocations": [
         "Die Jagd auf Gloucester macht mir Spaß. — Охота на Глостера доставляет мне удовольствие."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0558",
@@ -9733,7 +9857,8 @@
       ],
       "collocations": [
         "Er glaubt, wir stehen am Rand der Klippe. — Он думает, мы стоим на краю утёса."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0128",
@@ -9834,7 +9959,8 @@
       ],
       "collocations": [
         "Diese Kränkung werde ich nicht vergessen! — Эту обиду я не забуду!"
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0560",
@@ -9873,7 +9999,8 @@
       "collocations": [
         "Die Kälte dringt in unsere Knochen. — Холод проникает в наши кости.",
         "Die Kälte meines Herzens übertrifft den Winter. — Холод моего сердца превосходит зиму."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0127",
@@ -9937,7 +10064,8 @@
       ],
       "collocations": [
         "Ich hinterlasse nur Leere und Erinnerung. — Я оставляю только пустоту и воспоминание."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0130",
@@ -10039,7 +10167,8 @@
       ],
       "collocations": [
         "Meine Liebschaft mit beiden Schwestern ist gefährlich. — Моя любовная связь с обеими сёстрами опасна."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0563",
@@ -10087,7 +10216,8 @@
         "Meine List bewahrt ihn vor dem Selbstmord. — Моя хитрость спасает его от самоубийства.",
         "Mit List gewinne ich sein Vertrauen. — Хитростью я завоёвываю его доверие.",
         "Mit List kehre ich an den Hof zurück. — Хитростью я возвращаюсь ко двору."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0564",
@@ -10127,7 +10257,8 @@
       "collocations": [
         "Ihre Lust macht sie blind. — Их похоть делает их слепыми.",
         "Die Lust macht mich blind für Gefahr. — Похоть делает меня слепой к опасности."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0132",
@@ -10248,7 +10379,8 @@
       ],
       "collocations": [
         "Die Melodie erinnert an bessere Zeiten. — Мелодия напоминает о лучших временах."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0566",
@@ -10280,7 +10412,8 @@
       ],
       "collocations": [
         "Ohne Mitgift bin ich reicher an Ehre. — Без приданого я богаче честью."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0567",
@@ -10312,7 +10445,8 @@
       ],
       "collocations": [
         "Die Moral leitet nun meine Entscheidungen. — Мораль теперь руководит моими решениями."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0568",
@@ -10344,7 +10478,8 @@
       ],
       "collocations": [
         "Schreckliche Nachrichten erreichen mich aus England. — Ужасные известия доходят до меня из Англии."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0134",
@@ -10454,7 +10589,8 @@
       "collocations": [
         "Die Niederlage ist mein letztes Schicksal. — Поражение - моя последняя судьба.",
         "Die Niederlage ist vollkommen. — Поражение полное."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0136",
@@ -10523,7 +10659,8 @@
       ],
       "collocations": [
         "Neue Ordnung muss aus dem Chaos entstehen. — Новый порядок должен возникнуть из хаоса."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0137",
@@ -10597,7 +10734,8 @@
       ],
       "collocations": [
         "Meine Philosophie ist einfach: Alles ist Narretei. — Моя философия проста: всё - глупость."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0572",
@@ -10629,7 +10767,8 @@
       ],
       "collocations": [
         "Meine Prophezeiung wird wahr werden. — Моё пророчество сбудется."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0138",
@@ -10702,7 +10841,8 @@
       "collocations": [
         "Die Qual des Giftes zerreißt mich. — Мучение от яда разрывает меня.",
         "Seine Qual bereitet mir Vergnügen. — Его мука доставляет мне удовольствие."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0139",
@@ -10786,7 +10926,8 @@
       ],
       "collocations": [
         "Meine Respektlosigkeit kennt keine Grenzen. — Моё неуважение не знает границ."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0140",
@@ -10873,7 +11014,8 @@
       "collocations": [
         "Ihre Rivalität spielt mir in die Hände. — Их соперничество играет мне на руку.",
         "Unsere Rivalität wird tödlich enden. — Наше соперничество закончится смертью."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0141",
@@ -11080,7 +11222,8 @@
       ],
       "collocations": [
         "Meine Schwäche erlaubt das Böse zu wachsen. — Моя слабость позволяет злу расти."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0146",
@@ -11149,7 +11292,8 @@
       ],
       "collocations": [
         "Die Sehnsucht nach Versöhnung erfüllt mein Herz. — Тоска по примирению наполняет моё сердце."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0147",
@@ -11250,7 +11394,8 @@
       ],
       "collocations": [
         "Mit Standhaftigkeit ertrage ich die Schmach. — Со стойкостью я переношу позор."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0149",
@@ -11340,7 +11485,8 @@
       ],
       "collocations": [
         "Unsere Strategie wird ihn brechen. — Наша стратегия сломает его."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0150",
@@ -11563,7 +11709,8 @@
       ],
       "collocations": [
         "Unsere Tränen waschen den Schmerz fort. — Наши слёзы смывают боль."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0581",
@@ -11595,7 +11742,8 @@
       ],
       "collocations": [
         "Die Tugend wird mein Leitstern sein. — Добродетель будет моей путеводной звездой."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0582",
@@ -11627,7 +11775,8 @@
       ],
       "collocations": [
         "Meine Tyrannei erstickt jeden Widerstand. — Моя тирания душит любое сопротивление."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0583",
@@ -11668,7 +11817,8 @@
       "collocations": [
         "Die Täuschung ist vollkommen. — Обман совершенен.",
         "Edgars liebevolle Täuschung rettet mich. — Любящий обман Эдгара спасает меня."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0155",
@@ -11732,7 +11882,8 @@
       ],
       "collocations": [
         "Die Undankbarkeit ist schärfer als der Zahn einer Schlange! — Неблагодарность острее змеиного зуба!"
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0585",
@@ -11772,7 +11923,8 @@
       "collocations": [
         "Diese Ungerechtigkeit werde ich nicht akzeptieren. — Эту несправедливость я не приму.",
         "Ich begehe große Ungerechtigkeit. — Я совершаю большую несправедливость."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0586",
@@ -11804,7 +11956,8 @@
       ],
       "collocations": [
         "Die Unterdrückung ist mein Herrschaftsmittel. — Угнетение - моё средство правления."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0587",
@@ -11836,7 +11989,8 @@
       ],
       "collocations": [
         "Meine Verachtung für ihn wächst täglich. — Моё презрение к нему растёт ежедневно."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0588",
@@ -11868,7 +12022,8 @@
       ],
       "collocations": [
         "Die Verantwortung für alle wiegt schwer. — Ответственность за всех тяжела."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0589",
@@ -11901,7 +12056,8 @@
       ],
       "collocations": [
         "Die Verbannung ist der Preis für meine Ehrlichkeit. — Изгнание - цена моей честности."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0590",
@@ -11933,7 +12089,8 @@
       ],
       "collocations": [
         "Die Verfolgung des blinden Grafen beginnt. — Преследование слепого графа начинается."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0591",
@@ -11965,7 +12122,8 @@
       ],
       "collocations": [
         "Die Vergebung ist der Schlüssel zum Frieden. — Прощение - ключ к покою."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0592",
@@ -11997,7 +12155,8 @@
       ],
       "collocations": [
         "Die Vergeltung ereilt mich unerwartet. — Возмездие настигает меня неожиданно."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0593",
@@ -12029,7 +12188,8 @@
       ],
       "collocations": [
         "Die Vergänglichkeit der Macht ist offenbar. — Бренность власти очевидна."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0594",
@@ -12070,7 +12230,8 @@
       "collocations": [
         "Diese Verkleidung ist meine einzige Rettung. — Эта маскировка - моё единственное спасение.",
         "In Verkleidung diene ich meinem König weiter. — В переодевании я продолжаю служить королю."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0156",
@@ -12292,7 +12453,8 @@
       ],
       "collocations": [
         "Eine dunkle Vorahnung erfüllt mein Herz. — Тёмное предчувствие наполняет моё сердце."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0596",
@@ -12324,7 +12486,8 @@
       ],
       "collocations": [
         "Ich halte Wache über seinen Schlaf. — Я держу стражу над его сном."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0161",
@@ -12403,7 +12566,8 @@
       ],
       "collocations": [
         "Meine Warnung kommt als Rätsel verkleidet. — Моё предупреждение приходит замаскированным под загадку."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0598",
@@ -12457,7 +12621,8 @@
         "Die Weisheit kommt zu spät zu mir. — Мудрость приходит ко мне слишком поздно.",
         "Durch Leiden habe ich Weisheit erlangt. — Через страдания я обрёл мудрость.",
         "Hinter meinen Späßen verbirgt sich Weisheit. — За моими шутками скрывается мудрость."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0162",
@@ -12556,7 +12721,8 @@
       ],
       "collocations": [
         "Meine Willkür ist das einzige Gesetz. — Мой произвол - единственный закон."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0600",
@@ -12588,7 +12754,8 @@
       ],
       "collocations": [
         "Als Witwe bin ich endlich frei. — Как вдова я наконец свободна."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0601",
@@ -12620,7 +12787,8 @@
       ],
       "collocations": [
         "Die Wunde brennt wie Feuer in meinem Leib. — Рана горит как огонь в моём теле."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0165",
@@ -12761,7 +12929,8 @@
       "collocations": [
         "Die Zeremonie der Teilung beginnt jetzt. — Церемония раздела начинается сейчас.",
         "Die Zeremonie beginnt im prächtigen Thronsaal. — Церемония начинается в великолепном тронном зале."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0603",
@@ -12794,7 +12963,8 @@
       ],
       "collocations": [
         "Ich suche Zuflucht für uns beide. — Я ищу убежище для нас обоих."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0167",
@@ -12895,7 +13065,8 @@
       ],
       "collocations": [
         "Die Zwietracht zerstört unsere Ehe. — Раздор разрушает наш брак."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0605",
@@ -12927,7 +13098,8 @@
       ],
       "collocations": [
         "Die Überraschung des Angriffs schockiert mich. — Неожиданность нападения шокирует меня."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0195",
@@ -13034,7 +13206,8 @@
       ],
       "collocations": [
         "Ich dulde ihre Grausamkeit zu lange. — Я слишком долго терплю её жестокость."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0197",
@@ -13104,7 +13277,8 @@
       ],
       "collocations": [
         "Ich strebe nach edlen Taten. — Я стремлюсь к благородным поступкам."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0198",
@@ -13167,7 +13341,8 @@
       ],
       "collocations": [
         "Ich eile, um ihre Wünsche zu erfüllen. — Я тороплюсь исполнить её желания."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0609",
@@ -13199,7 +13374,8 @@
       ],
       "collocations": [
         "Ich greife ein, um das Schlimmste zu verhindern. — Я вмешиваюсь, чтобы предотвратить худшее."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0199",
@@ -13365,7 +13541,8 @@
       "collocations": [
         "Ich enthülle meine wahre Identität. — Я разоблачаю свою истинную личность.",
         "Spielerisch enthülle ich seine Fehler. — Играючи я раскрываю его ошибки."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0203",
@@ -13569,7 +13746,8 @@
         "Erbarmungslos verfolge ich mein Ziel. — Беспощадно я преследую свою цель.",
         "Ich bin erbarmungslos in meiner Rache. — Я беспощадна в своей мести.",
         "Erbarmungslos werfe ich ihn hinaus. — Беспощадно я выбрасываю его."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0208",
@@ -13678,7 +13856,8 @@
       ],
       "collocations": [
         "Erbärmlich ende ich wie ich gelebt habe. — Жалко я заканчиваю, как и жил."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0613",
@@ -13712,7 +13891,8 @@
       ],
       "collocations": [
         "Ich erdulde die Schande ohne Klage. — Я терплю позор без жалоб."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0210",
@@ -13841,7 +14021,8 @@
       ],
       "collocations": [
         "Ergeben folge ich jedem Befehl. — Покорно я следую каждому приказу."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0615",
@@ -13873,7 +14054,8 @@
       ],
       "collocations": [
         "Ich ergreife jede Gelegenheit zur Macht. — Я захватываю каждую возможность власти."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0213",
@@ -14021,7 +14203,8 @@
       ],
       "collocations": [
         "Der Tod soll mich von der Schuld erlösen. — Смерть должна избавить меня от вины."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0617",
@@ -14053,7 +14236,8 @@
       ],
       "collocations": [
         "Ich ermutige ihre dunkelsten Impulse. — Я поощряю её самые тёмные импульсы."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0618",
@@ -14085,7 +14269,8 @@
       ],
       "collocations": [
         "Das Reich will ich erneuern und heilen. — Королевство я хочу обновить и исцелить."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0619",
@@ -14126,7 +14311,8 @@
       "collocations": [
         "Ich erniedrige den einst mächtigen König. — Я унижаю некогда могущественного короля.",
         "Ich erniedrige den treuen Diener. — Я унижаю верного слугу."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0216",
@@ -14262,7 +14448,8 @@
       ],
       "collocations": [
         "Ich erschleiche mir sein Königreich. — Я выманиваю его королевство."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0219",
@@ -14479,7 +14666,8 @@
         "Unsere Liebe wird ewig dauern, mein Kind. — Наша любовь будет вечной, дитя моё.",
         "Unsere Liebe ist ewig, Vater. — Наша любовь вечна, отец.",
         "Meine Treue ist ewig, über den Tod hinaus. — Моя верность вечна, за пределами смерти."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0224",
@@ -14615,7 +14803,8 @@
       ],
       "collocations": [
         "Dieser feierliche Moment wird zur Tragödie. — Этот торжественный момент становится трагедией."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0623",
@@ -14647,7 +14836,8 @@
       ],
       "collocations": [
         "Feige verstecke ich mich hinter meiner Herrin. — Трусливо я прячусь за своей госпожой."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0624",
@@ -14679,7 +14869,8 @@
       ],
       "collocations": [
         "Sie fesseln mich wie einen gemeinen Dieb. — Они сковывают меня как обычного вора."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0227",
@@ -14856,7 +15047,8 @@
       "collocations": [
         "Ich foltere ihn mit kalten Worten. — Я пытаю его холодными словами.",
         "Mit Lust foltere ich den alten Mann. — С наслаждением я пытаю старика."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0626",
@@ -14888,7 +15080,8 @@
       ],
       "collocations": [
         "Ich gehe fort, wenn keiner es bemerkt. — Я ухожу, когда никто не замечает."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0231",
@@ -14951,7 +15144,8 @@
       ],
       "collocations": [
         "Frech widerspreche ich dem alten Mann. — Дерзко я возражаю старику."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0628",
@@ -14983,7 +15177,8 @@
       ],
       "collocations": [
         "Ich bin jetzt fremd in meinem eigenen Land. — Я теперь чужая в своей собственной стране."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0629",
@@ -15030,7 +15225,8 @@
         "Wir alle frieren in dieser kalten Welt. — Мы все мёрзнем в этом холодном мире.",
         "Wir frieren gemeinsam in dieser kalten Nacht. — Мы мёрзнем вместе в эту холодную ночь.",
         "Wir frieren gemeinsam in der kalten Nacht. — Мы мёрзнем вместе в холодную ночь."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0630",
@@ -15062,7 +15258,8 @@
       ],
       "collocations": [
         "Ich fälsche Edgars Brief perfekt. — Я идеально подделываю письмо Эдгара."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0233",
@@ -15224,7 +15421,8 @@
       ],
       "collocations": [
         "Obwohl gefangen, bin ich frei in meinem Herzen. — Хотя я в плену, в сердце я свободна."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0236",
@@ -15324,7 +15522,8 @@
       ],
       "collocations": [
         "Ich genieße jeden Schrei des Schmerzes. — Я наслаждаюсь каждым криком боли."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0633",
@@ -15356,7 +15555,8 @@
       ],
       "collocations": [
         "Ich kämpfe für das, was gerecht ist. — Я борюсь за то, что справедливо."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0238",
@@ -15492,7 +15692,8 @@
       ],
       "collocations": [
         "Gierig greife ich nach jedem Stück Macht. — Жадно я хватаюсь за каждый кусок власти."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0241",
@@ -15560,7 +15761,8 @@
       ],
       "collocations": [
         "Ich bin gnadenlos wie der Winter. — Я безжалостна как зима."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0636",
@@ -15592,7 +15794,8 @@
       ],
       "collocations": [
         "Ich bin grausam zu dem, der mir alles gab. — Я жестока к тому, кто дал мне всё."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0637",
@@ -15626,7 +15829,8 @@
       ],
       "collocations": [
         "Nachts grüble ich über richtig und falsch. — Ночами я размышляю о правильном и неправильном."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0242",
@@ -15792,7 +15996,8 @@
       ],
       "collocations": [
         "Ich haste von einem Ort zum anderen. — Я спешу с места на место."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0639",
@@ -15824,7 +16029,8 @@
       ],
       "collocations": [
         "Meine Liebe wird deine Wunden heilen. — Моя любовь исцелит твои раны."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0640",
@@ -15856,7 +16062,8 @@
       ],
       "collocations": [
         "Ich handle heimlich gegen die neuen Herrscher. — Я действую тайно против новых правителей."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0246",
@@ -15997,7 +16204,8 @@
       ],
       "collocations": [
         "Ich hetze ihn bis zum Ende. — Я травлю его до конца."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0642",
@@ -16029,7 +16237,8 @@
       ],
       "collocations": [
         "Ich muss vor meinem Vater heucheln. — Я должна лицемерить перед отцом."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0643",
@@ -16062,7 +16271,8 @@
       ],
       "collocations": [
         "Ich beginne ihre Taten zu hinterfragen. — Я начинаю подвергать сомнению её поступки."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0644",
@@ -16096,7 +16306,8 @@
       ],
       "collocations": [
         "Ich hintergehe jeden, der mir traut. — Я обманываю каждого, кто мне доверяет."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0249",
@@ -16190,7 +16401,8 @@
       ],
       "collocations": [
         "Ich intrigiere gegen meinen Bruder. — Я интригую против брата."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0251",
@@ -16262,7 +16474,8 @@
       "collocations": [
         "Wie ein Hund jage ich meine Beute. — Как собака я гонюсь за добычей.",
         "Ich jage meinen Sohn fort wie einen Verbrecher. — Я гоню сына прочь как преступника."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0647",
@@ -16294,7 +16507,8 @@
       ],
       "collocations": [
         "Ich jongliere mit zwei gefährlichen Frauen. — Я жонглирую двумя опасными женщинами."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0253",
@@ -16392,7 +16606,8 @@
       ],
       "collocations": [
         "Zum ersten Mal sehe ich klar. — Впервые я вижу ясно."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0649",
@@ -16424,7 +16639,8 @@
       ],
       "collocations": [
         "Meine Worte klingen lustig, doch sind traurig. — Мои слова звучат весело, но печальны."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0650",
@@ -16456,7 +16672,8 @@
       ],
       "collocations": [
         "Ich bin klüger als alle bei Hofe. — Я умнее всех при дворе."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0651",
@@ -16488,7 +16705,8 @@
       ],
       "collocations": [
         "Ich knechte alle, die mir unterstehen. — Я порабощаю всех, кто мне подчинён."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0255",
@@ -16551,7 +16769,8 @@
       ],
       "collocations": [
         "Ich konfrontiere sie mit ihrer Grausamkeit. — Я противостою ей с её жестокостью."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0257",
@@ -16750,7 +16969,8 @@
       ],
       "collocations": [
         "Heimlich lausche ich allen Gesprächen. — Тайно я подслушиваю все разговоры."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0260",
@@ -16814,7 +17034,8 @@
       ],
       "collocations": [
         "Ich bin der legitime Sohn des Grafen. — Я законный сын графа."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0655",
@@ -16846,7 +17067,8 @@
       ],
       "collocations": [
         "Ich bin zu leichtgläubig für diese Welt. — Я слишком легковерен для этого мира."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0261",
@@ -16934,7 +17156,8 @@
       ],
       "collocations": [
         "Ich lenke das Land in eine bessere Zukunft. — Я направляю страну в лучшее будущее."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0262",
@@ -17028,7 +17251,8 @@
       ],
       "collocations": [
         "Ich locke ihn mit Versprechungen. — Я заманиваю его обещаниями."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0264",
@@ -17129,7 +17353,8 @@
       ],
       "collocations": [
         "Ich manipuliere meinen Vater geschickt. — Я ловко манипулирую отцом."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0659",
@@ -17161,7 +17386,8 @@
       ],
       "collocations": [
         "Meine milde Art wird als Schwäche gesehen. — Моя мягкость воспринимается как слабость."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0660",
@@ -17193,7 +17419,8 @@
       ],
       "collocations": [
         "Ich missachte seinen früheren Rang. — Я пренебрегаю его прежним рангом."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0266",
@@ -17257,7 +17484,8 @@
       ],
       "collocations": [
         "Ich misshandle den alten Mann. — Я жестоко обращаюсь со стариком."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0267",
@@ -17366,7 +17594,8 @@
       ],
       "collocations": [
         "Ich murmle Unsinn, um verrückt zu wirken. — Я бормочу чепуху, чтобы казаться сумасшедшим."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0663",
@@ -17398,7 +17627,8 @@
       ],
       "collocations": [
         "Sei mutig, mein Herz, für die gerechte Sache. — Будь храбрым, моё сердце, ради правого дела."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0269",
@@ -17464,7 +17694,8 @@
       ],
       "collocations": [
         "Ich denke nach über des Lebens Sinn. — Я размышляю о смысле жизни."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0665",
@@ -17496,7 +17727,8 @@
       ],
       "collocations": [
         "Zu oft gebe ich ihrem Willen nach. — Слишком часто я уступаю её воле."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0666",
@@ -17536,7 +17768,8 @@
       "collocations": [
         "Nackt kam ich auf die Welt, nackt gehe ich! — Голым я пришёл в мир, голым и уйду!",
         "Fast nackt wandere ich durch die Wildnis. — Почти голый, я брожу по дикой местности."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0667",
@@ -17568,7 +17801,8 @@
       ],
       "collocations": [
         "Ich necke den König mit der Wahrheit. — Я дразню короля правдой."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0270",
@@ -17631,7 +17865,8 @@
       ],
       "collocations": [
         "Eine neue Ära beginnt für unser Land. — Новая эра начинается для нашей страны."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0669",
@@ -17663,7 +17898,8 @@
       ],
       "collocations": [
         "Ich opfere ihn für meine Ambitionen. — Я жертвую им ради своих амбиций."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0670",
@@ -17695,7 +17931,8 @@
       ],
       "collocations": [
         "Passiv schaue ich dem Unrecht zu. — Пассивно я наблюдаю за несправедливостью."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0671",
@@ -17727,7 +17964,8 @@
       ],
       "collocations": [
         "Ich pfeife gegen die Dunkelheit an. — Я свищу против темноты."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0672",
@@ -17759,7 +17997,8 @@
       ],
       "collocations": [
         "Wir planen den Untergang des alten Königs. — Мы планируем падение старого короля."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0673",
@@ -17791,7 +18030,8 @@
       ],
       "collocations": [
         "Ein prächtiger Tag für eine verhängnisvolle Entscheidung. — Великолепный день для рокового решения."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0271",
@@ -17895,7 +18135,8 @@
       ],
       "collocations": [
         "Als Кай rate ich ihm zur Vorsicht. — Как Кай я советую ему осторожность."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0274",
@@ -17966,7 +18207,8 @@
       "collocations": [
         "Ich will rechtschaffen leben und handeln. — Я хочу жить и действовать праведно.",
         "Ich bin ein rechtschaffener Mann. — Я праведный человек."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0275",
@@ -18246,7 +18488,8 @@
       ],
       "collocations": [
         "Ich riskiere alles für den alten König. — Я рискую всем ради старого короля."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0677",
@@ -18278,7 +18521,8 @@
       ],
       "collocations": [
         "Ich rivalisiere mit meiner Schwester um Edmund. — Я соперничаю с сестрой за Эдмунда."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0282",
@@ -18380,7 +18624,8 @@
       "collocations": [
         "Meine Worte bleiben rätselhaft und wahr. — Мои слова остаются загадочными и правдивыми.",
         "Mein Ende bleibt rätselhaft und stumm. — Мой конец остаётся загадочным и немым."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0679",
@@ -18412,7 +18657,8 @@
       ],
       "collocations": [
         "Röchelnd hauche ich mein Leben aus. — Хрипя, я испускаю дух."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0283",
@@ -18477,7 +18723,8 @@
       ],
       "collocations": [
         "Sei sanft zu dir selbst, lieber Vater. — Будь нежен к себе, дорогой отец."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0284",
@@ -18605,7 +18852,8 @@
       ],
       "collocations": [
         "Ich scherze, um den Schmerz zu verbergen. — Я шучу, чтобы скрыть боль."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0287",
@@ -18766,7 +19014,8 @@
       ],
       "collocations": [
         "Ich schmiede Pläne gegen alle Feinde. — Я кую планы против всех врагов."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0683",
@@ -18798,7 +19047,8 @@
       ],
       "collocations": [
         "Überall schnüffle ich nach Geheimnissen. — Везде я вынюхиваю секреты."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0291",
@@ -18869,7 +19119,8 @@
       "collocations": [
         "Ich schreie in den Wind meine Wut hinaus! — Я кричу в ветер свою ярость!",
         "Ich schreie vor unerträglichem Schmerz. — Я кричу от невыносимой боли."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0685",
@@ -18901,7 +19152,8 @@
       ],
       "collocations": [
         "Ich bin schuldig vor meiner Tochter. — Я виновен перед своей дочерью."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0292",
@@ -18964,7 +19216,8 @@
       ],
       "collocations": [
         "Die Verletzung schwächt meinen starken Körper. — Ранение ослабляет моё сильное тело."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0293",
@@ -19034,7 +19287,8 @@
       ],
       "collocations": [
         "Ich will den wahnsinnigen König schützen. — Я хочу защитить безумного короля."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0294",
@@ -19129,7 +19383,8 @@
       ],
       "collocations": [
         "Ich löse mich auf wie Nebel im Wind. — Я растворяюсь как туман на ветру."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0689",
@@ -19162,7 +19417,8 @@
       ],
       "collocations": [
         "Ich wehre mich gegen ihre Tyrannei. — Я защищаюсь от её тирании."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0296",
@@ -19465,7 +19721,8 @@
       ],
       "collocations": [
         "Ich spioniere für meine böse Herrin. — Я шпионю для моей злой госпожи."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0691",
@@ -19498,7 +19755,8 @@
       ],
       "collocations": [
         "Ich spotte über die Torheit der Mächtigen. — Я насмехаюсь над глупостью сильных."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0304",
@@ -19599,7 +19857,8 @@
       ],
       "collocations": [
         "Spurlos gehe ich aus dieser Welt. — Бесследно я ухожу из этого мира."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0306",
@@ -19787,7 +20046,8 @@
       ],
       "collocations": [
         "Ich strebe nach absoluter Kontrolle. — Я стремлюсь к абсолютному контролю."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0311",
@@ -19955,7 +20215,8 @@
       ],
       "collocations": [
         "Leise summe ich alte Melodien. — Тихо я напеваю старые мелодии."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0314",
@@ -20018,7 +20279,8 @@
       ],
       "collocations": [
         "Ich bleibe tapfer für dich, Vater. — Я остаюсь отважной ради тебя, отец."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0316",
@@ -20256,7 +20518,8 @@
       "collocations": [
         "Treu bleibe ich trotz der Verkleidung. — Верным остаюсь несмотря на переодевание.",
         "Ich bleibe treu, wenn alle anderen fliehen. — Я остаюсь верным, когда все остальные бегут."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0697",
@@ -20288,7 +20551,8 @@
       ],
       "collocations": [
         "Ich triumphiere über meinen Bruder. — Я торжествую над братом."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0320",
@@ -20509,7 +20773,8 @@
       ],
       "collocations": [
         "Tückisch plane ich meinen nächsten Schritt. — Коварно я планирую свой следующий шаг."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0699",
@@ -20549,7 +20814,8 @@
       "collocations": [
         "Lass mich dich umarmen und deine Tränen trocknen. — Позволь мне обнять тебя и вытереть твои слёзы.",
         "Ein letztes Mal umarme ich meinen Sohn. — В последний раз я обнимаю сына."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0328",
@@ -20645,7 +20911,8 @@
       ],
       "collocations": [
         "Meine uneheliche Geburt ist mein Fluch. — Моё внебрачное рождение - мой проклятие."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0701",
@@ -20677,7 +20944,8 @@
       ],
       "collocations": [
         "Unerkannt bleibe ich an seiner Seite. — Неузнанным я остаюсь рядом с ним."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0702",
@@ -20709,7 +20977,8 @@
       ],
       "collocations": [
         "Ich werde unsicher in meinem Schweigen. — Я становлюсь неуверенным в своём молчании."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0330",
@@ -20840,7 +21109,8 @@
       ],
       "collocations": [
         "Ich unterliege dem edlen Edgar. — Я проигрываю благородному Эдгару."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0334",
@@ -21006,7 +21276,8 @@
       ],
       "collocations": [
         "Unterwürfig krieche ich vor meiner Herrin. — Раболепно я пресмыкаюсь перед госпожой."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0337",
@@ -21070,7 +21341,8 @@
       ],
       "collocations": [
         "Ich verachte seine Schwäche und sein Alter. — Я презираю его слабость и старость."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0338",
@@ -21141,7 +21413,8 @@
       ],
       "collocations": [
         "Verbannt aus dem Land, das ich liebe. — Изгнан из страны, которую люблю."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0339",
@@ -21298,7 +21571,8 @@
       ],
       "collocations": [
         "Ich verbünde mich mit den bösen Schwestern. — Я объединяюсь со злыми сёстрами."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0344",
@@ -21392,7 +21666,8 @@
       ],
       "collocations": [
         "Ich verdränge den rechtmäßigen Erben. — Я вытесняю законного наследника."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0343",
@@ -21461,7 +21736,8 @@
       ],
       "collocations": [
         "Wir vereinbaren gemeinsame Grausamkeit. — Мы договариваемся о совместной жестокости."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0346",
@@ -21527,7 +21803,8 @@
       ],
       "collocations": [
         "Wie ein Tier verende ich elend. — Как зверь я издыхаю жалко."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0347",
@@ -21607,7 +21884,8 @@
       ],
       "collocations": [
         "Verflucht sei unser böses Blut! — Проклята наша злая кровь!"
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0348",
@@ -21688,7 +21966,8 @@
       "collocations": [
         "Ich verführe beide Schwestern gleichzeitig. — Я соблазняю обеих сестёр одновременно.",
         "Ich will Edmund verführen und besitzen. — Я хочу соблазнить и завладеть Эдмундом."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0349",
@@ -21829,7 +22108,8 @@
       ],
       "collocations": [
         "Ich bin von meiner eigenen Schwester vergiftet. — Я отравлена собственной сестрой."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0714",
@@ -21861,7 +22141,8 @@
       ],
       "collocations": [
         "Alles ist vergänglich, nur die Torheit bleibt. — Всё преходяще, только глупость остаётся."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0352",
@@ -22023,7 +22304,8 @@
       ],
       "collocations": [
         "Mein Herz verhärtet sich gegen alle Bitten. — Моё сердце ожесточается против всех просьб."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0716",
@@ -22065,7 +22347,8 @@
       "collocations": [
         "Ich verhöhne seine königliche Würde. — Я высмеиваю его королевское достоинство.",
         "Ich verhöhne seine väterliche Liebe. — Я насмехаюсь над его отцовской любовью."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0356",
@@ -22200,7 +22483,8 @@
       "collocations": [
         "Ich verkünde die Teilung meines Reiches. — Я провозглашаю раздел моего королевства.",
         "Ich verkünde nur die Wahrheit meines Herzens. — Я провозглашаю только правду моего сердца."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0359",
@@ -22475,7 +22759,8 @@
       ],
       "collocations": [
         "Ich verlocke sie mit falschen Versprechen. — Я завлекаю их ложными обещаниями."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0366",
@@ -22538,7 +22823,8 @@
       ],
       "collocations": [
         "Ich vermisse die süße Корделия sehr. — Я очень скучаю по милой Корделии."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0367",
@@ -22717,7 +23003,8 @@
       ],
       "collocations": [
         "Verschlagen verberge ich meine wahren Absichten. — Хитро я скрываю свои истинные намерения."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0371",
@@ -22995,7 +23282,8 @@
       ],
       "collocations": [
         "Ich verstelle meine Stimme und Haltung. — Я изменяю свой голос и осанку."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0379",
@@ -23082,7 +23370,8 @@
       ],
       "collocations": [
         "Ich verstümmle ihn ohne Erbarmen. — Я калечу его без милосердия."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0380",
@@ -23404,7 +23693,8 @@
       ],
       "collocations": [
         "Ich verweigere ihm jeden Komfort. — Я отказываю ему в любом комфорте."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0387",
@@ -23499,7 +23789,8 @@
       ],
       "collocations": [
         "Schwer verwundet sinke ich zu Boden. — Тяжело раненый я падаю на землю."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0388",
@@ -23564,7 +23855,8 @@
       ],
       "collocations": [
         "Ich verwünsche meine Schwester mit letzter Kraft. — Я проклинаю сестру последними силами."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0390",
@@ -23763,7 +24055,8 @@
       ],
       "collocations": [
         "Ich gebe vor, ein einfacher Mann zu sein. — Я притворяюсь простым человеком."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0727",
@@ -23795,7 +24088,8 @@
       ],
       "collocations": [
         "Ich sage das kommende Unheil vorher. — Я предсказываю грядущую беду."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0728",
@@ -23827,7 +24121,8 @@
       ],
       "collocations": [
         "Ich spiele ihm Töchterliebe vor. — Я разыгрываю перед ним дочернюю любовь."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0395",
@@ -23891,7 +24186,8 @@
       ],
       "collocations": [
         "Ich täusche Liebe vor, die nie existierte. — Я притворяюсь в любви, которой никогда не было."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0396",
@@ -24022,7 +24318,8 @@
       ],
       "collocations": [
         "Ich gebe vor, wahnsinnig zu sein. — Я притворяюсь безумным."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0400",
@@ -24116,7 +24413,8 @@
       ],
       "collocations": [
         "Ich warne den König vor seinem Fehler. — Я предупреждаю короля об его ошибке."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0402",
@@ -24439,7 +24737,8 @@
       ],
       "collocations": [
         "Wir wetteifern um das größte Erbe. — Мы состязаемся за большее наследство."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0733",
@@ -24471,7 +24770,8 @@
       ],
       "collocations": [
         "Wir wettkämpfen um Edmunds Liebe. — Мы соревнуемся за любовь Эдмунда."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0411",
@@ -24765,7 +25065,8 @@
       ],
       "collocations": [
         "Wimmernd bitte ich um Gnade. — Хныкая, я прошу о пощаде."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0419",
@@ -25060,7 +25361,8 @@
       ],
       "collocations": [
         "Ich zertrete seine Augen unter meinem Fuß. — Я растаптываю его глаза под ногой."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0427",
@@ -25376,7 +25678,8 @@
       ],
       "collocations": [
         "Öffentlich züchtige ich die Widerspenstigen. — Публично я наказываю непокорных."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0737",
@@ -25408,7 +25711,8 @@
       ],
       "collocations": [
         "Ich überbringe Befehle an alle Diener. — Я передаю приказы всем слугам."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0326",
@@ -25476,7 +25780,8 @@
       ],
       "collocations": [
         "Ich will meine Schwester in der Lüge übertreffen. — Я хочу превзойти сестру во лжи."
-      ]
+      ],
+      "visual_hint": "📚"
     },
     {
       "id": "word_0327",

--- a/generators/html_lira.py
+++ b/generators/html_lira.py
@@ -61,6 +61,21 @@ class LiraHTMLGenerator(BaseGenerator):
                 if 'collocations' not in word or not word['collocations']:
                     word['collocations'] = list(entry.get('collocations', []))
 
+                if not word.get('visual_hint') and entry.get('visual_hint'):
+                    word['visual_hint'] = entry['visual_hint']
+
+                if 'themes' not in word or not word['themes']:
+                    entry_themes = entry.get('themes')
+                    if entry_themes:
+                        if isinstance(entry_themes, str):
+                            entry_themes = [entry_themes]
+                        elif isinstance(entry_themes, tuple):
+                            entry_themes = list(entry_themes)
+                        elif not isinstance(entry_themes, list):
+                            entry_themes = [entry_themes]
+
+                        word['themes'] = list(entry_themes)
+
     def generate_journey(self, character_file):
         """Generate journey page for a character"""
         character = self.load_character(character_file)

--- a/output/journeys/albany.html
+++ b/output/journeys/albany.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["слабость", "молчание", "терпеть", "брак"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["брак", "слабость", "молчание", "терпеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["брак", "уступать", "мягкий", "пассивный"], "correct_index": 0}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["терпеть", "уступать", "мягкий", "пассивный"], "correct_index": 0}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["пассивный", "уступать", "слабость", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["уступать", "брак", "пассивный", "мягкий"], "correct_index": 0}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["мягкий", "колебаться", "уступать", "терпеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «mild»?", "choices": ["брак", "молчание", "пассивный", "мягкий"], "correct_index": 3}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["подвергать сомнению", "беспокойство", "совесть", "сомнение"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["сомнение", "беспокойство", "совесть", "подвергать сомнению"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["подвергать сомнению", "сомнение", "совесть", "беспокойство"], "correct_index": 3}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["тревожить", "подвергать сомнению", "размышлять", "совесть"], "correct_index": 1}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["тревожить", "беспокойство", "подвергать сомнению", "сомнение"], "correct_index": 0}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["беспокойство", "тревожить", "подвергать сомнению", "неуверенный"], "correct_index": 3}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["совесть", "сомнение", "беспокойство", "размышлять"], "correct_index": 3}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["осознание", "понимать", "ужас", "пробуждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["пробуждаться", "понимать", "ужас", "осознание"], "correct_index": 2}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["пробуждаться", "понимать", "осознание", "ужас"], "correct_index": 0}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["превращение", "осознание", "ужас", "понимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["понимать", "просыпаться", "пробуждаться", "пугаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["превращение", "понимать", "осознание", "просыпаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["ясно видеть", "превращение", "осознание", "пугаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["пробуждаться", "понимать", "превращение", "ужас"], "correct_index": 2}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["сопротивление", "мужество", "противостоять", "спор"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "противостоять", "сопротивление", "спор"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["сопротивление", "спор", "обвинять", "восставать"], "correct_index": 0}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["противостоять", "сопротивление", "мужество", "защищаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["обвинять", "противостоять", "мужество", "защищаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["защищаться", "сопротивление", "спор", "противостоять"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["восставать", "мужество", "защищаться", "обвинять"], "correct_index": 0}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["выбирать", "справедливость", "решение", "мораль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["решение", "выбирать", "справедливость", "мораль"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["праведный", "выбирать", "мораль", "решение"], "correct_index": 3}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["благородный", "справедливость", "выбирать", "решение"], "correct_index": 2}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["праведный", "решение", "добродетель", "благородный"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["решение", "мораль", "принцип", "благородный"], "correct_index": 2}, {"question": "Что означает немецкое слово «edel»?", "choices": ["добродетель", "справедливость", "принцип", "благородный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["принцип", "выбирать", "праведный", "добродетель"], "correct_index": 3}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["борьба", "наказывать", "доброта", "право"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["наказывать", "доброта", "борьба", "право"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["наказывать", "доброта", "право", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["борьба", "вмешиваться", "право", "наказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «richten»?", "choices": ["вмешиваться", "судить", "право", "наказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["доброта", "наказывать", "борьба", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["защищать", "вмешиваться", "право", "доброта"], "correct_index": 1}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["правление", "направлять", "новое начало", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["направлять", "мудрость", "правление", "новое начало"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["новое начало", "мир", "примирять", "направлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["мудрость", "направлять", "новое начало", "строить"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["новое начало", "строить", "обновлять", "примирять"], "correct_index": 1}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["новое начало", "направлять", "обновлять", "мир"], "correct_index": 2}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["примирять", "направлять", "строить", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["примирять", "строить", "обновлять", "мир"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["терпеть", "молчание", "брак", "слабость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["слабость", "брак", "терпеть", "молчание"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["пассивный", "колебаться", "брак", "слабость"], "correct_index": 2}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["молчание", "терпеть", "брак", "пассивный"], "correct_index": 1}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["уступать", "пассивный", "колебаться", "мягкий"], "correct_index": 1}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["мягкий", "терпеть", "пассивный", "уступать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["пассивный", "слабость", "колебаться", "терпеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «mild»?", "choices": ["мягкий", "слабость", "пассивный", "уступать"], "correct_index": 0}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["подвергать сомнению", "совесть", "беспокойство", "сомнение"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["подвергать сомнению", "совесть", "сомнение", "беспокойство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["размышлять", "беспокойство", "тревожить", "совесть"], "correct_index": 1}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["совесть", "подвергать сомнению", "сомнение", "тревожить"], "correct_index": 1}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["тревожить", "совесть", "беспокойство", "сомнение"], "correct_index": 0}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["подвергать сомнению", "совесть", "размышлять", "неуверенный"], "correct_index": 3}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["тревожить", "беспокойство", "размышлять", "сомнение"], "correct_index": 2}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["пробуждаться", "осознание", "понимать", "ужас"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["понимать", "осознание", "пробуждаться", "ужас"], "correct_index": 3}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["понимать", "пробуждаться", "превращение", "пугаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["понимать", "превращение", "пробуждаться", "просыпаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["пугаться", "пробуждаться", "превращение", "просыпаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["пугаться", "ужас", "просыпаться", "осознание"], "correct_index": 2}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["ужас", "ясно видеть", "осознание", "пугаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["просыпаться", "пугаться", "превращение", "понимать"], "correct_index": 2}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["спор", "сопротивление", "мужество", "противостоять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "спор", "противостоять", "сопротивление"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["защищаться", "восставать", "сопротивление", "обвинять"], "correct_index": 2}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["мужество", "защищаться", "восставать", "противостоять"], "correct_index": 3}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["мужество", "защищаться", "противостоять", "обвинять"], "correct_index": 3}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["защищаться", "противостоять", "обвинять", "мужество"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["противостоять", "восставать", "обвинять", "сопротивление"], "correct_index": 1}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["мораль", "выбирать", "решение", "справедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["выбирать", "мораль", "справедливость", "решение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["решение", "мораль", "благородный", "добродетель"], "correct_index": 0}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["решение", "праведный", "мораль", "выбирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["принцип", "благородный", "выбирать", "праведный"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["принцип", "мораль", "справедливость", "праведный"], "correct_index": 0}, {"question": "Что означает немецкое слово «edel»?", "choices": ["выбирать", "благородный", "добродетель", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["мораль", "добродетель", "праведный", "благородный"], "correct_index": 1}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["борьба", "наказывать", "право", "доброта"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["наказывать", "борьба", "право", "доброта"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["вмешиваться", "судить", "доброта", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["судить", "право", "борьба", "наказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «richten»?", "choices": ["доброта", "наказывать", "вмешиваться", "судить"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["защищать", "доброта", "наказывать", "судить"], "correct_index": 0}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["доброта", "защищать", "вмешиваться", "наказывать"], "correct_index": 2}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["новое начало", "мудрость", "правление", "направлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "направлять", "новое начало", "правление"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["правление", "строить", "новое начало", "мир"], "correct_index": 2}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["направлять", "мудрость", "новое начало", "строить"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["строить", "правление", "обновлять", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["новое начало", "правление", "обновлять", "мир"], "correct_index": 2}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["примирять", "обновлять", "новое начало", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["обновлять", "правление", "мир", "примирять"], "correct_index": 2}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -458,91 +458,75 @@
                         <div class="quiz-question">Что означает немецкое слово «das Schweigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Ehe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">уступать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пассивный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">уступать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пассивный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «passiv»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «nachgeben»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пассивный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «passiv»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">уступать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пассивный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
                             
@@ -550,15 +534,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «zögern»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «nachgeben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">уступать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «zögern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                             
@@ -566,17 +566,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «mild»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">уступать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -595,9 +595,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
                             
@@ -605,33 +605,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Gewissen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Unbehagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тревожить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -641,13 +641,13 @@
                         <div class="quiz-question">Что означает немецкое слово «hinterfragen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тревожить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -659,9 +659,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
                             
@@ -673,11 +673,11 @@
                         <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тревожить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
                             
@@ -685,17 +685,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «grübeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -708,47 +708,15 @@
             <div class="quiz-phase-container" data-phase="awakening">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Entsetzen»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ужас</button>
                             
@@ -756,31 +724,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Entsetzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">превращение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ужас</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пугаться</button>
                             
@@ -788,15 +756,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">превращение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">превращение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
                             
@@ -804,13 +772,45 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">просыпаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «klar sehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">превращение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                             
@@ -824,13 +824,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Verwandlung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ужас</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -843,17 +843,17 @@
             <div class="quiz-phase-container" data-phase="confrontation">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Streit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -865,59 +865,59 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопротивление</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Widerstand»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «konfrontieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «anklagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -929,27 +929,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">защищаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «aufbegehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопротивление</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -962,17 +962,17 @@
             <div class="quiz-phase-container" data-phase="moral_stand">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Moral»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -982,109 +982,109 @@
                         <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Entscheidung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">добродетель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «edel»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Tugend»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «edel»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">добродетель</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Tugend»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1105,39 +1105,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Recht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Güte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">судить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
@@ -1149,11 +1149,11 @@
                         <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
                             
@@ -1161,49 +1161,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «richten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">судить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вмешиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «eingreifen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «eingreifen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вмешиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1216,47 +1216,15 @@
             <div class="quiz-phase-container" data-phase="new_ruler">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">примирять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
                             
@@ -1264,13 +1232,45 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «lenken»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">правление</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">строить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мир</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «lenken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
                             
@@ -1280,17 +1280,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «aufbauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">строить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1302,7 +1302,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
                             
@@ -1318,27 +1318,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">примирять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">строить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Friede»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">примирять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обновлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">строить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1367,8 +1367,12 @@
                 "transcription": "[дас ШВАЙ-ген]",
                 "sentence": "Mein Schweigen macht mich zum Mitschuldigen.",
                 "sentenceTranslation": "Моё молчание делает меня соучастником.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
                 "wordFamily": [
                     "Основа: das Schweigen",
                     "Множественное число (пример): die Schweigen",
@@ -1387,8 +1391,12 @@
                 "transcription": "[ди ШВЕ-хе]",
                 "sentence": "Meine Schwäche erlaubt das Böse zu wachsen.",
                 "sentenceTranslation": "Моя слабость позволяет злу расти.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
                 "wordFamily": [
                     "Основа: die Schwäche",
                     "Множественное число (пример): die Schwäche",
@@ -1407,8 +1415,12 @@
                 "transcription": "[ди Э-е]",
                 "sentence": "Die Ehe bindet mich an eine grausame Frau.",
                 "sentenceTranslation": "Брак связывает меня с жестокой женой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
                 "wordFamily": [
                     "Основа: die Ehe",
                     "Множественное число (пример): die Ehe",
@@ -1427,8 +1439,12 @@
                 "transcription": "[ДУЛЬ-ден]",
                 "sentence": "Ich dulde ihre Grausamkeit zu lange.",
                 "sentenceTranslation": "Я слишком долго терплю её жестокость.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
                 "wordFamily": [
                     "Инфинитив: dulden",
                     "Презенс: ich dulde",
@@ -1449,8 +1465,12 @@
                 "transcription": "[па-СИФ]",
                 "sentence": "Passiv schaue ich dem Unrecht zu.",
                 "sentenceTranslation": "Пассивно я наблюдаю за несправедливостью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
                 "wordFamily": [
                     "Основная форма: passiv",
                     "Сравнительная степень: passiver",
@@ -1469,8 +1489,12 @@
                 "transcription": "[НАХ-ге-бен]",
                 "sentence": "Zu oft gebe ich ihrem Willen nach.",
                 "sentenceTranslation": "Слишком часто я уступаю её воле.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
                 "wordFamily": [
                     "Инфинитив: nachgeben",
                     "Презенс: ich gebe nach",
@@ -1489,8 +1513,10 @@
                 "transcription": "[ЦЁ-герн]",
                 "sentence": "Ich zögere, wenn ich handeln sollte.",
                 "sentenceTranslation": "Я колеблюсь, когда должен действовать.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: zögern",
                     "Презенс: ich zögere",
@@ -1511,8 +1537,12 @@
                 "transcription": "[МИЛЬД]",
                 "sentence": "Meine milde Art wird als Schwäche gesehen.",
                 "sentenceTranslation": "Моя мягкость воспринимается как слабость.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
                 "wordFamily": [
                     "Основная форма: mild",
                     "Сравнительная степень: milder",
@@ -1559,8 +1589,12 @@
                 "transcription": "[дер ЦВАЙ-фель]",
                 "sentence": "Der Zweifel an ihrer Güte wächst in mir.",
                 "sentenceTranslation": "Сомнение в её доброте растёт во мне.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
                 "wordFamily": [
                     "Основа: der Zweifel",
                     "Множественное число (пример): die Zweifel",
@@ -1579,8 +1613,10 @@
                 "transcription": "[дас ге-ВИ-сен]",
                 "sentence": "Mein Gewissen beginnt mich zu quälen.",
                 "sentenceTranslation": "Моя совесть начинает мучить меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Gewissen",
                     "Множественное число (пример): die Gewissen",
@@ -1600,8 +1636,12 @@
                 "transcription": "[дас УН-бе-ха-ген]",
                 "sentence": "Ein tiefes Unbehagen erfüllt meine Seele.",
                 "sentenceTranslation": "Глубокое беспокойство наполняет мою душу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
                 "wordFamily": [
                     "Основа: das Unbehagen",
                     "Множественное число (пример): die Unbehagen",
@@ -1620,8 +1660,12 @@
                 "transcription": "[ХИН-тер-фра-ген]",
                 "sentence": "Ich beginne ihre Taten zu hinterfragen.",
                 "sentenceTranslation": "Я начинаю подвергать сомнению её поступки.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
                 "wordFamily": [
                     "Инфинитив: hinterfragen",
                     "Презенс: ich terfrage hin",
@@ -1641,8 +1685,12 @@
                 "transcription": "[бе-УН-ру-и-ген]",
                 "sentence": "Ihre Grausamkeit beunruhigt mich zunehmend.",
                 "sentenceTranslation": "Её жестокость всё больше тревожит меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
                 "wordFamily": [
                     "Инфинитив: beunruhigen",
                     "Презенс: ich beunruhige",
@@ -1661,8 +1709,12 @@
                 "transcription": "[УН-зи-хер]",
                 "sentence": "Ich werde unsicher in meinem Schweigen.",
                 "sentenceTranslation": "Я становлюсь неуверенным в своём молчании.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
                 "wordFamily": [
                     "Основная форма: unsicher",
                     "Сравнительная степень: unsichrer",
@@ -1681,8 +1733,12 @@
                 "transcription": "[ГРЮ-бельн]",
                 "sentence": "Nachts grüble ich über richtig und falsch.",
                 "sentenceTranslation": "Ночами я размышляю о правильном и неправильном.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
                 "wordFamily": [
                     "Инфинитив: grübeln",
                     "Презенс: ich grübele",
@@ -1731,8 +1787,10 @@
                 "transcription": "[ди ер-КЕНТ-нис]",
                 "sentence": "Die Erkenntnis ihrer Bosheit erschüttert mich.",
                 "sentenceTranslation": "Осознание её злобы потрясает меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Erkenntnis",
                     "Множественное число (пример): die Erkenntnise",
@@ -1755,8 +1813,12 @@
                 "transcription": "[дас энт-ЗЕ-цен]",
                 "sentence": "Mit Entsetzen sehe ich ihr wahres Gesicht.",
                 "sentenceTranslation": "С ужасом я вижу её истинное лицо.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Entsetzen",
+                    "Erkenntnis",
+                    "Erwachen"
+                ],
                 "wordFamily": [
                     "Основа: das Entsetzen",
                     "Множественное число (пример): die Entsetzen",
@@ -1776,8 +1838,10 @@
                 "transcription": "[ер-ВА-хен]",
                 "sentence": "Endlich erwache ich aus meiner Blindheit.",
                 "sentenceTranslation": "Наконец я пробуждаюсь от своей слепоты.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: erwachen",
                     "Презенс: ich erwache",
@@ -1799,8 +1863,10 @@
                 "transcription": "[бе-ГРАЙ-фен]",
                 "sentence": "Ich begreife das Ausmaß ihrer Grausamkeit.",
                 "sentenceTranslation": "Я понимаю масштаб её жестокости.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: begreifen",
                     "Презенс: ich begreife",
@@ -1821,8 +1887,10 @@
                 "transcription": "[ер-ШРЕК-кен]",
                 "sentence": "Ihre Taten erschrecken mein gutes Herz.",
                 "sentenceTranslation": "Её поступки пугают моё доброе сердце.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: erschrecken",
                     "Презенс: ich erschrecke",
@@ -1843,8 +1911,12 @@
                 "transcription": "[АУФ-ва-хен]",
                 "sentence": "Ich wache auf aus meinem langen Schlaf.",
                 "sentenceTranslation": "Я просыпаюсь от долгого сна.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Entsetzen",
+                    "Erkenntnis",
+                    "Erwachen"
+                ],
                 "wordFamily": [
                     "Инфинитив: aufwachen",
                     "Презенс: ich wache auf",
@@ -1864,8 +1936,12 @@
                 "transcription": "[КЛАР ЗЕ-ен]",
                 "sentence": "Zum ersten Mal sehe ich klar.",
                 "sentenceTranslation": "Впервые я вижу ясно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Entsetzen",
+                    "Erkenntnis",
+                    "Erwachen"
+                ],
                 "wordFamily": [
                     "Инфинитив: klar sehen",
                     "Презенс: ich klar sehe",
@@ -1886,8 +1962,10 @@
                 "transcription": "[ди фер-ВАНД-лунг]",
                 "sentence": "Eine Verwandlung beginnt in meiner Seele.",
                 "sentenceTranslation": "Превращение начинается в моей душе.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Verwandlung",
                     "Множественное число (пример): die Verwandlungen",
@@ -1935,8 +2013,12 @@
                 "transcription": "[дер ШТРАЙТ]",
                 "sentence": "Der Streit mit meiner Frau eskaliert.",
                 "sentenceTranslation": "Спор с моей женой обостряется.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
                 "wordFamily": [
                     "Основа: der Streit",
                     "Множественное число (пример): die Streite",
@@ -1955,8 +2037,10 @@
                 "transcription": "[дер МУТ]",
                 "sentence": "Endlich finde ich den Mut zu widersprechen.",
                 "sentenceTranslation": "Наконец я нахожу мужество возражать.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Mut",
                     "Множественное число (пример): die Mute",
@@ -1977,8 +2061,12 @@
                 "transcription": "[дер ВИ-дер-штанд]",
                 "sentence": "Mein Widerstand gegen das Böse beginnt.",
                 "sentenceTranslation": "Моё сопротивление злу начинается.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
                 "wordFamily": [
                     "Основа: der Widerstand",
                     "Множественное число (пример): die Widerstande",
@@ -1997,8 +2085,12 @@
                 "transcription": "[кон-фрон-ТИ-рен]",
                 "sentence": "Ich konfrontiere sie mit ihrer Grausamkeit.",
                 "sentenceTranslation": "Я противостою ей с её жестокостью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
                 "wordFamily": [
                     "Инфинитив: konfrontieren",
                     "Презенс: ich konfrontiere",
@@ -2017,8 +2109,12 @@
                 "transcription": "[АН-кла-ген]",
                 "sentence": "Ich klage sie ihrer Unmenschlichkeit an.",
                 "sentenceTranslation": "Я обвиняю её в бесчеловечности.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
                 "wordFamily": [
                     "Инфинитив: anklagen",
                     "Презенс: ich klage an",
@@ -2039,8 +2135,12 @@
                 "transcription": "[зих ВЕ-рен]",
                 "sentence": "Ich wehre mich gegen ihre Tyrannei.",
                 "sentenceTranslation": "Я защищаюсь от её тирании.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
                 "wordFamily": [
                     "Инфинитив: sich wehren",
                     "Презенс: ich wehre mich",
@@ -2060,8 +2160,12 @@
                 "transcription": "[АУФ-бе-ге-рен]",
                 "sentence": "Ich begehre auf gegen das Unrecht.",
                 "sentenceTranslation": "Я восстаю против несправедливости.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
                 "wordFamily": [
                     "Инфинитив: aufbegehren",
                     "Презенс: ich begehre auf",
@@ -2108,8 +2212,12 @@
                 "transcription": "[ди мо-РАЛЬ]",
                 "sentence": "Die Moral leitet nun meine Entscheidungen.",
                 "sentenceTranslation": "Мораль теперь руководит моими решениями.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral"
+                ],
                 "wordFamily": [
                     "Основа: die Moral",
                     "Множественное число (пример): die Morale",
@@ -2128,8 +2236,10 @@
                 "transcription": "[ди ге-РЕХ-тиг-кайт]",
                 "sentence": "Für Gerechtigkeit will ich kämpfen.",
                 "sentenceTranslation": "За справедливость я хочу бороться.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Gerechtigkeit",
                     "Множественное число (пример): die Gerechtigkeiten",
@@ -2151,8 +2261,10 @@
                 "transcription": "[ди энт-ШАЙ-дунг]",
                 "sentence": "Meine Entscheidung steht fest: ich wähle das Gute.",
                 "sentenceTranslation": "Моё решение твёрдо: я выбираю добро.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Entscheidung",
                     "Множественное число (пример): die Entscheidungen",
@@ -2172,8 +2284,10 @@
                 "transcription": "[ВЕ-лен]",
                 "sentence": "Ich wähle den schweren Weg der Tugend.",
                 "sentenceTranslation": "Я выбираю трудный путь добродетели.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: wählen",
                     "Презенс: ich wähle",
@@ -2193,8 +2307,15 @@
                 "transcription": "[РЕХТ-ша-фен]",
                 "sentence": "Ich will rechtschaffen leben und handeln.",
                 "sentenceTranslation": "Я хочу жить и действовать праведно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Adel",
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral",
+                    "dienen",
+                    "vertrauen"
+                ],
                 "wordFamily": [
                     "Основная форма: rechtschaffen",
                     "Сравнительная степень: rechtschaffener",
@@ -2214,8 +2335,12 @@
                 "transcription": "[дас прин-ЦИП]",
                 "sentence": "Meine Prinzipien sind wichtiger als meine Ehe.",
                 "sentenceTranslation": "Мои принципы важнее моего брака.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral"
+                ],
                 "wordFamily": [
                     "Основа: das Prinzip",
                     "Множественное число (пример): die Prinzipe",
@@ -2234,8 +2359,12 @@
                 "transcription": "[Э-дель]",
                 "sentence": "Ich strebe nach edlen Taten.",
                 "sentenceTranslation": "Я стремлюсь к благородным поступкам.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral"
+                ],
                 "wordFamily": [
                     "Основная форма: edel",
                     "Сравнительная степень: edler",
@@ -2254,8 +2383,12 @@
                 "transcription": "[ди ТУ-генд]",
                 "sentence": "Die Tugend wird mein Leitstern sein.",
                 "sentenceTranslation": "Добродетель будет моей путеводной звездой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral"
+                ],
                 "wordFamily": [
                     "Основа: die Tugend",
                     "Множественное число (пример): die Tugende",
@@ -2302,8 +2435,10 @@
                 "transcription": "[дер КАМПФ]",
                 "sentence": "Der Kampf für das Recht beginnt jetzt.",
                 "sentenceTranslation": "Борьба за право начинается сейчас.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Kampf",
                     "Множественное число (пример): die Kampfe",
@@ -2326,8 +2461,10 @@
                 "transcription": "[дас РЕХТ]",
                 "sentence": "Das Recht muss über das Unrecht siegen.",
                 "sentenceTranslation": "Право должно победить неправду.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Recht",
                     "Множественное число (пример): die Rechte",
@@ -2347,8 +2484,12 @@
                 "transcription": "[ди ГЮ-те]",
                 "sentence": "Mit Güte will ich das Böse besiegen.",
                 "sentenceTranslation": "Добротой я хочу победить зло.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Güte",
+                    "Kampf",
+                    "Recht"
+                ],
                 "wordFamily": [
                     "Основа: die Güte",
                     "Множественное число (пример): die Güte",
@@ -2367,8 +2508,10 @@
                 "transcription": "[ШТРА-фен]",
                 "sentence": "Die Schuldigen müssen bestraft werden.",
                 "sentenceTranslation": "Виновные должны быть наказаны.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: strafen",
                     "Презенс: ich strafe",
@@ -2390,8 +2533,10 @@
                 "transcription": "[РИХ-тен]",
                 "sentence": "Gerecht will ich über die Verbrecher richten.",
                 "sentenceTranslation": "Справедливо я хочу судить преступников.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: richten",
                     "Презенс: ich richte",
@@ -2412,8 +2557,10 @@
                 "transcription": "[бе-ШЮ-цен]",
                 "sentence": "Die Unschuldigen will ich beschützen.",
                 "sentenceTranslation": "Невинных я хочу защитить.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: beschützen",
                     "Презенс: ich beschütze",
@@ -2437,8 +2584,12 @@
                 "transcription": "[АЙН-грай-фен]",
                 "sentence": "Ich greife ein, um das Schlimmste zu verhindern.",
                 "sentenceTranslation": "Я вмешиваюсь, чтобы предотвратить худшее.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Güte",
+                    "Kampf",
+                    "Recht"
+                ],
                 "wordFamily": [
                     "Инфинитив: eingreifen",
                     "Презенс: ich greife ein",
@@ -2485,8 +2636,15 @@
                 "transcription": "[ди ХЕР-шафт]",
                 "sentence": "Die Herrschaft fällt nun in meine Hände.",
                 "sentenceTranslation": "Правление теперь переходит в мои руки.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Herrschaft",
+                    "Macht",
+                    "Neuanfang",
+                    "Weisheit",
+                    "befehlen",
+                    "herrschen"
+                ],
                 "wordFamily": [
                     "Основа: die Herrschaft",
                     "Множественное число (пример): die Herrschafte",
@@ -2507,8 +2665,19 @@
                 "transcription": "[ди ВАЙС-хайт]",
                 "sentence": "Mit Weisheit will ich das Land führen.",
                 "sentenceTranslation": "С мудростью я хочу вести страну.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Erbe",
+                    "Herrschaft",
+                    "Narr",
+                    "Neuanfang",
+                    "Trauer",
+                    "Weisheit",
+                    "Zukunft",
+                    "erkennen",
+                    "verstehen",
+                    "überleben"
+                ],
                 "wordFamily": [
                     "Основа: die Weisheit",
                     "Множественное число (пример): die Weisheiten",
@@ -2530,8 +2699,12 @@
                 "transcription": "[дер НОЙ-ан-фанг]",
                 "sentence": "Ein Neuanfang für das Königreich beginnt.",
                 "sentenceTranslation": "Новое начало для королевства начинается.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Herrschaft",
+                    "Neuanfang",
+                    "Weisheit"
+                ],
                 "wordFamily": [
                     "Основа: der Neuanfang",
                     "Множественное число (пример): die Neuanfange",
@@ -2551,8 +2724,12 @@
                 "transcription": "[ЛЕН-кен]",
                 "sentence": "Ich lenke das Land in eine bessere Zukunft.",
                 "sentenceTranslation": "Я направляю страну в лучшее будущее.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Herrschaft",
+                    "Neuanfang",
+                    "Weisheit"
+                ],
                 "wordFamily": [
                     "Инфинитив: lenken",
                     "Презенс: ich lenke",
@@ -2571,8 +2748,12 @@
                 "transcription": "[АУФ-бау-ен]",
                 "sentence": "Ich baue auf, was zerstört wurde.",
                 "sentenceTranslation": "Я строю то, что было разрушено.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Herrschaft",
+                    "Neuanfang",
+                    "Weisheit"
+                ],
                 "wordFamily": [
                     "Инфинитив: aufbauen",
                     "Презенс: ich baue auf",
@@ -2591,8 +2772,12 @@
                 "transcription": "[ер-НОЙ-ерн]",
                 "sentence": "Das Reich will ich erneuern und heilen.",
                 "sentenceTranslation": "Королевство я хочу обновить и исцелить.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Herrschaft",
+                    "Neuanfang",
+                    "Weisheit"
+                ],
                 "wordFamily": [
                     "Инфинитив: erneuern",
                     "Презенс: ich erneuere",
@@ -2611,8 +2796,10 @@
                 "transcription": "[фер-ЗЁ-нен]",
                 "sentence": "Ich will die Getrennten versöhnen.",
                 "sentenceTranslation": "Я хочу примирить разделённых.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: versöhnen",
                     "Презенс: ich versöhne",
@@ -2632,8 +2819,12 @@
                 "transcription": "[дер ФРИ-де]",
                 "sentence": "Der Friede soll wieder ins Land kommen.",
                 "sentenceTranslation": "Мир должен вернуться в страну.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Herrschaft",
+                    "Neuanfang",
+                    "Weisheit"
+                ],
                 "wordFamily": [
                     "Основа: der Friede",
                     "Множественное число (пример): die Friede",

--- a/output/journeys/cordelia.html
+++ b/output/journeys/cordelia.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "церемония", "провозглашать", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "власть", "провозглашать", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["провозглашать", "торжественный", "правда", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["правда", "торжественный", "долг", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["долг", "провозглашать", "верность", "повиноваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["торжественный", "долг", "церемония", "верность"], "correct_index": 1}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["торжественный", "власть", "церемония", "долг"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["власть", "повиноваться", "торжественный", "верность"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["изгонять", "покидать", "гнев", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["гнев", "изгонять", "покидать", "наказание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["гнев", "надежда", "изгонять", "чужой"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["принимать", "изгонять", "приданое", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["надежда", "изгонять", "гнев", "чужой"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["наказание", "покидать", "чужой", "приданое"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["гнев", "надежда", "приданое", "принимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["принимать", "наказание", "надежда", "чужой"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["известие", "одиночество", "забота", "страх"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["одиночество", "забота", "страх", "известие"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["известие", "защищать", "тоска", "одиночество"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["молиться", "одиночество", "защищать", "страх"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["известие", "страдать", "одиночество", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["защищать", "страх", "одиночество", "известие"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["страх", "одиночество", "защищать", "тоска"], "correct_index": 3}, {"question": "Что означает немецкое слово «beten»?", "choices": ["страх", "страдать", "известие", "молиться"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["борьба", "битва", "спасать", "возвращаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["возвращаться", "борьба", "битва", "спасать"], "correct_index": 1}, {"question": "Что означает немецкое слово «retten»?", "choices": ["справедливость", "спасать", "армия", "возвращаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["армия", "битва", "спасать", "побеждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["битва", "храбрый", "армия", "возвращаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["возвращаться", "битва", "борьба", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["спасать", "побеждать", "справедливость", "возвращаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["храбрый", "армия", "побеждать", "возвращаться"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["прощать", "обнимать", "слёзы", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["обнимать", "узнавать", "прощать", "слёзы"], "correct_index": 3}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["обнимать", "прощать", "слёзы", "нежный"], "correct_index": 0}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["раскаяние", "узнавать", "исцелять", "нежный"], "correct_index": 1}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["слёзы", "прощать", "исцелять", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["нежный", "раскаяние", "исцелять", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["нежный", "слёзы", "прощение", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["слёзы", "прощение", "прощать", "узнавать"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["утешать", "достоинство", "пленный", "тюрьма"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["достоинство", "пленный", "тюрьма", "утешать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["тюрьма", "достоинство", "утешать", "смирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["отважный", "утешать", "судьба", "достоинство"], "correct_index": 1}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["судьба", "отважный", "честь", "смирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["судьба", "утешать", "смирение", "отважный"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["утешать", "достоинство", "судьба", "смирение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["смирение", "честь", "утешать", "достоинство"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["жертва", "умирать", "душа", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "смерть", "душа", "жертва"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["спасение", "смерть", "жертва", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["спасение", "конец", "душа", "жертва"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "вечный", "умирать", "прощание"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "душа", "прощание", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["душа", "смерть", "прощание", "жертва"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["умирать", "спасение", "прощание", "конец"], "correct_index": 1}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["церемония", "провозглашать", "власть", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["провозглашать", "правда", "власть", "церемония"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["повиноваться", "провозглашать", "верность", "церемония"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "церемония", "правда", "провозглашать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["провозглашать", "повиноваться", "долг", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["торжественный", "верность", "долг", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["верность", "долг", "провозглашать", "торжественный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["торжественный", "церемония", "долг", "верность"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["изгонять", "гнев", "наказание", "покидать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["покидать", "гнев", "наказание", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["покидать", "чужой", "приданое", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["изгонять", "чужой", "принимать", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["покидать", "надежда", "гнев", "чужой"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["приданое", "принимать", "надежда", "чужой"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["изгонять", "чужой", "принимать", "приданое"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["гнев", "чужой", "покидать", "надежда"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["одиночество", "забота", "страх", "известие"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["одиночество", "забота", "известие", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["известие", "забота", "страх", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["страх", "молиться", "одиночество", "забота"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "молиться", "одиночество", "известие"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["забота", "известие", "защищать", "страх"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["тоска", "известие", "молиться", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «beten»?", "choices": ["одиночество", "страдать", "молиться", "защищать"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["возвращаться", "спасать", "борьба", "битва"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["битва", "борьба", "спасать", "возвращаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «retten»?", "choices": ["спасать", "армия", "битва", "храбрый"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["битва", "храбрый", "борьба", "армия"], "correct_index": 0}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["борьба", "побеждать", "спасать", "храбрый"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["справедливость", "битва", "храбрый", "борьба"], "correct_index": 0}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["побеждать", "спасать", "борьба", "храбрый"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["спасать", "армия", "побеждать", "храбрый"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["слёзы", "обнимать", "прощать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["прощать", "обнимать", "слёзы", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["слёзы", "нежный", "обнимать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "исцелять", "прощать", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["обнимать", "прощать", "раскаяние", "исцелять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["нежный", "прощать", "исцелять", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["узнавать", "исцелять", "нежный", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["обнимать", "прощение", "раскаяние", "прощать"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["достоинство", "утешать", "тюрьма", "пленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["тюрьма", "достоинство", "пленный", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["достоинство", "тюрьма", "смирение", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["честь", "утешать", "пленный", "смирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["смирение", "тюрьма", "отважный", "честь"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["судьба", "смирение", "достоинство", "пленный"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["отважный", "честь", "утешать", "судьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["утешать", "честь", "судьба", "отважный"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["жертва", "умирать", "смерть", "душа"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "смерть", "жертва", "душа"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["вечный", "спасение", "жертва", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["жертва", "смерть", "конец", "душа"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["прощание", "смерть", "конец", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "умирать", "конец", "прощание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "спасение", "вечный", "душа"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["жертва", "спасение", "конец", "смерть"], "correct_index": 1}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -454,31 +454,15 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
                             
@@ -486,29 +470,61 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">повиноваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
                             
@@ -518,49 +534,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">повиноваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">торжественный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">торжественный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">торжественный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -570,11 +570,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">торжественный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">повиноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжественный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
                             
@@ -595,43 +595,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -641,11 +641,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">принимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
@@ -657,9 +657,9 @@
                         <div class="quiz-question">Что означает немецкое слово «fremd»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
@@ -669,15 +669,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Mitgift»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">приданое</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">принимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «aufnehmen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">приданое</button>
                             
@@ -685,33 +701,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufnehmen»?</div>
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Hoffnung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Hoffnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">принимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">надежда</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -724,24 +724,8 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Sorge»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
@@ -756,61 +740,61 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Nachricht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">тоска</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Angst»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">молиться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">молиться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
                             
@@ -820,33 +804,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Sehnsucht»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">известие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">тоска</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Sehnsucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">известие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «beten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -859,17 +859,17 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -879,27 +879,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
                             
@@ -907,65 +891,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">храбрый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «mutig»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">храбрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">армия</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «mutig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">храбрый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">храбрый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -975,13 +975,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Armee»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">храбрый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -994,8 +994,24 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
@@ -1010,59 +1026,59 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нежный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">исцелять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
@@ -1074,33 +1090,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «sanft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1110,13 +1110,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Vergebung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">прощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1129,31 +1129,31 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «gefangen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тюрьма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
@@ -1161,17 +1161,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Würde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1181,27 +1181,11 @@
                         <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отважный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
                             
@@ -1209,33 +1193,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">отважный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смирение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отважный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отважный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1245,13 +1245,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отважный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1264,7 +1264,7 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
@@ -1272,9 +1272,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1288,9 +1288,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1300,9 +1300,9 @@
                         <div class="quiz-question">Что означает немецкое слово «das Opfer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
                             
@@ -1312,33 +1312,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Seele»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1350,27 +1350,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1380,13 +1380,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Erlösung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1415,8 +1415,10 @@
                 "transcription": "[ди ВАР-хайт]",
                 "sentence": "Die Wahrheit war vor meinen Augen verborgen.",
                 "sentenceTranslation": "Правда была скрыта от моих глаз.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Wahrheit",
                     "Множественное число (пример): die Wahrheiten",
@@ -1438,8 +1440,15 @@
                 "transcription": "[ди це-ре-мо-НИ]",
                 "sentence": "Die Zeremonie beginnt im prächtigen Thronsaal.",
                 "sentenceTranslation": "Церемония начинается в великолепном тронном зале.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehrlichkeit",
+                    "König",
+                    "Liebe",
+                    "Macht",
+                    "Thron",
+                    "Wahrheit"
+                ],
                 "wordFamily": [
                     "Основа: die Zeremonie",
                     "Множественное число (пример): die Zeremonie",
@@ -1459,8 +1468,15 @@
                 "transcription": "[фер-КЮН-ден]",
                 "sentence": "Ich verkünde nur die Wahrheit meines Herzens.",
                 "sentenceTranslation": "Я провозглашаю только правду моего сердца.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehrlichkeit",
+                    "König",
+                    "Liebe",
+                    "Macht",
+                    "Thron",
+                    "Wahrheit"
+                ],
                 "wordFamily": [
                     "Инфинитив: verkünden",
                     "Презенс: ich verkünde",
@@ -1480,8 +1496,10 @@
                 "transcription": "[ди МАХТ]",
                 "sentence": "Die Macht bedeutet nichts ohne wahre Liebe.",
                 "sentenceTranslation": "Власть ничего не значит без истинной любви.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Macht",
                     "Множественное число (пример): die Machte",
@@ -1504,8 +1522,10 @@
                 "transcription": "[ге-ХОР-хен]",
                 "sentence": "Ich kann der Lüge nicht gehorchen.",
                 "sentenceTranslation": "Я не могу повиноваться лжи.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: gehorchen",
                     "Презенс: ich gehorche",
@@ -1526,8 +1546,10 @@
                 "transcription": "[ди ПФЛИХТ]",
                 "sentence": "Meine Pflicht ist es, ehrlich zu sein.",
                 "sentenceTranslation": "Мой долг - быть честной.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Pflicht",
                     "Множественное число (пример): die Pflichte",
@@ -1548,8 +1570,12 @@
                 "transcription": "[ФАЙ-ер-лих]",
                 "sentence": "Dieser feierliche Moment wird zur Tragödie.",
                 "sentenceTranslation": "Этот торжественный момент становится трагедией.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehrlichkeit",
+                    "Liebe",
+                    "Wahrheit"
+                ],
                 "wordFamily": [
                     "Основная форма: feierlich",
                     "Сравнительная степень: feierlicher",
@@ -1568,8 +1594,10 @@
                 "transcription": "[ди ТРОЙ-е]",
                 "sentence": "Meine Treue gilt der Wahrheit und der echten Liebe.",
                 "sentenceTranslation": "Моя верность принадлежит правде и истинной любви.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Treue",
                     "Множественное число (пример): die Treue",
@@ -1618,8 +1646,10 @@
                 "transcription": "[фер-ШТО-сен]",
                 "sentence": "Der König verstößt mich aus seinem Herzen.",
                 "sentenceTranslation": "Король изгоняет меня из своего сердца.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verstoßen",
                     "Презенс: ich verstoße",
@@ -1646,8 +1676,10 @@
                 "transcription": "[фер-ЛА-сен]",
                 "sentence": "Schweren Herzens verlasse ich mein Vaterland.",
                 "sentenceTranslation": "С тяжёлым сердцем я покидаю родину.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verlassen",
                     "Презенс: ich verlasse",
@@ -1668,8 +1700,10 @@
                 "transcription": "[дер ЦОРН]",
                 "sentence": "Sein Zorn ist grenzenlos und blind.",
                 "sentenceTranslation": "Его гнев безграничен и слеп.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Zorn",
                     "Множественное число (пример): die Zorne",
@@ -1692,8 +1726,10 @@
                 "transcription": "[ди ШТРА-фе]",
                 "sentence": "Diese Strafe ist der Preis für meine Ehrlichkeit.",
                 "sentenceTranslation": "Это наказание - цена моей честности.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Strafe",
                     "Множественное число (пример): die Strafe",
@@ -1718,8 +1754,12 @@
                 "transcription": "[ФРЕМД]",
                 "sentence": "Ich bin jetzt fremd in meinem eigenen Land.",
                 "sentenceTranslation": "Я теперь чужая в своей собственной стране.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Frankreich",
+                    "verlassen",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основная форма: fremd",
                     "Сравнительная степень: fremder",
@@ -1738,8 +1778,12 @@
                 "transcription": "[ди МИТ-гифт]",
                 "sentence": "Ohne Mitgift bin ich reicher an Ehre.",
                 "sentenceTranslation": "Без приданого я богаче честью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Frankreich",
+                    "verlassen",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основа: die Mitgift",
                     "Множественное число (пример): die Mitgifte",
@@ -1758,8 +1802,12 @@
                 "transcription": "[АУФ-не-мен]",
                 "sentence": "Der König von Frankreich nimmt mich liebevoll auf.",
                 "sentenceTranslation": "Король Франции принимает меня с любовью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Frankreich",
+                    "verlassen",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Инфинитив: aufnehmen",
                     "Презенс: ich nehme auf",
@@ -1778,8 +1826,10 @@
                 "transcription": "[ди ХОФ-нунг]",
                 "sentence": "Die Hoffnung auf Versöhnung stirbt nie in meinem Herzen.",
                 "sentenceTranslation": "Надежда на примирение никогда не умирает в моём сердце.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Hoffnung",
                     "Множественное число (пример): die Hoffnungen",
@@ -1827,8 +1877,10 @@
                 "transcription": "[ди ЗОР-ге]",
                 "sentence": "Die Sorge um meinen Vater lässt mich nicht schlafen.",
                 "sentenceTranslation": "Забота об отце не даёт мне спать.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Sorge",
                     "Множественное число (пример): die Sorge",
@@ -1848,8 +1900,10 @@
                 "transcription": "[ди АЙН-зам-кайт]",
                 "sentence": "In der Einsamkeit denke ich an ihn.",
                 "sentenceTranslation": "В одиночестве я думаю о нём.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Einsamkeit",
                     "Множественное число (пример): die Einsamkeiten",
@@ -1870,8 +1924,12 @@
                 "transcription": "[ди НАХ-рихт]",
                 "sentence": "Schreckliche Nachrichten erreichen mich aus England.",
                 "sentenceTranslation": "Ужасные известия доходят до меня из Англии.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "beten",
+                    "sorgen",
+                    "warten"
+                ],
                 "wordFamily": [
                     "Основа: die Nachricht",
                     "Множественное число (пример): die Nachrichte",
@@ -1890,8 +1948,10 @@
                 "transcription": "[ди АНГСТ]",
                 "sentence": "Die Angst um meinen Vater wächst täglich.",
                 "sentenceTranslation": "Страх за отца растёт с каждым днём.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Angst",
                     "Множественное число (пример): die Angste",
@@ -1912,8 +1972,10 @@
                 "transcription": "[ЛАЙ-ден]",
                 "sentence": "Er muss furchtbar leiden ohne mich.",
                 "sentenceTranslation": "Он должно быть ужасно страдает без меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: leiden",
                     "Презенс: ich leide",
@@ -1937,8 +1999,10 @@
                 "transcription": "[бе-ШЮ-цен]",
                 "sentence": "Ich kann ihn aus der Ferne nicht beschützen.",
                 "sentenceTranslation": "Я не могу защитить его издалека.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: beschützen",
                     "Презенс: ich beschütze",
@@ -1962,8 +2026,12 @@
                 "transcription": "[ди ЗЕН-зухт]",
                 "sentence": "Die Sehnsucht nach Versöhnung erfüllt mein Herz.",
                 "sentenceTranslation": "Тоска по примирению наполняет моё сердце.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "beten",
+                    "sorgen",
+                    "warten"
+                ],
                 "wordFamily": [
                     "Основа: die Sehnsucht",
                     "Множественное число (пример): die Sehnsuchte",
@@ -1982,8 +2050,12 @@
                 "transcription": "[БЕ-тен]",
                 "sentence": "Jeden Tag bete ich für seine Sicherheit.",
                 "sentenceTranslation": "Каждый день я молюсь за его безопасность.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "beten",
+                    "sorgen",
+                    "warten"
+                ],
                 "wordFamily": [
                     "Инфинитив: beten",
                     "Презенс: ich bete",
@@ -2030,8 +2102,10 @@
                 "transcription": "[цу-РЮК-ке-рен]",
                 "sentence": "Mit einer Armee kehre ich zurück, meinen Vater zu retten.",
                 "sentenceTranslation": "С армией я возвращаюсь спасти моего отца.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: zurückkehren",
                     "Презенс: ich rückkehre zu",
@@ -2054,8 +2128,10 @@
                 "transcription": "[дер КАМПФ]",
                 "sentence": "Dieser Kampf ist für die Ehre meines Vaters.",
                 "sentenceTranslation": "Эта борьба за честь моего отца.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Kampf",
                     "Множественное число (пример): die Kampfe",
@@ -2078,8 +2154,10 @@
                 "transcription": "[РЕ-тен]",
                 "sentence": "Ich muss meinen Vater vor seinen grausamen Töchtern retten.",
                 "sentenceTranslation": "Я должна спасти отца от его жестоких дочерей.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: retten",
                     "Презенс: ich rette",
@@ -2100,8 +2178,10 @@
                 "transcription": "[ди ШЛАХТ]",
                 "sentence": "Diese Schlacht entscheidet über das Schicksal des Königreichs.",
                 "sentenceTranslation": "Эта битва решает судьбу королевства.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Schlacht",
                     "Множественное число (пример): die Schlachte",
@@ -2121,8 +2201,12 @@
                 "transcription": "[МУ-тиг]",
                 "sentence": "Sei mutig, mein Herz, für die gerechte Sache.",
                 "sentenceTranslation": "Будь храбрым, моё сердце, ради правого дела.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "kämpfen",
+                    "retten",
+                    "zurückkehren"
+                ],
                 "wordFamily": [
                     "Основная форма: mutig",
                     "Сравнительная степень: mutiger",
@@ -2141,8 +2225,10 @@
                 "transcription": "[ди ге-РЕХ-тиг-кайт]",
                 "sentence": "Die Gerechtigkeit führt meine Klinge.",
                 "sentenceTranslation": "Справедливость ведёт мой клинок.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Gerechtigkeit",
                     "Множественное число (пример): die Gerechtigkeiten",
@@ -2164,8 +2250,10 @@
                 "transcription": "[ЗИ-ген]",
                 "sentence": "Die Liebe wird über den Hass siegen.",
                 "sentenceTranslation": "Любовь победит ненависть.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: siegen",
                     "Презенс: ich siege",
@@ -2186,8 +2274,12 @@
                 "transcription": "[ди ар-МЭ]",
                 "sentence": "Diese Armee kämpft für Gerechtigkeit und Liebe.",
                 "sentenceTranslation": "Эта армия сражается за справедливость и любовь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "kämpfen",
+                    "retten",
+                    "zurückkehren"
+                ],
                 "wordFamily": [
                     "Основа: die Armee",
                     "Множественное число (пример): die Armee",
@@ -2234,8 +2326,10 @@
                 "transcription": "[фер-ЦАЙ-ен]",
                 "sentence": "Ich verzeihe dir alles, mein lieber Vater.",
                 "sentenceTranslation": "Я прощаю тебе всё, мой дорогой отец.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verzeihen",
                     "Презенс: ich verzeihe",
@@ -2257,8 +2351,12 @@
                 "transcription": "[ди ТРЕ-нен]",
                 "sentence": "Unsere Tränen waschen den Schmerz fort.",
                 "sentenceTranslation": "Наши слёзы смывают боль.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "heilen",
+                    "umarmen",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Основа: die Tränen",
                     "Множественное число (пример): die Tränen",
@@ -2277,8 +2375,15 @@
                 "transcription": "[ум-АР-мен]",
                 "sentence": "Lass mich dich umarmen und deine Tränen trocknen.",
                 "sentenceTranslation": "Позволь мне обнять тебя и вытереть твои слёзы.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "erkennen",
+                    "heilen",
+                    "sterben",
+                    "umarmen",
+                    "vergeben",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Инфинитив: umarmen",
                     "Презенс: ich umarme",
@@ -2298,8 +2403,10 @@
                 "transcription": "[ер-КЕН-нен]",
                 "sentence": "Erkennst du mich, dein Kind Cordelia?",
                 "sentenceTranslation": "Узнаёшь ли ты меня, твоё дитя Корделия?",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: erkennen",
                     "Презенс: ich erkenne",
@@ -2325,8 +2432,12 @@
                 "transcription": "[ХАЙ-лен]",
                 "sentence": "Meine Liebe wird deine Wunden heilen.",
                 "sentenceTranslation": "Моя любовь исцелит твои раны.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "heilen",
+                    "umarmen",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Инфинитив: heilen",
                     "Презенс: ich heile",
@@ -2345,8 +2456,10 @@
                 "transcription": "[ди РОЙ-е]",
                 "sentence": "Deine Reue ist nicht nötig, nur deine Liebe.",
                 "sentenceTranslation": "Твоё раскаяние не нужно, только твоя любовь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Reue",
                     "Множественное число (пример): die Reue",
@@ -2368,8 +2481,12 @@
                 "transcription": "[ЗАНФТ]",
                 "sentence": "Sei sanft zu dir selbst, lieber Vater.",
                 "sentenceTranslation": "Будь нежен к себе, дорогой отец.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "heilen",
+                    "umarmen",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Основная форма: sanft",
                     "Сравнительная степень: sanfter",
@@ -2388,8 +2505,12 @@
                 "transcription": "[ди фер-ГЕ-бунг]",
                 "sentence": "Die Vergebung ist der Schlüssel zum Frieden.",
                 "sentenceTranslation": "Прощение - ключ к покою.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "heilen",
+                    "umarmen",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Основа: die Vergebung",
                     "Множественное число (пример): die Vergebungen",
@@ -2436,8 +2557,12 @@
                 "transcription": "[ге-ФАН-ген]",
                 "sentence": "Obwohl gefangen, bin ich frei in meinem Herzen.",
                 "sentenceTranslation": "Хотя я в плену, в сердце я свободна.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gerechtigkeit",
+                    "Würde",
+                    "gefangen"
+                ],
                 "wordFamily": [
                     "Основная форма: gefangen",
                     "Сравнительная степень: gefangener",
@@ -2456,8 +2581,10 @@
                 "transcription": "[дас ге-ФЭНГ-нис]",
                 "sentence": "Dieses Gefängnis kann meine Liebe nicht einsperren.",
                 "sentenceTranslation": "Эта тюрьма не может запереть мою любовь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Gefängnis",
                     "Множественное число (пример): die Gefängnise",
@@ -2477,8 +2604,10 @@
                 "transcription": "[ди ВЮР-де]",
                 "sentence": "Mit Würde trage ich mein Schicksal.",
                 "sentenceTranslation": "С достоинством я несу свою судьбу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Würde",
                     "Множественное число (пример): die Würde",
@@ -2498,8 +2627,10 @@
                 "transcription": "[ТРЁС-тен]",
                 "sentence": "Lass mich dich trösten in dieser dunklen Stunde.",
                 "sentenceTranslation": "Позволь мне утешить тебя в этот тёмный час.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: trösten",
                     "Презенс: ich tröste",
@@ -2521,8 +2652,12 @@
                 "transcription": "[ТАП-фер]",
                 "sentence": "Ich bleibe tapfer für dich, Vater.",
                 "sentenceTranslation": "Я остаюсь отважной ради тебя, отец.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gerechtigkeit",
+                    "Würde",
+                    "gefangen"
+                ],
                 "wordFamily": [
                     "Основная форма: tapfer",
                     "Сравнительная степень: tapfrer",
@@ -2541,8 +2676,12 @@
                 "transcription": "[ди ДЕ-мут]",
                 "sentence": "In der Demut finden wir wahre Größe.",
                 "sentenceTranslation": "В смирении мы находим истинное величие.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gerechtigkeit",
+                    "Würde",
+                    "gefangen"
+                ],
                 "wordFamily": [
                     "Основа: die Demut",
                     "Множественное число (пример): die Demute",
@@ -2561,8 +2700,10 @@
                 "transcription": "[дас ШИК-заль]",
                 "sentence": "Unser Schicksal ist miteinander verwoben.",
                 "sentenceTranslation": "Наши судьбы переплетены.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Schicksal",
                     "Множественное число (пример): die Schicksale",
@@ -2583,8 +2724,10 @@
                 "transcription": "[ди Э-ре]",
                 "sentence": "Unsere Ehre bleibt unbefleckt.",
                 "sentenceTranslation": "Наша честь остаётся незапятнанной.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Ehre",
                     "Множественное число (пример): die Ehre",
@@ -2634,8 +2777,10 @@
                 "transcription": "[дер ТОД]",
                 "sentence": "Der Tod trennt uns nur für kurze Zeit.",
                 "sentenceTranslation": "Смерть разлучает нас лишь ненадолго.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Tod",
                     "Множественное число (пример): die Tode",
@@ -2659,8 +2804,10 @@
                 "transcription": "[ШТЕР-бен]",
                 "sentence": "Wenn ich sterben muss, sterbe ich mit reinem Herzen.",
                 "sentenceTranslation": "Если я должна умереть, я умру с чистым сердцем.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: sterben",
                     "Презенс: ich sterbe",
@@ -2684,8 +2831,10 @@
                 "transcription": "[дас ОП-фер]",
                 "sentence": "Ich bin das Opfer der Wahrheit und Liebe.",
                 "sentenceTranslation": "Я жертва правды и любви.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Opfer",
                     "Множественное число (пример): die Opfer",
@@ -2705,8 +2854,10 @@
                 "transcription": "[ди ЗЕ-ле]",
                 "sentence": "Meine Seele ist rein vor Gott.",
                 "sentenceTranslation": "Моя душа чиста перед Богом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Seele",
                     "Множественное число (пример): die Seele",
@@ -2726,8 +2877,10 @@
                 "transcription": "[дас ЕН-де]",
                 "sentence": "Dies ist nicht das Ende, nur ein Übergang.",
                 "sentenceTranslation": "Это не конец, только переход.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Ende",
                     "Множественное число (пример): die Ende",
@@ -2750,8 +2903,17 @@
                 "transcription": "[Э-виг]",
                 "sentence": "Unsere Liebe ist ewig, Vater.",
                 "sentenceTranslation": "Наша любовь вечна, отец.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Основная форма: ewig",
                     "Сравнительная степень: ewiger",
@@ -2772,8 +2934,20 @@
                 "transcription": "[дер АБ-шид]",
                 "sentence": "Unser Abschied ist nur vorübergehend.",
                 "sentenceTranslation": "Наше прощание лишь временно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Основа: der Abschied",
                     "Множественное число (пример): die Abschiede",
@@ -2795,8 +2969,10 @@
                 "transcription": "[ди ер-ЛЁ-зунг]",
                 "sentence": "Im Tod finde ich Erlösung und Frieden.",
                 "sentenceTranslation": "В смерти я нахожу спасение и покой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Erlösung",
                     "Множественное число (пример): die Erlösungen",

--- a/output/journeys/cornwall.html
+++ b/output/journeys/cornwall.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["стремиться", "жадность", "честолюбие", "желать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["стремиться", "честолюбие", "желать", "жадность"], "correct_index": 3}, {"question": "Что означает немецкое слово «streben»?", "choices": ["захватывать", "властолюбие", "стремиться", "вожделеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["вожделеть", "желать", "стремиться", "властолюбие"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["стремиться", "захватывать", "жадность", "вожделеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["жадность", "желать", "захватывать", "жадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["захватывать", "властолюбие", "вожделеть", "стремиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["честолюбие", "жадность", "захватывать", "стремиться"], "correct_index": 2}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["поддерживать", "жестокость", "одобрять", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["жестокость", "одобрять", "поддерживать", "злоба"], "correct_index": 3}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["суровость", "злоба", "одобрять", "поддерживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["поощрять", "поддерживать", "злоба", "суровость"], "correct_index": 1}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["поддерживать", "поощрять", "подстрекать", "суровость"], "correct_index": 2}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["одобрять", "поощрять", "жестокость", "поддерживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["суровость", "поощрять", "поддерживать", "одобрять"], "correct_index": 0}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["подавлять", "страх", "тирания", "угнетение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["угнетение", "страх", "подавлять", "тирания"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["порабощать", "произвол", "страх", "угнетение"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["подавлять", "брутальный", "страх", "тирания"], "correct_index": 0}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["тирания", "порабощать", "подавлять", "брутальный"], "correct_index": 1}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["принуждать", "страх", "угнетение", "тирания"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["порабощать", "страх", "произвол", "угнетение"], "correct_index": 2}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["страх", "тирания", "брутальный", "угнетение"], "correct_index": 2}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["гнев", "наказывать", "наказание", "карать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["карать", "наказывать", "наказание", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["унижать", "карать", "наказывать", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["мучить", "наказание", "карать", "наказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["наказание", "унижать", "гнев", "карать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["унижать", "гнев", "карать", "мучить"], "correct_index": 0}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["наказывать", "унижать", "мучить", "карать"], "correct_index": 2}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытать", "кровь", "садизм", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытать", "кровь", "садизм", "пытка"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["ослеплять", "кровь", "калечить", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["ослеплять", "калечить", "пытать", "пытка"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["кровь", "калечить", "пытка", "мука"], "correct_index": 1}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["выкалывать", "ослеплять", "пытка", "калечить"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["пытка", "выкалывать", "ослеплять", "калечить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["мука", "выкалывать", "садизм", "ослеплять"], "correct_index": 0}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["кровоточить", "удивление", "боль", "рана"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["боль", "рана", "удивление", "кровоточить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["удивление", "боль", "страдать", "кровоточить"], "correct_index": 0}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["раненый", "боль", "ослаблять", "кровоточить"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["страдать", "ослаблять", "раненый", "рана"], "correct_index": 2}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["рана", "раненый", "ослаблять", "удивление"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["удивление", "страдать", "раненый", "боль"], "correct_index": 1}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["конец", "смерть", "умирать", "возмездие"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["конец", "смерть", "умирать", "возмездие"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["хрипеть", "кара", "проклинать", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "конец", "кара", "возмездие"], "correct_index": 0}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["умирать", "возмездие", "конец", "издыхать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["умирать", "кара", "смерть", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["возмездие", "проклинать", "хрипеть", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["проклинать", "умирать", "конец", "кара"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["честолюбие", "жадность", "желать", "стремиться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["жадность", "желать", "стремиться", "честолюбие"], "correct_index": 0}, {"question": "Что означает немецкое слово «streben»?", "choices": ["желать", "захватывать", "стремиться", "жадный"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["вожделеть", "жадный", "честолюбие", "желать"], "correct_index": 3}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["властолюбие", "желать", "вожделеть", "жадный"], "correct_index": 2}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["честолюбие", "жадный", "властолюбие", "захватывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["властолюбие", "вожделеть", "стремиться", "жадный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["захватывать", "стремиться", "жадность", "жадный"], "correct_index": 0}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["одобрять", "жестокость", "злоба", "поддерживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["поддерживать", "злоба", "одобрять", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["одобрять", "суровость", "подстрекать", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["жестокость", "одобрять", "подстрекать", "поддерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["поддерживать", "подстрекать", "злоба", "поощрять"], "correct_index": 1}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["поддерживать", "жестокость", "поощрять", "подстрекать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["поощрять", "одобрять", "суровость", "поддерживать"], "correct_index": 2}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["тирания", "подавлять", "страх", "угнетение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["подавлять", "страх", "тирания", "угнетение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["порабощать", "тирания", "страх", "произвол"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["подавлять", "страх", "принуждать", "угнетение"], "correct_index": 0}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["произвол", "порабощать", "брутальный", "тирания"], "correct_index": 1}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["принуждать", "подавлять", "произвол", "угнетение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["тирания", "произвол", "брутальный", "порабощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["тирания", "страх", "брутальный", "принуждать"], "correct_index": 2}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказывать", "карать", "гнев", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["карать", "наказание", "гнев", "наказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["карать", "наказывать", "наказание", "унижать"], "correct_index": 0}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["карать", "наказывать", "унижать", "мучить"], "correct_index": 1}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["мучить", "унижать", "гнев", "карать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["унижать", "гнев", "карать", "мучить"], "correct_index": 0}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["унижать", "мучить", "гнев", "унижать"], "correct_index": 1}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["садизм", "пытать", "кровь", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытка", "пытать", "садизм", "кровь"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["кровь", "пытать", "выкалывать", "садизм"], "correct_index": 0}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["выкалывать", "пытать", "ослеплять", "мука"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["ослеплять", "пытка", "калечить", "садизм"], "correct_index": 2}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "пытать", "кровь", "калечить"], "correct_index": 0}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["пытать", "выкалывать", "калечить", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["кровь", "мука", "выкалывать", "садизм"], "correct_index": 1}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["боль", "удивление", "кровоточить", "рана"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["удивление", "боль", "рана", "кровоточить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["кровоточить", "удивление", "боль", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["кровоточить", "страдать", "ослаблять", "раненый"], "correct_index": 0}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["рана", "страдать", "ослаблять", "раненый"], "correct_index": 3}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["кровоточить", "ослаблять", "рана", "боль"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["раненый", "страдать", "удивление", "боль"], "correct_index": 1}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "возмездие", "конец", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["смерть", "конец", "умирать", "возмездие"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["умирать", "конец", "проклинать", "издыхать"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["издыхать", "умирать", "хрипеть", "кара"], "correct_index": 1}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["конец", "смерть", "издыхать", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "кара", "смерть", "издыхать"], "correct_index": 0}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["смерть", "кара", "проклинать", "хрипеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["конец", "издыхать", "смерть", "кара"], "correct_index": 3}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -454,33 +454,33 @@
             <div class="quiz-phase-container active" data-phase="ambitious_duke">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Ehrgeiz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -490,59 +490,11 @@
                         <div class="quiz-question">Что означает немецкое слово «streben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">властолюбие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verlangen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
                             
@@ -550,33 +502,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verlangen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">властолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «ergreifen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">властолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">захватывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «ergreifen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -593,43 +593,59 @@
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">суровость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">суровость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
                             
@@ -637,65 +653,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поощрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">суровость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подстрекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">суровость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подстрекать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">суровость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поощрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">суровость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -708,8 +708,24 @@
             <div class="quiz-phase-container" data-phase="tyrant">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Tyrannei»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
@@ -724,33 +740,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Furcht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">произвол</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -762,11 +762,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">принуждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -776,13 +776,13 @@
                         <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">произвол</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -794,23 +794,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">принуждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">произвол</button>
                             
@@ -820,17 +804,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">произвол</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
                     <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «brutal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">принуждать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -843,24 +843,40 @@
             <div class="quiz-phase-container" data-phase="punishment">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «bestrafen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
@@ -869,39 +885,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «bestrafen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «züchtigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -911,7 +911,7 @@
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
@@ -939,17 +939,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -966,11 +966,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
@@ -982,59 +982,43 @@
                         <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Blut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
                             
@@ -1042,15 +1026,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
                             
@@ -1062,29 +1062,29 @@
                         <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мука</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мука</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1101,11 +1101,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Wunde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">удивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
                             
@@ -1113,31 +1113,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
                             
@@ -1145,49 +1129,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">удивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «bluten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ослаблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раненый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раненый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раненый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ослаблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раненый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1197,11 +1197,11 @@
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раненый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                             
@@ -1216,17 +1216,17 @@
             <div class="quiz-phase-container" data-phase="death">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1236,9 +1236,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Vergeltung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
@@ -1248,47 +1248,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                             
@@ -1296,33 +1264,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «röcheln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хрипеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1332,11 +1332,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
                             
@@ -1367,8 +1367,12 @@
                 "transcription": "[дер ЭР-гайц]",
                 "sentence": "Mein Ehrgeiz kennt keine Grenzen mehr.",
                 "sentenceTranslation": "Моё честолюбие не знает больше границ.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehrgeiz",
+                    "Gier",
+                    "Macht"
+                ],
                 "wordFamily": [
                     "Основа: der Ehrgeiz",
                     "Множественное число (пример): die Ehrgeize",
@@ -1387,8 +1391,10 @@
                 "transcription": "[ди ГИР]",
                 "sentence": "Die Gier nach Macht verzehrt meine Seele.",
                 "sentenceTranslation": "Жадность к власти пожирает мою душу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Gier",
                     "Множественное число (пример): die Gier",
@@ -1409,8 +1415,12 @@
                 "transcription": "[ШТРЕ-бен]",
                 "sentence": "Ich strebe nach absoluter Kontrolle.",
                 "sentenceTranslation": "Я стремлюсь к абсолютному контролю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehrgeiz",
+                    "Gier",
+                    "Macht"
+                ],
                 "wordFamily": [
                     "Инфинитив: streben",
                     "Презенс: ich strebe",
@@ -1429,8 +1439,10 @@
                 "transcription": "[фер-ЛАН-ген]",
                 "sentence": "Ich verlange mehr als mir zusteht.",
                 "sentenceTranslation": "Я желаю больше, чем мне положено.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verlangen",
                     "Презенс: ich verlange",
@@ -1453,8 +1465,10 @@
                 "transcription": "[бе-ГЕ-рен]",
                 "sentence": "Ich begehre die Krone für mich selbst.",
                 "sentenceTranslation": "Я вожделею корону для себя.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: begehren",
                     "Презенс: ich begehre",
@@ -1479,8 +1493,12 @@
                 "transcription": "[ГИ-риг]",
                 "sentence": "Gierig greife ich nach jedem Stück Macht.",
                 "sentenceTranslation": "Жадно я хватаюсь за каждый кусок власти.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehrgeiz",
+                    "Gier",
+                    "Macht"
+                ],
                 "wordFamily": [
                     "Основная форма: gierig",
                     "Сравнительная степень: gieriger",
@@ -1499,8 +1517,12 @@
                 "transcription": "[ди ХЕР-зухт]",
                 "sentence": "Die Herrschsucht bestimmt all meine Taten.",
                 "sentenceTranslation": "Властолюбие определяет все мои поступки.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehrgeiz",
+                    "Gier",
+                    "Macht"
+                ],
                 "wordFamily": [
                     "Основа: die Herrschsucht",
                     "Множественное число (пример): die Herrschsuchte",
@@ -1519,8 +1541,12 @@
                 "transcription": "[ер-ГРАЙ-фен]",
                 "sentence": "Ich ergreife jede Gelegenheit zur Macht.",
                 "sentenceTranslation": "Я захватываю каждую возможность власти.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehrgeiz",
+                    "Gier",
+                    "Macht"
+                ],
                 "wordFamily": [
                     "Инфинитив: ergreifen",
                     "Презенс: ich ergreife",
@@ -1567,8 +1593,20 @@
                 "transcription": "[ди ГРАУ-зам-кайт]",
                 "sentence": "Die Grausamkeit meiner Frau gefällt mir.",
                 "sentenceTranslation": "Жестокость моей жены мне нравится.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "Verzweiflung",
+                    "blenden",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen",
+                    "verlassen",
+                    "verraten",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основа: die Grausamkeit",
                     "Множественное число (пример): die Grausamkeiten",
@@ -1590,8 +1628,15 @@
                 "transcription": "[ди БОС-хайт]",
                 "sentence": "Unsere Bosheit macht uns zum perfekten Paar.",
                 "sentenceTranslation": "Наша злоба делает нас идеальной парой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Основа: die Bosheit",
                     "Множественное число (пример): die Bosheiten",
@@ -1611,8 +1656,12 @@
                 "transcription": "[БИ-ли-ген]",
                 "sentence": "Ich billige alle ihre grausamen Pläne.",
                 "sentenceTranslation": "Я одобряю все её жестокие планы.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit"
+                ],
                 "wordFamily": [
                     "Инфинитив: billigen",
                     "Презенс: ich billige",
@@ -1631,8 +1680,10 @@
                 "transcription": "[ун-тер-ШТЮ-цен]",
                 "sentence": "Ich unterstütze ihre Unmenschlichkeit.",
                 "sentenceTranslation": "Я поддерживаю её бесчеловечность.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: unterstützen",
                     "Презенс: ich unterstütze",
@@ -1652,8 +1703,12 @@
                 "transcription": "[АН-шта-хельн]",
                 "sentence": "Ich stachle sie zu größerer Grausamkeit an.",
                 "sentenceTranslation": "Я подстрекаю её к большей жестокости.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit"
+                ],
                 "wordFamily": [
                     "Инфинитив: anstacheln",
                     "Презенс: ich stachele an",
@@ -1672,8 +1727,12 @@
                 "transcription": "[ер-МУ-ти-ген]",
                 "sentence": "Ich ermutige ihre dunkelsten Impulse.",
                 "sentenceTranslation": "Я поощряю её самые тёмные импульсы.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit"
+                ],
                 "wordFamily": [
                     "Инфинитив: ermutigen",
                     "Презенс: ich ermutige",
@@ -1692,8 +1751,15 @@
                 "transcription": "[ди ХЕР-те]",
                 "sentence": "Mit eiserner Härte regieren wir zusammen.",
                 "sentenceTranslation": "С железной суровостью мы правим вместе.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Основа: die Härte",
                     "Множественное число (пример): die Härte",
@@ -1742,8 +1808,12 @@
                 "transcription": "[ди тю-ра-НАЙ]",
                 "sentence": "Meine Tyrannei erstickt jeden Widerstand.",
                 "sentenceTranslation": "Моя тирания душит любое сопротивление.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
                 "wordFamily": [
                     "Основа: die Tyrannei",
                     "Множественное число (пример): die Tyranneie",
@@ -1762,8 +1832,12 @@
                 "transcription": "[ди ун-тер-ДРЮ-кунг]",
                 "sentence": "Die Unterdrückung ist mein Herrschaftsmittel.",
                 "sentenceTranslation": "Угнетение - моё средство правления.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
                 "wordFamily": [
                     "Основа: die Unterdrückung",
                     "Множественное число (пример): die Unterdrückungen",
@@ -1782,8 +1856,12 @@
                 "transcription": "[ди ФУРХТ]",
                 "sentence": "Durch Furcht halte ich alle unter Kontrolle.",
                 "sentenceTranslation": "Страхом я держу всех под контролем.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
                 "wordFamily": [
                     "Основа: die Furcht",
                     "Множественное число (пример): die Furchte",
@@ -1803,8 +1881,10 @@
                 "transcription": "[ун-тер-ДРЮ-кен]",
                 "sentence": "Ich unterdrücke jeden freien Gedanken.",
                 "sentenceTranslation": "Я подавляю любую свободную мысль.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: unterdrücken",
                     "Презенс: ich unterdrücke",
@@ -1824,8 +1904,12 @@
                 "transcription": "[КНЕХ-тен]",
                 "sentence": "Ich knechte alle, die mir unterstehen.",
                 "sentenceTranslation": "Я порабощаю всех, кто мне подчинён.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
                 "wordFamily": [
                     "Инфинитив: knechten",
                     "Презенс: ich knechte",
@@ -1844,8 +1928,10 @@
                 "transcription": "[ЦВИН-ген]",
                 "sentence": "Ich zwinge alle zu absolutem Gehorsam.",
                 "sentenceTranslation": "Я принуждаю всех к абсолютному послушанию.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: zwingen",
                     "Презенс: ich zwinge",
@@ -1866,8 +1952,12 @@
                 "transcription": "[ди ВИЛЬ-кюр]",
                 "sentence": "Meine Willkür ist das einzige Gesetz.",
                 "sentenceTranslation": "Мой произвол - единственный закон.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
                 "wordFamily": [
                     "Основа: die Willkür",
                     "Множественное число (пример): die Willküre",
@@ -1886,8 +1976,12 @@
                 "transcription": "[бру-ТАЛЬ]",
                 "sentence": "Brutal zerschlage ich jeden Widerstand.",
                 "sentenceTranslation": "Брутально я сокрушаю любое сопротивление.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
                 "wordFamily": [
                     "Основная форма: brutal",
                     "Сравнительная степень: brutaler",
@@ -1934,8 +2028,10 @@
                 "transcription": "[ди ШТРА-фе]",
                 "sentence": "Die Strafe für Widerspruch ist hart.",
                 "sentenceTranslation": "Наказание за возражение сурово.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Strafe",
                     "Множественное число (пример): die Strafe",
@@ -1960,8 +2056,10 @@
                 "transcription": "[дер ЦОРН]",
                 "sentence": "Mein Zorn kennt keine Barmherzigkeit.",
                 "sentenceTranslation": "Мой гнев не знает милосердия.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Zorn",
                     "Множественное число (пример): die Zorne",
@@ -1984,8 +2082,10 @@
                 "transcription": "[бе-ШТРА-фен]",
                 "sentence": "Ich bestrafe Kent für seine Frechheit.",
                 "sentenceTranslation": "Я караю Кента за его дерзость.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: bestrafen",
                     "Презенс: ich bestrafe",
@@ -2008,8 +2108,12 @@
                 "transcription": "[ЦЮХ-ти-ген]",
                 "sentence": "Öffentlich züchtige ich die Widerspenstigen.",
                 "sentenceTranslation": "Публично я наказываю непокорных.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn"
+                ],
                 "wordFamily": [
                     "Инфинитив: züchtigen",
                     "Презенс: ich züchtige",
@@ -2030,8 +2134,16 @@
                 "transcription": "[де-МЮ-ти-ген]",
                 "sentence": "Ich demütige ihn vor aller Augen.",
                 "sentenceTranslation": "Я унижаю его на глазах у всех.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn",
+                    "demütigen",
+                    "grausam",
+                    "reduzieren",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Инфинитив: demütigen",
                     "Презенс: ich demütige",
@@ -2053,8 +2165,15 @@
                 "transcription": "[ер-НИД-ри-ген]",
                 "sentence": "Ich erniedrige den treuen Diener.",
                 "sentenceTranslation": "Я унижаю верного слугу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Инфинитив: erniedrigen",
                     "Презенс: ich erniedrige",
@@ -2075,8 +2194,10 @@
                 "transcription": "[КВЕ-лен]",
                 "sentence": "Es bereitet mir Freude, ihn zu quälen.",
                 "sentenceTranslation": "Мне доставляет радость мучить его.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: quälen",
                     "Презенс: ich quäle",
@@ -2125,8 +2246,17 @@
                 "transcription": "[ди ФОЛЬ-тер]",
                 "sentence": "Die Folter ist mein liebstes Werkzeug.",
                 "sentenceTranslation": "Пытка - мой любимый инструмент.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Schmerz",
+                    "blenden",
+                    "genießen",
+                    "verraten"
+                ],
                 "wordFamily": [
                     "Основа: die Folter",
                     "Множественное число (пример): die Folter",
@@ -2148,8 +2278,14 @@
                 "transcription": "[дер за-ДИС-мус]",
                 "sentence": "Mein Sadismus kennt keine Grenzen.",
                 "sentenceTranslation": "Мой садизм не знает границ.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
                 "wordFamily": [
                     "Основа: der Sadismus",
                     "Множественное число (пример): die Sadismuse",
@@ -2169,8 +2305,10 @@
                 "transcription": "[дас БЛУТ]",
                 "sentence": "Das Blut des Grafen befleckt meine Hände.",
                 "sentenceTranslation": "Кровь графа пятнает мои руки.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Blut",
                     "Множественное число (пример): die Blute",
@@ -2190,8 +2328,15 @@
                 "transcription": "[ФОЛЬ-терн]",
                 "sentence": "Mit Lust foltere ich den alten Mann.",
                 "sentenceTranslation": "С наслаждением я пытаю старика.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Инфинитив: foltern",
                     "Презенс: ich foltere",
@@ -2211,8 +2356,12 @@
                 "transcription": "[фер-ШТЮМ-мельн]",
                 "sentence": "Ich verstümmle ihn ohne Erbarmen.",
                 "sentenceTranslation": "Я калечу его без милосердия.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus"
+                ],
                 "wordFamily": [
                     "Инфинитив: verstümmeln",
                     "Презенс: ich verstümmele",
@@ -2231,8 +2380,10 @@
                 "transcription": "[БЛЕН-ден]",
                 "sentence": "Eigenhändig blende ich Gloucester.",
                 "sentenceTranslation": "Собственноручно я ослепляю Глостера.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: blenden",
                     "Презенс: ich blende",
@@ -2255,8 +2406,14 @@
                 "transcription": "[АУС-ште-хен]",
                 "sentence": "Seine Augen steche ich mit Freude aus.",
                 "sentenceTranslation": "Его глаза я выкалываю с радостью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
                 "wordFamily": [
                     "Инфинитив: ausstechen",
                     "Презенс: ich steche aus",
@@ -2276,8 +2433,15 @@
                 "transcription": "[ди КВАЛЬ]",
                 "sentence": "Seine Qual bereitet mir Vergnügen.",
                 "sentenceTranslation": "Его мука доставляет мне удовольствие.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
                 "wordFamily": [
                     "Основа: die Qual",
                     "Множественное число (пример): die Quale",
@@ -2326,8 +2490,12 @@
                 "transcription": "[ди ВУН-де]",
                 "sentence": "Die Wunde brennt wie Feuer in meinem Leib.",
                 "sentenceTranslation": "Рана горит как огонь в моём теле.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Schmerz",
+                    "Wunde",
+                    "Überraschung"
+                ],
                 "wordFamily": [
                     "Основа: die Wunde",
                     "Множественное число (пример): die Wunde",
@@ -2346,8 +2514,10 @@
                 "transcription": "[дер ШМЕРЦ]",
                 "sentence": "Der Schmerz durchbohrt meinen Körper.",
                 "sentenceTranslation": "Боль пронзает моё тело.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Schmerz",
                     "Множественное число (пример): die Schmerze",
@@ -2368,8 +2538,12 @@
                 "transcription": "[ди ю-бер-РА-шунг]",
                 "sentence": "Die Überraschung des Angriffs schockiert mich.",
                 "sentenceTranslation": "Неожиданность нападения шокирует меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Schmerz",
+                    "Wunde",
+                    "Überraschung"
+                ],
                 "wordFamily": [
                     "Основа: die Überraschung",
                     "Множественное число (пример): die Überraschungen",
@@ -2388,8 +2562,12 @@
                 "transcription": "[БЛУ-тен]",
                 "sentence": "Ich blute wie ein geschlachtetes Schwein.",
                 "sentenceTranslation": "Я кровоточу как зарезанная свинья.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Schmerz",
+                    "Wunde",
+                    "Überraschung"
+                ],
                 "wordFamily": [
                     "Инфинитив: bluten",
                     "Презенс: ich blute",
@@ -2408,8 +2586,12 @@
                 "transcription": "[фер-ВУН-дет]",
                 "sentence": "Schwer verwundet sinke ich zu Boden.",
                 "sentenceTranslation": "Тяжело раненый я падаю на землю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Schmerz",
+                    "Wunde",
+                    "Überraschung"
+                ],
                 "wordFamily": [
                     "Основная форма: verwundet",
                     "Сравнительная степень: verwundeter",
@@ -2428,8 +2610,12 @@
                 "transcription": "[ШВЕ-хен]",
                 "sentence": "Die Verletzung schwächt meinen starken Körper.",
                 "sentenceTranslation": "Ранение ослабляет моё сильное тело.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Schmerz",
+                    "Wunde",
+                    "Überraschung"
+                ],
                 "wordFamily": [
                     "Инфинитив: schwächen",
                     "Презенс: ich schwäche",
@@ -2448,8 +2634,10 @@
                 "transcription": "[ЛАЙ-ден]",
                 "sentence": "Zum ersten Mal leide ich selbst.",
                 "sentenceTranslation": "Впервые я сам страдаю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: leiden",
                     "Презенс: ich leide",
@@ -2501,8 +2689,10 @@
                 "transcription": "[дер ТОД]",
                 "sentence": "Der Tod kommt für mich zu früh.",
                 "sentenceTranslation": "Смерть приходит ко мне слишком рано.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Tod",
                     "Множественное число (пример): die Tode",
@@ -2526,8 +2716,12 @@
                 "transcription": "[ди фер-ГЕЛЬ-тунг]",
                 "sentence": "Die Vergeltung ereilt mich unerwartet.",
                 "sentenceTranslation": "Возмездие настигает меня неожиданно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ende",
+                    "Tod",
+                    "Vergeltung"
+                ],
                 "wordFamily": [
                     "Основа: die Vergeltung",
                     "Множественное число (пример): die Vergeltungen",
@@ -2546,8 +2740,10 @@
                 "transcription": "[дас ЕН-де]",
                 "sentence": "Mein Ende kommt durch eines Dieners Hand.",
                 "sentenceTranslation": "Мой конец приходит от руки слуги.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Ende",
                     "Множественное число (пример): die Ende",
@@ -2570,8 +2766,10 @@
                 "transcription": "[ШТЕР-бен]",
                 "sentence": "Ich sterbe ohne Reue für meine Taten.",
                 "sentenceTranslation": "Я умираю без раскаяния за свои дела.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: sterben",
                     "Презенс: ich sterbe",
@@ -2595,8 +2793,15 @@
                 "transcription": "[фер-ЕН-ден]",
                 "sentence": "Wie ein Tier verende ich elend.",
                 "sentenceTranslation": "Как зверь я издыхаю жалко.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ende",
+                    "Tod",
+                    "Vergeltung",
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
                 "wordFamily": [
                     "Инфинитив: verenden",
                     "Презенс: ich verende",
@@ -2615,8 +2820,10 @@
                 "transcription": "[фер-ФЛУ-хен]",
                 "sentence": "Sterbend verfluche ich meine Mörder.",
                 "sentenceTranslation": "Умирая, я проклинаю своих убийц.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verfluchen",
                     "Презенс: ich verfluche",
@@ -2640,8 +2847,12 @@
                 "transcription": "[РЁ-хельн]",
                 "sentence": "Röchelnd hauche ich mein Leben aus.",
                 "sentenceTranslation": "Хрипя, я испускаю дух.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ende",
+                    "Tod",
+                    "Vergeltung"
+                ],
                 "wordFamily": [
                     "Инфинитив: röcheln",
                     "Презенс: ich röchele",
@@ -2660,8 +2871,10 @@
                 "transcription": "[ди ШТРА-фе]",
                 "sentence": "Dies ist die gerechte Strafe für meine Grausamkeit.",
                 "sentenceTranslation": "Это справедливая кара за мою жестокость.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Strafe",
                     "Множественное число (пример): die Strafe",

--- a/output/journeys/edgar.html
+++ b/output/journeys/edgar.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["наследник", "доверять", "знать", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["наследник", "знать", "доверять", "королевство"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["знать", "королевство", "честь", "наследник"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["законный", "королевство", "доверять", "ничего не подозревающий"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["честь", "знать", "королевство", "граф"], "correct_index": 0}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["законный", "граф", "ничего не подозревающий", "честь"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["наследник", "королевство", "ничего не подозревающий", "граф"], "correct_index": 3}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["наследник", "ничего не подозревающий", "честь", "граф"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["преследовать", "предательство", "бежать", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["бежать", "предательство", "опасность", "преследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["предательство", "прятаться", "опасность", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["предательство", "обман", "интрига", "преследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["прятаться", "изгнать", "преследовать", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "изгнать", "опасность", "преследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["опасность", "предательство", "обман", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["интрига", "преследовать", "изгнать", "прятаться"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["маскировка", "голый", "безумие", "нищий"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["нищий", "маскировка", "безумие", "голый"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["бормотать", "безумие", "нищета", "маскировка"], "correct_index": 3}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["голый", "нищий", "безумный", "дрожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["нищета", "бормотать", "нищий", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["голый", "дрожать", "бормотать", "безумный"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищета", "бормотать", "безумный", "нищий"], "correct_index": 0}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["безумный", "голый", "нищий", "безумие"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "мёрзнуть", "хижина", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["буря", "хижина", "страдать", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["хижина", "буря", "гром", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["защищать", "страдать", "хижина", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["буря", "мёрзнуть", "сопровождать", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["страдать", "гром", "сопровождать", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["хижина", "страдать", "буря", "гром"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["молния", "буря", "страдать", "сопровождать"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["обманывать", "утёс", "слепой", "вести"], "correct_index": 2}, {"question": "Что означает немецкое слово «führen»?", "choices": ["обманывать", "вести", "утёс", "слепой"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["утёс", "вести", "спасать", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["вести", "утёс", "хитрость", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["спасать", "отчаяние", "хитрость", "слепой"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["хитрость", "спасать", "слепой", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["утешать", "вести", "слепой", "утёс"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["обманывать", "утешать", "слепой", "отчаяние"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["месть", "бой", "разоблачать", "дуэль"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["дуэль", "бой", "разоблачать", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["брат", "бой", "месть", "справедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["побеждать", "справедливость", "брат", "разоблачать"], "correct_index": 3}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["побеждать", "месть", "меч", "разоблачать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["разоблачать", "бой", "справедливость", "дуэль"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["меч", "дуэль", "брат", "разоблачать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["меч", "справедливость", "дуэль", "брат"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["править", "будущее", "наследовать", "выживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erben»?", "choices": ["будущее", "править", "выживать", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["выживать", "ответственность", "будущее", "порядок"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["порядок", "ответственность", "править", "будущее"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["будущее", "ответственность", "править", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["будущее", "порядок", "править", "новый"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["порядок", "ответственность", "выживать", "новый"], "correct_index": 1}, {"question": "Что означает немецкое слово «neu»?", "choices": ["новый", "порядок", "править", "мудрость"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["наследник", "доверять", "знать", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["наследник", "знать", "доверять", "королевство"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["ничего не подозревающий", "королевство", "доверять", "граф"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["доверять", "граф", "ничего не подозревающий", "королевство"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["граф", "наследник", "знать", "честь"], "correct_index": 3}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["королевство", "законный", "доверять", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["наследник", "ничего не подозревающий", "граф", "доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["доверять", "королевство", "знать", "ничего не подозревающий"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["предательство", "опасность", "бежать", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["бежать", "предательство", "преследовать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["интрига", "опасность", "прятаться", "изгнать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["преследовать", "опасность", "предательство", "прятаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["прятаться", "обман", "интрига", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["опасность", "интрига", "преследовать", "бежать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["обман", "опасность", "изгнать", "предательство"], "correct_index": 0}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["изгнать", "интрига", "опасность", "бежать"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["голый", "безумие", "нищий", "маскировка"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["голый", "маскировка", "нищий", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["нищета", "безумие", "нищий", "маскировка"], "correct_index": 3}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["бормотать", "голый", "нищета", "безумный"], "correct_index": 1}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["нищий", "голый", "безумие", "бормотать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["дрожать", "безумный", "нищий", "маскировка"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["безумие", "голый", "маскировка", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["дрожать", "нищий", "безумие", "безумный"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["хижина", "страдать", "буря", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["страдать", "хижина", "мёрзнуть", "буря"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["защищать", "страдать", "сопровождать", "молния"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["защищать", "мёрзнуть", "хижина", "сопровождать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["мёрзнуть", "хижина", "страдать", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["хижина", "сопровождать", "гром", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["буря", "гром", "защищать", "хижина"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["мёрзнуть", "защищать", "молния", "гром"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["слепой", "вести", "обманывать", "утёс"], "correct_index": 0}, {"question": "Что означает немецкое слово «führen»?", "choices": ["обманывать", "слепой", "утёс", "вести"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["вести", "утёс", "хитрость", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["вести", "спасать", "обманывать", "хитрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «retten»?", "choices": ["обманывать", "отчаяние", "спасать", "утешать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die List»?", "choices": ["утешать", "вести", "хитрость", "спасать"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["вести", "слепой", "отчаяние", "утешать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["спасать", "утешать", "утёс", "отчаяние"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["бой", "разоблачать", "месть", "дуэль"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["дуэль", "бой", "разоблачать", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["брат", "разоблачать", "побеждать", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["бой", "разоблачать", "брат", "дуэль"], "correct_index": 1}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["побеждать", "бой", "меч", "справедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["разоблачать", "бой", "справедливость", "меч"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["меч", "бой", "брат", "справедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["разоблачать", "брат", "побеждать", "дуэль"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["править", "наследовать", "будущее", "выживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erben»?", "choices": ["править", "будущее", "выживать", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["ответственность", "наследовать", "будущее", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["будущее", "ответственность", "править", "порядок"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["будущее", "новый", "наследовать", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["новый", "порядок", "выживать", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["ответственность", "наследовать", "мудрость", "новый"], "correct_index": 0}, {"question": "Что означает немецкое слово «neu»?", "choices": ["новый", "править", "ответственность", "порядок"], "correct_index": 0}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -490,43 +490,11 @@
                         <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ничего не подозревающий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
@@ -534,15 +502,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ничего не подозревающий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                             
@@ -550,33 +534,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ничего не подозревающий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ничего не подозревающий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -593,13 +593,13 @@
                         <div class="quiz-question">Что означает немецкое слово «fliehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -613,41 +613,41 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прятаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгнать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -659,59 +659,59 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прятаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -724,33 +724,33 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">маскировка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -760,11 +760,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бормотать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">маскировка</button>
                             
@@ -772,47 +772,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бормотать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бормотать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">безумный</button>
                             
@@ -820,33 +788,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бормотать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бормотать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «wahnsinnig»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">маскировка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «wahnsinnig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -859,31 +859,15 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
@@ -891,17 +875,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -913,11 +913,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -927,11 +927,11 @@
                         <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
@@ -939,49 +939,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -994,15 +994,31 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «blind»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утёс</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «führen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утёс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
                             
@@ -1010,40 +1026,8 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «führen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Klippe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
@@ -1058,31 +1042,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
@@ -1090,17 +1074,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">утёс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1110,11 +1110,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
@@ -1129,15 +1129,15 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
                             
@@ -1161,33 +1161,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1199,11 +1199,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1219,7 +1219,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">меч</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1231,27 +1231,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Bruder»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1270,9 +1270,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
                             
@@ -1284,9 +1284,9 @@
                         <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
                             
@@ -1300,13 +1300,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Zukunft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ответственность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1316,13 +1316,13 @@
                         <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1334,9 +1334,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
@@ -1348,27 +1348,27 @@
                         <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">порядок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ответственность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
                             
@@ -1382,11 +1382,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ответственность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1415,8 +1415,10 @@
                 "transcription": "[дер А-дель]",
                 "sentence": "Der Adel erwartet von mir ehrenhaftes Verhalten.",
                 "sentenceTranslation": "Знать ожидает от меня достойного поведения.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Adel",
                     "Множественное число (пример): die Adel",
@@ -1440,8 +1442,10 @@
                 "transcription": "[дер ЕР-бе]",
                 "sentence": "Als rechtmäßiger Erbe habe ich Pflichten.",
                 "sentenceTranslation": "Как законный наследник, у меня есть обязанности.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Erbe",
                     "Множественное число (пример): die Erbe",
@@ -1461,8 +1465,10 @@
                 "transcription": "[дас КЁ-ниг-райх]",
                 "sentence": "Ich diene dem Königreich mit Ehre.",
                 "sentenceTranslation": "Я служу королевству с честью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Königreich",
                     "Множественное число (пример): die Königreiche",
@@ -1483,8 +1489,10 @@
                 "transcription": "[фер-ТРАУ-ен]",
                 "sentence": "Mein Vater vertraut mir vollkommen.",
                 "sentenceTranslation": "Мой отец полностью мне доверяет.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: vertrauen",
                     "Презенс: ich vertraue",
@@ -1507,8 +1515,10 @@
                 "transcription": "[ди Э-ре]",
                 "sentence": "Die Ehre der Familie liegt in meinen Händen.",
                 "sentenceTranslation": "Честь семьи в моих руках.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Ehre",
                     "Множественное число (пример): die Ehre",
@@ -1530,8 +1540,12 @@
                 "transcription": "[ле-ги-ТИМ]",
                 "sentence": "Ich bin der legitime Sohn des Grafen.",
                 "sentenceTranslation": "Я законный сын графа.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Erbe",
+                    "Sohn",
+                    "edel"
+                ],
                 "wordFamily": [
                     "Основная форма: legitim",
                     "Сравнительная степень: legitimer",
@@ -1550,8 +1564,10 @@
                 "transcription": "[дер ГРАФ]",
                 "sentence": "Mein Vater, der Graf, ist ein edler Mann.",
                 "sentenceTranslation": "Мой отец, граф, благородный человек.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Graf",
                     "Множественное число (пример): die Grafe",
@@ -1572,8 +1588,12 @@
                 "transcription": "[А-нунгс-лос]",
                 "sentence": "Ahnungslos vertraue ich meinem Bruder.",
                 "sentenceTranslation": "Ничего не подозревая, я доверяю брату.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Erbe",
+                    "Sohn",
+                    "edel"
+                ],
                 "wordFamily": [
                     "Основная форма: ahnungslos",
                     "Сравнительная степень: ahnungsloser",
@@ -1623,8 +1643,10 @@
                 "transcription": "[ФЛИ-ен]",
                 "sentence": "Ich muss vor falschen Anschuldigungen fliehen.",
                 "sentenceTranslation": "Я должен бежать от ложных обвинений.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: fliehen",
                     "Презенс: ich fliehe",
@@ -1645,8 +1667,10 @@
                 "transcription": "[дер фер-РАТ]",
                 "sentence": "Der Verrat meines Bruders zerstört mein Leben.",
                 "sentenceTranslation": "Предательство моего брата разрушает мою жизнь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Verrat",
                     "Множественное число (пример): die Verrate",
@@ -1669,8 +1693,10 @@
                 "transcription": "[ди ге-ФАР]",
                 "sentence": "Die Gefahr lauert überall um mich herum.",
                 "sentenceTranslation": "Опасность подстерегает меня повсюду.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Gefahr",
                     "Множественное число (пример): die Gefahre",
@@ -1692,8 +1718,10 @@
                 "transcription": "[фер-ФОЛЬ-ген]",
                 "sentence": "Die Soldaten verfolgen mich wie einen Verbrecher.",
                 "sentenceTranslation": "Солдаты преследуют меня как преступника.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verfolgen",
                     "Презенс: ich verfolge",
@@ -1714,8 +1742,10 @@
                 "transcription": "[фер-ШТЕ-кен]",
                 "sentence": "Ich muss mich in den Wäldern verstecken.",
                 "sentenceTranslation": "Я должен прятаться в лесах.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verstecken",
                     "Презенс: ich verstecke",
@@ -1736,8 +1766,10 @@
                 "transcription": "[ди ин-ТРИ-ге]",
                 "sentence": "Edmunds Intrige hat mich zum Geächteten gemacht.",
                 "sentenceTranslation": "Интрига Эдмунда сделала меня изгоем.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Intrige",
                     "Множественное число (пример): die Intrige",
@@ -1760,8 +1792,10 @@
                 "transcription": "[дер бе-ТРУГ]",
                 "sentence": "Dieser Betrug wird eines Tages aufgedeckt.",
                 "sentenceTranslation": "Этот обман однажды раскроется.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Betrug",
                     "Множественное число (пример): die Betruge",
@@ -1783,8 +1817,10 @@
                 "transcription": "[фер-БАН-нен]",
                 "sentence": "Mein Vater will mich aus dem Land verbannen.",
                 "sentenceTranslation": "Мой отец хочет изгнать меня из страны.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verbannen",
                     "Презенс: ich verbanne",
@@ -1835,8 +1871,10 @@
                 "transcription": "[дер ВАН-зин]",
                 "sentence": "Ich spiele den Wahnsinn, um zu überleben.",
                 "sentenceTranslation": "Я играю безумие, чтобы выжить.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Wahnsinn",
                     "Множественное число (пример): die Wahnsinne",
@@ -1858,8 +1896,14 @@
                 "transcription": "[дер БЕТ-лер]",
                 "sentence": "Als Bettler bin ich unsichtbar für meine Feinde.",
                 "sentenceTranslation": "Как нищий, я невидим для врагов.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
                 "wordFamily": [
                     "Основа: der Bettler",
                     "Множественное число (пример): die Bettler",
@@ -1879,8 +1923,15 @@
                 "transcription": "[ди фер-КЛАЙ-дунг]",
                 "sentence": "Diese Verkleidung ist meine einzige Rettung.",
                 "sentenceTranslation": "Эта маскировка - моё единственное спасение.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung",
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
                 "wordFamily": [
                     "Основа: die Verkleidung",
                     "Множественное число (пример): die Verkleidungen",
@@ -1901,8 +1952,15 @@
                 "transcription": "[НАКТ]",
                 "sentence": "Fast nackt wandere ich durch die Wildnis.",
                 "sentenceTranslation": "Почти голый, я брожу по дикой местности.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Sturm",
+                    "Wahnsinn",
+                    "arm",
+                    "nackt",
+                    "toben",
+                    "verrückt"
+                ],
                 "wordFamily": [
                     "Основная форма: nackt",
                     "Сравнительная степень: nackter",
@@ -1922,8 +1980,12 @@
                 "transcription": "[МУР-мельн]",
                 "sentence": "Ich murmle Unsinn, um verrückt zu wirken.",
                 "sentenceTranslation": "Я бормочу чепуху, чтобы казаться сумасшедшим.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
                 "wordFamily": [
                     "Инфинитив: murmeln",
                     "Презенс: ich murmele",
@@ -1942,8 +2004,10 @@
                 "transcription": "[ЦИ-терн]",
                 "sentence": "Vor Kälte und Angst zittere ich ständig.",
                 "sentenceTranslation": "От холода и страха я постоянно дрожу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: zittern",
                     "Презенс: ich zittere",
@@ -1964,8 +2028,10 @@
                 "transcription": "[дас Э-ленд]",
                 "sentence": "Im Elend lerne ich die wahre Natur des Menschen.",
                 "sentenceTranslation": "В нищете я познаю истинную природу человека.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Elend",
                     "Множественное число (пример): die Elende",
@@ -1986,8 +2052,12 @@
                 "transcription": "[ВАН-зи-ниг]",
                 "sentence": "Ich gebe vor, wahnsinnig zu sein.",
                 "sentenceTranslation": "Я притворяюсь безумным.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
                 "wordFamily": [
                     "Основная форма: wahnsinnig",
                     "Сравнительная степень: wahnsinniger",
@@ -2034,8 +2104,10 @@
                 "transcription": "[дер ШТУРМ]",
                 "sentence": "Der Sturm tobt über unseren Köpfen.",
                 "sentenceTranslation": "Буря бушует над нашими головами.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Sturm",
                     "Множественное число (пример): die Sturme",
@@ -2058,8 +2130,17 @@
                 "transcription": "[ФРИ-рен]",
                 "sentence": "Wir frieren gemeinsam in dieser kalten Nacht.",
                 "sentenceTranslation": "Мы мёрзнем вместе в эту холодную ночь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "Freundschaft",
+                    "Sturm",
+                    "Wahnsinn",
+                    "arm",
+                    "frieren",
+                    "leiden"
+                ],
                 "wordFamily": [
                     "Инфинитив: frieren",
                     "Презенс: ich friere",
@@ -2080,8 +2161,10 @@
                 "transcription": "[ЛАЙ-ден]",
                 "sentence": "Der König leidet mehr als ich jemals gelitten habe.",
                 "sentenceTranslation": "Король страдает больше, чем я когда-либо страдал.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: leiden",
                     "Презенс: ich leide",
@@ -2105,8 +2188,15 @@
                 "transcription": "[ди ХЮ-те]",
                 "sentence": "In dieser armseligen Hütte finden wir Zuflucht.",
                 "sentenceTranslation": "В этой жалкой хижине мы находим убежище.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "Sturm",
+                    "arm",
+                    "frieren",
+                    "leiden"
+                ],
                 "wordFamily": [
                     "Основа: die Hütte",
                     "Множественное число (пример): die Hütte",
@@ -2126,8 +2216,10 @@
                 "transcription": "[бе-ШЮ-цен]",
                 "sentence": "Heimlich beschütze ich den wahnsinnigen König.",
                 "sentenceTranslation": "Тайно я защищаю безумного короля.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: beschützen",
                     "Презенс: ich beschütze",
@@ -2151,8 +2243,16 @@
                 "transcription": "[бе-ГЛАЙ-тен]",
                 "sentence": "Als Tom begleite ich Lear durch seine dunkelste Stunde.",
                 "sentenceTranslation": "Как Том, я сопровождаю Лира в его самый тёмный час.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beistand",
+                    "Freundschaft",
+                    "Sturm",
+                    "Treue",
+                    "Wahnsinn",
+                    "frieren",
+                    "leiden"
+                ],
                 "wordFamily": [
                     "Инфинитив: begleiten",
                     "Презенс: ich begleite",
@@ -2173,8 +2273,10 @@
                 "transcription": "[дер ДО-нер]",
                 "sentence": "Der Donner übertönt unsere Schreie.",
                 "sentenceTranslation": "Гром заглушает наши крики.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Donner",
                     "Множественное число (пример): die Donner",
@@ -2195,8 +2297,10 @@
                 "transcription": "[дер БЛИЦ]",
                 "sentence": "Die Blitze erhellen unser Elend.",
                 "sentenceTranslation": "Молнии освещают нашу нищету.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Blitz",
                     "Множественное число (пример): die Blitze",
@@ -2245,8 +2349,15 @@
                 "transcription": "[БЛИНД]",
                 "sentence": "Mein blinder Vater erkennt mich nicht.",
                 "sentenceTranslation": "Мой слепой отец не узнаёт меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Klippe",
+                    "bereuen",
+                    "blind",
+                    "führen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основная форма: blind",
                     "Сравнительная степень: blinder",
@@ -2266,8 +2377,10 @@
                 "transcription": "[ФЮ-рен]",
                 "sentence": "Ich führe ihn sicher durch die Dunkelheit.",
                 "sentenceTranslation": "Я веду его безопасно сквозь тьму.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: führen",
                     "Презенс: ich führe",
@@ -2288,8 +2401,12 @@
                 "transcription": "[ди КЛИ-пе]",
                 "sentence": "Er glaubt, wir stehen am Rand der Klippe.",
                 "sentenceTranslation": "Он думает, мы стоим на краю утёса.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Klippe",
+                    "blind",
+                    "führen"
+                ],
                 "wordFamily": [
                     "Основа: die Klippe",
                     "Множественное число (пример): die Klippe",
@@ -2308,8 +2425,10 @@
                 "transcription": "[ТОЙ-шен]",
                 "sentence": "Ich täusche ihn, um sein Leben zu retten.",
                 "sentenceTranslation": "Я обманываю его, чтобы спасти его жизнь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: täuschen",
                     "Презенс: ich täusche",
@@ -2333,8 +2452,10 @@
                 "transcription": "[РЕ-тен]",
                 "sentence": "Mit List will ich meinen Vater retten.",
                 "sentenceTranslation": "Хитростью я хочу спасти отца.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: retten",
                     "Презенс: ich rette",
@@ -2355,8 +2476,18 @@
                 "transcription": "[ди ЛИСТ]",
                 "sentence": "Meine List bewahrt ihn vor dem Selbstmord.",
                 "sentenceTranslation": "Моя хитрость спасает его от самоубийства.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Klippe",
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung",
+                    "blind",
+                    "führen",
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
                 "wordFamily": [
                     "Основа: die List",
                     "Множественное число (пример): die Liste",
@@ -2377,8 +2508,10 @@
                 "transcription": "[ТРЁС-тен]",
                 "sentence": "Als Fremder tröste ich meinen eigenen Vater.",
                 "sentenceTranslation": "Как чужой, я утешаю собственного отца.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: trösten",
                     "Презенс: ich tröste",
@@ -2400,8 +2533,10 @@
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
                 "sentence": "Seine Verzweiflung bricht mir das Herz.",
                 "sentenceTranslation": "Его отчаяние разбивает мне сердце.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Verzweiflung",
                     "Множественное число (пример): die Verzweiflungen",
@@ -2452,8 +2587,10 @@
                 "transcription": "[дер КАМПФ]",
                 "sentence": "Der Kampf gegen meinen Bruder ist unvermeidlich.",
                 "sentenceTranslation": "Бой с моим братом неизбежен.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Kampf",
                     "Множественное число (пример): die Kampfe",
@@ -2476,8 +2613,10 @@
                 "transcription": "[дас ду-ЭЛЬ]",
                 "sentence": "In diesem Duell kämpfe ich für die Gerechtigkeit.",
                 "sentenceTranslation": "В этой дуэли я сражаюсь за справедливость.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Duell",
                     "Множественное число (пример): die Duelle",
@@ -2498,8 +2637,10 @@
                 "transcription": "[ди РА-хе]",
                 "sentence": "Nicht Rache, sondern Gerechtigkeit leitet meine Klinge.",
                 "sentenceTranslation": "Не месть, а справедливость ведёт мой клинок.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Rache",
                     "Множественное число (пример): die Rache",
@@ -2522,8 +2663,14 @@
                 "transcription": "[энт-ХЮ-лен]",
                 "sentence": "Ich enthülle meine wahre Identität.",
                 "sentenceTranslation": "Я разоблачаю свою истинную личность.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bruder",
+                    "Kampf",
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
                 "wordFamily": [
                     "Инфинитив: enthüllen",
                     "Презенс: ich enthülle",
@@ -2544,8 +2691,10 @@
                 "transcription": "[ЗИ-ген]",
                 "sentence": "Die Wahrheit wird über die Lüge siegen.",
                 "sentenceTranslation": "Правда победит ложь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: siegen",
                     "Презенс: ich siege",
@@ -2566,8 +2715,10 @@
                 "transcription": "[ди ге-РЕХ-тиг-кайт]",
                 "sentence": "Die Gerechtigkeit fordert diesen Kampf.",
                 "sentenceTranslation": "Справедливость требует этого боя.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Gerechtigkeit",
                     "Множественное число (пример): die Gerechtigkeiten",
@@ -2589,8 +2740,10 @@
                 "transcription": "[дас ШВЕРТ]",
                 "sentence": "Mein Schwert ist die Waffe der Wahrheit.",
                 "sentenceTranslation": "Мой меч - оружие правды.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Schwert",
                     "Множественное число (пример): die Schwerte",
@@ -2610,8 +2763,10 @@
                 "transcription": "[дер БРУ-дер]",
                 "sentence": "Mein Bruder muss für seine Verbrechen büßen.",
                 "sentenceTranslation": "Мой брат должен поплатиться за свои преступления.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Bruder",
                     "Множественное число (пример): die Bruder",
@@ -2659,8 +2814,10 @@
                 "transcription": "[ю-бер-ЛЕ-бен]",
                 "sentence": "Ich habe alle Prüfungen überlebt.",
                 "sentenceTranslation": "Я пережил все испытания.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: überleben",
                     "Презенс: ich lebe über",
@@ -2680,8 +2837,10 @@
                 "transcription": "[ЭР-бен]",
                 "sentence": "Nun erbe ich Titel und Verantwortung.",
                 "sentenceTranslation": "Теперь я наследую титул и ответственность.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: erben",
                     "Презенс: ich erbe",
@@ -2702,8 +2861,10 @@
                 "transcription": "[ди ЦУ-кунфт]",
                 "sentence": "Die Zukunft des Königreichs liegt in unseren Händen.",
                 "sentenceTranslation": "Будущее королевства в наших руках.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Zukunft",
                     "Множественное число (пример): die Zukunfte",
@@ -2723,8 +2884,10 @@
                 "transcription": "[ре-ГИ-рен]",
                 "sentence": "Mit Weisheit werde ich regieren.",
                 "sentenceTranslation": "С мудростью я буду править.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: regieren",
                     "Презенс: ich regiere",
@@ -2747,8 +2910,19 @@
                 "transcription": "[ди ВАЙС-хайт]",
                 "sentence": "Durch Leiden habe ich Weisheit erlangt.",
                 "sentenceTranslation": "Через страдания я обрёл мудрость.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Erbe",
+                    "Herrschaft",
+                    "Narr",
+                    "Neuanfang",
+                    "Trauer",
+                    "Weisheit",
+                    "Zukunft",
+                    "erkennen",
+                    "verstehen",
+                    "überleben"
+                ],
                 "wordFamily": [
                     "Основа: die Weisheit",
                     "Множественное число (пример): die Weisheiten",
@@ -2770,8 +2944,12 @@
                 "transcription": "[ди ОРД-нунг]",
                 "sentence": "Neue Ordnung muss aus dem Chaos entstehen.",
                 "sentenceTranslation": "Новый порядок должен возникнуть из хаоса.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Erbe",
+                    "Zukunft",
+                    "überleben"
+                ],
                 "wordFamily": [
                     "Основа: die Ordnung",
                     "Множественное число (пример): die Ordnungen",
@@ -2790,8 +2968,12 @@
                 "transcription": "[ди фер-АНТ-вор-тунг]",
                 "sentence": "Die Verantwortung für alle wiegt schwer.",
                 "sentenceTranslation": "Ответственность за всех тяжела.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Erbe",
+                    "Zukunft",
+                    "überleben"
+                ],
                 "wordFamily": [
                     "Основа: die Verantwortung",
                     "Множественное число (пример): die Verantwortungen",
@@ -2810,8 +2992,12 @@
                 "transcription": "[НОЙ]",
                 "sentence": "Eine neue Ära beginnt für unser Land.",
                 "sentenceTranslation": "Новая эра начинается для нашей страны.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Erbe",
+                    "Zukunft",
+                    "überleben"
+                ],
                 "wordFamily": [
                     "Основная форма: neu",
                     "Сравнительная степень: neuer",

--- a/output/journeys/edmund.html
+++ b/output/journeys/edmund.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["обделённый", "амбиция", "зависть", "бастард"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["бастард", "зависть", "обделённый", "амбиция"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["бастард", "природа", "возвышаться", "амбиция"], "correct_index": 3}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["природа", "внебрачный", "обделённый", "бастард"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["бастард", "амбиция", "внебрачный", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["амбиция", "возвышаться", "месть", "обделённый"], "correct_index": 1}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["бастард", "внебрачный", "обделённый", "амбиция"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["зависть", "амбиция", "внебрачный", "природа"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["обвинять", "подделывать", "интриговать", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["обвинять", "интриговать", "подделывать", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["подделывать", "лгать", "обвинять", "письмо"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["подделывать", "план", "обвинять", "манипулировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["манипулировать", "обвинять", "план", "лгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["план", "письмо", "интриговать", "обвинять"], "correct_index": 1}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["интриговать", "обвинять", "лгать", "план"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["манипулировать", "обман", "интриговать", "письмо"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["торжествовать", "изгонять", "успех", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["торжествовать", "успех", "изгонять", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erben»?", "choices": ["вытеснять", "выигрывать", "изгонять", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["выигрывать", "успех", "наследовать", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["награда", "наследовать", "изгонять", "выигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["успех", "награда", "торжествовать", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["награда", "успех", "наследовать", "вытеснять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["успех", "победа", "торжествовать", "вытеснять"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["объединяться", "власть", "союз", "завоёвывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "союз", "завоёвывать", "объединяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["союз", "завоёвывать", "завоевание", "соблазнять"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["господствовать", "союз", "власть", "завоевание"], "correct_index": 1}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["завоевание", "объединяться", "союз", "соблазнять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["союз", "завоевание", "объединяться", "господствовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["завоевание", "союз", "завоёвывать", "господствовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["объединяться", "альянс", "завоевание", "завоёвывать"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["доносить", "ослеплять", "жестокость", "предавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "жестокость", "предавать", "доносить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "беспощадный", "жертвовать", "предавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["выдавать", "доносить", "предавать", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["доносить", "ослеплять", "жертвовать", "выдавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["доносить", "жертвовать", "предавать", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["пытка", "доносить", "предавать", "жертвовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["беспощадный", "выдавать", "ослеплять", "доносить"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["играть", "завлекать", "соперничество", "любовная связь"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["играть", "любовная связь", "соперничество", "завлекать"], "correct_index": 2}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["играть", "использовать", "жонглировать", "интрига"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["соперничество", "жонглировать", "завлекать", "играть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["похоть", "использовать", "соперничество", "жонглировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["интрига", "жонглировать", "использовать", "соперничество"], "correct_index": 2}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["похоть", "играть", "интрига", "жонглировать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["интрига", "завлекать", "соперничество", "любовная связь"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["сожалеть", "падать", "поражение", "дуэль"], "correct_index": 3}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["дуэль", "сожалеть", "падать", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["проигрывать", "сожалеть", "дуэль", "признаваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["поражение", "дуэль", "падать", "признаваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["поражение", "сожалеть", "падение", "проигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["падение", "поражение", "конец", "проигрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["падать", "конец", "проигрывать", "признаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["падать", "конец", "дуэль", "признаваться"], "correct_index": 1}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["амбиция", "обделённый", "зависть", "бастард"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["амбиция", "зависть", "обделённый", "бастард"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["месть", "обделённый", "возвышаться", "амбиция"], "correct_index": 3}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["амбиция", "месть", "обделённый", "внебрачный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["внебрачный", "месть", "природа", "зависть"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["природа", "возвышаться", "внебрачный", "бастард"], "correct_index": 1}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["амбиция", "бастард", "зависть", "внебрачный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["амбиция", "бастард", "обделённый", "природа"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["обвинять", "план", "интриговать", "подделывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["обвинять", "интриговать", "подделывать", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["лгать", "обвинять", "манипулировать", "письмо"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["обман", "обвинять", "план", "интриговать"], "correct_index": 2}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["интриговать", "лгать", "письмо", "манипулировать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["письмо", "подделывать", "лгать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["лгать", "обман", "план", "интриговать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["обман", "обвинять", "манипулировать", "план"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["наследовать", "торжествовать", "изгонять", "успех"], "correct_index": 2}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["наследовать", "торжествовать", "успех", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "торжествовать", "выигрывать", "победа"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["успех", "торжествовать", "изгонять", "награда"], "correct_index": 0}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["вытеснять", "торжествовать", "награда", "выигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["награда", "вытеснять", "наследовать", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["наследовать", "успех", "выигрывать", "вытеснять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["победа", "наследовать", "награда", "успех"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["власть", "союз", "завоёвывать", "объединяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["объединяться", "завоёвывать", "союз", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоёвывать", "господствовать", "соблазнять", "объединяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["соблазнять", "власть", "союз", "объединяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["соблазнять", "завоевание", "завоёвывать", "союз"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["объединяться", "завоёвывать", "завоевание", "соблазнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["власть", "господствовать", "завоевание", "завоёвывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["завоевание", "альянс", "союз", "объединяться"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["ослеплять", "предавать", "жестокость", "доносить"], "correct_index": 1}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["доносить", "ослеплять", "предавать", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["ослеплять", "предавать", "доносить", "жестокость"], "correct_index": 3}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["выдавать", "ослеплять", "доносить", "пытка"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["беспощадный", "ослеплять", "выдавать", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["ослеплять", "доносить", "пытка", "выдавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["жестокость", "пытка", "жертвовать", "доносить"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["выдавать", "жестокость", "беспощадный", "доносить"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["завлекать", "играть", "любовная связь", "соперничество"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["любовная связь", "играть", "соперничество", "завлекать"], "correct_index": 2}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["завлекать", "играть", "любовная связь", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["любовная связь", "завлекать", "играть", "жонглировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["завлекать", "использовать", "соперничество", "похоть"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["любовная связь", "использовать", "играть", "похоть"], "correct_index": 1}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["интрига", "играть", "любовная связь", "жонглировать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["играть", "соперничество", "интрига", "использовать"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["поражение", "дуэль", "падать", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["поражение", "дуэль", "сожалеть", "падать"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "поражение", "падение", "проигрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["дуэль", "падение", "поражение", "признаваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["признаваться", "проигрывать", "конец", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["признаваться", "сожалеть", "дуэль", "падение"], "correct_index": 3}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["признаваться", "проигрывать", "поражение", "сожалеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["дуэль", "сожалеть", "признаваться", "конец"], "correct_index": 3}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -458,9 +458,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Bastard»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
                             
@@ -474,13 +474,13 @@
                         <div class="quiz-question">Что означает немецкое слово «der Neid»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">зависть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -490,9 +490,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">природа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
                             
@@ -506,29 +506,29 @@
                         <div class="quiz-question">Что означает немецкое слово «benachteiligt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">внебрачный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">внебрачный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">природа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">зависть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -538,29 +538,29 @@
                         <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">возвышаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">внебрачный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -570,11 +570,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Natur»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">внебрачный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
                             
@@ -589,17 +589,17 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «fälschen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -621,15 +621,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «beschuldigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">лгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                             
@@ -637,15 +637,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">лгать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">манипулировать</button>
                             
@@ -653,31 +669,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">лгать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">лгать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                             
@@ -685,33 +685,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «lügen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">лгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -724,65 +724,65 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вытеснять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">победа</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Erfolg»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">награда</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -792,11 +792,11 @@
                         <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вытеснять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">награда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
                             
@@ -804,15 +804,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
@@ -824,11 +824,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
                             
@@ -836,17 +836,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Sieg»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">награда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -859,24 +859,8 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verbünden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
@@ -891,11 +875,75 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоевание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Eroberung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
@@ -907,65 +955,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">господствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоевание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">объединяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Eroberung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -975,13 +975,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Allianz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">альянс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -994,31 +994,15 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
@@ -1026,15 +1010,63 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
                             
@@ -1042,31 +1074,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
                             
@@ -1074,47 +1090,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жертвовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «opfern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертвовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
@@ -1129,17 +1129,17 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Liebschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1149,9 +1149,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
                             
@@ -1161,47 +1161,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verlocken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
                             
@@ -1209,17 +1193,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «ausnutzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">использовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1229,11 +1229,11 @@
                         <div class="quiz-question">Что означает немецкое слово «jonglieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
                             
@@ -1241,17 +1241,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Affäre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">использовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1264,56 +1264,8 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
@@ -1322,19 +1274,35 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">падение</button>
                             
@@ -1344,49 +1312,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">падение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">признаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">признаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">признаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">признаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1415,8 +1415,10 @@
                 "transcription": "[дер БАС-тард]",
                 "sentence": "Als Bastard habe ich keine Rechte.",
                 "sentenceTranslation": "Как бастард я не имею прав.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Bastard",
                     "Множественное число (пример): die Bastarde",
@@ -1436,8 +1438,12 @@
                 "transcription": "[дер НАЙД]",
                 "sentence": "Der Neid auf Edgar verzehrt mich.",
                 "sentenceTranslation": "Зависть к Эдгару пожирает меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ambition",
+                    "Bastard",
+                    "Neid"
+                ],
                 "wordFamily": [
                     "Основа: der Neid",
                     "Множественное число (пример): die Neide",
@@ -1456,8 +1462,12 @@
                 "transcription": "[ди ам-би-ЦИ-он]",
                 "sentence": "Meine Ambition kennt keine Grenzen.",
                 "sentenceTranslation": "Моя амбиция не знает границ.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ambition",
+                    "Bastard",
+                    "Neid"
+                ],
                 "wordFamily": [
                     "Основа: die Ambition",
                     "Множественное число (пример): die Ambitione",
@@ -1476,8 +1486,12 @@
                 "transcription": "[бе-НАХ-тай-лигт]",
                 "sentence": "Ich bin von Geburt an benachteiligt.",
                 "sentenceTranslation": "Я обделён с рождения.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ambition",
+                    "Bastard",
+                    "Neid"
+                ],
                 "wordFamily": [
                     "Основная форма: benachteiligt",
                     "Сравнительная степень: benachteiligter",
@@ -1496,8 +1510,10 @@
                 "transcription": "[ди РА-хе]",
                 "sentence": "Die Rache an der Gesellschaft ist mein Ziel.",
                 "sentenceTranslation": "Месть обществу - моя цель.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Rache",
                     "Множественное число (пример): die Rache",
@@ -1520,8 +1536,12 @@
                 "transcription": "[АУФ-штай-ген]",
                 "sentence": "Ich will über alle aufsteigen.",
                 "sentenceTranslation": "Я хочу возвыситься над всеми.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ambition",
+                    "Bastard",
+                    "Neid"
+                ],
                 "wordFamily": [
                     "Инфинитив: aufsteigen",
                     "Презенс: ich steige auf",
@@ -1540,8 +1560,12 @@
                 "transcription": "[УН-э-е-лих]",
                 "sentence": "Meine uneheliche Geburt ist mein Fluch.",
                 "sentenceTranslation": "Моё внебрачное рождение - мой проклятие.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ambition",
+                    "Bastard",
+                    "Neid"
+                ],
                 "wordFamily": [
                     "Основная форма: unehelich",
                     "Сравнительная степень: unehelicher",
@@ -1560,8 +1584,10 @@
                 "transcription": "[ди на-ТУР]",
                 "sentence": "Die Natur ist meine Göttin, nicht das Gesetz.",
                 "sentenceTranslation": "Природа - моя богиня, не закон.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Natur",
                     "Множественное число (пример): die Nature",
@@ -1610,8 +1636,12 @@
                 "transcription": "[ФЕЛЬ-шен]",
                 "sentence": "Ich fälsche Edgars Brief perfekt.",
                 "sentenceTranslation": "Я идеально подделываю письмо Эдгара.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
                 "wordFamily": [
                     "Инфинитив: fälschen",
                     "Презенс: ich fälsche",
@@ -1630,8 +1660,12 @@
                 "transcription": "[ин-три-ГИ-рен]",
                 "sentence": "Ich intrigiere gegen meinen Bruder.",
                 "sentenceTranslation": "Я интригую против брата.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
                 "wordFamily": [
                     "Инфинитив: intrigieren",
                     "Презенс: ich intrigiere",
@@ -1650,8 +1684,12 @@
                 "transcription": "[бе-ШУЛЬ-ди-ген]",
                 "sentence": "Ich beschuldige Edgar des Verrats.",
                 "sentenceTranslation": "Я обвиняю Эдгара в предательстве.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
                 "wordFamily": [
                     "Инфинитив: beschuldigen",
                     "Презенс: ich beschuldige",
@@ -1672,8 +1710,15 @@
                 "transcription": "[дер ПЛАН]",
                 "sentence": "Mein Plan wird perfekt ausgeführt.",
                 "sentenceTranslation": "Мой план выполняется идеально.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan",
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
                 "wordFamily": [
                     "Основа: der Plan",
                     "Множественное число (пример): die Plane",
@@ -1693,8 +1738,12 @@
                 "transcription": "[ма-ни-пу-ЛИ-рен]",
                 "sentence": "Ich manipuliere meinen Vater geschickt.",
                 "sentenceTranslation": "Я ловко манипулирую отцом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
                 "wordFamily": [
                     "Инфинитив: manipulieren",
                     "Презенс: ich manipuliere",
@@ -1713,8 +1762,10 @@
                 "transcription": "[дер БРИФ]",
                 "sentence": "Der gefälschte Brief ist mein Beweis.",
                 "sentenceTranslation": "Поддельное письмо - моё доказательство.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Brief",
                     "Множественное число (пример): die Briefe",
@@ -1735,8 +1786,10 @@
                 "transcription": "[ЛЮ-ген]",
                 "sentence": "Ich lüge ohne mit der Wimper zu zucken.",
                 "sentenceTranslation": "Я лгу не моргнув глазом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: lügen",
                     "Презенс: ich lüge",
@@ -1757,8 +1810,15 @@
                 "transcription": "[ди ТОЙ-шунг]",
                 "sentence": "Die Täuschung ist vollkommen.",
                 "sentenceTranslation": "Обман совершенен.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Täuschung",
+                    "Verzweiflung",
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren",
+                    "springen"
+                ],
                 "wordFamily": [
                     "Основа: die Täuschung",
                     "Множественное число (пример): die Täuschungen",
@@ -1807,8 +1867,10 @@
                 "transcription": "[фер-ТРАЙ-бен]",
                 "sentence": "Ich vertreibe Edgar aus seinem Erbe.",
                 "sentenceTranslation": "Я изгоняю Эдгара из его наследства.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: vertreiben",
                     "Презенс: ich vertreibe",
@@ -1833,8 +1895,12 @@
                 "transcription": "[три-ум-ФИ-рен]",
                 "sentence": "Ich triumphiere über meinen Bruder.",
                 "sentenceTranslation": "Я торжествую над братом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "erben",
+                    "triumphieren",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Инфинитив: triumphieren",
                     "Презенс: ich triumphiere",
@@ -1853,8 +1919,10 @@
                 "transcription": "[ЭР-бен]",
                 "sentence": "Nun erbe ich alles, was Edgar zustand.",
                 "sentenceTranslation": "Теперь я наследую всё, что полагалось Эдгару.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: erben",
                     "Презенс: ich erbe",
@@ -1875,8 +1943,12 @@
                 "transcription": "[дер эр-ФОЛЬГ]",
                 "sentence": "Mein Erfolg ist vollkommen.",
                 "sentenceTranslation": "Мой успех полный.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "erben",
+                    "triumphieren",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Основа: der Erfolg",
                     "Множественное число (пример): die Erfolge",
@@ -1895,8 +1967,10 @@
                 "transcription": "[ге-ВИН-нен]",
                 "sentence": "Ich gewinne alles durch List.",
                 "sentenceTranslation": "Я выигрываю всё хитростью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: gewinnen",
                     "Презенс: ich gewinne",
@@ -1916,8 +1990,12 @@
                 "transcription": "[ди бе-ЛО-нунг]",
                 "sentence": "Die Belohnung für meine Intrige ist groß.",
                 "sentenceTranslation": "Награда за мою интригу велика.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "erben",
+                    "triumphieren",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Основа: die Belohnung",
                     "Множественное число (пример): die Belohnungen",
@@ -1936,8 +2014,12 @@
                 "transcription": "[фер-ДРЕН-ген]",
                 "sentence": "Ich verdränge den rechtmäßigen Erben.",
                 "sentenceTranslation": "Я вытесняю законного наследника.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "erben",
+                    "triumphieren",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Инфинитив: verdrängen",
                     "Презенс: ich verdränge",
@@ -1956,8 +2038,12 @@
                 "transcription": "[дер ЗИГ]",
                 "sentence": "Der Sieg über Edgar ist süß.",
                 "sentenceTranslation": "Победа над Эдгаром сладка.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "erben",
+                    "triumphieren",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Основа: der Sieg",
                     "Множественное число (пример): die Siege",
@@ -2004,8 +2090,12 @@
                 "transcription": "[фер-БЮН-ден]",
                 "sentence": "Ich verbünde mich mit den bösen Schwestern.",
                 "sentenceTranslation": "Я объединяюсь со злыми сёстрами.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Macht",
+                    "erobern",
+                    "verbünden"
+                ],
                 "wordFamily": [
                     "Инфинитив: verbünden",
                     "Презенс: ich verbünde",
@@ -2024,8 +2114,10 @@
                 "transcription": "[ди МАХТ]",
                 "sentence": "Die Macht über das Königreich ist nah.",
                 "sentenceTranslation": "Власть над королевством близка.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Macht",
                     "Множественное число (пример): die Machte",
@@ -2048,8 +2140,10 @@
                 "transcription": "[эр-О-берн]",
                 "sentence": "Wir erobern das Reich gemeinsam.",
                 "sentenceTranslation": "Мы завоёвываем королевство вместе.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: erobern",
                     "Презенс: ich erobere",
@@ -2071,8 +2165,15 @@
                 "transcription": "[дас БЮНД-нис]",
                 "sentence": "Unser Bündnis ist stark und grausam.",
                 "sentenceTranslation": "Наш союз силён и жесток.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bündnis",
+                    "Macht",
+                    "erobern",
+                    "planen",
+                    "teilen",
+                    "verbünden"
+                ],
                 "wordFamily": [
                     "Основа: das Bündnis",
                     "Множественное число (пример): die Bündnise",
@@ -2092,8 +2193,15 @@
                 "transcription": "[фер-ФЮ-рен]",
                 "sentence": "Ich verführe beide Schwestern gleichzeitig.",
                 "sentenceTranslation": "Я соблазняю обеих сестёр одновременно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Macht",
+                    "Witwe",
+                    "begehren",
+                    "erobern",
+                    "verbünden",
+                    "verführen"
+                ],
                 "wordFamily": [
                     "Инфинитив: verführen",
                     "Презенс: ich verführe",
@@ -2113,8 +2221,12 @@
                 "transcription": "[ди эр-О-бе-рунг]",
                 "sentence": "Die Eroberung des Throns ist mein Ziel.",
                 "sentenceTranslation": "Завоевание трона - моя цель.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Macht",
+                    "erobern",
+                    "verbünden"
+                ],
                 "wordFamily": [
                     "Основа: die Eroberung",
                     "Множественное число (пример): die Eroberungen",
@@ -2133,8 +2245,10 @@
                 "transcription": "[бе-ХЕР-шен]",
                 "sentence": "Ich beherrsche das Spiel der Macht.",
                 "sentenceTranslation": "Я господствую в игре власти.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: beherrschen",
                     "Презенс: ich beherrsche",
@@ -2155,8 +2269,12 @@
                 "transcription": "[ди а-ли-АНЦС]",
                 "sentence": "Unsere Allianz wird alle Feinde vernichten.",
                 "sentenceTranslation": "Наш альянс уничтожит всех врагов.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Macht",
+                    "erobern",
+                    "verbünden"
+                ],
                 "wordFamily": [
                     "Основа: die Allianz",
                     "Множественное число (пример): die Allianze",
@@ -2203,8 +2321,10 @@
                 "transcription": "[фер-РА-тен]",
                 "sentence": "Ich verrate meinen eigenen Vater.",
                 "sentenceTranslation": "Я предаю собственного отца.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verraten",
                     "Презенс: ich verrate",
@@ -2229,8 +2349,10 @@
                 "transcription": "[БЛЕН-ден]",
                 "sentence": "Sie blenden ihn auf meinen Hinweis.",
                 "sentenceTranslation": "Они ослепляют его по моей наводке.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: blenden",
                     "Презенс: ich blende",
@@ -2253,8 +2375,20 @@
                 "transcription": "[ди ГРАУ-зам-кайт]",
                 "sentence": "Meine Grausamkeit kennt keine Grenzen.",
                 "sentenceTranslation": "Моя жестокость не знает границ.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "Verzweiflung",
+                    "blenden",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen",
+                    "verlassen",
+                    "verraten",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основа: die Grausamkeit",
                     "Множественное число (пример): die Grausamkeiten",
@@ -2276,8 +2410,12 @@
                 "transcription": "[де-нун-ЦИ-рен]",
                 "sentence": "Ich denunziere meinen Vater als Verräter.",
                 "sentenceTranslation": "Я доношу на отца как на предателя.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Grausamkeit",
+                    "blenden",
+                    "verraten"
+                ],
                 "wordFamily": [
                     "Инфинитив: denunzieren",
                     "Презенс: ich denunziere",
@@ -2296,8 +2434,12 @@
                 "transcription": "[АУС-ли-ферн]",
                 "sentence": "Ich liefere ihn seinen Feinden aus.",
                 "sentenceTranslation": "Я выдаю его врагам.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Grausamkeit",
+                    "blenden",
+                    "verraten"
+                ],
                 "wordFamily": [
                     "Инфинитив: ausliefern",
                     "Презенс: ich liefere aus",
@@ -2318,8 +2460,17 @@
                 "transcription": "[ди ФОЛЬ-тер]",
                 "sentence": "Die Folter meines Vaters stört mich nicht.",
                 "sentenceTranslation": "Пытка моего отца меня не тревожит.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Schmerz",
+                    "blenden",
+                    "genießen",
+                    "verraten"
+                ],
                 "wordFamily": [
                     "Основа: die Folter",
                     "Множественное число (пример): die Folter",
@@ -2341,8 +2492,12 @@
                 "transcription": "[ОП-ферн]",
                 "sentence": "Ich opfere ihn für meine Ambitionen.",
                 "sentenceTranslation": "Я жертвую им ради своих амбиций.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Grausamkeit",
+                    "blenden",
+                    "verraten"
+                ],
                 "wordFamily": [
                     "Инфинитив: opfern",
                     "Презенс: ich opfere",
@@ -2361,8 +2516,17 @@
                 "transcription": "[эр-БАР-мунгс-лос]",
                 "sentence": "Erbarmungslos verfolge ich mein Ziel.",
                 "sentenceTranslation": "Беспощадно я преследую свою цель.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Sturm",
+                    "blenden",
+                    "genießen",
+                    "gnadenlos",
+                    "verraten",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основная форма: erbarmungslos",
                     "Сравнительная степень: erbarmungsloser",
@@ -2411,8 +2575,12 @@
                 "transcription": "[ди ЛИБ-шафт]",
                 "sentence": "Meine Liebschaft mit beiden Schwestern ist gefährlich.",
                 "sentenceTranslation": "Моя любовная связь с обеими сёстрами опасна.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "spielen"
+                ],
                 "wordFamily": [
                     "Основа: die Liebschaft",
                     "Множественное число (пример): die Liebschafte",
@@ -2432,8 +2600,15 @@
                 "transcription": "[ди ри-ва-ли-ТЕТ]",
                 "sentence": "Ihre Rivalität spielt mir in die Hände.",
                 "sentenceTranslation": "Их соперничество играет мне на руку.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "bedrohen",
+                    "hassen",
+                    "spielen",
+                    "wettkämpfen"
+                ],
                 "wordFamily": [
                     "Основа: die Rivalität",
                     "Множественное число (пример): die Rivalitäte",
@@ -2453,8 +2628,10 @@
                 "transcription": "[ШПИ-лен]",
                 "sentence": "Ich spiele mit ihren Gefühlen.",
                 "sentenceTranslation": "Я играю с их чувствами.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: spielen",
                     "Презенс: ich spiele",
@@ -2474,8 +2651,12 @@
                 "transcription": "[фер-ЛО-кен]",
                 "sentence": "Ich verlocke sie mit falschen Versprechen.",
                 "sentenceTranslation": "Я завлекаю их ложными обещаниями.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "spielen"
+                ],
                 "wordFamily": [
                     "Инфинитив: verlocken",
                     "Презенс: ich verlocke",
@@ -2494,8 +2675,15 @@
                 "transcription": "[ди ЛУСТ]",
                 "sentence": "Ihre Lust macht sie blind.",
                 "sentenceTranslation": "Их похоть делает их слепыми.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "Witwe",
+                    "begehren",
+                    "spielen",
+                    "verführen"
+                ],
                 "wordFamily": [
                     "Основа: die Lust",
                     "Множественное число (пример): die Luste",
@@ -2515,8 +2703,12 @@
                 "transcription": "[АУС-нут-цен]",
                 "sentence": "Ich nutze ihre Leidenschaft aus.",
                 "sentenceTranslation": "Я использую их страсть.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "spielen"
+                ],
                 "wordFamily": [
                     "Инфинитив: ausnutzen",
                     "Презенс: ich nutze aus",
@@ -2535,8 +2727,12 @@
                 "transcription": "[жон-ГЛИ-рен]",
                 "sentence": "Ich jongliere mit zwei gefährlichen Frauen.",
                 "sentenceTranslation": "Я жонглирую двумя опасными женщинами.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "spielen"
+                ],
                 "wordFamily": [
                     "Инфинитив: jonglieren",
                     "Презенс: ich jongliere",
@@ -2555,8 +2751,12 @@
                 "transcription": "[ди а-ФЕ-ре]",
                 "sentence": "Diese Affäre wird tödlich enden.",
                 "sentenceTranslation": "Эта интрига закончится смертью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "spielen"
+                ],
                 "wordFamily": [
                     "Основа: die Affäre",
                     "Множественное число (пример): die Affäre",
@@ -2604,8 +2804,10 @@
                 "transcription": "[дас ду-ЭЛЬ]",
                 "sentence": "Das Duell mit Edgar ist mein Ende.",
                 "sentenceTranslation": "Дуэль с Эдгаром - мой конец.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Duell",
                     "Множественное число (пример): die Duelle",
@@ -2626,8 +2828,10 @@
                 "transcription": "[ФАЛ-лен]",
                 "sentence": "Ich falle von seinem gerechten Schwert.",
                 "sentenceTranslation": "Я падаю от его справедливого меча.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: fallen",
                     "Презенс: ich falle",
@@ -2649,8 +2853,10 @@
                 "transcription": "[бе-РОЙ-ен]",
                 "sentence": "Am Ende bereue ich meine Taten.",
                 "sentenceTranslation": "В конце я сожалею о своих делах.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: bereuen",
                     "Презенс: ich bereue",
@@ -2673,8 +2879,15 @@
                 "transcription": "[ди НИ-дер-ла-ге]",
                 "sentence": "Die Niederlage ist vollkommen.",
                 "sentenceTranslation": "Поражение полное.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Duell",
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod",
+                    "bereuen",
+                    "fallen"
+                ],
                 "wordFamily": [
                     "Основа: die Niederlage",
                     "Множественное число (пример): die Niederlage",
@@ -2694,8 +2907,10 @@
                 "transcription": "[фер-ЛИ-рен]",
                 "sentence": "Ich verliere alles, was ich gewann.",
                 "sentenceTranslation": "Я проигрываю всё, что выиграл.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verlieren",
                     "Презенс: ich verliere",
@@ -2717,8 +2932,12 @@
                 "transcription": "[дер УН-тер-ганг]",
                 "sentence": "Mein Untergang ist gerecht.",
                 "sentenceTranslation": "Моё падение справедливо.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Duell",
+                    "bereuen",
+                    "fallen"
+                ],
                 "wordFamily": [
                     "Основа: der Untergang",
                     "Множественное число (пример): die Untergange",
@@ -2737,8 +2956,10 @@
                 "transcription": "[ге-ШТЕ-ен]",
                 "sentence": "Ich gestehe alle meine Verbrechen.",
                 "sentenceTranslation": "Я признаюсь во всех преступлениях.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: gestehen",
                     "Презенс: ich gestehe",
@@ -2758,8 +2979,10 @@
                 "transcription": "[дас ЭН-де]",
                 "sentence": "Das Ende kommt schnell und gerecht.",
                 "sentenceTranslation": "Конец приходит быстро и справедливо.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Ende",
                     "Множественное число (пример): die Ende",

--- a/output/journeys/fool.html
+++ b/output/journeys/fool.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "печаль", "мудрость", "шутить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["печаль", "мудрость", "шут", "шутить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["скучать", "шут", "шутить", "печаль"], "correct_index": 3}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["шутить", "печаль", "шут", "забава"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["печаль", "умный", "забава", "шутить"], "correct_index": 2}, {"question": "Что означает немецкое слово «klug»?", "choices": ["скучать", "забава", "шутить", "умный"], "correct_index": 3}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["шутить", "скучать", "печаль", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["остроумие", "забава", "шутить", "умный"], "correct_index": 0}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["горький", "шутка", "предупреждение", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["предупреждение", "правда", "горький", "шутка"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["раскрывать", "шутка", "правда", "предупреждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["предупреждение", "насмехаться", "горький", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["предупреждение", "насмехаться", "раскрывать", "правда"], "correct_index": 1}, {"question": "Что означает немецкое слово «necken»?", "choices": ["дразнить", "правда", "шутка", "предупреждение"], "correct_index": 0}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["шутка", "насмехаться", "раскрывать", "правда"], "correct_index": 2}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["пророчество", "предсказывать", "загадка", "предчувствие"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["пророчество", "предчувствие", "предсказывать", "загадка"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["загадка", "предсказывать", "пророчество", "предчувствие"], "correct_index": 3}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["пророчество", "предсказывать", "загадка", "толковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["толковать", "предчувствовать", "пророчество", "предсказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["загадка", "предчувствовать", "знамение", "предсказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["предчувствие", "толковать", "знамение", "загадка"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["толковать", "загадочный", "загадка", "пророчество"], "correct_index": 1}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["дружба", "мёрзнуть", "безумие", "сопровождать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["сопровождать", "мёрзнуть", "безумие", "дружба"], "correct_index": 3}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["мёрзнуть", "сопровождать", "безумие", "дрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "дружба", "безумие", "петь"], "correct_index": 0}, {"question": "Что означает немецкое слово «singen»?", "choices": ["мёрзнуть", "петь", "сопровождать", "дрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["дрожать", "дружба", "петь", "верный"], "correct_index": 0}, {"question": "Что означает немецкое слово «treu»?", "choices": ["безумие", "мёрзнуть", "верный", "сопровождать"], "correct_index": 2}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["ирония", "напевать", "песня", "утешение"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["напевать", "песня", "ирония", "утешение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["песня", "звучать", "свистеть", "ирония"], "correct_index": 3}, {"question": "Что означает немецкое слово «summen»?", "choices": ["песня", "ирония", "напевать", "звучать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["ирония", "утешение", "звучать", "мелодия"], "correct_index": 3}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["рифма", "напевать", "свистеть", "мелодия"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["звучать", "напевать", "мелодия", "рифма"], "correct_index": 3}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["песня", "рифма", "звучать", "мелодия"], "correct_index": 2}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["судьба", "бренность", "размышлять", "философия"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["философия", "бренность", "судьба", "размышлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["философия", "смысл", "бренность", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["философия", "размышлять", "познавать", "преходящий"], "correct_index": 1}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["философия", "познавать", "смысл", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["бренность", "смысл", "судьба", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["преходящий", "познавать", "философия", "размышлять"], "correct_index": 0}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["тайна", "пустота", "исчезать", "растворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["тайна", "исчезать", "пустота", "растворяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["исчезать", "загадочный", "туман", "пустота"], "correct_index": 3}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["загадочный", "туман", "растворяться", "исчезать"], "correct_index": 2}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["бесследно", "пустота", "исчезать", "загадочный"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["растворяться", "туман", "тайна", "бесследно"], "correct_index": 1}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["пустота", "загадочный", "бесследно", "уходить"], "correct_index": 1}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["загадочный", "исчезать", "уходить", "пустота"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["шутить", "мудрость", "шут", "печаль"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["шут", "печаль", "мудрость", "шутить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["скучать", "печаль", "шутить", "забава"], "correct_index": 1}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["остроумие", "забава", "печаль", "шутить"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["скучать", "шут", "забава", "остроумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «klug»?", "choices": ["умный", "печаль", "остроумие", "шутить"], "correct_index": 0}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["шут", "скучать", "забава", "умный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["остроумие", "умный", "скучать", "печаль"], "correct_index": 0}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "шутка", "предупреждение", "горький"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["горький", "предупреждение", "правда", "шутка"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["шутка", "предупреждение", "насмехаться", "раскрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["насмехаться", "горький", "предупреждение", "правда"], "correct_index": 1}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["дразнить", "правда", "шутка", "насмехаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «necken»?", "choices": ["правда", "насмехаться", "раскрывать", "дразнить"], "correct_index": 3}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["насмехаться", "правда", "раскрывать", "дразнить"], "correct_index": 2}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["предсказывать", "предчувствие", "загадка", "пророчество"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["пророчество", "предсказывать", "загадка", "предчувствие"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["предсказывать", "предчувствие", "пророчество", "загадочный"], "correct_index": 1}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["предчувствовать", "пророчество", "предсказывать", "загадка"], "correct_index": 2}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["знамение", "загадка", "толковать", "пророчество"], "correct_index": 2}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["загадочный", "предчувствовать", "толковать", "предчувствие"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["предсказывать", "толковать", "загадка", "знамение"], "correct_index": 3}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["предчувствие", "толковать", "загадочный", "знамение"], "correct_index": 2}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["безумие", "дружба", "мёрзнуть", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["мёрзнуть", "сопровождать", "дружба", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["верный", "мёрзнуть", "петь", "сопровождать"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["дрожать", "дружба", "петь", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «singen»?", "choices": ["дружба", "сопровождать", "петь", "дрожать"], "correct_index": 2}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["дрожать", "сопровождать", "верный", "безумие"], "correct_index": 0}, {"question": "Что означает немецкое слово «treu»?", "choices": ["дружба", "сопровождать", "дрожать", "верный"], "correct_index": 3}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["напевать", "ирония", "утешение", "песня"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["ирония", "утешение", "напевать", "песня"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["рифма", "ирония", "утешение", "свистеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «summen»?", "choices": ["ирония", "утешение", "мелодия", "напевать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["рифма", "мелодия", "напевать", "песня"], "correct_index": 1}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["утешение", "песня", "рифма", "свистеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["ирония", "рифма", "мелодия", "напевать"], "correct_index": 1}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["утешение", "ирония", "звучать", "песня"], "correct_index": 2}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["размышлять", "философия", "бренность", "судьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["судьба", "философия", "бренность", "размышлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["судьба", "смысл", "бренность", "познавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["судьба", "познавать", "размышлять", "смысл"], "correct_index": 2}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["судьба", "смысл", "познавать", "размышлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["судьба", "размышлять", "преходящий", "смысл"], "correct_index": 3}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["преходящий", "смысл", "размышлять", "бренность"], "correct_index": 0}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["исчезать", "пустота", "растворяться", "тайна"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["исчезать", "пустота", "растворяться", "тайна"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["загадочный", "исчезать", "пустота", "растворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["тайна", "бесследно", "растворяться", "пустота"], "correct_index": 2}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["туман", "бесследно", "загадочный", "исчезать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["исчезать", "туман", "пустота", "загадочный"], "correct_index": 1}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["растворяться", "туман", "загадочный", "тайна"], "correct_index": 2}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["уходить", "исчезать", "пустота", "загадочный"], "correct_index": 0}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -454,8 +454,24 @@
             <div class="quiz-phase-container active" data-phase="jester">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
@@ -470,49 +486,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «scherzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">остроумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -522,29 +522,29 @@
                         <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «klug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">остроумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -554,13 +554,13 @@
                         <div class="quiz-question">Что означает немецкое слово «vermissen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">скучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -572,11 +572,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">остроумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">скучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -589,17 +589,17 @@
             <div class="quiz-phase-container" data-phase="bitter_truths">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -609,11 +609,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Scherz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
                             
@@ -621,31 +621,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
                             
@@ -653,24 +653,8 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «necken»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
@@ -679,7 +663,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «necken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">дразнить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -689,13 +689,13 @@
                         <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">раскрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дразнить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -708,8 +708,24 @@
             <div class="quiz-phase-container" data-phase="prophecies">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Prophezeiung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Rätsel»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
@@ -724,13 +740,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Rätsel»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Vorahnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «vorhersagen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
                             
@@ -740,49 +772,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Vorahnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vorhersagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -792,45 +792,45 @@
                         <div class="quiz-question">Что означает немецкое слово «ahnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Omen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">предчувствие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -843,15 +843,15 @@
             <div class="quiz-phase-container" data-phase="mad_companion">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                             
@@ -859,63 +859,63 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «singen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
                             
@@ -929,27 +929,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -962,113 +962,113 @@
             <div class="quiz-phase-container" data-phase="songs">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Lied»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">песня</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Trost»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Ironie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">свистеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «summen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Trost»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Ironie»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">свистеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">свистеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «summen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">напевать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">рифма</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">свистеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">напевать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1078,13 +1078,13 @@
                         <div class="quiz-question">Что означает немецкое слово «klingen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">звучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1097,31 +1097,31 @@
             <div class="quiz-phase-container" data-phase="wisdom">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Philosophie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
@@ -1133,43 +1133,43 @@
                         <div class="quiz-question">Что означает немецкое слово «die Vergänglichkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">смысл</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">познавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преходящий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">познавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">смысл</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">смысл</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
@@ -1177,17 +1177,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смысл</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преходящий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смысл</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1199,11 +1199,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">преходящий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">познавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смысл</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1216,27 +1216,43 @@
             <div class="quiz-phase-container" data-phase="vanishing">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verschwinden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
                             
@@ -1248,15 +1264,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">туман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
                             
@@ -1264,33 +1280,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">туман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1300,45 +1300,45 @@
                         <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
                         <div class="quiz-choices">
                             
+                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
+                        <div class="quiz-choices">
+                            
                             <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бесследно</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «fortgehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">уходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1367,8 +1367,10 @@
                 "transcription": "[дер НАР]",
                 "sentence": "Als Narr sage ich die Wahrheit durch Scherze.",
                 "sentenceTranslation": "Как шут я говорю правду через шутки.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Narr",
                     "Множественное число (пример): die Narre",
@@ -1389,8 +1391,19 @@
                 "transcription": "[ди ВАЙС-хайт]",
                 "sentence": "Hinter meinen Späßen verbirgt sich Weisheit.",
                 "sentenceTranslation": "За моими шутками скрывается мудрость.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Erbe",
+                    "Herrschaft",
+                    "Narr",
+                    "Neuanfang",
+                    "Trauer",
+                    "Weisheit",
+                    "Zukunft",
+                    "erkennen",
+                    "verstehen",
+                    "überleben"
+                ],
                 "wordFamily": [
                     "Основа: die Weisheit",
                     "Множественное число (пример): die Weisheiten",
@@ -1412,8 +1425,10 @@
                 "transcription": "[ди ТРАУ-ер]",
                 "sentence": "Die Trauer um Корделия macht mich stumm.",
                 "sentenceTranslation": "Печаль о Корделии делает меня немым.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Trauer",
                     "Множественное число (пример): die Trauer",
@@ -1436,8 +1451,12 @@
                 "transcription": "[ШЕР-цен]",
                 "sentence": "Ich scherze, um den Schmerz zu verbergen.",
                 "sentenceTranslation": "Я шучу, чтобы скрыть боль.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Narr",
+                    "Trauer",
+                    "Weisheit"
+                ],
                 "wordFamily": [
                     "Инфинитив: scherzen",
                     "Презенс: ich scherze",
@@ -1456,8 +1475,12 @@
                 "transcription": "[дер ШПАС]",
                 "sentence": "Der Spaß ist meine Maske vor der Welt.",
                 "sentenceTranslation": "Забава - моя маска перед миром.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Narr",
+                    "Trauer",
+                    "Weisheit"
+                ],
                 "wordFamily": [
                     "Основа: der Spaß",
                     "Множественное число (пример): die Spaße",
@@ -1476,8 +1499,12 @@
                 "transcription": "[КЛУГ]",
                 "sentence": "Ich bin klüger als alle bei Hofe.",
                 "sentenceTranslation": "Я умнее всех при дворе.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Narr",
+                    "Trauer",
+                    "Weisheit"
+                ],
                 "wordFamily": [
                     "Основная форма: klug",
                     "Сравнительная степень: kluger",
@@ -1496,8 +1523,12 @@
                 "transcription": "[фер-МИ-сен]",
                 "sentence": "Ich vermisse die süße Корделия sehr.",
                 "sentenceTranslation": "Я очень скучаю по милой Корделии.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Narr",
+                    "Trauer",
+                    "Weisheit"
+                ],
                 "wordFamily": [
                     "Инфинитив: vermissen",
                     "Презенс: ich vermisse",
@@ -1516,8 +1547,12 @@
                 "transcription": "[дер ВИТЦ]",
                 "sentence": "Mein Witz ist scharf wie ein Schwert.",
                 "sentenceTranslation": "Моё остроумие остро как меч.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Narr",
+                    "Trauer",
+                    "Weisheit"
+                ],
                 "wordFamily": [
                     "Основа: der Witz",
                     "Множественное число (пример): die Witze",
@@ -1564,8 +1599,10 @@
                 "transcription": "[ди ВАР-хайт]",
                 "sentence": "Die Wahrheit verpacke ich in lustige Lieder.",
                 "sentenceTranslation": "Правду я заворачиваю в весёлые песни.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Wahrheit",
                     "Множественное число (пример): die Wahrheiten",
@@ -1587,8 +1624,12 @@
                 "transcription": "[дер ШЕРЦ]",
                 "sentence": "Jeder Scherz enthält eine bittere Lehre.",
                 "sentenceTranslation": "Каждая шутка содержит горький урок.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
                 "wordFamily": [
                     "Основа: der Scherz",
                     "Множественное число (пример): die Scherze",
@@ -1607,8 +1648,12 @@
                 "transcription": "[ди ВАР-нунг]",
                 "sentence": "Meine Warnung kommt als Rätsel verkleidet.",
                 "sentenceTranslation": "Моё предупреждение приходит замаскированным под загадку.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
                 "wordFamily": [
                     "Основа: die Warnung",
                     "Множественное число (пример): die Warnungen",
@@ -1627,8 +1672,12 @@
                 "transcription": "[БИ-тер]",
                 "sentence": "Die Wahrheit schmeckt bitter wie Galle.",
                 "sentenceTranslation": "Правда горька как желчь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
                 "wordFamily": [
                     "Основная форма: bitter",
                     "Сравнительная степень: bittrer",
@@ -1647,8 +1696,12 @@
                 "transcription": "[ШПО-тен]",
                 "sentence": "Ich spotte über die Torheit der Mächtigen.",
                 "sentenceTranslation": "Я насмехаюсь над глупостью сильных.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
                 "wordFamily": [
                     "Инфинитив: spotten",
                     "Презенс: ich spotte",
@@ -1668,8 +1721,12 @@
                 "transcription": "[НЕ-кен]",
                 "sentence": "Ich necke den König mit der Wahrheit.",
                 "sentenceTranslation": "Я дразню короля правдой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
                 "wordFamily": [
                     "Инфинитив: necken",
                     "Презенс: ich necke",
@@ -1688,8 +1745,14 @@
                 "transcription": "[энт-ХЮ-лен]",
                 "sentence": "Spielerisch enthülle ich seine Fehler.",
                 "sentenceTranslation": "Играючи я раскрываю его ошибки.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bruder",
+                    "Kampf",
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
                 "wordFamily": [
                     "Инфинитив: enthüllen",
                     "Презенс: ich enthülle",
@@ -1738,8 +1801,12 @@
                 "transcription": "[ди про-фе-ЦАЙ-унг]",
                 "sentence": "Meine Prophezeiung wird wahr werden.",
                 "sentenceTranslation": "Моё пророчество сбудется.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
                 "wordFamily": [
                     "Основа: die Prophezeiung",
                     "Множественное число (пример): die Prophezeiungen",
@@ -1758,8 +1825,12 @@
                 "transcription": "[дас РЕТ-зель]",
                 "sentence": "In Rätseln spreche ich von der Zukunft.",
                 "sentenceTranslation": "В загадках я говорю о будущем.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
                 "wordFamily": [
                     "Основа: das Rätsel",
                     "Множественное число (пример): die Rätsel",
@@ -1778,8 +1849,12 @@
                 "transcription": "[ди ФОР-а-нунг]",
                 "sentence": "Eine dunkle Vorahnung erfüllt mein Herz.",
                 "sentenceTranslation": "Тёмное предчувствие наполняет моё сердце.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
                 "wordFamily": [
                     "Основа: die Vorahnung",
                     "Множественное число (пример): die Vorahnungen",
@@ -1798,8 +1873,12 @@
                 "transcription": "[ФОР-хер-за-ген]",
                 "sentence": "Ich sage das kommende Unheil vorher.",
                 "sentenceTranslation": "Я предсказываю грядущую беду.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
                 "wordFamily": [
                     "Инфинитив: vorhersagen",
                     "Презенс: ich hersage vor",
@@ -1818,8 +1897,12 @@
                 "transcription": "[ДОЙ-тен]",
                 "sentence": "Die Zeichen deute ich besser als alle.",
                 "sentenceTranslation": "Знаки я толкую лучше всех.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
                 "wordFamily": [
                     "Инфинитив: deuten",
                     "Презенс: ich deute",
@@ -1838,8 +1921,12 @@
                 "transcription": "[А-нен]",
                 "sentence": "Ich ahne das schlimme Ende voraus.",
                 "sentenceTranslation": "Я предчувствую плохой конец.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
                 "wordFamily": [
                     "Инфинитив: ahnen",
                     "Презенс: ich ahne",
@@ -1858,8 +1945,12 @@
                 "transcription": "[дас О-мен]",
                 "sentence": "Jedes Omen zeigt auf Untergang.",
                 "sentenceTranslation": "Каждое знамение указывает на гибель.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
                 "wordFamily": [
                     "Основа: das Omen",
                     "Множественное число (пример): die Omen",
@@ -1878,8 +1969,15 @@
                 "transcription": "[РЕТ-зель-хафт]",
                 "sentence": "Meine Worte bleiben rätselhaft und wahr.",
                 "sentenceTranslation": "Мои слова остаются загадочными и правдивыми.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Verschwinden",
+                    "Vorahnung"
+                ],
                 "wordFamily": [
                     "Основная форма: rätselhaft",
                     "Сравнительная степень: rätselhafter",
@@ -1927,8 +2025,10 @@
                 "transcription": "[дер ВАН-зин]",
                 "sentence": "Im Wahnsinn finden wir uns als Brüder.",
                 "sentenceTranslation": "В безумии мы находим друг друга как братья.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Wahnsinn",
                     "Множественное число (пример): die Wahnsinne",
@@ -1950,8 +2050,12 @@
                 "transcription": "[ди ФРОЙНД-шафт]",
                 "sentence": "Unsere Freundschaft überdauert den Sturm.",
                 "sentenceTranslation": "Наша дружба переживёт бурю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Freundschaft",
+                    "Sturm",
+                    "Wahnsinn"
+                ],
                 "wordFamily": [
                     "Основа: die Freundschaft",
                     "Множественное число (пример): die Freundschafte",
@@ -1970,8 +2074,16 @@
                 "transcription": "[бе-ГЛАЙ-тен]",
                 "sentence": "Treu begleite ich meinen verrückten König.",
                 "sentenceTranslation": "Верно я сопровождаю своего безумного короля.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beistand",
+                    "Freundschaft",
+                    "Sturm",
+                    "Treue",
+                    "Wahnsinn",
+                    "frieren",
+                    "leiden"
+                ],
                 "wordFamily": [
                     "Инфинитив: begleiten",
                     "Презенс: ich begleite",
@@ -1992,8 +2104,17 @@
                 "transcription": "[ФРИ-рен]",
                 "sentence": "Wir frieren gemeinsam in der kalten Nacht.",
                 "sentenceTranslation": "Мы мёрзнем вместе в холодную ночь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "Freundschaft",
+                    "Sturm",
+                    "Wahnsinn",
+                    "arm",
+                    "frieren",
+                    "leiden"
+                ],
                 "wordFamily": [
                     "Инфинитив: frieren",
                     "Презенс: ich friere",
@@ -2014,8 +2135,10 @@
                 "transcription": "[ЗИН-ген]",
                 "sentence": "Ich singe, um seine Angst zu lindern.",
                 "sentenceTranslation": "Я пою, чтобы облегчить его страх.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: singen",
                     "Презенс: ich singe",
@@ -2035,8 +2158,10 @@
                 "transcription": "[ЦИ-терн]",
                 "sentence": "Vor Kälte zittern wir wie Espenlaub.",
                 "sentenceTranslation": "От холода мы дрожим как осиновый лист.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: zittern",
                     "Презенс: ich zittere",
@@ -2057,8 +2182,15 @@
                 "transcription": "[ТРОЙ]",
                 "sentence": "Ich bleibe treu, wenn alle anderen fliehen.",
                 "sentenceTranslation": "Я остаюсь верным, когда все остальные бегут.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Freundschaft",
+                    "List",
+                    "Rückkehr",
+                    "Sturm",
+                    "Verkleidung",
+                    "Wahnsinn"
+                ],
                 "wordFamily": [
                     "Основная форма: treu",
                     "Сравнительная степень: treuer",
@@ -2106,8 +2238,12 @@
                 "transcription": "[дас ЛИД]",
                 "sentence": "Mein Lied erzählt von vergangenen Tagen.",
                 "sentenceTranslation": "Моя песня рассказывает о прошлых днях.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
                 "wordFamily": [
                     "Основа: das Lied",
                     "Множественное число (пример): die Liede",
@@ -2126,8 +2262,12 @@
                 "transcription": "[дер ТРОСТ]",
                 "sentence": "Mit Liedern bringe ich kleinen Trost.",
                 "sentenceTranslation": "Песнями я приношу малое утешение.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
                 "wordFamily": [
                     "Основа: der Trost",
                     "Множественное число (пример): die Troste",
@@ -2146,8 +2286,12 @@
                 "transcription": "[ди и-ро-НИ]",
                 "sentence": "Die Ironie ist meine letzte Waffe.",
                 "sentenceTranslation": "Ирония - моё последнее оружие.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
                 "wordFamily": [
                     "Основа: die Ironie",
                     "Множественное число (пример): die Ironie",
@@ -2166,8 +2310,12 @@
                 "transcription": "[ЗУ-мен]",
                 "sentence": "Leise summe ich alte Melodien.",
                 "sentenceTranslation": "Тихо я напеваю старые мелодии.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
                 "wordFamily": [
                     "Инфинитив: summen",
                     "Презенс: ich summe",
@@ -2186,8 +2334,12 @@
                 "transcription": "[ди ме-ло-ДИ]",
                 "sentence": "Die Melodie erinnert an bessere Zeiten.",
                 "sentenceTranslation": "Мелодия напоминает о лучших временах.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
                 "wordFamily": [
                     "Основа: die Melodie",
                     "Множественное число (пример): die Melodie",
@@ -2206,8 +2358,12 @@
                 "transcription": "[ПФАЙ-фен]",
                 "sentence": "Ich pfeife gegen die Dunkelheit an.",
                 "sentenceTranslation": "Я свищу против темноты.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
                 "wordFamily": [
                     "Инфинитив: pfeifen",
                     "Презенс: ich pfeife",
@@ -2226,8 +2382,12 @@
                 "transcription": "[дер РАЙМ]",
                 "sentence": "Jeder Reim verbirgt eine tiefe Wahrheit.",
                 "sentenceTranslation": "Каждая рифма скрывает глубокую правду.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
                 "wordFamily": [
                     "Основа: der Reim",
                     "Множественное число (пример): die Reime",
@@ -2246,8 +2406,12 @@
                 "transcription": "[КЛИН-ген]",
                 "sentence": "Meine Worte klingen lustig, doch sind traurig.",
                 "sentenceTranslation": "Мои слова звучат весело, но печальны.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
                 "wordFamily": [
                     "Инфинитив: klingen",
                     "Презенс: ich klinge",
@@ -2294,8 +2458,12 @@
                 "transcription": "[ди фи-ло-зо-ФИ]",
                 "sentence": "Meine Philosophie ist einfach: Alles ist Narretei.",
                 "sentenceTranslation": "Моя философия проста: всё - глупость.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Philosophie",
+                    "Schicksal",
+                    "Vergänglichkeit"
+                ],
                 "wordFamily": [
                     "Основа: die Philosophie",
                     "Множественное число (пример): die Philosophie",
@@ -2314,8 +2482,10 @@
                 "transcription": "[дас ШИК-заль]",
                 "sentence": "Das Schicksal macht Narren aus uns allen.",
                 "sentenceTranslation": "Судьба делает дураков из всех нас.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Schicksal",
                     "Множественное число (пример): die Schicksale",
@@ -2336,8 +2506,12 @@
                 "transcription": "[ди фер-ГЕНГ-лих-кайт]",
                 "sentence": "Die Vergänglichkeit der Macht ist offenbar.",
                 "sentenceTranslation": "Бренность власти очевидна.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Philosophie",
+                    "Schicksal",
+                    "Vergänglichkeit"
+                ],
                 "wordFamily": [
                     "Основа: die Vergänglichkeit",
                     "Множественное число (пример): die Vergänglichkeiten",
@@ -2356,8 +2530,12 @@
                 "transcription": "[НАХ-ден-кен]",
                 "sentence": "Ich denke nach über des Lebens Sinn.",
                 "sentenceTranslation": "Я размышляю о смысле жизни.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Philosophie",
+                    "Schicksal",
+                    "Vergänglichkeit"
+                ],
                 "wordFamily": [
                     "Инфинитив: nachdenken",
                     "Презенс: ich denke nach",
@@ -2378,8 +2556,10 @@
                 "transcription": "[ер-КЕН-нен]",
                 "sentence": "Ich erkenne die Wahrheit hinter dem Schein.",
                 "sentenceTranslation": "Я познаю правду за видимостью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: erkennen",
                     "Презенс: ich erkenne",
@@ -2405,8 +2585,12 @@
                 "transcription": "[дер ЗИН]",
                 "sentence": "Der Sinn des Lebens ist ein schlechter Witz.",
                 "sentenceTranslation": "Смысл жизни - плохая шутка.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Philosophie",
+                    "Schicksal",
+                    "Vergänglichkeit"
+                ],
                 "wordFamily": [
                     "Основа: der Sinn",
                     "Множественное число (пример): die Sinne",
@@ -2425,8 +2609,12 @@
                 "transcription": "[фер-ГЕНГ-лих]",
                 "sentence": "Alles ist vergänglich, nur die Torheit bleibt.",
                 "sentenceTranslation": "Всё преходяще, только глупость остаётся.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Philosophie",
+                    "Schicksal",
+                    "Vergänglichkeit"
+                ],
                 "wordFamily": [
                     "Основная форма: vergänglich",
                     "Сравнительная степень: vergänglicher",
@@ -2473,8 +2661,10 @@
                 "transcription": "[фер-ШВИН-ден]",
                 "sentence": "Ich verschwinde wie ein Traum im Morgen.",
                 "sentenceTranslation": "Я исчезаю как сон поутру.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verschwinden",
                     "Презенс: ich verschwinde",
@@ -2494,8 +2684,10 @@
                 "transcription": "[дас ге-ХАЙМ-нис]",
                 "sentence": "Mein Verschwinden bleibt ein ewiges Geheimnis.",
                 "sentenceTranslation": "Моё исчезновение остаётся вечной тайной.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Geheimnis",
                     "Множественное число (пример): die Geheimnise",
@@ -2515,8 +2707,12 @@
                 "transcription": "[ди ЛЕ-ре]",
                 "sentence": "Ich hinterlasse nur Leere und Erinnerung.",
                 "sentenceTranslation": "Я оставляю только пустоту и воспоминание.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Verschwinden"
+                ],
                 "wordFamily": [
                     "Основа: die Leere",
                     "Множественное число (пример): die Leere",
@@ -2535,8 +2731,12 @@
                 "transcription": "[зих АУФ-лё-зен]",
                 "sentence": "Ich löse mich auf wie Nebel im Wind.",
                 "sentenceTranslation": "Я растворяюсь как туман на ветру.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Verschwinden"
+                ],
                 "wordFamily": [
                     "Инфинитив: sich auflösen",
                     "Презенс: ich löse mich auf",
@@ -2555,8 +2755,12 @@
                 "transcription": "[ШПУР-лос]",
                 "sentence": "Spurlos gehe ich aus dieser Welt.",
                 "sentenceTranslation": "Бесследно я ухожу из этого мира.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Verschwinden"
+                ],
                 "wordFamily": [
                     "Основная форма: spurlos",
                     "Сравнительная степень: spurloser",
@@ -2575,8 +2779,12 @@
                 "transcription": "[дер НЕ-бель]",
                 "sentence": "Im Nebel verliere ich mich für immer.",
                 "sentenceTranslation": "В тумане я теряюсь навсегда.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Verschwinden"
+                ],
                 "wordFamily": [
                     "Основа: der Nebel",
                     "Множественное число (пример): die Nebel",
@@ -2595,8 +2803,15 @@
                 "transcription": "[РЕТ-зель-хафт]",
                 "sentence": "Mein Ende bleibt rätselhaft und stumm.",
                 "sentenceTranslation": "Мой конец остаётся загадочным и немым.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Verschwinden",
+                    "Vorahnung"
+                ],
                 "wordFamily": [
                     "Основная форма: rätselhaft",
                     "Сравнительная степень: rätselhafter",
@@ -2616,8 +2831,12 @@
                 "transcription": "[ФОРТ-ге-ен]",
                 "sentence": "Ich gehe fort, wenn keiner es bemerkt.",
                 "sentenceTranslation": "Я ухожу, когда никто не замечает.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Verschwinden"
+                ],
                 "wordFamily": [
                     "Инфинитив: fortgehen",
                     "Презенс: ich fortgehe",

--- a/output/journeys/gloucester.html
+++ b/output/journeys/gloucester.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["доверять", "знать", "служить", "граф"], "correct_index": 1}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["знать", "служить", "граф", "доверять"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["честь", "долг", "праведный", "доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["служить", "праведный", "граф", "долг"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["уважать", "честь", "граф", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["праведный", "знать", "доверять", "долг"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["честь", "уважать", "граф", "долг"], "correct_index": 3}, {"question": "Что означает немецкое слово «achten»?", "choices": ["граф", "уважать", "служить", "доверять"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["обман", "обманывать", "письмо", "верить"], "correct_index": 2}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["письмо", "обманывать", "верить", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["подозревать", "обманывать", "обман", "верить"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["письмо", "обман", "подозревать", "легковерный"], "correct_index": 1}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["ловушка", "обман", "простодушный", "легковерный"], "correct_index": 2}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["подозревать", "верить", "легковерный", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["обман", "подозревать", "легковерный", "верить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["ловушка", "обман", "простодушный", "легковерный"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["проклинать", "заблуждение", "изгонять", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "заблуждение", "сожалеть", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["слепой", "несправедливость", "проклинать", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["сожалеть", "слепой", "проклинать", "заблуждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «blind»?", "choices": ["заблуждение", "изгонять", "слепой", "несправедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["проклинать", "несправедливость", "слепой", "гнать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["слепой", "изгонять", "проклинать", "несправедливость"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["сострадание", "помогать", "опасность", "рисковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["рисковать", "помогать", "опасность", "сострадание"], "correct_index": 3}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["сострадание", "измена", "осмеливаться", "рисковать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["сострадание", "осмеливаться", "опасность", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["осмеливаться", "опасность", "помогать", "тайно"], "correct_index": 3}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["рисковать", "сострадание", "защищать", "помогать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["защищать", "помогать", "измена", "рисковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["измена", "опасность", "рисковать", "осмеливаться"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["пытка", "ослеплять", "боль", "темнота"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["ослеплять", "боль", "темнота", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["ослеплять", "боль", "кричать", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["темнота", "слепнуть", "месть", "кричать"], "correct_index": 0}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["темнота", "месть", "ослеплять", "кричать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["ослеплять", "боль", "слепнуть", "месть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "темнота", "пытка", "слепнуть"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["пропасть", "обман", "прыгать", "отчаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «springen»?", "choices": ["пропасть", "отчаяние", "прыгать", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["сдаваться", "обман", "отчаяние", "пропасть"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["пропасть", "сдаваться", "отчаяние", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["безнадёжность", "сдаваться", "прыгать", "пропасть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["безнадёжность", "обман", "прыгать", "избавлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["падать", "избавлять", "сдаваться", "прыгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["безнадёжность", "обман", "пропасть", "избавлять"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["осознание", "умирать", "узнавать", "прощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "осознание", "узнавать", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["примирение", "прощать", "умирать", "обнимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["осознание", "раскаяние", "прощать", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["умирать", "примирение", "раскаяние", "осознание"], "correct_index": 2}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["умирать", "узнавать", "обнимать", "примирение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["узнавать", "прощать", "умирать", "примирение"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["умирать", "осознание", "сердце", "узнавать"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["знать", "граф", "служить", "доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["доверять", "граф", "знать", "служить"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["праведный", "граф", "доверять", "честь"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["знать", "граф", "уважать", "долг"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["праведный", "знать", "честь", "доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["праведный", "долг", "уважать", "доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["долг", "праведный", "уважать", "граф"], "correct_index": 0}, {"question": "Что означает немецкое слово «achten»?", "choices": ["граф", "уважать", "долг", "честь"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["письмо", "обманывать", "верить", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["верить", "обманывать", "обман", "письмо"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["ловушка", "простодушный", "обманывать", "легковерный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["обманывать", "обман", "подозревать", "легковерный"], "correct_index": 1}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["простодушный", "обман", "обманывать", "письмо"], "correct_index": 0}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["простодушный", "легковерный", "подозревать", "обманывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["легковерный", "обман", "ловушка", "подозревать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["легковерный", "подозревать", "ловушка", "простодушный"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["проклинать", "сожалеть", "заблуждение", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["изгонять", "заблуждение", "проклинать", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "заблуждение", "изгонять", "несправедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["изгонять", "сожалеть", "заблуждение", "несправедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «blind»?", "choices": ["сожалеть", "слепой", "заблуждение", "гнать"], "correct_index": 1}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["гнать", "изгонять", "несправедливость", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["несправедливость", "гнать", "изгонять", "заблуждение"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["помогать", "сострадание", "опасность", "рисковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["помогать", "рисковать", "опасность", "сострадание"], "correct_index": 3}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["опасность", "тайно", "рисковать", "помогать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["помогать", "тайно", "измена", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["сострадание", "рисковать", "тайно", "осмеливаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["измена", "тайно", "защищать", "помогать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["измена", "тайно", "помогать", "рисковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["помогать", "рисковать", "опасность", "осмеливаться"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["пытка", "темнота", "боль", "ослеплять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["боль", "пытка", "ослеплять", "темнота"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["пытка", "кричать", "боль", "слепнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["темнота", "кричать", "слепнуть", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["темнота", "ослеплять", "кричать", "боль"], "correct_index": 2}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["месть", "пытка", "слепнуть", "темнота"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["слепнуть", "пытка", "кричать", "месть"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["обман", "пропасть", "отчаяние", "прыгать"], "correct_index": 2}, {"question": "Что означает немецкое слово «springen»?", "choices": ["обман", "пропасть", "отчаяние", "прыгать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["прыгать", "сдаваться", "падать", "обман"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["безнадёжность", "пропасть", "отчаяние", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["пропасть", "сдаваться", "обман", "прыгать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["безнадёжность", "прыгать", "сдаваться", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["прыгать", "обман", "избавлять", "падать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["падать", "пропасть", "отчаяние", "избавлять"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "прощать", "осознание", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["узнавать", "умирать", "прощать", "осознание"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["осознание", "раскаяние", "примирение", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["сердце", "прощать", "осознание", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["примирение", "осознание", "обнимать", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["обнимать", "умирать", "сердце", "примирение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["осознание", "умирать", "узнавать", "примирение"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["обнимать", "умирать", "сердце", "примирение"], "correct_index": 2}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -454,31 +454,15 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
                             
@@ -486,31 +470,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
                             
@@ -518,17 +518,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">уважать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -540,27 +540,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -574,9 +574,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -589,24 +589,8 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «glauben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
@@ -621,17 +605,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «glauben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">простодушный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">легковерный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -641,7 +641,7 @@
                         <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
@@ -653,31 +653,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «arglos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">простодушный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">легковерный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">легковерный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
@@ -685,33 +685,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «leichtgläubig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">легковерный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">легковерный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">простодушный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">легковерный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -724,31 +724,15 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
@@ -756,13 +740,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
@@ -772,31 +756,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «blind»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
@@ -804,15 +772,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «blind»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гнать</button>
                             
@@ -820,17 +804,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -843,13 +843,13 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «helfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
@@ -863,9 +863,9 @@
                         <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
@@ -875,49 +875,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «riskieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">измена</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «heimlich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тайно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">тайно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -927,9 +927,9 @@
                         <div class="quiz-question">Что означает немецкое слово «schützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">измена</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
@@ -939,15 +939,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">измена</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">измена</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
                             
@@ -959,11 +959,11 @@
                         <div class="quiz-question">Что означает немецкое слово «wagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">измена</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
                             
@@ -978,15 +978,31 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
                             
@@ -994,33 +1010,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1032,27 +1032,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1062,29 +1062,29 @@
                         <div class="quiz-question">Что означает немецкое слово «erblinden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слепнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1097,65 +1097,65 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «springen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Abgrund»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безнадёжность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1165,13 +1165,13 @@
                         <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безнадёжность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1183,27 +1183,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">безнадёжность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">избавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">избавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">избавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1213,11 +1213,11 @@
                         <div class="quiz-question">Что означает немецкое слово «erlösen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безнадёжность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">избавлять</button>
                             
@@ -1232,31 +1232,15 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
@@ -1264,47 +1248,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">примирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">примирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
                             
@@ -1312,15 +1264,63 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">примирение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">примирение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
                             
@@ -1332,11 +1332,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
                             
@@ -1348,13 +1348,13 @@
                         <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1383,8 +1383,10 @@
                 "transcription": "[дер А-дель]",
                 "sentence": "Als Adel diene ich meinem König treu.",
                 "sentenceTranslation": "Как знать я верно служу своему королю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Adel",
                     "Множественное число (пример): die Adel",
@@ -1408,8 +1410,10 @@
                 "transcription": "[ДИ-нен]",
                 "sentence": "Ich diene dem König seit vielen Jahren.",
                 "sentenceTranslation": "Я служу королю много лет.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: dienen",
                     "Презенс: ich diene",
@@ -1430,8 +1434,10 @@
                 "transcription": "[фер-ТРАУ-ен]",
                 "sentence": "Ich vertraue beiden Söhnen gleich.",
                 "sentenceTranslation": "Я доверяю обоим сыновьям одинаково.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: vertrauen",
                     "Презенс: ich vertraue",
@@ -1454,8 +1460,10 @@
                 "transcription": "[дер ГРАФ]",
                 "sentence": "Als Graf habe ich große Verantwortung.",
                 "sentenceTranslation": "Как граф я несу большую ответственность.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Graf",
                     "Множественное число (пример): die Grafe",
@@ -1476,8 +1484,10 @@
                 "transcription": "[ди Э-ре]",
                 "sentence": "Meine Ehre ist mein höchstes Gut.",
                 "sentenceTranslation": "Моя честь - моё высшее благо.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Ehre",
                     "Множественное число (пример): die Ehre",
@@ -1499,8 +1509,15 @@
                 "transcription": "[РЕХТ-ша-фен]",
                 "sentence": "Ich bin ein rechtschaffener Mann.",
                 "sentenceTranslation": "Я праведный человек.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Adel",
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral",
+                    "dienen",
+                    "vertrauen"
+                ],
                 "wordFamily": [
                     "Основная форма: rechtschaffen",
                     "Сравнительная степень: rechtschaffener",
@@ -1520,8 +1537,10 @@
                 "transcription": "[ди ПФЛИХТ]",
                 "sentence": "Meine Pflicht ruft mich zum König.",
                 "sentenceTranslation": "Мой долг зовёт меня к королю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Pflicht",
                     "Множественное число (пример): die Pflichte",
@@ -1542,8 +1561,12 @@
                 "transcription": "[АХ-тен]",
                 "sentence": "Ich achte beide Söhne, Edgar und Edmund.",
                 "sentenceTranslation": "Я уважаю обоих сыновей, Эдгара и Эдмунда.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Adel",
+                    "dienen",
+                    "vertrauen"
+                ],
                 "wordFamily": [
                     "Инфинитив: achten",
                     "Презенс: ich achte",
@@ -1590,8 +1613,10 @@
                 "transcription": "[дер БРИФ]",
                 "sentence": "Dieser Brief beweist Edgars Verrat.",
                 "sentenceTranslation": "Это письмо доказывает предательство Эдгара.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Brief",
                     "Множественное число (пример): die Briefe",
@@ -1612,8 +1637,10 @@
                 "transcription": "[ГЛАУ-бен]",
                 "sentence": "Ich glaube Edmunds Lügen sofort.",
                 "sentenceTranslation": "Я сразу верю лжи Эдмунда.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: glauben",
                     "Презенс: ich glaube",
@@ -1633,8 +1660,10 @@
                 "transcription": "[ТОЙ-шен]",
                 "sentence": "Edmund täuscht mich mit falschen Beweisen.",
                 "sentenceTranslation": "Эдмунд обманывает меня ложными доказательствами.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: täuschen",
                     "Презенс: ich täusche",
@@ -1658,8 +1687,10 @@
                 "transcription": "[дер бе-ТРУГ]",
                 "sentence": "Ich erkenne den Betrug nicht.",
                 "sentenceTranslation": "Я не распознаю обман.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Betrug",
                     "Множественное число (пример): die Betruge",
@@ -1681,8 +1712,12 @@
                 "transcription": "[АРГ-лос]",
                 "sentence": "Ich bin zu arglos für solche Intrigen.",
                 "sentenceTranslation": "Я слишком простодушен для таких интриг.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Brief",
+                    "glauben",
+                    "täuschen"
+                ],
                 "wordFamily": [
                     "Основная форма: arglos",
                     "Сравнительная степень: argloser",
@@ -1701,8 +1736,10 @@
                 "transcription": "[фер-ДЕХ-ти-ген]",
                 "sentence": "Ich verdächtige meinen guten Sohn Edgar.",
                 "sentenceTranslation": "Я подозреваю моего доброго сына Эдгара.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verdächtigen",
                     "Презенс: ich verdächtige",
@@ -1723,8 +1760,12 @@
                 "transcription": "[ЛАЙХТ-глой-биг]",
                 "sentence": "Ich bin zu leichtgläubig für diese Welt.",
                 "sentenceTranslation": "Я слишком легковерен для этого мира.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Brief",
+                    "glauben",
+                    "täuschen"
+                ],
                 "wordFamily": [
                     "Основная форма: leichtgläubig",
                     "Сравнительная степень: leichtgläubiger",
@@ -1743,8 +1784,15 @@
                 "transcription": "[ди ФА-ле]",
                 "sentence": "Ich tappe blind in Edmunds Falle.",
                 "sentenceTranslation": "Я слепо попадаю в ловушку Эдмунда.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Brief",
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan",
+                    "glauben",
+                    "täuschen"
+                ],
                 "wordFamily": [
                     "Основа: die Falle",
                     "Множественное число (пример): die Falle",
@@ -1792,8 +1840,10 @@
                 "transcription": "[фер-ШТО-сен]",
                 "sentence": "Ich verstoße meinen unschuldigen Sohn.",
                 "sentenceTranslation": "Я изгоняю своего невинного сына.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verstoßen",
                     "Презенс: ich verstoße",
@@ -1820,8 +1870,10 @@
                 "transcription": "[фер-ФЛУ-хен]",
                 "sentence": "Im Zorn verfluche ich Edgar.",
                 "sentenceTranslation": "В гневе я проклинаю Эдгара.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verfluchen",
                     "Презенс: ich verfluche",
@@ -1845,8 +1897,10 @@
                 "transcription": "[бе-РОЙ-ен]",
                 "sentence": "Später werde ich diese Tat bitter bereuen.",
                 "sentenceTranslation": "Позже я горько пожалею об этом поступке.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: bereuen",
                     "Презенс: ich bereue",
@@ -1869,8 +1923,10 @@
                 "transcription": "[дер ИР-тум]",
                 "sentence": "Mein Irrtum zerstört meine Familie.",
                 "sentenceTranslation": "Моё заблуждение разрушает мою семью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Irrtum",
                     "Множественное число (пример): die Irrtume",
@@ -1891,8 +1947,15 @@
                 "transcription": "[БЛИНД]",
                 "sentence": "Ich bin blind für die Wahrheit.",
                 "sentenceTranslation": "Я слеп к правде.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Klippe",
+                    "bereuen",
+                    "blind",
+                    "führen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основная форма: blind",
                     "Сравнительная степень: blinder",
@@ -1912,8 +1975,15 @@
                 "transcription": "[Я-ген]",
                 "sentence": "Ich jage meinen Sohn fort wie einen Verbrecher.",
                 "sentenceTranslation": "Я гоню сына прочь как преступника.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung",
+                    "bereuen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Инфинитив: jagen",
                     "Презенс: ich jage",
@@ -1934,8 +2004,15 @@
                 "transcription": "[ди УН-ге-рех-тиг-кайт]",
                 "sentence": "Ich begehe große Ungerechtigkeit.",
                 "sentenceTranslation": "Я совершаю большую несправедливость.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "bereuen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основа: die Ungerechtigkeit",
                     "Множественное число (пример): die Ungerechtigkeiten",
@@ -1983,8 +2060,10 @@
                 "transcription": "[ХЕЛЬ-фен]",
                 "sentence": "Heimlich helfe ich dem verstoßenen König.",
                 "sentenceTranslation": "Тайно я помогаю изгнанному королю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: helfen",
                     "Презенс: ich helfe",
@@ -2004,8 +2083,10 @@
                 "transcription": "[дас МИТ-лайд]",
                 "sentence": "Mitleid erfüllt mein Herz für Lear.",
                 "sentenceTranslation": "Сострадание наполняет моё сердце к Лиру.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Mitleid",
                     "Множественное число (пример): die Mitleide",
@@ -2025,8 +2106,12 @@
                 "transcription": "[рис-КИ-рен]",
                 "sentence": "Ich riskiere alles für den alten König.",
                 "sentenceTranslation": "Я рискую всем ради старого короля.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mitleid",
+                    "helfen",
+                    "riskieren"
+                ],
                 "wordFamily": [
                     "Инфинитив: riskieren",
                     "Презенс: ich riskiere",
@@ -2045,8 +2130,10 @@
                 "transcription": "[ди ге-ФАР]",
                 "sentence": "Die Gefahr der Entdeckung ist groß.",
                 "sentenceTranslation": "Опасность разоблачения велика.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Gefahr",
                     "Множественное число (пример): die Gefahre",
@@ -2068,8 +2155,12 @@
                 "transcription": "[ХАЙМ-лих]",
                 "sentence": "Ich handle heimlich gegen die neuen Herrscher.",
                 "sentenceTranslation": "Я действую тайно против новых правителей.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mitleid",
+                    "helfen",
+                    "riskieren"
+                ],
                 "wordFamily": [
                     "Основная форма: heimlich",
                     "Сравнительная степень: heimlicher",
@@ -2088,8 +2179,12 @@
                 "transcription": "[ШЮ-цен]",
                 "sentence": "Ich will den wahnsinnigen König schützen.",
                 "sentenceTranslation": "Я хочу защитить безумного короля.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mitleid",
+                    "helfen",
+                    "riskieren"
+                ],
                 "wordFamily": [
                     "Инфинитив: schützen",
                     "Презенс: ich schütze",
@@ -2110,8 +2205,10 @@
                 "transcription": "[дер фер-РАТ]",
                 "sentence": "Meine Hilfe gilt als Verrat.",
                 "sentenceTranslation": "Моя помощь считается изменой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Verrat",
                     "Множественное число (пример): die Verrate",
@@ -2134,8 +2231,10 @@
                 "transcription": "[ВА-ген]",
                 "sentence": "Ich wage es, gegen die Töchter zu handeln.",
                 "sentenceTranslation": "Я осмеливаюсь действовать против дочерей.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: wagen",
                     "Презенс: ich wage",
@@ -2183,8 +2282,10 @@
                 "transcription": "[БЛЕН-ден]",
                 "sentence": "Sie blenden mich für meinen Verrat.",
                 "sentenceTranslation": "Они ослепляют меня за мою измену.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: blenden",
                     "Презенс: ich blende",
@@ -2207,8 +2308,17 @@
                 "transcription": "[ди ФОЛЬ-тер]",
                 "sentence": "Die Folter ist grausam und erbarmungslos.",
                 "sentenceTranslation": "Пытка жестока и беспощадна.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Schmerz",
+                    "blenden",
+                    "genießen",
+                    "verraten"
+                ],
                 "wordFamily": [
                     "Основа: die Folter",
                     "Множественное число (пример): die Folter",
@@ -2230,8 +2340,10 @@
                 "transcription": "[дер ШМЕРЦ]",
                 "sentence": "Der Schmerz durchbohrt meine Seele.",
                 "sentenceTranslation": "Боль пронзает мою душу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Schmerz",
                     "Множественное число (пример): die Schmerze",
@@ -2252,8 +2364,10 @@
                 "transcription": "[ди ДУН-кель-хайт]",
                 "sentence": "Ewige Dunkelheit umgibt mich nun.",
                 "sentenceTranslation": "Вечная темнота окружает меня теперь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Dunkelheit",
                     "Множественное число (пример): die Dunkelheiten",
@@ -2273,8 +2387,15 @@
                 "transcription": "[ШРАЙ-ен]",
                 "sentence": "Ich schreie vor unerträglichem Schmerz.",
                 "sentenceTranslation": "Я кричу от невыносимой боли.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Folter",
+                    "Schmerz",
+                    "Sturm",
+                    "Wahnsinn",
+                    "blenden",
+                    "toben"
+                ],
                 "wordFamily": [
                     "Инфинитив: schreien",
                     "Презенс: ich schreie",
@@ -2294,8 +2415,10 @@
                 "transcription": "[ер-БЛИН-ден]",
                 "sentence": "Ich erblinde durch ihre Grausamkeit.",
                 "sentenceTranslation": "Я слепну от их жестокости.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: erblinden",
                     "Презенс: ich erblinde",
@@ -2315,8 +2438,10 @@
                 "transcription": "[ди РА-хе]",
                 "sentence": "Dies ist ihre Rache für meine Treue.",
                 "sentenceTranslation": "Это их месть за мою верность.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Rache",
                     "Множественное число (пример): die Rache",
@@ -2367,8 +2492,10 @@
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
                 "sentence": "Die Verzweiflung treibt mich zum Abgrund.",
                 "sentenceTranslation": "Отчаяние гонит меня к пропасти.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Verzweiflung",
                     "Множественное число (пример): die Verzweiflungen",
@@ -2391,8 +2518,10 @@
                 "transcription": "[ШПРИН-ген]",
                 "sentence": "Ich will von den Klippen springen.",
                 "sentenceTranslation": "Я хочу прыгнуть со скал.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: springen",
                     "Презенс: ich springe",
@@ -2412,8 +2541,15 @@
                 "transcription": "[ди ТОЙ-шунг]",
                 "sentence": "Edgars liebevolle Täuschung rettet mich.",
                 "sentenceTranslation": "Любящий обман Эдгара спасает меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Täuschung",
+                    "Verzweiflung",
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren",
+                    "springen"
+                ],
                 "wordFamily": [
                     "Основа: die Täuschung",
                     "Множественное число (пример): die Täuschungen",
@@ -2434,8 +2570,12 @@
                 "transcription": "[дер АБ-грунд]",
                 "sentence": "Der Abgrund ruft nach mir.",
                 "sentenceTranslation": "Пропасть зовёт меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Täuschung",
+                    "Verzweiflung",
+                    "springen"
+                ],
                 "wordFamily": [
                     "Основа: der Abgrund",
                     "Множественное число (пример): die Abgrunde",
@@ -2454,8 +2594,15 @@
                 "transcription": "[АУФ-ге-бен]",
                 "sentence": "Ich will das Leben aufgeben.",
                 "sentenceTranslation": "Я хочу отказаться от жизни.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Abschied",
+                    "Tod",
+                    "Täuschung",
+                    "Verzweiflung",
+                    "ewige Treue",
+                    "springen"
+                ],
                 "wordFamily": [
                     "Инфинитив: aufgeben",
                     "Презенс: ich gebe auf",
@@ -2475,8 +2622,12 @@
                 "transcription": "[ди ХОФ-нунгс-ло-зиг-кайт]",
                 "sentence": "Die Hoffnungslosigkeit erdrückt mich.",
                 "sentenceTranslation": "Безнадёжность давит меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Täuschung",
+                    "Verzweiflung",
+                    "springen"
+                ],
                 "wordFamily": [
                     "Основа: die Hoffnungslosigkeit",
                     "Множественное число (пример): die Hoffnungslosigkeiten",
@@ -2495,8 +2646,10 @@
                 "transcription": "[ШТЮР-цен]",
                 "sentence": "Ich glaube, von hohen Klippen zu stürzen.",
                 "sentenceTranslation": "Я верю, что падаю с высоких скал.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: stürzen",
                     "Презенс: ich stürze",
@@ -2517,8 +2670,12 @@
                 "transcription": "[ер-ЛЁ-зен]",
                 "sentence": "Der Tod soll mich von der Schuld erlösen.",
                 "sentenceTranslation": "Смерть должна избавить меня от вины.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Täuschung",
+                    "Verzweiflung",
+                    "springen"
+                ],
                 "wordFamily": [
                     "Инфинитив: erlösen",
                     "Презенс: ich erlöse",
@@ -2565,8 +2722,10 @@
                 "transcription": "[ер-КЕН-нен]",
                 "sentence": "Endlich erkenne ich meinen treuen Edgar.",
                 "sentenceTranslation": "Наконец я узнаю моего верного Эдгара.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: erkennen",
                     "Презенс: ich erkenne",
@@ -2592,8 +2751,10 @@
                 "transcription": "[фер-ГЕ-бен]",
                 "sentence": "Edgar vergibt mir meine Blindheit.",
                 "sentenceTranslation": "Эдгар прощает мне мою слепоту.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: vergeben",
                     "Презенс: ich vergebe",
@@ -2615,8 +2776,10 @@
                 "transcription": "[ШТЕР-бен]",
                 "sentence": "Ich sterbe vor Freude und Kummer.",
                 "sentenceTranslation": "Я умираю от радости и горя.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: sterben",
                     "Презенс: ich sterbe",
@@ -2640,8 +2803,10 @@
                 "transcription": "[ди ер-КЕНТ-нис]",
                 "sentence": "Die späte Erkenntnis bricht mein Herz.",
                 "sentenceTranslation": "Позднее осознание разбивает моё сердце.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Erkenntnis",
                     "Множественное число (пример): die Erkenntnise",
@@ -2664,8 +2829,10 @@
                 "transcription": "[ди РОЙ-е]",
                 "sentence": "Die Reue überwältigt meine Seele.",
                 "sentenceTranslation": "Раскаяние переполняет мою душу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Reue",
                     "Множественное число (пример): die Reue",
@@ -2687,8 +2854,15 @@
                 "transcription": "[ум-АР-мен]",
                 "sentence": "Ein letztes Mal umarme ich meinen Sohn.",
                 "sentenceTranslation": "В последний раз я обнимаю сына.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "erkennen",
+                    "heilen",
+                    "sterben",
+                    "umarmen",
+                    "vergeben",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Инфинитив: umarmen",
                     "Презенс: ich umarme",
@@ -2708,8 +2882,10 @@
                 "transcription": "[ди фер-ЗЁ-нунг]",
                 "sentence": "Die Versöhnung kommt zu spät.",
                 "sentenceTranslation": "Примирение приходит слишком поздно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Versöhnung",
                     "Множественное число (пример): die Versöhnungen",
@@ -2729,8 +2905,10 @@
                 "transcription": "[дас ХЕРЦ]",
                 "sentence": "Mein Herz zerbricht vor Glück und Leid.",
                 "sentenceTranslation": "Моё сердце разрывается от счастья и горя.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Herz",
                     "Множественное число (пример): die Herze",

--- a/output/journeys/goneril.html
+++ b/output/journeys/goneril.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["ложь", "наследство", "клясться", "лицемерить"], "correct_index": 0}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["лицемерить", "ложь", "наследство", "клясться"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["обманывать", "наследство", "состояние", "ложь"], "correct_index": 1}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["льстить", "лицемерить", "наследство", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["жадность", "обманывать", "состояние", "ложь"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["лицемерить", "обманывать", "жадность", "клясться"], "correct_index": 1}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["ложь", "лицемерить", "клясться", "льстить"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["обманывать", "состояние", "льстить", "клясться"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["трон", "править", "власть", "приказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["приказывать", "править", "трон", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["господство", "править", "приказывать", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["приказывать", "трон", "подчинять", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["управлять", "приказывать", "подчинять", "завоёвывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["господство", "управлять", "трон", "подчинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["власть", "господство", "трон", "управлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["править", "управлять", "приказывать", "подчинять"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["жестокий", "месть", "изгонять", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["изгонять", "месть", "унижать", "жестокий"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["презирать", "жестокий", "месть", "ограничивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["изгонять", "отказывать", "жестокий", "унижать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["отказывать", "изгонять", "презирать", "жестокий"], "correct_index": 2}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["унижать", "отказывать", "ограничивать", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["унижать", "презирать", "мучить", "ограничивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["отказывать", "жестокий", "изгонять", "ограничивать"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["отвергать", "буря", "запирать", "безжалостный"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["запирать", "безжалостный", "отвергать", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["отвергать", "ожесточаться", "безжалостный", "беспощадный"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["беспощадный", "запирать", "ожесточаться", "отвергать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["запирать", "холод", "буря", "беспощадный"], "correct_index": 1}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["холод", "запирать", "буря", "беспощадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["ожесточаться", "запирать", "безжалостный", "беспощадный"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["ненавидеть", "предавать", "раздор", "ссориться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["предавать", "ненавидеть", "ссориться", "раздор"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["раздор", "разрушать", "предавать", "страсть"], "correct_index": 0}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["изменять", "ненавидеть", "разрушать", "раздор"], "correct_index": 1}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["презрение", "разрушать", "изменять", "раздор"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["презрение", "раздор", "изменять", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["изменять", "разрушать", "презрение", "раздор"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["презрение", "предавать", "разрушать", "страсть"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["желать", "бороться", "ревность", "соперничать"], "correct_index": 2}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["ревность", "желать", "соперничать", "бороться"], "correct_index": 2}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["яд", "желать", "бороться", "устранять"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["убивать", "ревность", "желать", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["соперничать", "бороться", "убивать", "устранять"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["бороться", "яд", "желать", "интрига"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["соперничать", "интрига", "убивать", "яд"], "correct_index": 1}, {"question": "Что означает немецкое слово «morden»?", "choices": ["интрига", "убивать", "ревность", "яд"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["отравлять", "умирать", "отчаяние", "вина"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отравлять", "вина", "умирать", "отчаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["уничтожать", "отравлять", "умирать", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["вина", "сожалеть", "ад", "погибель"], "correct_index": 0}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["умирать", "погибель", "ад", "уничтожать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["отчаяние", "сожалеть", "умирать", "погибель"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "вина", "уничтожать", "погибель"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["вина", "отравлять", "сожалеть", "ад"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["ложь", "лицемерить", "клясться", "наследство"], "correct_index": 0}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["ложь", "клясться", "лицемерить", "наследство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["ложь", "обманывать", "льстить", "наследство"], "correct_index": 3}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["жадность", "состояние", "лицемерить", "наследство"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["лицемерить", "обманывать", "ложь", "жадность"], "correct_index": 3}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["наследство", "жадность", "лицемерить", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["лицемерить", "обманывать", "клясться", "льстить"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["наследство", "клясться", "ложь", "состояние"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["приказывать", "трон", "власть", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["править", "трон", "власть", "приказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["приказывать", "трон", "завоёвывать", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["трон", "господство", "править", "завоёвывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоёвывать", "приказывать", "власть", "подчинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["господство", "завоёвывать", "приказывать", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["править", "управлять", "завоёвывать", "господство"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["трон", "подчинять", "приказывать", "господство"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["жестокий", "изгонять", "месть", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["месть", "жестокий", "унижать", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["унижать", "месть", "изгонять", "мучить"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["месть", "изгонять", "презирать", "мучить"], "correct_index": 1}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["жестокий", "месть", "унижать", "презирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["жестокий", "ограничивать", "унижать", "отказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["отказывать", "мучить", "изгонять", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["изгонять", "ограничивать", "месть", "отказывать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["буря", "запирать", "безжалостный", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "безжалостный", "запирать", "отвергать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["безжалостный", "буря", "беспощадный", "холод"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["беспощадный", "отвергать", "запирать", "буря"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["холод", "ожесточаться", "буря", "безжалостный"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["запирать", "беспощадный", "безжалостный", "ожесточаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["безжалостный", "беспощадный", "ожесточаться", "запирать"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["раздор", "ненавидеть", "ссориться", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["раздор", "ссориться", "ненавидеть", "предавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["страсть", "разрушать", "раздор", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["предавать", "ссориться", "разрушать", "ненавидеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["презрение", "ненавидеть", "разрушать", "изменять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["разрушать", "ссориться", "изменять", "презрение"], "correct_index": 3}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["презрение", "изменять", "ссориться", "разрушать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["разрушать", "презрение", "предавать", "страсть"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["ревность", "желать", "соперничать", "бороться"], "correct_index": 0}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["соперничать", "ревность", "бороться", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["ревность", "желать", "интрига", "бороться"], "correct_index": 3}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["желать", "соперничать", "убивать", "интрига"], "correct_index": 0}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["яд", "соперничать", "ревность", "устранять"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["устранять", "убивать", "соперничать", "яд"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["ревность", "желать", "интрига", "устранять"], "correct_index": 2}, {"question": "Что означает немецкое слово «morden»?", "choices": ["соперничать", "интрига", "ревность", "убивать"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["умирать", "отравлять", "отчаяние", "вина"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["умирать", "отчаяние", "вина", "отравлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["отчаяние", "сожалеть", "отравлять", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["вина", "сожалеть", "ад", "уничтожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["уничтожать", "вина", "сожалеть", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["вина", "умирать", "сожалеть", "погибель"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["уничтожать", "сожалеть", "вина", "отравлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["ад", "погибель", "сожалеть", "умирать"], "correct_index": 0}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -460,91 +460,91 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «schwören»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Erbe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">льстить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -554,9 +554,9 @@
                         <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
                             
@@ -566,17 +566,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Vermögen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">льстить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">состояние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -593,9 +593,25 @@
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
@@ -605,47 +621,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «befehlen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">господство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подчинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
@@ -653,17 +637,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">управлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подчинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -675,43 +675,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">господство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">управлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">подчинять</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -730,89 +730,105 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">презирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verweigern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ограничивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отказывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
@@ -820,33 +836,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «beschränken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -859,63 +859,15 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «gnadenlos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verschließen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                             
@@ -923,49 +875,97 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «gnadenlos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verschließen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verhärten»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ожесточаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verhärten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ожесточаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -978,95 +978,63 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «streiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страсть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">страсть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">разрушать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
@@ -1074,17 +1042,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">разрушать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1094,11 +1094,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Leidenschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">разрушать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">страсть</button>
                             
@@ -1113,24 +1113,8 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Eifersucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
@@ -1145,31 +1129,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">убивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
                             
@@ -1181,11 +1181,11 @@
                         <div class="quiz-question">Что означает немецкое слово «beseitigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
                             
@@ -1193,49 +1193,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Gift»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">яд</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «morden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">яд</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «morden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">убивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1248,13 +1248,13 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vergiften»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
@@ -1264,33 +1264,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1306,23 +1306,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ад</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">погибель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «vernichten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1332,45 +1332,45 @@
                         <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">погибель</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">уничтожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">погибель</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Hölle»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">погибель</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Hölle»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1399,8 +1399,10 @@
                 "transcription": "[ди ЛЮ-ге]",
                 "sentence": "Die Lüge klingt süßer als die Wahrheit.",
                 "sentenceTranslation": "Ложь звучит слаще правды.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Lüge",
                     "Множественное число (пример): die Lüge",
@@ -1420,8 +1422,10 @@
                 "transcription": "[ШВЁ-рен]",
                 "sentence": "Ich schwöre, dass ich Euch mehr liebe als mein Leben.",
                 "sentenceTranslation": "Я клянусь, что люблю вас больше жизни.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: schwören",
                     "Презенс: ich schwöre",
@@ -1441,8 +1445,10 @@
                 "transcription": "[дас ЕР-бе]",
                 "sentence": "Das Erbe ist endlich mein.",
                 "sentenceTranslation": "Наследство наконец моё.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Erbe",
                     "Множественное число (пример): die Erbe",
@@ -1462,8 +1468,12 @@
                 "transcription": "[ХОЙ-хельн]",
                 "sentence": "Ich muss vor meinem Vater heucheln.",
                 "sentenceTranslation": "Я должна лицемерить перед отцом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Erbe",
+                    "Heuchelei",
+                    "Lüge"
+                ],
                 "wordFamily": [
                     "Инфинитив: heucheln",
                     "Презенс: ich heuchele",
@@ -1482,8 +1492,10 @@
                 "transcription": "[ди ГИР]",
                 "sentence": "Die Gier nach Macht treibt mich an.",
                 "sentenceTranslation": "Жадность к власти движет мной.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Gier",
                     "Множественное число (пример): die Gier",
@@ -1504,8 +1516,10 @@
                 "transcription": "[ТОЙ-шен]",
                 "sentence": "Ich täusche meinen alten Vater leicht.",
                 "sentenceTranslation": "Я легко обманываю старого отца.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: täuschen",
                     "Презенс: ich täusche",
@@ -1529,8 +1543,10 @@
                 "transcription": "[ШМАЙ-хельн]",
                 "sentence": "Mit süßen Worten schmeichle ich ihm.",
                 "sentenceTranslation": "Сладкими словами я льщу ему.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: schmeicheln",
                     "Презенс: ich schmeichele",
@@ -1550,8 +1566,12 @@
                 "transcription": "[дас фер-МЁ-ген]",
                 "sentence": "Sein ganzes Vermögen wird mir gehören.",
                 "sentenceTranslation": "Всё его состояние будет моим.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Erbe",
+                    "Heuchelei",
+                    "Lüge"
+                ],
                 "wordFamily": [
                     "Основа: das Vermögen",
                     "Множественное число (пример): die Vermögen",
@@ -1598,8 +1618,10 @@
                 "transcription": "[ди МАХТ]",
                 "sentence": "Die Macht über das halbe Königreich ist mein.",
                 "sentenceTranslation": "Власть над половиной королевства моя.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Macht",
                     "Множественное число (пример): die Machte",
@@ -1622,8 +1644,10 @@
                 "transcription": "[ХЕР-шен]",
                 "sentence": "Jetzt herrsche ich über meine Länder.",
                 "sentenceTranslation": "Теперь я правлю своими землями.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: herrschen",
                     "Презенс: ich rsche her",
@@ -1645,8 +1669,10 @@
                 "transcription": "[бе-ФЕ-лен]",
                 "sentence": "Ich befehle, und alle gehorchen mir.",
                 "sentenceTranslation": "Я приказываю, и все подчиняются мне.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: befehlen",
                     "Презенс: ich befehle",
@@ -1666,8 +1692,10 @@
                 "transcription": "[дер ТРОН]",
                 "sentence": "Der Thron meines Vaters wird bald leer sein.",
                 "sentenceTranslation": "Трон моего отца скоро опустеет.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Thron",
                     "Множественное число (пример): die Throne",
@@ -1688,8 +1716,10 @@
                 "transcription": "[ер-О-берн]",
                 "sentence": "Ich erobere, was mir zusteht.",
                 "sentenceTranslation": "Я завоёвываю то, что мне положено.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: erobern",
                     "Презенс: ich erobere",
@@ -1711,8 +1741,15 @@
                 "transcription": "[ди ХЕР-шафт]",
                 "sentence": "Die Herrschaft über alle ist mein Ziel.",
                 "sentenceTranslation": "Господство над всеми - моя цель.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Herrschaft",
+                    "Macht",
+                    "Neuanfang",
+                    "Weisheit",
+                    "befehlen",
+                    "herrschen"
+                ],
                 "wordFamily": [
                     "Основа: die Herrschaft",
                     "Множественное число (пример): die Herrschafte",
@@ -1733,8 +1770,10 @@
                 "transcription": "[ре-ГИ-рен]",
                 "sentence": "Ich werde mit eiserner Hand regieren.",
                 "sentenceTranslation": "Я буду управлять железной рукой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: regieren",
                     "Презенс: ich regiere",
@@ -1757,8 +1796,10 @@
                 "transcription": "[ун-тер-ВЕР-фен]",
                 "sentence": "Alle müssen sich mir unterwerfen.",
                 "sentenceTranslation": "Все должны мне подчиниться.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: unterwerfen",
                     "Презенс: ich unterwerfe",
@@ -1806,8 +1847,16 @@
                 "transcription": "[де-МЮ-ти-ген]",
                 "sentence": "Ich demütige meinen alten Vater ohne Mitleid.",
                 "sentenceTranslation": "Я унижаю старого отца без жалости.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn",
+                    "demütigen",
+                    "grausam",
+                    "reduzieren",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Инфинитив: demütigen",
                     "Презенс: ich demütige",
@@ -1829,8 +1878,12 @@
                 "transcription": "[ГРАУ-зам]",
                 "sentence": "Ich bin grausam zu dem, der mir alles gab.",
                 "sentenceTranslation": "Я жестока к тому, кто дал мне всё.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "demütigen",
+                    "grausam",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Основная форма: grausam",
                     "Сравнительная степень: grausamer",
@@ -1849,8 +1902,10 @@
                 "transcription": "[ди РА-хе]",
                 "sentence": "Die Rache für Jahre der Unterwerfung.",
                 "sentenceTranslation": "Месть за годы подчинения.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Rache",
                     "Множественное число (пример): die Rache",
@@ -1873,8 +1928,10 @@
                 "transcription": "[фер-ТРАЙ-бен]",
                 "sentence": "Ich vertreibe ihn aus meinem Haus.",
                 "sentenceTranslation": "Я изгоняю его из моего дома.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: vertreiben",
                     "Презенс: ich vertreibe",
@@ -1899,8 +1956,12 @@
                 "transcription": "[фер-АХ-тен]",
                 "sentence": "Ich verachte seine Schwäche und sein Alter.",
                 "sentenceTranslation": "Я презираю его слабость и старость.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "demütigen",
+                    "grausam",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Инфинитив: verachten",
                     "Презенс: ich verachte",
@@ -1919,8 +1980,12 @@
                 "transcription": "[фер-ВАЙ-герн]",
                 "sentence": "Ich verweigere ihm jeden Komfort.",
                 "sentenceTranslation": "Я отказываю ему в любом комфорте.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "demütigen",
+                    "grausam",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Инфинитив: verweigern",
                     "Презенс: ich verweigere",
@@ -1939,8 +2004,10 @@
                 "transcription": "[КВЕ-лен]",
                 "sentence": "Es macht mir Freude, ihn zu quälen.",
                 "sentenceTranslation": "Мне доставляет радость мучить его.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: quälen",
                     "Презенс: ich quäle",
@@ -1961,8 +2028,12 @@
                 "transcription": "[бе-ШРЕН-кен]",
                 "sentence": "Ich beschränke seine Dienerschaft auf null.",
                 "sentenceTranslation": "Я ограничиваю его свиту до нуля.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "demütigen",
+                    "grausam",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Инфинитив: beschränken",
                     "Презенс: ich beschränke",
@@ -2009,8 +2080,10 @@
                 "transcription": "[фер-ШТО-сен]",
                 "sentence": "Ich verstoße meinen Vater in die Nacht.",
                 "sentenceTranslation": "Я отвергаю отца в ночь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verstoßen",
                     "Презенс: ich verstoße",
@@ -2037,8 +2110,10 @@
                 "transcription": "[дер ШТУРМ]",
                 "sentence": "Der Sturm soll sein neues Zuhause sein.",
                 "sentenceTranslation": "Буря пусть будет его новым домом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Sturm",
                     "Множественное число (пример): die Sturme",
@@ -2061,8 +2136,12 @@
                 "transcription": "[ГНА-ден-лос]",
                 "sentence": "Ich bin gnadenlos wie der Winter.",
                 "sentenceTranslation": "Я безжалостна как зима.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Sturm",
+                    "gnadenlos",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основная форма: gnadenlos",
                     "Сравнительная степень: gnadenloser",
@@ -2081,8 +2160,10 @@
                 "transcription": "[фер-ШЛИ-сен]",
                 "sentence": "Ich verschließe meine Türen vor ihm.",
                 "sentenceTranslation": "Я запираю двери перед ним.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verschließen",
                     "Презенс: ich verschließe",
@@ -2103,8 +2184,14 @@
                 "transcription": "[ди КЕЛ-те]",
                 "sentence": "Die Kälte meines Herzens übertrifft den Winter.",
                 "sentenceTranslation": "Холод моего сердца превосходит зиму.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beistand",
+                    "Sturm",
+                    "Treue",
+                    "gnadenlos",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основа: die Kälte",
                     "Множественное число (пример): die Kälte",
@@ -2124,8 +2211,17 @@
                 "transcription": "[ер-БАР-мунгс-лос]",
                 "sentence": "Erbarmungslos werfe ich ihn hinaus.",
                 "sentenceTranslation": "Беспощадно я выбрасываю его.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Sturm",
+                    "blenden",
+                    "genießen",
+                    "gnadenlos",
+                    "verraten",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основная форма: erbarmungslos",
                     "Сравнительная степень: erbarmungsloser",
@@ -2146,8 +2242,12 @@
                 "transcription": "[фер-ХЕР-тен]",
                 "sentence": "Mein Herz verhärtet sich gegen alle Bitten.",
                 "sentenceTranslation": "Моё сердце ожесточается против всех просьб.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Sturm",
+                    "gnadenlos",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Инфинитив: verhärten",
                     "Презенс: ich verhärte",
@@ -2194,8 +2294,10 @@
                 "transcription": "[ШТРАЙ-тен]",
                 "sentence": "Ich streite mit meinem schwachen Mann.",
                 "sentenceTranslation": "Я ссорюсь со своим слабым мужем.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: streiten",
                     "Презенс: ich streite",
@@ -2216,8 +2318,10 @@
                 "transcription": "[фер-РА-тен]",
                 "sentence": "Ich verrate meinen Mann für Edmund.",
                 "sentenceTranslation": "Я предаю мужа ради Эдмунда.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verraten",
                     "Презенс: ich verrate",
@@ -2242,8 +2346,12 @@
                 "transcription": "[ди ЦВИ-трахт]",
                 "sentence": "Die Zwietracht zerstört unsere Ehe.",
                 "sentenceTranslation": "Раздор разрушает наш брак.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Zwietracht",
+                    "streiten",
+                    "verraten"
+                ],
                 "wordFamily": [
                     "Основа: die Zwietracht",
                     "Множественное число (пример): die Zwietrachte",
@@ -2262,8 +2370,10 @@
                 "transcription": "[ХА-сен]",
                 "sentence": "Ich hasse seine Schwäche und Güte.",
                 "sentenceTranslation": "Я ненавижу его слабость и доброту.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: hassen",
                     "Презенс: ich hasse",
@@ -2284,8 +2394,10 @@
                 "transcription": "[бе-ТРЮ-ген]",
                 "sentence": "Ich betrüge ihn mit Edmund.",
                 "sentenceTranslation": "Я изменяю ему с Эдмундом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: betrügen",
                     "Презенс: ich betrüge",
@@ -2309,8 +2421,12 @@
                 "transcription": "[ди фер-АХ-тунг]",
                 "sentence": "Meine Verachtung für ihn wächst täglich.",
                 "sentenceTranslation": "Моё презрение к нему растёт ежедневно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Zwietracht",
+                    "streiten",
+                    "verraten"
+                ],
                 "wordFamily": [
                     "Основа: die Verachtung",
                     "Множественное число (пример): die Verachtungen",
@@ -2329,8 +2445,10 @@
                 "transcription": "[цер-ШТЁ-рен]",
                 "sentence": "Ich zerstöre alles, was uns verband.",
                 "sentenceTranslation": "Я разрушаю всё, что нас связывало.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: zerstören",
                     "Презенс: ich zerstöre",
@@ -2350,8 +2468,10 @@
                 "transcription": "[ди ЛАЙ-ден-шафт]",
                 "sentence": "Meine Leidenschaft gilt nur Edmund.",
                 "sentenceTranslation": "Моя страсть принадлежит только Эдмунду.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Leidenschaft",
                     "Множественное число (пример): die Leidenschafte",
@@ -2399,8 +2519,10 @@
                 "transcription": "[ди АЙ-фер-зухт]",
                 "sentence": "Die Eifersucht verzehrt mich von innen.",
                 "sentenceTranslation": "Ревность пожирает меня изнутри.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Eifersucht",
                     "Множественное число (пример): die Eifersuchte",
@@ -2420,8 +2542,12 @@
                 "transcription": "[ри-ва-ли-ЗИ-рен]",
                 "sentence": "Ich rivalisiere mit meiner Schwester um Edmund.",
                 "sentenceTranslation": "Я соперничаю с сестрой за Эдмунда.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Eifersucht",
+                    "kämpfen",
+                    "rivalisieren"
+                ],
                 "wordFamily": [
                     "Инфинитив: rivalisieren",
                     "Презенс: ich rivalisiere",
@@ -2440,8 +2566,10 @@
                 "transcription": "[КЕМП-фен]",
                 "sentence": "Ich kämpfe um das, was ich begehre.",
                 "sentenceTranslation": "Я борюсь за то, чего желаю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: kämpfen",
                     "Презенс: ich kämpfe",
@@ -2464,8 +2592,10 @@
                 "transcription": "[бе-ГЕ-рен]",
                 "sentence": "Ich begehre Edmund mehr als mein Leben.",
                 "sentenceTranslation": "Я желаю Эдмунда больше жизни.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: begehren",
                     "Презенс: ich begehre",
@@ -2490,8 +2620,12 @@
                 "transcription": "[бе-ЗАЙ-ти-ген]",
                 "sentence": "Ich muss meine Schwester beseitigen.",
                 "sentenceTranslation": "Я должна устранить свою сестру.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Eifersucht",
+                    "kämpfen",
+                    "rivalisieren"
+                ],
                 "wordFamily": [
                     "Инфинитив: beseitigen",
                     "Презенс: ich beseitige",
@@ -2510,8 +2644,12 @@
                 "transcription": "[дас ГИФТ]",
                 "sentence": "Das Gift ist bereit für meine Schwester.",
                 "sentenceTranslation": "Яд готов для моей сестры.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Eifersucht",
+                    "kämpfen",
+                    "rivalisieren"
+                ],
                 "wordFamily": [
                     "Основа: das Gift",
                     "Множественное число (пример): die Gifte",
@@ -2530,8 +2668,10 @@
                 "transcription": "[ди ин-ТРИ-ге]",
                 "sentence": "Meine Intrige wird sie vernichten.",
                 "sentenceTranslation": "Моя интрига уничтожит её.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Intrige",
                     "Множественное число (пример): die Intrige",
@@ -2554,8 +2694,10 @@
                 "transcription": "[МОР-ден]",
                 "sentence": "Ich bin bereit zu morden für meine Lust.",
                 "sentenceTranslation": "Я готова убивать ради своей страсти.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: morden",
                     "Презенс: ich morde",
@@ -2604,8 +2746,10 @@
                 "transcription": "[фер-ГИФ-тен]",
                 "sentence": "Ich vergifte erst meine Schwester, dann mich selbst.",
                 "sentenceTranslation": "Я отравляю сначала сестру, потом себя.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: vergiften",
                     "Презенс: ich vergifte",
@@ -2625,8 +2769,10 @@
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
                 "sentence": "Die Verzweiflung führt mich zum Tod.",
                 "sentenceTranslation": "Отчаяние ведёт меня к смерти.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Verzweiflung",
                     "Множественное число (пример): die Verzweiflungen",
@@ -2649,8 +2795,10 @@
                 "transcription": "[ШТЕР-бен]",
                 "sentence": "Ich sterbe durch meine eigene Hand.",
                 "sentenceTranslation": "Я умираю от своей собственной руки.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: sterben",
                     "Презенс: ich sterbe",
@@ -2674,8 +2822,10 @@
                 "transcription": "[ди ШУЛЬД]",
                 "sentence": "Die Schuld erdrückt mich am Ende.",
                 "sentenceTranslation": "Вина давит меня в конце.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Schuld",
                     "Множественное число (пример): die Schulde",
@@ -2695,8 +2845,10 @@
                 "transcription": "[фер-НИХ-тен]",
                 "sentence": "Ich vernichte mich selbst durch meine Bosheit.",
                 "sentenceTranslation": "Я уничтожаю себя своим злом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: vernichten",
                     "Презенс: ich vernichte",
@@ -2716,8 +2868,12 @@
                 "transcription": "[дас фер-ДЕР-бен]",
                 "sentence": "Das Verderben holt mich ein.",
                 "sentenceTranslation": "Погибель настигает меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Verzweiflung",
+                    "sterben",
+                    "vergiften"
+                ],
                 "wordFamily": [
                     "Основа: das Verderben",
                     "Множественное число (пример): die Verderben",
@@ -2736,8 +2892,10 @@
                 "transcription": "[бе-РОЙ-ен]",
                 "sentence": "Zu spät bereue ich meine Taten.",
                 "sentenceTranslation": "Слишком поздно я сожалею о своих делах.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: bereuen",
                     "Презенс: ich bereue",
@@ -2760,8 +2918,10 @@
                 "transcription": "[ди ХЁ-ле]",
                 "sentence": "Die Hölle wartet auf meine schwarze Seele.",
                 "sentenceTranslation": "Ад ждёт мою чёрную душу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Hölle",
                     "Множественное число (пример): die Hölle",

--- a/output/journeys/kent.html
+++ b/output/journeys/kent.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["возражать", "верность", "защищать", "мужество"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["возражать", "мужество", "верность", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["мужество", "слуга", "возражать", "предупреждать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["слуга", "мужество", "возражать", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["искренний", "защищать", "слуга", "верность"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["слуга", "справедливый", "возражать", "искренний"], "correct_index": 0}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["мужество", "возражать", "предупреждать", "справедливый"], "correct_index": 2}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["возражать", "искренний", "справедливый", "верность"], "correct_index": 2}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["изгнание", "гнев", "несправедливость", "изгнанный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["изгнанный", "гнев", "изгнание", "несправедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["изгнанный", "наказание", "гнев", "изгнание"], "correct_index": 2}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["прощание", "изгнанный", "несправедливость", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "изгнанный", "гнев", "несправедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["несправедливость", "наказание", "гнев", "изгнание"], "correct_index": 1}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["прощание", "возвращаться", "несправедливость", "наказание"], "correct_index": 1}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["переодевание", "притворяться", "хитрость", "неузнанный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["притворяться", "хитрость", "переодевание", "неузнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["неузнанный", "переодевание", "притворяться", "хитрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["наниматься", "неузнанный", "притворяться", "переодевание"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["изменять", "притворяться", "переодевание", "борода"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["наниматься", "переодевание", "притворяться", "борода"], "correct_index": 3}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["изменять", "наниматься", "переодевание", "верный"], "correct_index": 1}, {"question": "Что означает немецкое слово «treu»?", "choices": ["хитрость", "наниматься", "неузнанный", "верный"], "correct_index": 3}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["опасность", "служба", "защита", "охранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["охранять", "защита", "служба", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["стража", "защита", "служба", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["защита", "охранять", "советовать", "служба"], "correct_index": 1}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["сражаться", "защита", "охранять", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «raten»?", "choices": ["охранять", "сражаться", "опасность", "советовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["служба", "охранять", "советовать", "стража"], "correct_index": 3}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["унижение", "наказание", "сковывать", "стойкость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["сковывать", "наказание", "стойкость", "унижение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["колодка", "стойкость", "выдерживать", "сковывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["стойкость", "сковывать", "наказание", "унижение"], "correct_index": 1}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["выдерживать", "сковывать", "наказание", "терпеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["стойкость", "наказание", "позор", "колодка"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["наказание", "выдерживать", "терпеть", "колодка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["стойкость", "позор", "унижение", "наказание"], "correct_index": 1}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["сопровождать", "поддержка", "утешать", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["утешать", "поддержка", "буря", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["холод", "сопровождать", "буря", "утешать"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["буря", "утешать", "поддержка", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["поддержка", "буря", "убежище", "выдерживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["сопровождать", "утешать", "убежище", "выдерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["поддержка", "холод", "выдерживать", "буря"], "correct_index": 1}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["прощание", "плакать", "смерть", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "смерть", "плакать", "вечный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["прощание", "скорбь", "смерть", "вечный"], "correct_index": 3}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["прощание", "скорбь", "плакать", "следовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["прощание", "сдаваться", "скорбь", "истощение"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["сдаваться", "смерть", "истощение", "следовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["прощание", "плакать", "истощение", "скорбь"], "correct_index": 3}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["сдаваться", "смерть", "вечный", "следовать"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["защищать", "верность", "возражать", "мужество"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["возражать", "защищать", "верность", "мужество"], "correct_index": 3}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["слуга", "мужество", "возражать", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["защищать", "слуга", "искренний", "предупреждать"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["мужество", "искренний", "справедливый", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["защищать", "мужество", "слуга", "искренний"], "correct_index": 2}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["защищать", "предупреждать", "возражать", "справедливый"], "correct_index": 1}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["мужество", "предупреждать", "справедливый", "верность"], "correct_index": 2}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["несправедливость", "изгнанный", "изгнание", "гнев"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["гнев", "изгнанный", "несправедливость", "изгнание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["изгнание", "наказание", "гнев", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["изгнание", "наказание", "прощание", "изгнанный"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["изгнание", "наказание", "изгнанный", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возвращаться", "наказание", "прощание", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["возвращаться", "наказание", "прощание", "несправедливость"], "correct_index": 0}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["хитрость", "притворяться", "неузнанный", "переодевание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die List»?", "choices": ["неузнанный", "притворяться", "переодевание", "хитрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["переодевание", "верный", "изменять", "неузнанный"], "correct_index": 3}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["наниматься", "притворяться", "изменять", "верный"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["хитрость", "наниматься", "изменять", "неузнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["изменять", "борода", "притворяться", "верный"], "correct_index": 1}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["изменять", "наниматься", "неузнанный", "борода"], "correct_index": 1}, {"question": "Что означает немецкое слово «treu»?", "choices": ["неузнанный", "верный", "изменять", "борода"], "correct_index": 1}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["защита", "служба", "охранять", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["опасность", "охранять", "служба", "защита"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["опасность", "служба", "сражаться", "охранять"], "correct_index": 0}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["советовать", "служба", "охранять", "сражаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["сражаться", "стража", "охранять", "советовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «raten»?", "choices": ["сражаться", "советовать", "стража", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["защита", "стража", "сражаться", "опасность"], "correct_index": 1}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "сковывать", "стойкость", "унижение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["стойкость", "унижение", "сковывать", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["колодка", "унижение", "стойкость", "наказание"], "correct_index": 2}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["сковывать", "позор", "выдерживать", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["унижение", "терпеть", "сковывать", "колодка"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["унижение", "терпеть", "колодка", "наказание"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["сковывать", "позор", "наказание", "выдерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["наказание", "терпеть", "колодка", "позор"], "correct_index": 3}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["сопровождать", "поддержка", "буря", "утешать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["утешать", "поддержка", "буря", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["буря", "сопровождать", "утешать", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["выдерживать", "холод", "поддержка", "утешать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["убежище", "выдерживать", "буря", "поддержка"], "correct_index": 0}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["холод", "утешать", "выдерживать", "поддержка"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["холод", "утешать", "убежище", "сопровождать"], "correct_index": 0}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "плакать", "вечный", "прощание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["смерть", "прощание", "плакать", "вечный"], "correct_index": 1}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "прощание", "следовать", "истощение"], "correct_index": 0}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["следовать", "плакать", "прощание", "скорбь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["прощание", "смерть", "истощение", "сдаваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["истощение", "сдаваться", "скорбь", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["истощение", "скорбь", "прощание", "плакать"], "correct_index": 1}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["прощание", "скорбь", "вечный", "следовать"], "correct_index": 3}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -458,11 +458,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
                             
@@ -470,17 +470,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -490,22 +490,6 @@
                         <div class="quiz-question">Что означает немецкое слово «widersprechen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
@@ -518,31 +502,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">искренний</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">искренний</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">искренний</button>
                             
@@ -550,15 +550,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «warnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">справедливый</button>
                             
@@ -570,9 +570,9 @@
                         <div class="quiz-question">Что означает немецкое слово «gerecht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
                             
@@ -589,33 +589,33 @@
             <div class="quiz-phase-container" data-phase="banishment">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verbannung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -625,45 +625,45 @@
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verbannt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -673,29 +673,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -708,63 +708,15 @@
             <div class="quiz-phase-container" data-phase="disguise">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «vorgeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наниматься</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">переодевание</button>
                             
@@ -772,33 +724,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «vorgeben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наниматься</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">борода</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -812,25 +812,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -847,11 +847,43 @@
                         <div class="quiz-question">Что означает немецкое слово «der Dienst»?</div>
                         <div class="quiz-choices">
                             
+                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">защита</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
+                        <div class="quiz-choices">
+                            
                             <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
@@ -859,49 +891,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стража</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «bewachen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">советовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">советовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сражаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -913,25 +913,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «raten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сражаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">советовать</button>
                             
@@ -939,17 +923,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «raten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">советовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">стража</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Wache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">советовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -962,29 +962,13 @@
             <div class="quiz-phase-container" data-phase="stocks">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
                             
@@ -994,47 +978,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Standhaftigkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">колодка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «fesseln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erdulden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                             
@@ -1042,15 +1026,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erdulden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">позор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">колодка</button>
                             
@@ -1058,33 +1042,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">колодка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «ausharren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">колодка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">колодка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1097,7 +1097,7 @@
             <div class="quiz-phase-container" data-phase="storm_companion">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
@@ -1105,9 +1105,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1133,27 +1133,11 @@
                         <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
                             
@@ -1161,49 +1145,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">убежище</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">убежище</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1216,29 +1216,29 @@
             <div class="quiz-phase-container" data-phase="final_loyalty">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
                             
@@ -1248,47 +1248,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">следовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Erschöpfung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">истощение</button>
                             
@@ -1296,33 +1264,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">следовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">истощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">следовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Erschöpfung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">истощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1332,9 +1332,9 @@
                         <div class="quiz-question">Что означает немецкое слово «folgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                             
@@ -1367,8 +1367,10 @@
                 "transcription": "[ди ТРОЙ-е]",
                 "sentence": "Die Treue zu meinem König ist unerschütterlich.",
                 "sentenceTranslation": "Верность моему королю непоколебима.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Treue",
                     "Множественное число (пример): die Treue",
@@ -1389,8 +1391,10 @@
                 "transcription": "[дер МУТ]",
                 "sentence": "Der Mut fordert mich, die Wahrheit zu sagen.",
                 "sentenceTranslation": "Мужество требует от меня говорить правду.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Mut",
                     "Множественное число (пример): die Mute",
@@ -1411,8 +1415,10 @@
                 "transcription": "[ВИ-дер-шпре-хен]",
                 "sentence": "Ich widerspreche dem König für seine eigene Ehre.",
                 "sentenceTranslation": "Я возражаю королю ради его же чести.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: widersprechen",
                     "Презенс: ich widerspreche",
@@ -1433,8 +1439,10 @@
                 "transcription": "[фер-ТАЙ-ди-ген]",
                 "sentence": "Ich verteidige Корделия gegen Ungerechtigkeit.",
                 "sentenceTranslation": "Я защищаю Корделию от несправедливости.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verteidigen",
                     "Презенс: ich verteidige",
@@ -1456,8 +1464,12 @@
                 "transcription": "[АУФ-рих-тиг]",
                 "sentence": "Ich bin aufrichtig, auch wenn es gefährlich ist.",
                 "sentenceTranslation": "Я искренен, даже если это опасно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mut",
+                    "Treue",
+                    "Wahrheit"
+                ],
                 "wordFamily": [
                     "Основная форма: aufrichtig",
                     "Сравнительная степень: aufrichtiger",
@@ -1476,8 +1488,10 @@
                 "transcription": "[дер ДИ-нер]",
                 "sentence": "Als treuer Diener spreche ich offen.",
                 "sentenceTranslation": "Как верный слуга, я говорю открыто.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Diener",
                     "Множественное число (пример): die Diener",
@@ -1498,8 +1512,12 @@
                 "transcription": "[ВАР-нен]",
                 "sentence": "Ich warne den König vor seinem Fehler.",
                 "sentenceTranslation": "Я предупреждаю короля об его ошибке.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mut",
+                    "Treue",
+                    "Wahrheit"
+                ],
                 "wordFamily": [
                     "Инфинитив: warnen",
                     "Презенс: ich warne",
@@ -1518,8 +1536,12 @@
                 "transcription": "[ге-РЕХТ]",
                 "sentence": "Ich kämpfe für das, was gerecht ist.",
                 "sentenceTranslation": "Я борюсь за то, что справедливо.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Mut",
+                    "Treue",
+                    "Wahrheit"
+                ],
                 "wordFamily": [
                     "Основная форма: gerecht",
                     "Сравнительная степень: gerechter",
@@ -1566,8 +1588,12 @@
                 "transcription": "[ди фер-БА-нунг]",
                 "sentence": "Die Verbannung ist der Preis für meine Ehrlichkeit.",
                 "sentenceTranslation": "Изгнание - цена моей честности.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn"
+                ],
                 "wordFamily": [
                     "Основа: die Verbannung",
                     "Множественное число (пример): die Verbannungen",
@@ -1587,8 +1613,15 @@
                 "transcription": "[ди УН-ге-рех-тиг-кайт]",
                 "sentence": "Diese Ungerechtigkeit werde ich nicht akzeptieren.",
                 "sentenceTranslation": "Эту несправедливость я не приму.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "bereuen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основа: die Ungerechtigkeit",
                     "Множественное число (пример): die Ungerechtigkeiten",
@@ -1608,8 +1641,10 @@
                 "transcription": "[дер ЦОРН]",
                 "sentence": "Der Zorn des Königs trifft mich ungerecht.",
                 "sentenceTranslation": "Гнев короля поражает меня несправедливо.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Zorn",
                     "Множественное число (пример): die Zorne",
@@ -1632,8 +1667,12 @@
                 "transcription": "[фер-БАНТ]",
                 "sentence": "Verbannt aus dem Land, das ich liebe.",
                 "sentenceTranslation": "Изгнан из страны, которую люблю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn"
+                ],
                 "wordFamily": [
                     "Основная форма: verbannt",
                     "Сравнительная степень: verbannter",
@@ -1652,8 +1691,20 @@
                 "transcription": "[дер АБ-шид]",
                 "sentence": "Der Abschied vom Hof schmerzt mich tief.",
                 "sentenceTranslation": "Прощание с двором глубоко ранит меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Основа: der Abschied",
                     "Множественное число (пример): die Abschiede",
@@ -1675,8 +1726,10 @@
                 "transcription": "[ди ШТРА-фе]",
                 "sentence": "Diese Strafe nehme ich mit Würde an.",
                 "sentenceTranslation": "Это наказание я принимаю с достоинством.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Strafe",
                     "Множественное число (пример): die Strafe",
@@ -1701,8 +1754,10 @@
                 "transcription": "[цу-РЮК-ке-рен]",
                 "sentence": "Ich schwöre, verkleidet zurückzukehren.",
                 "sentenceTranslation": "Я клянусь вернуться переодетым.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: zurückkehren",
                     "Презенс: ich rückkehre zu",
@@ -1753,8 +1808,15 @@
                 "transcription": "[ди фер-КЛАЙ-дунг]",
                 "sentence": "In Verkleidung diene ich meinem König weiter.",
                 "sentenceTranslation": "В переодевании я продолжаю служить королю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung",
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
                 "wordFamily": [
                     "Основа: die Verkleidung",
                     "Множественное число (пример): die Verkleidungen",
@@ -1775,8 +1837,18 @@
                 "transcription": "[ди ЛИСТ]",
                 "sentence": "Mit List kehre ich an den Hof zurück.",
                 "sentenceTranslation": "Хитростью я возвращаюсь ко двору.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Klippe",
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung",
+                    "blind",
+                    "führen",
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
                 "wordFamily": [
                     "Основа: die List",
                     "Множественное число (пример): die Liste",
@@ -1797,8 +1869,12 @@
                 "transcription": "[УН-ер-кант]",
                 "sentence": "Unerkannt bleibe ich an seiner Seite.",
                 "sentenceTranslation": "Неузнанным я остаюсь рядом с ним.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung"
+                ],
                 "wordFamily": [
                     "Основная форма: unerkannt",
                     "Сравнительная степень: unerkannter",
@@ -1817,8 +1893,12 @@
                 "transcription": "[ФОР-ге-бен]",
                 "sentence": "Ich gebe vor, ein einfacher Mann zu sein.",
                 "sentenceTranslation": "Я притворяюсь простым человеком.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung"
+                ],
                 "wordFamily": [
                     "Инфинитив: vorgeben",
                     "Презенс: ich gebe vor",
@@ -1838,8 +1918,12 @@
                 "transcription": "[фер-ШТЕ-лен]",
                 "sentence": "Ich verstelle meine Stimme und Haltung.",
                 "sentenceTranslation": "Я изменяю свой голос и осанку.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung"
+                ],
                 "wordFamily": [
                     "Инфинитив: verstellen",
                     "Презенс: ich verstelle",
@@ -1859,8 +1943,12 @@
                 "transcription": "[дер БАРТ]",
                 "sentence": "Mit falschem Bart bin ich nicht zu erkennen.",
                 "sentenceTranslation": "С фальшивой бородой меня не узнать.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung"
+                ],
                 "wordFamily": [
                     "Основа: der Bart",
                     "Множественное число (пример): die Barte",
@@ -1879,8 +1967,12 @@
                 "transcription": "[АН-хой-ерн]",
                 "sentence": "Als Кай heuere ich beim König an.",
                 "sentenceTranslation": "Как Кай я нанимаюсь к королю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung"
+                ],
                 "wordFamily": [
                     "Инфинитив: anheuern",
                     "Презенс: ich heuere an",
@@ -1899,8 +1991,15 @@
                 "transcription": "[ТРОЙ]",
                 "sentence": "Treu bleibe ich trotz der Verkleidung.",
                 "sentenceTranslation": "Верным остаюсь несмотря на переодевание.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Freundschaft",
+                    "List",
+                    "Rückkehr",
+                    "Sturm",
+                    "Verkleidung",
+                    "Wahnsinn"
+                ],
                 "wordFamily": [
                     "Основная форма: treu",
                     "Сравнительная степень: treuer",
@@ -1948,8 +2047,12 @@
                 "transcription": "[дер ДИНСТ]",
                 "sentence": "Mein Dienst geht über die Verbannung hinaus.",
                 "sentenceTranslation": "Моя служба идёт дальше изгнания.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Dienst",
+                    "Gefahr",
+                    "Schutz"
+                ],
                 "wordFamily": [
                     "Основа: der Dienst",
                     "Множественное число (пример): die Dienste",
@@ -1968,8 +2071,12 @@
                 "transcription": "[дер ШУТЦ]",
                 "sentence": "Ich biete Schutz, ohne erkannt zu werden.",
                 "sentenceTranslation": "Я предоставляю защиту, не будучи узнанным.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Dienst",
+                    "Gefahr",
+                    "Schutz"
+                ],
                 "wordFamily": [
                     "Основа: der Schutz",
                     "Множественное число (пример): die Schutze",
@@ -1988,8 +2095,10 @@
                 "transcription": "[ди ге-ФАР]",
                 "sentence": "Trotz Gefahr bleibe ich beim König.",
                 "sentenceTranslation": "Несмотря на опасность, я остаюсь с королём.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Gefahr",
                     "Множественное число (пример): die Gefahre",
@@ -2011,8 +2120,12 @@
                 "transcription": "[бе-ВА-хен]",
                 "sentence": "Heimlich bewache ich meinen alten Herrn.",
                 "sentenceTranslation": "Тайно я охраняю своего старого господина.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Dienst",
+                    "Gefahr",
+                    "Schutz"
+                ],
                 "wordFamily": [
                     "Инфинитив: bewachen",
                     "Презенс: ich bewache",
@@ -2031,8 +2144,10 @@
                 "transcription": "[КЕМП-фен]",
                 "sentence": "Ich kämpfe gegen alle seine Feinde.",
                 "sentenceTranslation": "Я сражаюсь против всех его врагов.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: kämpfen",
                     "Презенс: ich kämpfe",
@@ -2055,8 +2170,12 @@
                 "transcription": "[РА-тен]",
                 "sentence": "Als Кай rate ich ihm zur Vorsicht.",
                 "sentenceTranslation": "Как Кай я советую ему осторожность.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Dienst",
+                    "Gefahr",
+                    "Schutz"
+                ],
                 "wordFamily": [
                     "Инфинитив: raten",
                     "Презенс: ich rate",
@@ -2075,8 +2194,12 @@
                 "transcription": "[ди ВА-хе]",
                 "sentence": "Ich halte Wache über seinen Schlaf.",
                 "sentenceTranslation": "Я держу стражу над его сном.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Dienst",
+                    "Gefahr",
+                    "Schutz"
+                ],
                 "wordFamily": [
                     "Основа: die Wache",
                     "Множественное число (пример): die Wache",
@@ -2123,8 +2246,10 @@
                 "transcription": "[ди ШТРА-фе]",
                 "sentence": "Diese Strafe erdulde ich für meinen König.",
                 "sentenceTranslation": "Это наказание я терплю ради короля.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Strafe",
                     "Множественное число (пример): die Strafe",
@@ -2149,8 +2274,12 @@
                 "transcription": "[ди де-МЮ-ти-гунг]",
                 "sentence": "Die Demütigung macht mich nur stärker.",
                 "sentenceTranslation": "Унижение делает меня только сильнее.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
                 "wordFamily": [
                     "Основа: die Demütigung",
                     "Множественное число (пример): die Demütigungen",
@@ -2169,8 +2298,12 @@
                 "transcription": "[ди ШТАНД-хаф-тиг-кайт]",
                 "sentence": "Mit Standhaftigkeit ertrage ich die Schmach.",
                 "sentenceTranslation": "Со стойкостью я переношу позор.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
                 "wordFamily": [
                     "Основа: die Standhaftigkeit",
                     "Множественное число (пример): die Standhaftigkeiten",
@@ -2189,8 +2322,12 @@
                 "transcription": "[ФЕ-сельн]",
                 "sentence": "Sie fesseln mich wie einen gemeinen Dieb.",
                 "sentenceTranslation": "Они сковывают меня как обычного вора.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
                 "wordFamily": [
                     "Инфинитив: fesseln",
                     "Презенс: ich fessele",
@@ -2209,8 +2346,12 @@
                 "transcription": "[ер-ДУЛЬ-ден]",
                 "sentence": "Ich erdulde die Schande ohne Klage.",
                 "sentenceTranslation": "Я терплю позор без жалоб.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
                 "wordFamily": [
                     "Инфинитив: erdulden",
                     "Презенс: ich erdulde",
@@ -2231,8 +2372,12 @@
                 "transcription": "[дер ШТОК]",
                 "sentence": "Im Stock sitze ich die ganze Nacht.",
                 "sentenceTranslation": "В колодке я сижу всю ночь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
                 "wordFamily": [
                     "Основа: der Stock",
                     "Множественное число (пример): die Stocke",
@@ -2251,8 +2396,12 @@
                 "transcription": "[АУС-ха-рен]",
                 "sentence": "Ich harre aus bis zur Befreiung.",
                 "sentenceTranslation": "Я выдерживаю до освобождения.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
                 "wordFamily": [
                     "Инфинитив: ausharren",
                     "Презенс: ich harre aus",
@@ -2273,8 +2422,10 @@
                 "transcription": "[ди ШАН-де]",
                 "sentence": "Diese Schande ist Cornwall's, nicht meine.",
                 "sentenceTranslation": "Этот позор Корнуолла, не мой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Schande",
                     "Множественное число (пример): die Schande",
@@ -2322,8 +2473,10 @@
                 "transcription": "[дер ШТУРМ]",
                 "sentence": "Im Sturm bleibe ich bei meinem König.",
                 "sentenceTranslation": "В буре я остаюсь с моим королём.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Sturm",
                     "Множественное число (пример): die Sturme",
@@ -2346,8 +2499,12 @@
                 "transcription": "[дер БАЙ-штанд]",
                 "sentence": "Mein Beistand ist alles, was ich bieten kann.",
                 "sentenceTranslation": "Моя поддержка - всё, что я могу предложить.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beistand",
+                    "Sturm",
+                    "Treue"
+                ],
                 "wordFamily": [
                     "Основа: der Beistand",
                     "Множественное число (пример): die Beistande",
@@ -2366,8 +2523,16 @@
                 "transcription": "[бе-ГЛАЙ-тен]",
                 "sentence": "Ich begleite ihn durch Wind und Regen.",
                 "sentenceTranslation": "Я сопровождаю его сквозь ветер и дождь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beistand",
+                    "Freundschaft",
+                    "Sturm",
+                    "Treue",
+                    "Wahnsinn",
+                    "frieren",
+                    "leiden"
+                ],
                 "wordFamily": [
                     "Инфинитив: begleiten",
                     "Презенс: ich begleite",
@@ -2388,8 +2553,10 @@
                 "transcription": "[ТРЁС-тен]",
                 "sentence": "Mit Worten tröste ich den wahnsinnigen König.",
                 "sentenceTranslation": "Словами я утешаю безумного короля.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: trösten",
                     "Презенс: ich tröste",
@@ -2411,8 +2578,12 @@
                 "transcription": "[ди ЦУ-флухт]",
                 "sentence": "Ich suche Zuflucht für uns beide.",
                 "sentenceTranslation": "Я ищу убежище для нас обоих.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beistand",
+                    "Sturm",
+                    "Treue"
+                ],
                 "wordFamily": [
                     "Основа: die Zuflucht",
                     "Множественное число (пример): die Zufluchte",
@@ -2432,8 +2603,10 @@
                 "transcription": "[ДУРХ-халь-тен]",
                 "sentence": "Gemeinsam werden wir durchhalten.",
                 "sentenceTranslation": "Вместе мы выдержим.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: durchhalten",
                     "Презенс: ich durchhalte",
@@ -2455,8 +2628,14 @@
                 "transcription": "[ди КЕЛ-те]",
                 "sentence": "Die Kälte dringt in unsere Knochen.",
                 "sentenceTranslation": "Холод проникает в наши кости.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beistand",
+                    "Sturm",
+                    "Treue",
+                    "gnadenlos",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основа: die Kälte",
                     "Множественное число (пример): die Kälte",
@@ -2504,8 +2683,10 @@
                 "transcription": "[дер ТОД]",
                 "sentence": "Bis zum Tod bleibe ich an seiner Seite.",
                 "sentenceTranslation": "До смерти я остаюсь рядом с ним.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Tod",
                     "Множественное число (пример): die Tode",
@@ -2529,8 +2710,20 @@
                 "transcription": "[дер АБ-шид]",
                 "sentence": "Der Abschied von meinem König bricht mein Herz.",
                 "sentenceTranslation": "Прощание с моим королём разбивает моё сердце.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Основа: der Abschied",
                     "Множественное число (пример): die Abschiede",
@@ -2552,8 +2745,17 @@
                 "transcription": "[Э-виг]",
                 "sentence": "Meine Treue ist ewig, über den Tod hinaus.",
                 "sentenceTranslation": "Моя верность вечна, за пределами смерти.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Основная форма: ewig",
                     "Сравнительная степень: ewiger",
@@ -2574,8 +2776,10 @@
                 "transcription": "[ВАЙ-нен]",
                 "sentence": "Ich weine um meinen gefallenen König.",
                 "sentenceTranslation": "Я плачу о моём павшем короле.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: weinen",
                     "Презенс: ich weine",
@@ -2595,8 +2799,12 @@
                 "transcription": "[ди ер-ШЁП-фунг]",
                 "sentence": "Die Erschöpfung überwältigt meinen alten Körper.",
                 "sentenceTranslation": "Истощение одолевает моё старое тело.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Abschied",
+                    "Tod",
+                    "ewige Treue"
+                ],
                 "wordFamily": [
                     "Основа: die Erschöpfung",
                     "Множественное число (пример): die Erschöpfungen",
@@ -2615,8 +2823,15 @@
                 "transcription": "[АУФ-ге-бен]",
                 "sentence": "Ich gebe auf, nachdem mein Herr gestorben ist.",
                 "sentenceTranslation": "Я сдаюсь после смерти моего господина.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Abschied",
+                    "Tod",
+                    "Täuschung",
+                    "Verzweiflung",
+                    "ewige Treue",
+                    "springen"
+                ],
                 "wordFamily": [
                     "Инфинитив: aufgeben",
                     "Презенс: ich gebe auf",
@@ -2636,8 +2851,10 @@
                 "transcription": "[ди ТРАУ-ер]",
                 "sentence": "Die Trauer ist zu schwer zu ertragen.",
                 "sentenceTranslation": "Скорбь слишком тяжела, чтобы вынести.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Trauer",
                     "Множественное число (пример): die Trauer",
@@ -2660,8 +2877,10 @@
                 "transcription": "[ФОЛЬ-ген]",
                 "sentence": "Bald folge ich meinem König ins Jenseits.",
                 "sentenceTranslation": "Скоро я последую за королём в иной мир.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: folgen",
                     "Презенс: ich folge",

--- a/output/journeys/king_lear.html
+++ b/output/journeys/king_lear.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["королевство", "власть", "трон", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["трон", "королевство", "править", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["королевство", "власть", "трон", "церемония"], "correct_index": 1}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["корона", "править", "королевство", "провозглашать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["править", "корона", "церемония", "провозглашать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["власть", "великолепный", "корона", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "трон", "корона", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["власть", "церемония", "править", "великолепный"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["гнев", "унижать", "неблагодарность", "проклинать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["проклинать", "унижать", "гнев", "неблагодарность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["проклинать", "неблагодарность", "изгонять", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["гнев", "проклинать", "сожалеть", "неблагодарность"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["сожалеть", "изгонять", "проклинать", "неблагодарность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["сожалеть", "обида", "неблагодарность", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["изгонять", "сожалеть", "проклятие", "проклинать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["проклинать", "проклятие", "унижать", "гнев"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["жестокость", "покидать", "отчаяние", "отвергать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["отчаяние", "жестокость", "отвергать", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "слеза", "отчаяние", "нужда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "покидать", "просить", "отвергать"], "correct_index": 0}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["отчаяние", "покидать", "просить", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["нужда", "слеза", "одиночество", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["отчаяние", "отвергать", "слеза", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["нужда", "отвергать", "одиночество", "жестокость"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "безумие", "гром", "бушевать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["гром", "безумие", "бушевать", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «toben»?", "choices": ["бушевать", "гром", "кричать", "хаос"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["бушевать", "гром", "хаос", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["бушевать", "хаос", "безумие", "молния"], "correct_index": 3}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["безумие", "бушевать", "кричать", "хаос"], "correct_index": 2}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["голый", "кричать", "молния", "бушевать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["хаос", "кричать", "бушевать", "гром"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["мёрзнуть", "бедный", "нищий", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["мёрзнуть", "нищета", "бедный", "нищий"], "correct_index": 3}, {"question": "Что означает немецкое слово «arm»?", "choices": ["страдать", "нищий", "бедный", "хижина"], "correct_index": 2}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["нищий", "шут", "мёрзнуть", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["хижина", "шут", "познание", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["бедный", "нищий", "страдать", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "нищий", "бедный", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["познание", "нищета", "нищий", "бедный"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["правда", "узнавать", "понимать", "раскаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["узнавать", "раскаяние", "правда", "понимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["узнавать", "правда", "понимать", "виновный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["прощать", "правда", "раскаяние", "прозрение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "понимать", "узнавать", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "узнавать", "виновный", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["виновный", "прозрение", "раскаяние", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["мудрость", "виновный", "правда", "прозрение"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["умирать", "прощать", "смерть", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["прощать", "смерть", "умирать", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["конец", "скорбь", "вечный", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["сердце", "конец", "умирать", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["прощать", "сердце", "умирать", "прощание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["сердце", "вечный", "скорбь", "прощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["вечный", "сердце", "прощание", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["умирать", "прощать", "вечный", "скорбь"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["трон", "власть", "королевство", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["править", "трон", "власть", "королевство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["корона", "королевство", "власть", "церемония"], "correct_index": 2}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["великолепный", "править", "власть", "королевство"], "correct_index": 1}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["провозглашать", "править", "королевство", "великолепный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["великолепный", "корона", "провозглашать", "церемония"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["власть", "корона", "трон", "церемония"], "correct_index": 3}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["королевство", "церемония", "великолепный", "власть"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["неблагодарность", "гнев", "проклинать", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["неблагодарность", "проклинать", "унижать", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["проклятие", "сожалеть", "обида", "неблагодарность"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["неблагодарность", "проклинать", "проклятие", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["обида", "изгонять", "проклятие", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["гнев", "унижать", "обида", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["обида", "проклятие", "неблагодарность", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["проклятие", "сожалеть", "проклинать", "неблагодарность"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["отчаяние", "покидать", "отвергать", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["жестокость", "отвергать", "покидать", "отчаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["нужда", "отвергать", "жестокость", "слеза"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отвергать", "покидать", "слеза", "отчаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["нужда", "отвергать", "жестокость", "просить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["одиночество", "нужда", "жестокость", "покидать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["просить", "покидать", "слеза", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["нужда", "просить", "одиночество", "покидать"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["бушевать", "буря", "гром", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["гром", "безумие", "бушевать", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «toben»?", "choices": ["безумие", "бушевать", "гром", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["бушевать", "гром", "безумие", "кричать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["гром", "молния", "бушевать", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["хаос", "голый", "кричать", "буря"], "correct_index": 2}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["голый", "безумие", "молния", "хаос"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["хаос", "безумие", "молния", "бушевать"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["бедный", "нищета", "мёрзнуть", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["бедный", "нищета", "мёрзнуть", "нищий"], "correct_index": 3}, {"question": "Что означает немецкое слово «arm»?", "choices": ["бедный", "мёрзнуть", "познание", "шут"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["бедный", "мёрзнуть", "нищий", "хижина"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["мёрзнуть", "бедный", "хижина", "нищий"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["шут", "страдать", "нищета", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "страдать", "бедный", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["нищий", "познание", "шут", "хижина"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "правда", "раскаяние", "понимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["раскаяние", "узнавать", "понимать", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["виновный", "правда", "прозрение", "узнавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["правда", "узнавать", "мудрость", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["виновный", "понимать", "мудрость", "прозрение"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "понимать", "виновный", "прозрение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["прозрение", "понимать", "мудрость", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["узнавать", "прозрение", "правда", "виновный"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["умирать", "конец", "прощать", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "прощать", "конец", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["сердце", "прощание", "умирать", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["прощать", "сердце", "прощание", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["скорбь", "сердце", "конец", "вечный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["скорбь", "вечный", "смерть", "конец"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "смерть", "сердце", "скорбь"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "смерть", "прощание", "конец"], "correct_index": 0}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -454,15 +454,15 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">править</button>
                             
@@ -470,31 +470,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">корона</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                             
@@ -506,77 +506,77 @@
                         <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">корона</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">великолепный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">великолепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">корона</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">корона</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «prächtig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">великолепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">великолепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -589,49 +589,49 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Undankbarkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обида</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -641,13 +641,13 @@
                         <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -657,61 +657,61 @@
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обида</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклятие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Fluch»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Fluch»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклятие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -728,93 +728,93 @@
                         <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нужда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">просить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">просить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слеза</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">нужда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -824,13 +824,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -842,11 +842,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">просить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -859,17 +859,17 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -891,17 +891,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «toben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -915,25 +915,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -943,13 +943,13 @@
                         <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -961,11 +961,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хаос</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -977,11 +977,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -994,17 +994,17 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1014,11 +1014,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
@@ -1026,15 +1026,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «arm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">познание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
                             
@@ -1042,49 +1058,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">познание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1096,7 +1096,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
                             
@@ -1106,17 +1106,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">познание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">познание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1129,33 +1129,33 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verstehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1165,45 +1165,45 @@
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">виновный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прозрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">виновный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1215,43 +1215,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">виновный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">виновный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прозрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «schuldig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">виновный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1264,63 +1264,15 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1328,43 +1280,43 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
                             
@@ -1376,17 +1328,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1415,8 +1415,10 @@
                 "transcription": "[дер ТРОН]",
                 "sentence": "Vom Thron herab verkünde ich meinen Willen.",
                 "sentenceTranslation": "С трона я провозглашаю свою волю.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Thron",
                     "Множественное число (пример): die Throne",
@@ -1437,8 +1439,10 @@
                 "transcription": "[дас КЁ-ниг-райх]",
                 "sentence": "Mein Königreich teile ich unter meinen Töchtern.",
                 "sentenceTranslation": "Моё королевство я делю между дочерьми.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Königreich",
                     "Множественное число (пример): die Königreiche",
@@ -1459,8 +1463,10 @@
                 "transcription": "[ди МАХТ]",
                 "sentence": "Die Macht gebe ich an jene, die mich am meisten liebt.",
                 "sentenceTranslation": "Власть я отдаю той, кто любит меня больше всех.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Macht",
                     "Множественное число (пример): die Machte",
@@ -1483,8 +1489,10 @@
                 "transcription": "[ХЕР-шен]",
                 "sentence": "Ich habe lange genug geherrscht.",
                 "sentenceTranslation": "Я правил достаточно долго.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: herrschen",
                     "Презенс: ich rsche her",
@@ -1506,8 +1514,15 @@
                 "transcription": "[фер-КЮН-ден]",
                 "sentence": "Ich verkünde die Teilung meines Reiches.",
                 "sentenceTranslation": "Я провозглашаю раздел моего королевства.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehrlichkeit",
+                    "König",
+                    "Liebe",
+                    "Macht",
+                    "Thron",
+                    "Wahrheit"
+                ],
                 "wordFamily": [
                     "Инфинитив: verkünden",
                     "Презенс: ich verkünde",
@@ -1527,8 +1542,10 @@
                 "transcription": "[ди КРО-не]",
                 "sentence": "Diese Krone ist schwer geworden für mein altes Haupt.",
                 "sentenceTranslation": "Эта корона стала тяжела для моей старой головы.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Krone",
                     "Множественное число (пример): die Krone",
@@ -1548,8 +1565,15 @@
                 "transcription": "[ди це-ре-мо-НИ]",
                 "sentence": "Die Zeremonie der Teilung beginnt jetzt.",
                 "sentenceTranslation": "Церемония раздела начинается сейчас.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ehrlichkeit",
+                    "König",
+                    "Liebe",
+                    "Macht",
+                    "Thron",
+                    "Wahrheit"
+                ],
                 "wordFamily": [
                     "Основа: die Zeremonie",
                     "Множественное число (пример): die Zeremonie",
@@ -1569,8 +1593,12 @@
                 "transcription": "[ПРЕХ-тиг]",
                 "sentence": "Ein prächtiger Tag für eine verhängnisvolle Entscheidung.",
                 "sentenceTranslation": "Великолепный день для рокового решения.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "König",
+                    "Macht",
+                    "Thron"
+                ],
                 "wordFamily": [
                     "Основная форма: prächtig",
                     "Сравнительная степень: prächtiger",
@@ -1617,8 +1645,16 @@
                 "transcription": "[де-МЮ-ти-ген]",
                 "sentence": "Meine eigene Tochter will mich demütigen!",
                 "sentenceTranslation": "Моя собственная дочь хочет меня унизить!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn",
+                    "demütigen",
+                    "grausam",
+                    "reduzieren",
+                    "vertreiben"
+                ],
                 "wordFamily": [
                     "Инфинитив: demütigen",
                     "Презенс: ich demütige",
@@ -1640,8 +1676,10 @@
                 "transcription": "[дер ЦОРН]",
                 "sentence": "Mein Zorn brennt wie Feuer in meiner Brust!",
                 "sentenceTranslation": "Мой гнев горит как огонь в моей груди!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Zorn",
                     "Множественное число (пример): die Zorne",
@@ -1664,8 +1702,12 @@
                 "transcription": "[ди УН-данк-бар-кайт]",
                 "sentence": "Die Undankbarkeit ist schärfer als der Zahn einer Schlange!",
                 "sentenceTranslation": "Неблагодарность острее змеиного зуба!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Zorn",
+                    "demütigen",
+                    "reduzieren"
+                ],
                 "wordFamily": [
                     "Основа: die Undankbarkeit",
                     "Множественное число (пример): die Undankbarkeiten",
@@ -1684,8 +1726,10 @@
                 "transcription": "[фер-ФЛУ-хен]",
                 "sentence": "Ich verfluche dich bei allen Sternen!",
                 "sentenceTranslation": "Я проклинаю тебя всеми звёздами!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verfluchen",
                     "Презенс: ich verfluche",
@@ -1709,8 +1753,10 @@
                 "transcription": "[фер-ТРАЙ-бен]",
                 "sentence": "Aus meinem eigenen Haus will sie mich vertreiben!",
                 "sentenceTranslation": "Из моего собственного дома она хочет меня изгнать!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: vertreiben",
                     "Презенс: ich vertreibe",
@@ -1735,8 +1781,12 @@
                 "transcription": "[ди КРЭН-кунг]",
                 "sentence": "Diese Kränkung werde ich nicht vergessen!",
                 "sentenceTranslation": "Эту обиду я не забуду!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Zorn",
+                    "demütigen",
+                    "reduzieren"
+                ],
                 "wordFamily": [
                     "Основа: die Kränkung",
                     "Множественное число (пример): die Kränkungen",
@@ -1755,8 +1805,10 @@
                 "transcription": "[бе-РОЙ-ен]",
                 "sentence": "Sie wird ihre Grausamkeit bereuen!",
                 "sentenceTranslation": "Она пожалеет о своей жестокости!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: bereuen",
                     "Презенс: ich bereue",
@@ -1779,8 +1831,10 @@
                 "transcription": "[дер ФЛУХ]",
                 "sentence": "Mein Fluch soll über dich kommen!",
                 "sentenceTranslation": "Моё проклятие падёт на тебя!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Fluch",
                     "Множественное число (пример): die Fluche",
@@ -1828,8 +1882,10 @@
                 "transcription": "[фер-ЛА-сен]",
                 "sentence": "Auch Regan will mich verlassen und verstoßen!",
                 "sentenceTranslation": "И Регана хочет меня покинуть и отвергнуть!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verlassen",
                     "Презенс: ich verlasse",
@@ -1850,8 +1906,10 @@
                 "transcription": "[фер-ШТО-сен]",
                 "sentence": "Meine Töchter verstoßen mich wie einen Bettler!",
                 "sentenceTranslation": "Мои дочери отвергают меня как нищего!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verstoßen",
                     "Презенс: ich verstoße",
@@ -1878,8 +1936,20 @@
                 "transcription": "[ди ГРАУ-зам-кайт]",
                 "sentence": "Ihre Grausamkeit übertrifft die ihrer Schwester!",
                 "sentenceTranslation": "Её жестокость превосходит жестокость сестры!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "Verzweiflung",
+                    "blenden",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen",
+                    "verlassen",
+                    "verraten",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основа: die Grausamkeit",
                     "Множественное число (пример): die Grausamkeiten",
@@ -1901,8 +1971,10 @@
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
                 "sentence": "Die Verzweiflung packt mein altes Herz!",
                 "sentenceTranslation": "Отчаяние охватывает моё старое сердце!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Verzweiflung",
                     "Множественное число (пример): die Verzweiflungen",
@@ -1925,8 +1997,15 @@
                 "transcription": "[БЕ-тельн]",
                 "sentence": "Muss ich um Unterkunft betteln bei meinen eigenen Kindern?",
                 "sentenceTranslation": "Должен ли я просить крова у собственных детей?",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod",
+                    "Verzweiflung",
+                    "verlassen",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Инфинитив: betteln",
                     "Презенс: ich bettele",
@@ -1948,8 +2027,10 @@
                 "transcription": "[ди АЙН-зам-кайт]",
                 "sentence": "Die Einsamkeit umgibt mich wie ein kalter Mantel.",
                 "sentenceTranslation": "Одиночество окружает меня как холодный плащ.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Einsamkeit",
                     "Множественное число (пример): die Einsamkeiten",
@@ -1970,8 +2051,10 @@
                 "transcription": "[ди ТРЭ-не]",
                 "sentence": "Keine Träne will ich für diese Undankbaren vergießen!",
                 "sentenceTranslation": "Ни одной слезы я не пролью за этих неблагодарных!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Träne",
                     "Множественное число (пример): die Träne",
@@ -1991,8 +2074,10 @@
                 "transcription": "[ди НОТ]",
                 "sentence": "In meiner Not erkennen sie mich nicht als Vater.",
                 "sentenceTranslation": "В моей нужде они не признают меня отцом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Not",
                     "Множественное число (пример): die Note",
@@ -2040,8 +2125,10 @@
                 "transcription": "[дер ШТУРМ]",
                 "sentence": "Der Sturm in meinem Kopf ist schlimmer als draußen!",
                 "sentenceTranslation": "Буря в моей голове хуже, чем снаружи!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Sturm",
                     "Множественное число (пример): die Sturme",
@@ -2064,8 +2151,10 @@
                 "transcription": "[дер ВАН-зин]",
                 "sentence": "Der Wahnsinn ist gnädiger als die Vernunft!",
                 "sentenceTranslation": "Безумие милосерднее разума!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Wahnsinn",
                     "Множественное число (пример): die Wahnsinne",
@@ -2087,8 +2176,10 @@
                 "transcription": "[ТО-бен]",
                 "sentence": "Lasst die Winde toben und die Blitze fallen!",
                 "sentenceTranslation": "Пусть ветры бушуют и молнии падают!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: toben",
                     "Презенс: ich tobe",
@@ -2108,8 +2199,10 @@
                 "transcription": "[дер ДО-нер]",
                 "sentence": "Der Donner ist die Stimme der Götter!",
                 "sentenceTranslation": "Гром - это голос богов!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Donner",
                     "Множественное число (пример): die Donner",
@@ -2130,8 +2223,10 @@
                 "transcription": "[дер БЛИЦ]",
                 "sentence": "Die Blitze sollen meine weißen Haare verbrennen!",
                 "sentenceTranslation": "Пусть молнии сожгут мои седые волосы!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Blitz",
                     "Множественное число (пример): die Blitze",
@@ -2152,8 +2247,15 @@
                 "transcription": "[ШРАЙ-ен]",
                 "sentence": "Ich schreie in den Wind meine Wut hinaus!",
                 "sentenceTranslation": "Я кричу в ветер свою ярость!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Folter",
+                    "Schmerz",
+                    "Sturm",
+                    "Wahnsinn",
+                    "blenden",
+                    "toben"
+                ],
                 "wordFamily": [
                     "Инфинитив: schreien",
                     "Презенс: ich schreie",
@@ -2173,8 +2275,15 @@
                 "transcription": "[НАКТ]",
                 "sentence": "Nackt kam ich auf die Welt, nackt gehe ich!",
                 "sentenceTranslation": "Голым я пришёл в мир, голым и уйду!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Sturm",
+                    "Wahnsinn",
+                    "arm",
+                    "nackt",
+                    "toben",
+                    "verrückt"
+                ],
                 "wordFamily": [
                     "Основная форма: nackt",
                     "Сравнительная степень: nackter",
@@ -2194,8 +2303,10 @@
                 "transcription": "[дас ХА-ос]",
                 "sentence": "Das Chaos in der Natur spiegelt meine Seele!",
                 "sentenceTranslation": "Хаос в природе отражает мою душу!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Chaos",
                     "Множественное число (пример): die Chaose",
@@ -2243,8 +2354,10 @@
                 "transcription": "[дас Э-ленд]",
                 "sentence": "Im Elend erkenne ich die Wahrheit der Welt.",
                 "sentenceTranslation": "В нищете я познаю истину мира.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Elend",
                     "Множественное число (пример): die Elende",
@@ -2265,8 +2378,14 @@
                 "transcription": "[дер БЕТ-лер]",
                 "sentence": "Dieser Bettler ist glücklicher als ich, der König!",
                 "sentenceTranslation": "Этот нищий счастливее меня, короля!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
                 "wordFamily": [
                     "Основа: der Bettler",
                     "Множественное число (пример): die Bettler",
@@ -2286,8 +2405,12 @@
                 "transcription": "[АРМ]",
                 "sentence": "Die Armen leiden mehr als Könige jemals wissen.",
                 "sentenceTranslation": "Бедные страдают больше, чем короли когда-либо узнают.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "arm"
+                ],
                 "wordFamily": [
                     "Основная форма: arm",
                     "Сравнительная степень: armer",
@@ -2306,8 +2429,17 @@
                 "transcription": "[ФРИ-рен]",
                 "sentence": "Wir alle frieren in dieser kalten Welt.",
                 "sentenceTranslation": "Мы все мёрзнем в этом холодном мире.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "Freundschaft",
+                    "Sturm",
+                    "Wahnsinn",
+                    "arm",
+                    "frieren",
+                    "leiden"
+                ],
                 "wordFamily": [
                     "Инфинитив: frieren",
                     "Презенс: ich friere",
@@ -2328,8 +2460,15 @@
                 "transcription": "[ди ХЮ-те]",
                 "sentence": "Diese Hütte ist ein Palast für die Verlassenen.",
                 "sentenceTranslation": "Эта хижина - дворец для покинутых.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "Sturm",
+                    "arm",
+                    "frieren",
+                    "leiden"
+                ],
                 "wordFamily": [
                     "Основа: die Hütte",
                     "Множественное число (пример): die Hütte",
@@ -2349,8 +2488,10 @@
                 "transcription": "[ЛАЙ-ден]",
                 "sentence": "Wer nicht gelitten hat, kennt das Leben nicht.",
                 "sentenceTranslation": "Кто не страдал, не знает жизни.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: leiden",
                     "Презенс: ich leide",
@@ -2374,8 +2515,10 @@
                 "transcription": "[дер НАР]",
                 "sentence": "Mein Narr ist weiser als ich je war.",
                 "sentenceTranslation": "Мой шут мудрее, чем я когда-либо был.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Narr",
                     "Множественное число (пример): die Narre",
@@ -2396,8 +2539,10 @@
                 "transcription": "[ди ер-КЕНТ-нис]",
                 "sentence": "Die Erkenntnis kommt durch Schmerz und Verlust.",
                 "sentenceTranslation": "Познание приходит через боль и утрату.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Erkenntnis",
                     "Множественное число (пример): die Erkenntnise",
@@ -2448,8 +2593,10 @@
                 "transcription": "[эр-КЕ-нен]",
                 "sentence": "Ich erkenne dich, meine treue Cordelia!",
                 "sentenceTranslation": "Я узнаю тебя, моя верная Корделия!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: erkennen",
                     "Презенс: ich erkenne",
@@ -2475,8 +2622,10 @@
                 "transcription": "[фер-ШТЕ-ен]",
                 "sentence": "Jetzt verstehe ich, wer mich wirklich liebte.",
                 "sentenceTranslation": "Теперь я понимаю, кто действительно меня любил.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verstehen",
                     "Презенс: ich verstehe",
@@ -2497,8 +2646,10 @@
                 "transcription": "[ди ВАР-хайт]",
                 "sentence": "Die Wahrheit war immer in deinen Worten, Kind.",
                 "sentenceTranslation": "Правда всегда была в твоих словах, дитя.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Wahrheit",
                     "Множественное число (пример): die Wahrheiten",
@@ -2520,8 +2671,10 @@
                 "transcription": "[ди РОЙ-е]",
                 "sentence": "Die Reue brennt heißer als alle Feuer der Hölle.",
                 "sentenceTranslation": "Раскаяние жжёт горячее всех адских огней.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Reue",
                     "Множественное число (пример): die Reue",
@@ -2543,8 +2696,19 @@
                 "transcription": "[ди ВАЙС-хайт]",
                 "sentence": "Die Weisheit kommt zu spät zu mir.",
                 "sentenceTranslation": "Мудрость приходит ко мне слишком поздно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Erbe",
+                    "Herrschaft",
+                    "Narr",
+                    "Neuanfang",
+                    "Trauer",
+                    "Weisheit",
+                    "Zukunft",
+                    "erkennen",
+                    "verstehen",
+                    "überleben"
+                ],
                 "wordFamily": [
                     "Основа: die Weisheit",
                     "Множественное число (пример): die Weisheiten",
@@ -2566,8 +2730,10 @@
                 "transcription": "[фер-ГЕ-бен]",
                 "sentence": "Kannst du einem törichten alten Mann vergeben?",
                 "sentenceTranslation": "Можешь ли ты простить глупого старика?",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: vergeben",
                     "Презенс: ich vergebe",
@@ -2589,8 +2755,12 @@
                 "transcription": "[ди АЙН-зихт]",
                 "sentence": "Die Einsicht verbrennt meine Seele.",
                 "sentenceTranslation": "Прозрение сжигает мою душу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Weisheit",
+                    "erkennen",
+                    "verstehen"
+                ],
                 "wordFamily": [
                     "Основа: die Einsicht",
                     "Множественное число (пример): die Einsichte",
@@ -2609,8 +2779,12 @@
                 "transcription": "[ШУЛЬ-диг]",
                 "sentence": "Ich bin schuldig vor meiner Tochter.",
                 "sentenceTranslation": "Я виновен перед своей дочерью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Weisheit",
+                    "erkennen",
+                    "verstehen"
+                ],
                 "wordFamily": [
                     "Основная форма: schuldig",
                     "Сравнительная степень: schuldiger",
@@ -2657,8 +2831,10 @@
                 "transcription": "[фер-ЦАЙ-ен]",
                 "sentence": "Verzeih mir, ich bin nur ein törichter alter Mann.",
                 "sentenceTranslation": "Прости меня, я всего лишь глупый старик.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verzeihen",
                     "Презенс: ich verzeihe",
@@ -2680,8 +2856,10 @@
                 "transcription": "[дер ТОД]",
                 "sentence": "Der Tod ist gnädiger als das Leben ohne dich.",
                 "sentenceTranslation": "Смерть милосерднее жизни без тебя.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Tod",
                     "Множественное число (пример): die Tode",
@@ -2705,8 +2883,10 @@
                 "transcription": "[ШТЕР-бен]",
                 "sentence": "Lass mich an deiner Seite sterben, Cordelia.",
                 "sentenceTranslation": "Позволь мне умереть рядом с тобой, Корделия.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: sterben",
                     "Презенс: ich sterbe",
@@ -2730,8 +2910,10 @@
                 "transcription": "[дас ЕН-де]",
                 "sentence": "Das Ende kommt, aber mit dir bin ich nicht allein.",
                 "sentenceTranslation": "Конец приходит, но с тобой я не одинок.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Ende",
                     "Множественное число (пример): die Ende",
@@ -2754,8 +2936,10 @@
                 "transcription": "[дас ХЕРЦ]",
                 "sentence": "Mein Herz bricht vor Schmerz und Liebe.",
                 "sentenceTranslation": "Моё сердце разбивается от боли и любви.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: das Herz",
                     "Множественное число (пример): die Herze",
@@ -2776,8 +2960,10 @@
                 "transcription": "[ди ТРАУ-ер]",
                 "sentence": "Die Trauer überwältigt meine Seele.",
                 "sentenceTranslation": "Скорбь переполняет мою душу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Trauer",
                     "Множественное число (пример): die Trauer",
@@ -2800,8 +2986,20 @@
                 "transcription": "[дер АБ-шид]",
                 "sentence": "Das ist unser letzter Abschied, mein Kind.",
                 "sentenceTranslation": "Это наше последнее прощание, дитя моё.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Основа: der Abschied",
                     "Множественное число (пример): die Abschiede",
@@ -2823,8 +3021,17 @@
                 "transcription": "[Э-виг]",
                 "sentence": "Unsere Liebe wird ewig dauern, mein Kind.",
                 "sentenceTranslation": "Наша любовь будет вечной, дитя моё.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
                 "wordFamily": [
                     "Основная форма: ewig",
                     "Сравнительная степень: ewiger",

--- a/output/journeys/oswald.html
+++ b/output/journeys/oswald.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["слуга", "преданность", "служить", "послушание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["слуга", "послушание", "преданность", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["служить", "преданность", "покорный", "послушание"], "correct_index": 1}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["исполнять", "служить", "слуга", "раболепный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["управляющий", "слуга", "служить", "раболепный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["слуга", "управляющий", "исполнять", "покорный"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["покорный", "управляющий", "исполнять", "раболепный"], "correct_index": 3}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["послушание", "управляющий", "слуга", "исполнять"], "correct_index": 3}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["спешка", "передавать", "гонец", "поручение"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["гонец", "поручение", "передавать", "спешка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["спешка", "передавать", "спешить", "поручение"], "correct_index": 0}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["передавать", "гонец", "послание", "торопиться"], "correct_index": 0}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["передавать", "торопиться", "спешка", "спешить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["спешить", "передавать", "послание", "поручение"], "correct_index": 2}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["торопиться", "поручение", "гонец", "спешка"], "correct_index": 0}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["неуважение", "оскорблять", "трусость", "оскорбление"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорбление", "трусость", "оскорблять", "неуважение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["оскорбление", "трусость", "оскорблять", "дерзкий"], "correct_index": 1}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["высмеивать", "неуважение", "оскорблять", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["оскорбление", "трусость", "дерзкий", "высмеивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «frech»?", "choices": ["неуважение", "оскорбление", "высмеивать", "дерзкий"], "correct_index": 3}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["высмеивать", "пренебрегать", "трусость", "трусливый"], "correct_index": 1}, {"question": "Что означает немецкое слово «feige»?", "choices": ["дерзкий", "трусливый", "пренебрегать", "оскорбление"], "correct_index": 1}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["шпионить", "предательство", "шпион", "скрытность"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["скрытность", "шпион", "шпионить", "предательство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["скрытность", "шпионить", "шпион", "выдавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["выдавать", "шпион", "шпионить", "предательство"], "correct_index": 2}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["подслушивать", "шпионить", "шпион", "скрытность"], "correct_index": 0}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["подслушивать", "шпион", "предательство", "выдавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["выдавать", "шпионить", "вынюхивать", "предательство"], "correct_index": 2}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["план", "ковать", "коварство", "интрига"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["ковать", "интрига", "коварство", "план"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["коварный", "ковать", "коварство", "ловушка"], "correct_index": 2}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["план", "обманывать", "ковать", "ловушка"], "correct_index": 2}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["коварный", "ловушка", "обманывать", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["коварный", "интрига", "обманывать", "хитрый"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["план", "коварство", "коварный", "хитрый"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["ловушка", "хитрый", "коварный", "обманывать"], "correct_index": 0}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["охота", "гнаться", "преследовать", "преследование"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["гнаться", "преследование", "охота", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["гнаться", "преследование", "охота", "преследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["преследование", "преследовать", "гнаться", "охота"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["преследование", "выслеживать", "гнаться", "охота"], "correct_index": 1}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["выслеживать", "добыча", "гнаться", "травить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["преследовать", "преследование", "добыча", "гнаться"], "correct_index": 2}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["поражение", "смерть", "трусость", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["смерть", "поражение", "трусость", "падать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["проигрывать", "трусость", "поражение", "хныкать"], "correct_index": 2}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["умолять", "жалкий", "поражение", "падать"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["хныкать", "трусость", "падать", "проигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["умолять", "хныкать", "проигрывать", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["умолять", "трусость", "смерть", "проигрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["жалкий", "умолять", "хныкать", "трусость"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["преданность", "служить", "слуга", "послушание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["слуга", "послушание", "преданность", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["преданность", "управляющий", "покорный", "исполнять"], "correct_index": 0}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["слуга", "покорный", "служить", "раболепный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["слуга", "управляющий", "послушание", "покорный"], "correct_index": 1}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["покорный", "преданность", "служить", "слуга"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["раболепный", "исполнять", "слуга", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["покорный", "служить", "слуга", "исполнять"], "correct_index": 3}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["поручение", "передавать", "спешка", "гонец"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["передавать", "поручение", "спешка", "гонец"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["спешить", "гонец", "спешка", "торопиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["торопиться", "спешка", "передавать", "поручение"], "correct_index": 2}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["передавать", "торопиться", "послание", "спешить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["спешить", "гонец", "послание", "спешка"], "correct_index": 2}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["передавать", "торопиться", "спешить", "послание"], "correct_index": 1}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["трусость", "оскорбление", "оскорблять", "неуважение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорблять", "оскорбление", "неуважение", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["дерзкий", "трусость", "пренебрегать", "трусливый"], "correct_index": 1}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["дерзкий", "оскорблять", "высмеивать", "трусость"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["трусость", "неуважение", "высмеивать", "оскорблять"], "correct_index": 2}, {"question": "Что означает немецкое слово «frech»?", "choices": ["оскорблять", "дерзкий", "высмеивать", "неуважение"], "correct_index": 1}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["трусость", "дерзкий", "пренебрегать", "высмеивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «feige»?", "choices": ["пренебрегать", "трусливый", "высмеивать", "неуважение"], "correct_index": 1}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["скрытность", "шпионить", "шпион", "предательство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["шпионить", "предательство", "шпион", "скрытность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["шпионить", "скрытность", "выдавать", "шпион"], "correct_index": 1}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["скрытность", "подслушивать", "шпионить", "предательство"], "correct_index": 2}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["шпион", "скрытность", "вынюхивать", "подслушивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["шпионить", "предательство", "выдавать", "подслушивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["подслушивать", "вынюхивать", "предательство", "шпион"], "correct_index": 1}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["план", "ковать", "интрига", "коварство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["план", "интрига", "коварство", "ковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["хитрый", "обманывать", "план", "коварство"], "correct_index": 3}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["интрига", "коварство", "ковать", "коварный"], "correct_index": 2}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["хитрый", "ковать", "коварный", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["план", "коварство", "интрига", "коварный"], "correct_index": 3}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["интрига", "хитрый", "ковать", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["ловушка", "коварство", "план", "интрига"], "correct_index": 0}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["охота", "гнаться", "преследование", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["преследовать", "гнаться", "охота", "преследование"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["добыча", "преследовать", "выслеживать", "травить"], "correct_index": 1}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["охота", "выслеживать", "гнаться", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["выслеживать", "травить", "охота", "гнаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["гнаться", "преследовать", "добыча", "травить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["гнаться", "преследование", "выслеживать", "добыча"], "correct_index": 3}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "поражение", "трусость", "падать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["трусость", "падать", "смерть", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["поражение", "трусость", "проигрывать", "хныкать"], "correct_index": 0}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "смерть", "жалкий", "хныкать"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["смерть", "проигрывать", "хныкать", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["умолять", "жалкий", "хныкать", "проигрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["трусость", "жалкий", "умолять", "проигрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["трусость", "жалкий", "смерть", "поражение"], "correct_index": 1}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -454,15 +454,15 @@
             <div class="quiz-phase-container active" data-phase="steward">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
                             
@@ -486,45 +486,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Ergebenheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">покорный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раболепный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">управляющий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
@@ -534,15 +518,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">исполнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">покорный</button>
                             
@@ -550,17 +534,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">исполнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раболепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">исполнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -570,9 +570,9 @@
                         <div class="quiz-question">Что означает немецкое слово «befolgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                             
@@ -589,17 +589,17 @@
             <div class="quiz-phase-container" data-phase="messenger">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Bote»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -609,45 +609,45 @@
                         <div class="quiz-question">Что означает немецкое слово «der Auftrag»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Eile»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «überbringen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">торопиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">послание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -661,7 +661,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">послание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">спешить</button>
                             
@@ -675,27 +675,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">послание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «eilen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">торопиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -708,29 +708,13 @@
             <div class="quiz-phase-container" data-phase="insult">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Beleidigung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Respektlosigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
                             
@@ -740,31 +724,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Respektlosigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дерзкий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «beleidigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">высмеивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">неуважение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
                             
@@ -772,49 +740,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пренебрегать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусливый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «frech»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «beleidigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дерзкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">неуважение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «frech»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дерзкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">высмеивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пренебрегать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дерзкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пренебрегать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">трусливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -824,13 +824,13 @@
                         <div class="quiz-question">Что означает немецкое слово «feige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">трусливый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пренебрегать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -847,6 +847,22 @@
                         <div class="quiz-question">Что означает немецкое слово «der Spion»?</div>
                         <div class="quiz-choices">
                             
+                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
+                        <div class="quiz-choices">
+                            
                             <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
@@ -859,33 +875,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -895,9 +895,9 @@
                         <div class="quiz-question">Что означает немецкое слово «spionieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
                             
@@ -907,49 +907,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «lauschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подслушивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подслушивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «schnüffeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">вынюхивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «schnüffeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подслушивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вынюхивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -962,7 +962,7 @@
             <div class="quiz-phase-container" data-phase="schemer">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                         <div class="quiz-choices">
                             
@@ -970,41 +970,41 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1014,61 +1014,61 @@
                         <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «hintergehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «tückisch»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verschlagen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verschlagen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1080,11 +1080,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1097,7 +1097,7 @@
             <div class="quiz-phase-container" data-phase="pursuer">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verfolgung»?</div>
                         <div class="quiz-choices">
                             
@@ -1105,9 +1105,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1117,29 +1117,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Jagd»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">добыча</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выслеживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1149,29 +1149,29 @@
                         <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выслеживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1181,11 +1181,11 @@
                         <div class="quiz-question">Что означает немецкое слово «hetzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выслеживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">добыча</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
                             
@@ -1193,17 +1193,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Beute»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выслеживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">добыча</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1216,24 +1216,8 @@
             <div class="quiz-phase-container" data-phase="coward_death">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
@@ -1248,63 +1232,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хныкать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
@@ -1312,15 +1248,63 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
                             
@@ -1328,17 +1312,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erbärmlich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жалкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умолять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1367,8 +1367,10 @@
                 "transcription": "[дер ДИ-нер]",
                 "sentence": "Als Diener gehorche ich meiner Herrin blind.",
                 "sentenceTranslation": "Как слуга я слепо подчиняюсь своей госпоже.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Diener",
                     "Множественное число (пример): die Diener",
@@ -1389,8 +1391,12 @@
                 "transcription": "[дер ге-ХОР-зам]",
                 "sentence": "Mein Gehorsam kennt keine Fragen.",
                 "sentenceTranslation": "Моё послушание не знает вопросов.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
                 "wordFamily": [
                     "Основа: der Gehorsam",
                     "Множественное число (пример): die Gehorsame",
@@ -1409,8 +1415,12 @@
                 "transcription": "[ди ер-ГЕ-бен-хайт]",
                 "sentence": "Meine Ergebenheit gilt nur Lady Goneril.",
                 "sentenceTranslation": "Моя преданность принадлежит только леди Гонерилье.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
                 "wordFamily": [
                     "Основа: die Ergebenheit",
                     "Множественное число (пример): die Ergebenheiten",
@@ -1429,8 +1439,10 @@
                 "transcription": "[ДИ-нен]",
                 "sentence": "Ich diene ohne Gewissen oder Ehre.",
                 "sentenceTranslation": "Я служу без совести и чести.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: dienen",
                     "Презенс: ich diene",
@@ -1451,8 +1463,12 @@
                 "transcription": "[дер фер-ВАЛЬ-тер]",
                 "sentence": "Als Verwalter kontrolliere ich den Haushalt.",
                 "sentenceTranslation": "Как управляющий я контролирую дом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
                 "wordFamily": [
                     "Основа: der Verwalter",
                     "Множественное число (пример): die Verwalter",
@@ -1471,8 +1487,12 @@
                 "transcription": "[ер-ГЕ-бен]",
                 "sentence": "Ergeben folge ich jedem Befehl.",
                 "sentenceTranslation": "Покорно я следую каждому приказу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
                 "wordFamily": [
                     "Основная форма: ergeben",
                     "Сравнительная степень: ergebener",
@@ -1491,8 +1511,12 @@
                 "transcription": "[УН-тер-вюр-фиг]",
                 "sentence": "Unterwürfig krieche ich vor meiner Herrin.",
                 "sentenceTranslation": "Раболепно я пресмыкаюсь перед госпожой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
                 "wordFamily": [
                     "Основная форма: unterwürfig",
                     "Сравнительная степень: unterwürfiger",
@@ -1511,8 +1535,12 @@
                 "transcription": "[бе-ФОЛЬ-ген]",
                 "sentence": "Jeden Befehl befolge ich sofort.",
                 "sentenceTranslation": "Каждый приказ я исполняю немедленно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
                 "wordFamily": [
                     "Инфинитив: befolgen",
                     "Презенс: ich befolge",
@@ -1560,8 +1588,10 @@
                 "transcription": "[дер БО-те]",
                 "sentence": "Als Bote überbringe ich böse Nachrichten.",
                 "sentenceTranslation": "Как гонец я приношу дурные вести.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Bote",
                     "Множественное число (пример): die Bote",
@@ -1582,8 +1612,12 @@
                 "transcription": "[дер АУФ-траг]",
                 "sentence": "Jeden Auftrag erfülle ich gewissenhaft.",
                 "sentenceTranslation": "Каждое поручение я выполняю добросовестно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
                 "wordFamily": [
                     "Основа: der Auftrag",
                     "Множественное число (пример): die Auftrage",
@@ -1602,8 +1636,12 @@
                 "transcription": "[ди АЙ-ле]",
                 "sentence": "In großer Eile renne ich hin und her.",
                 "sentenceTranslation": "В большой спешке я бегаю туда-сюда.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
                 "wordFamily": [
                     "Основа: die Eile",
                     "Множественное число (пример): die Eile",
@@ -1622,8 +1660,12 @@
                 "transcription": "[ю-бер-БРИН-ген]",
                 "sentence": "Ich überbringe Befehle an alle Diener.",
                 "sentenceTranslation": "Я передаю приказы всем слугам.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
                 "wordFamily": [
                     "Инфинитив: überbringen",
                     "Презенс: ich bringe über",
@@ -1642,8 +1684,12 @@
                 "transcription": "[ХАС-тен]",
                 "sentence": "Ich haste von einem Ort zum anderen.",
                 "sentenceTranslation": "Я спешу с места на место.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
                 "wordFamily": [
                     "Инфинитив: hasten",
                     "Презенс: ich haste",
@@ -1662,8 +1708,12 @@
                 "transcription": "[ди БОТ-шафт]",
                 "sentence": "Die Botschaft meiner Herrin ist grausam.",
                 "sentenceTranslation": "Послание моей госпожи жестоко.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
                 "wordFamily": [
                     "Основа: die Botschaft",
                     "Множественное число (пример): die Botschafte",
@@ -1682,8 +1732,12 @@
                 "transcription": "[АЙ-лен]",
                 "sentence": "Ich eile, um ihre Wünsche zu erfüllen.",
                 "sentenceTranslation": "Я тороплюсь исполнить её желания.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
                 "wordFamily": [
                     "Инфинитив: eilen",
                     "Презенс: ich eile",
@@ -1730,8 +1784,12 @@
                 "transcription": "[ди бе-ЛАЙ-ди-гунг]",
                 "sentence": "Jede Beleidigung spreche ich mit Genuss aus.",
                 "sentenceTranslation": "Каждое оскорбление я произношу с наслаждением.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit"
+                ],
                 "wordFamily": [
                     "Основа: die Beleidigung",
                     "Множественное число (пример): die Beleidigungen",
@@ -1750,8 +1808,12 @@
                 "transcription": "[ди рес-ПЕКТ-ло-зиг-кайт]",
                 "sentence": "Meine Respektlosigkeit kennt keine Grenzen.",
                 "sentenceTranslation": "Моё неуважение не знает границ.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit"
+                ],
                 "wordFamily": [
                     "Основа: die Respektlosigkeit",
                     "Множественное число (пример): die Respektlosigkeiten",
@@ -1770,8 +1832,14 @@
                 "transcription": "[ди ФАЙГ-хайт]",
                 "sentence": "Aus Feigheit greife ich nur Schwache an.",
                 "sentenceTranslation": "Из трусости я нападаю только на слабых.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Niederlage",
+                    "Respektlosigkeit",
+                    "Tod"
+                ],
                 "wordFamily": [
                     "Основа: die Feigheit",
                     "Множественное число (пример): die Feigheiten",
@@ -1791,8 +1859,10 @@
                 "transcription": "[бе-ЛАЙ-ди-ген]",
                 "sentence": "Ich beleidige den alten König ohne Scham.",
                 "sentenceTranslation": "Я оскорбляю старого короля без стыда.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: beleidigen",
                     "Презенс: ich beleidige",
@@ -1812,8 +1882,15 @@
                 "transcription": "[фер-ХЁ-нен]",
                 "sentence": "Ich verhöhne seine königliche Würde.",
                 "sentenceTranslation": "Я высмеиваю его королевское достоинство.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Инфинитив: verhöhnen",
                     "Презенс: ich verhöhne",
@@ -1835,8 +1912,12 @@
                 "transcription": "[ФРЕХ]",
                 "sentence": "Frech widerspreche ich dem alten Mann.",
                 "sentenceTranslation": "Дерзко я возражаю старику.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit"
+                ],
                 "wordFamily": [
                     "Основная форма: frech",
                     "Сравнительная степень: frecher",
@@ -1855,8 +1936,12 @@
                 "transcription": "[МИС-ах-тен]",
                 "sentence": "Ich missachte seinen früheren Rang.",
                 "sentenceTranslation": "Я пренебрегаю его прежним рангом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit"
+                ],
                 "wordFamily": [
                     "Инфинитив: missachten",
                     "Презенс: ich missachte",
@@ -1875,8 +1960,12 @@
                 "transcription": "[ФАЙ-ге]",
                 "sentence": "Feige verstecke ich mich hinter meiner Herrin.",
                 "sentenceTranslation": "Трусливо я прячусь за своей госпожой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit"
+                ],
                 "wordFamily": [
                     "Основная форма: feige",
                     "Сравнительная степень: feiger",
@@ -1923,8 +2012,12 @@
                 "transcription": "[дер шпи-ОН]",
                 "sentence": "Als Spion lausche ich an jeder Tür.",
                 "sentenceTranslation": "Как шпион я подслушиваю у каждой двери.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Heimlichkeit",
+                    "Spion",
+                    "Verrat"
+                ],
                 "wordFamily": [
                     "Основа: der Spion",
                     "Множественное число (пример): die Spione",
@@ -1943,8 +2036,10 @@
                 "transcription": "[дер фер-РАТ]",
                 "sentence": "Der Verrat ist mein tägliches Geschäft.",
                 "sentenceTranslation": "Предательство - моё ежедневное дело.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Verrat",
                     "Множественное число (пример): die Verrate",
@@ -1967,8 +2062,12 @@
                 "transcription": "[ди ХАЙМ-лих-кайт]",
                 "sentence": "In Heimlichkeit sammle ich Informationen.",
                 "sentenceTranslation": "В скрытности я собираю информацию.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Heimlichkeit",
+                    "Spion",
+                    "Verrat"
+                ],
                 "wordFamily": [
                     "Основа: die Heimlichkeit",
                     "Множественное число (пример): die Heimlichkeiten",
@@ -1987,8 +2086,12 @@
                 "transcription": "[шпи-о-НИ-рен]",
                 "sentence": "Ich spioniere für meine böse Herrin.",
                 "sentenceTranslation": "Я шпионю для моей злой госпожи.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Heimlichkeit",
+                    "Spion",
+                    "Verrat"
+                ],
                 "wordFamily": [
                     "Инфинитив: spionieren",
                     "Презенс: ich spioniere",
@@ -2007,8 +2110,12 @@
                 "transcription": "[ЛАУ-шен]",
                 "sentence": "Heimlich lausche ich allen Gesprächen.",
                 "sentenceTranslation": "Тайно я подслушиваю все разговоры.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Heimlichkeit",
+                    "Spion",
+                    "Verrat"
+                ],
                 "wordFamily": [
                     "Инфинитив: lauschen",
                     "Презенс: ich lausche",
@@ -2027,8 +2134,10 @@
                 "transcription": "[фер-РА-тен]",
                 "sentence": "Ich verrate jeden an meine Herrin.",
                 "sentenceTranslation": "Я выдаю каждого своей госпоже.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verraten",
                     "Презенс: ich verrate",
@@ -2053,8 +2162,12 @@
                 "transcription": "[ШНЮФ-фельн]",
                 "sentence": "Überall schnüffle ich nach Geheimnissen.",
                 "sentenceTranslation": "Везде я вынюхиваю секреты.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Heimlichkeit",
+                    "Spion",
+                    "Verrat"
+                ],
                 "wordFamily": [
                     "Инфинитив: schnüffeln",
                     "Презенс: ich schnüffele",
@@ -2101,8 +2214,10 @@
                 "transcription": "[ди ин-ТРИ-ге]",
                 "sentence": "Jede Intrige spinne ich mit Freude.",
                 "sentenceTranslation": "Каждую интригу я плету с радостью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: die Intrige",
                     "Множественное число (пример): die Intrige",
@@ -2125,8 +2240,15 @@
                 "transcription": "[дер ПЛАН]",
                 "sentence": "Mein hinterhältiger Plan wird funktionieren.",
                 "sentenceTranslation": "Мой коварный план сработает.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan",
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
                 "wordFamily": [
                     "Основа: der Plan",
                     "Множественное число (пример): die Plane",
@@ -2146,8 +2268,12 @@
                 "transcription": "[ди ХИН-тер-лист]",
                 "sentence": "Mit Hinterlist verfolge ich meine Ziele.",
                 "sentenceTranslation": "С коварством я преследую свои цели.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan"
+                ],
                 "wordFamily": [
                     "Основа: die Hinterlist",
                     "Множественное число (пример): die Hinterliste",
@@ -2166,8 +2292,12 @@
                 "transcription": "[ШМИ-ден]",
                 "sentence": "Ich schmiede Pläne gegen alle Feinde.",
                 "sentenceTranslation": "Я кую планы против всех врагов.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan"
+                ],
                 "wordFamily": [
                     "Инфинитив: schmieden",
                     "Презенс: ich schmiede",
@@ -2186,8 +2316,12 @@
                 "transcription": "[ХИН-тер-ге-ен]",
                 "sentence": "Ich hintergehe jeden, der mir traut.",
                 "sentenceTranslation": "Я обманываю каждого, кто мне доверяет.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan"
+                ],
                 "wordFamily": [
                     "Инфинитив: hintergehen",
                     "Презенс: ich tergehe hin",
@@ -2208,8 +2342,12 @@
                 "transcription": "[ТЮ-киш]",
                 "sentence": "Tückisch plane ich meinen nächsten Schritt.",
                 "sentenceTranslation": "Коварно я планирую свой следующий шаг.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan"
+                ],
                 "wordFamily": [
                     "Основная форма: tückisch",
                     "Сравнительная степень: tückischer",
@@ -2228,8 +2366,12 @@
                 "transcription": "[фер-ШЛАГ-ен]",
                 "sentence": "Verschlagen verberge ich meine wahren Absichten.",
                 "sentenceTranslation": "Хитро я скрываю свои истинные намерения.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan"
+                ],
                 "wordFamily": [
                     "Основная форма: verschlagen",
                     "Сравнительная степень: verschlagener",
@@ -2248,8 +2390,15 @@
                 "transcription": "[ди ФА-ле]",
                 "sentence": "Ich stelle Fallen für die Ahnungslosen.",
                 "sentenceTranslation": "Я ставлю ловушки для ничего не подозревающих.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Brief",
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan",
+                    "glauben",
+                    "täuschen"
+                ],
                 "wordFamily": [
                     "Основа: die Falle",
                     "Множественное число (пример): die Falle",
@@ -2297,8 +2446,12 @@
                 "transcription": "[ди фер-ФОЛЬ-гунг]",
                 "sentence": "Die Verfolgung des blinden Grafen beginnt.",
                 "sentenceTranslation": "Преследование слепого графа начинается.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung"
+                ],
                 "wordFamily": [
                     "Основа: die Verfolgung",
                     "Множественное число (пример): die Verfolgungen",
@@ -2317,8 +2470,12 @@
                 "transcription": "[ди ЯГДТ]",
                 "sentence": "Die Jagd auf Gloucester macht mir Spaß.",
                 "sentenceTranslation": "Охота на Глостера доставляет мне удовольствие.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung"
+                ],
                 "wordFamily": [
                     "Основа: die Jagd",
                     "Множественное число (пример): die Jagde",
@@ -2337,8 +2494,10 @@
                 "transcription": "[фер-ФОЛЬ-ген]",
                 "sentence": "Gnadenlos verfolge ich den alten Mann.",
                 "sentenceTranslation": "Безжалостно я преследую старика.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verfolgen",
                     "Презенс: ich verfolge",
@@ -2359,8 +2518,15 @@
                 "transcription": "[Я-ген]",
                 "sentence": "Wie ein Hund jage ich meine Beute.",
                 "sentenceTranslation": "Как собака я гонюсь за добычей.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung",
+                    "bereuen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Инфинитив: jagen",
                     "Презенс: ich jage",
@@ -2381,8 +2547,12 @@
                 "transcription": "[АУФ-шпю-рен]",
                 "sentence": "Ich spüre den Flüchtling überall auf.",
                 "sentenceTranslation": "Я выслеживаю беглеца повсюду.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung"
+                ],
                 "wordFamily": [
                     "Инфинитив: aufspüren",
                     "Презенс: ich spüre auf",
@@ -2401,8 +2571,12 @@
                 "transcription": "[ХЕ-цен]",
                 "sentence": "Ich hetze ihn bis zum Ende.",
                 "sentenceTranslation": "Я травлю его до конца.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung"
+                ],
                 "wordFamily": [
                     "Инфинитив: hetzen",
                     "Презенс: ich hetze",
@@ -2421,8 +2595,12 @@
                 "transcription": "[ди БОЙ-те]",
                 "sentence": "Der Graf ist meine leichte Beute.",
                 "sentenceTranslation": "Граф - моя лёгкая добыча.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung"
+                ],
                 "wordFamily": [
                     "Основа: die Beute",
                     "Множественное число (пример): die Beute",
@@ -2469,8 +2647,10 @@
                 "transcription": "[дер ТОД]",
                 "sentence": "Der Tod ereilt mich durch Эдгars Hand.",
                 "sentenceTranslation": "Смерть настигает меня от руки Эдгара.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Основа: der Tod",
                     "Множественное число (пример): die Tode",
@@ -2494,8 +2674,14 @@
                 "transcription": "[ди ФАЙГ-хайт]",
                 "sentence": "Meine Feigheit führt zu meinem Ende.",
                 "sentenceTranslation": "Моя трусость приводит к моему концу.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Niederlage",
+                    "Respektlosigkeit",
+                    "Tod"
+                ],
                 "wordFamily": [
                     "Основа: die Feigheit",
                     "Множественное число (пример): die Feigheiten",
@@ -2515,8 +2701,15 @@
                 "transcription": "[ди НИ-дер-ла-ге]",
                 "sentence": "Die Niederlage ist mein letztes Schicksal.",
                 "sentenceTranslation": "Поражение - моя последняя судьба.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Duell",
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod",
+                    "bereuen",
+                    "fallen"
+                ],
                 "wordFamily": [
                     "Основа: die Niederlage",
                     "Множественное число (пример): die Niederlage",
@@ -2536,8 +2729,10 @@
                 "transcription": "[ФА-лен]",
                 "sentence": "Ich falle wie der Feigling, der ich bin.",
                 "sentenceTranslation": "Я падаю как трус, которым являюсь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: fallen",
                     "Презенс: ich falle",
@@ -2559,8 +2754,12 @@
                 "transcription": "[ун-тер-ЛИ-ген]",
                 "sentence": "Ich unterliege dem edlen Edgar.",
                 "sentenceTranslation": "Я проигрываю благородному Эдгару.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod"
+                ],
                 "wordFamily": [
                     "Инфинитив: unterliegen",
                     "Презенс: ich unterliege",
@@ -2580,8 +2779,12 @@
                 "transcription": "[ВИМ-мерн]",
                 "sentence": "Wimmernd bitte ich um Gnade.",
                 "sentenceTranslation": "Хныкая, я прошу о пощаде.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod"
+                ],
                 "wordFamily": [
                     "Инфинитив: wimmern",
                     "Презенс: ich wimmere",
@@ -2600,8 +2803,15 @@
                 "transcription": "[БЕ-тельн]",
                 "sentence": "Um mein Leben bettle ich vergeblich.",
                 "sentenceTranslation": "О жизни я умоляю напрасно.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod",
+                    "Verzweiflung",
+                    "verlassen",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Инфинитив: betteln",
                     "Презенс: ich bettele",
@@ -2623,8 +2833,12 @@
                 "transcription": "[ер-БЕРМ-лих]",
                 "sentence": "Erbärmlich ende ich wie ich gelebt habe.",
                 "sentenceTranslation": "Жалко я заканчиваю, как и жил.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod"
+                ],
                 "wordFamily": [
                     "Основная форма: erbärmlich",
                     "Сравнительная степень: erbärmlicher",

--- a/output/journeys/regan.html
+++ b/output/journeys/regan.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["состязаться", "превосходить", "фальшь", "притворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["превосходить", "состязаться", "фальшь", "притворяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["разыгрывать", "превосходить", "состязаться", "фальшь"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["состязаться", "фальшь", "притворяться", "выманивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["состязаться", "разыгрывать", "хитрость", "фальшь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["превосходить", "хитрость", "притворяться", "алчность"], "correct_index": 1}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["притворяться", "превосходить", "выманивать", "состязаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["алчность", "притворяться", "выманивать", "разыгрывать"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["союз", "делить", "заговорить", "планировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["заговорить", "союз", "делить", "планировать"], "correct_index": 2}, {"question": "Что означает немецкое слово «planen»?", "choices": ["стратегия", "сговор", "планировать", "союз"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["союз", "заговорить", "стратегия", "делить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["сговор", "союз", "стратегия", "планировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["планировать", "договариваться", "делить", "сговор"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["союз", "делить", "планировать", "стратегия"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["насмехаться", "пытать", "злоба", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["злоба", "пытать", "насмехаться", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["жестокость", "злоба", "насмехаться", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["отвергать", "жёсткость", "злоба", "жестоко обращаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["жестоко обращаться", "унижать", "отвергать", "жёсткость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жестоко обращаться", "жёсткость", "пытать", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["отвергать", "жестокость", "жестоко обращаться", "жёсткость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестоко обращаться", "жестокость", "пытать", "отвергать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["наслаждаться", "садизм", "ослеплять", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["наслаждаться", "ослеплять", "выкалывать", "садизм"], "correct_index": 3}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["ослеплять", "растаптывать", "наслаждаться", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["наслаждаться", "садизм", "брутальность", "выкалывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["выкалывать", "пытка", "беспощадный", "растаптывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["беспощадный", "выкалывать", "брутальность", "пытка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["брутальность", "пытка", "ослеплять", "наслаждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["наслаждаться", "растаптывать", "брутальность", "беспощадный"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["соблазнять", "вожделение", "вожделеть", "вдова"], "correct_index": 3}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["соблазнять", "вожделение", "вожделеть", "вдова"], "correct_index": 2}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["добиваться", "вожделение", "соблазнять", "заманивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["вожделеть", "заманивать", "похоть", "вожделение"], "correct_index": 3}, {"question": "Что означает немецкое слово «locken»?", "choices": ["заманивать", "вдова", "добиваться", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["вожделение", "вдова", "вожделеть", "похоть"], "correct_index": 3}, {"question": "Что означает немецкое слово «werben»?", "choices": ["похоть", "вожделеть", "вдова", "добиваться"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["ненавидеть", "соревноваться", "соперничество", "угрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["угрожать", "ненавидеть", "соревноваться", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["соперничество", "бороться", "угрожать", "подозревать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["соревноваться", "соперничество", "не доверять", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["ненавидеть", "бороться", "соревноваться", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["ненавидеть", "не доверять", "угрожать", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["соревноваться", "подозревать", "не доверять", "бороться"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["страдать", "мучение", "издыхать", "отравленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["мучение", "отравленный", "издыхать", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["расплачиваться", "страдать", "проклятый", "издыхать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["страдать", "расплачиваться", "проклинать", "мучение"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["мучение", "страдать", "проклинать", "проклятый"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["мучение", "издыхать", "проклинать", "рок"], "correct_index": 3}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["страдать", "расплачиваться", "издыхать", "проклятый"], "correct_index": 1}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["рок", "расплачиваться", "проклятый", "мучение"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["состязаться", "превосходить", "притворяться", "фальшь"], "correct_index": 2}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["превосходить", "состязаться", "притворяться", "фальшь"], "correct_index": 0}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["состязаться", "алчность", "фальшь", "выманивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["состязаться", "фальшь", "хитрость", "алчность"], "correct_index": 1}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["разыгрывать", "превосходить", "хитрость", "состязаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["хитрость", "притворяться", "фальшь", "выманивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["выманивать", "притворяться", "разыгрывать", "состязаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["алчность", "превосходить", "фальшь", "разыгрывать"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["делить", "планировать", "союз", "заговорить"], "correct_index": 2}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["заговорить", "союз", "делить", "планировать"], "correct_index": 2}, {"question": "Что означает немецкое слово «planen»?", "choices": ["сговор", "союз", "заговорить", "планировать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["заговорить", "договариваться", "планировать", "делить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["союз", "сговор", "заговорить", "делить"], "correct_index": 1}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["заговорить", "планировать", "договариваться", "союз"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["сговор", "планировать", "стратегия", "делить"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["пытать", "насмехаться", "злоба", "унижать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["унижать", "злоба", "пытать", "насмехаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["отвергать", "насмехаться", "жёсткость", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["злоба", "унижать", "жестокость", "жёсткость"], "correct_index": 0}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["жёсткость", "пытать", "жестокость", "жестоко обращаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["насмехаться", "жёсткость", "жестокость", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["жёсткость", "злоба", "отвергать", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "унижать", "пытать", "насмехаться"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "выкалывать", "наслаждаться", "садизм"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["садизм", "ослеплять", "выкалывать", "наслаждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["выкалывать", "садизм", "беспощадный", "наслаждаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["брутальность", "ослеплять", "выкалывать", "растаптывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["выкалывать", "брутальность", "пытка", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["ослеплять", "беспощадный", "наслаждаться", "выкалывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["наслаждаться", "растаптывать", "беспощадный", "брутальность"], "correct_index": 3}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["брутальность", "ослеплять", "растаптывать", "пытка"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вожделеть", "вдова", "вожделение", "соблазнять"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вожделеть", "вожделение", "соблазнять", "вдова"], "correct_index": 0}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["вдова", "добиваться", "похоть", "соблазнять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["вожделение", "соблазнять", "заманивать", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «locken»?", "choices": ["заманивать", "похоть", "добиваться", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["вожделеть", "заманивать", "похоть", "добиваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «werben»?", "choices": ["соблазнять", "добиваться", "вожделение", "вдова"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["соперничество", "соревноваться", "ненавидеть", "угрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["угрожать", "соревноваться", "соперничество", "ненавидеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["соперничество", "подозревать", "угрожать", "ненавидеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["не доверять", "подозревать", "соперничество", "бороться"], "correct_index": 2}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["бороться", "угрожать", "соревноваться", "не доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["подозревать", "соревноваться", "ненавидеть", "не доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["соперничество", "соревноваться", "подозревать", "угрожать"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["отравленный", "мучение", "издыхать", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["отравленный", "страдать", "мучение", "издыхать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["проклятый", "отравленный", "проклинать", "издыхать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["страдать", "расплачиваться", "мучение", "издыхать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["проклятый", "расплачиваться", "проклинать", "мучение"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["проклинать", "рок", "издыхать", "мучение"], "correct_index": 1}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["издыхать", "расплачиваться", "проклинать", "рок"], "correct_index": 1}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["отравленный", "проклятый", "расплачиваться", "страдать"], "correct_index": 1}]}'>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
 
@@ -454,7 +454,7 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «vortäuschen»?</div>
                         <div class="quiz-choices">
                             
@@ -462,9 +462,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -478,25 +478,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «wetteifern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">алчность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">состязаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -510,39 +510,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">разыгрывать</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">алчность</button>
                             
@@ -550,15 +518,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «erschleichen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erschleichen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выманивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
                             
@@ -572,9 +572,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">разыгрывать</button>
                             
@@ -589,17 +589,17 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -621,47 +621,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «planen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стратегия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сговор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
                             
@@ -669,33 +637,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">договариваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Strategie»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">договариваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Strategie»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сговор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">стратегия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -708,13 +708,13 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                             
@@ -724,65 +724,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жёсткость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестоко обращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестоко обращаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -792,11 +792,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жёсткость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
                             
@@ -804,33 +804,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «abweisen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестоко обращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -843,31 +843,15 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
                             
@@ -875,13 +859,77 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «genießen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">брутальность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">растаптывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">растаптывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
                             
@@ -891,81 +939,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">растаптывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Brutalität»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">брутальность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">растаптывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">брутальность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">растаптывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -978,65 +978,65 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Witwe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">добиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">заманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">заманивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1048,7 +1048,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
                             
@@ -1058,33 +1058,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «werben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1101,11 +1101,11 @@
                         <div class="quiz-question">Что означает немецкое слово «wettkämpfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
                             
@@ -1113,17 +1113,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1135,25 +1135,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">не доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
@@ -1161,49 +1145,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «argwöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">не доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">не доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">не доверять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">не доверять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «argwöhnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1216,29 +1216,13 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «vergiftet»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                             
@@ -1248,15 +1232,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">расплачиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                             
@@ -1264,7 +1248,23 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклятый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
                         <div class="quiz-choices">
                             
@@ -1272,9 +1272,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1284,29 +1284,29 @@
                         <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклятый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Verhängnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1316,29 +1316,29 @@
                         <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verflucht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">рок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклятый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1367,8 +1367,12 @@
                 "transcription": "[ФОР-той-шен]",
                 "sentence": "Ich täusche Liebe vor, die nie existierte.",
                 "sentenceTranslation": "Я притворяюсь в любви, которой никогда не было.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
                 "wordFamily": [
                     "Инфинитив: vortäuschen",
                     "Презенс: ich täusche vor",
@@ -1388,8 +1392,12 @@
                 "transcription": "[ю-бер-ТРЕ-фен]",
                 "sentence": "Ich will meine Schwester in der Lüge übertreffen.",
                 "sentenceTranslation": "Я хочу превзойти сестру во лжи.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
                 "wordFamily": [
                     "Инфинитив: übertreffen",
                     "Презенс: ich treffe über",
@@ -1408,8 +1416,12 @@
                 "transcription": "[ВЕТ-ай-ферн]",
                 "sentence": "Wir wetteifern um das größte Erbe.",
                 "sentenceTranslation": "Мы состязаемся за большее наследство.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
                 "wordFamily": [
                     "Инфинитив: wetteifern",
                     "Презенс: ich wetteifere",
@@ -1428,8 +1440,12 @@
                 "transcription": "[ди ФАЛЬШ-хайт]",
                 "sentence": "Meine Falschheit kennt keine Grenzen.",
                 "sentenceTranslation": "Моя фальшь не знает границ.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
                 "wordFamily": [
                     "Основа: die Falschheit",
                     "Множественное число (пример): die Falschheiten",
@@ -1448,8 +1464,12 @@
                 "transcription": "[ФОР-шпи-лен]",
                 "sentence": "Ich spiele ihm Töchterliebe vor.",
                 "sentenceTranslation": "Я разыгрываю перед ним дочернюю любовь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
                 "wordFamily": [
                     "Инфинитив: vorspielen",
                     "Презенс: ich spiele vor",
@@ -1468,8 +1488,18 @@
                 "transcription": "[ди ЛИСТ]",
                 "sentence": "Mit List gewinne ich sein Vertrauen.",
                 "sentenceTranslation": "Хитростью я завоёвываю его доверие.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Klippe",
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung",
+                    "blind",
+                    "führen",
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
                 "wordFamily": [
                     "Основа: die List",
                     "Множественное число (пример): die Liste",
@@ -1490,8 +1520,12 @@
                 "transcription": "[ер-ШЛАЙ-хен]",
                 "sentence": "Ich erschleiche mir sein Königreich.",
                 "sentenceTranslation": "Я выманиваю его королевство.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
                 "wordFamily": [
                     "Инфинитив: erschleichen",
                     "Презенс: ich erschleiche",
@@ -1510,8 +1544,12 @@
                 "transcription": "[ди ХАБ-гир]",
                 "sentence": "Die Habgier treibt meine süßen Worte.",
                 "sentenceTranslation": "Алчность движет моими сладкими словами.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
                 "wordFamily": [
                     "Основа: die Habgier",
                     "Множественное число (пример): die Habgier",
@@ -1558,8 +1596,15 @@
                 "transcription": "[дас БЮНД-нис]",
                 "sentence": "Ein Bündnis mit Goneril gegen unseren Vater.",
                 "sentenceTranslation": "Союз с Гонерильей против нашего отца.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bündnis",
+                    "Macht",
+                    "erobern",
+                    "planen",
+                    "teilen",
+                    "verbünden"
+                ],
                 "wordFamily": [
                     "Основа: das Bündnis",
                     "Множественное число (пример): die Bündnise",
@@ -1579,8 +1624,10 @@
                 "transcription": "[ТАЙ-лен]",
                 "sentence": "Wir teilen das Reich zwischen uns.",
                 "sentenceTranslation": "Мы делим королевство между собой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: teilen",
                     "Презенс: ich teile",
@@ -1600,8 +1647,12 @@
                 "transcription": "[ПЛА-нен]",
                 "sentence": "Wir planen den Untergang des alten Königs.",
                 "sentenceTranslation": "Мы планируем падение старого короля.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bündnis",
+                    "planen",
+                    "teilen"
+                ],
                 "wordFamily": [
                     "Инфинитив: planen",
                     "Презенс: ich plane",
@@ -1620,8 +1671,10 @@
                 "transcription": "[фер-ШВЁ-рен]",
                 "sentence": "Wir verschwören uns gegen ihn.",
                 "sentenceTranslation": "Мы составляем заговор против него.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: verschwören",
                     "Презенс: ich verschwöre",
@@ -1641,8 +1694,12 @@
                 "transcription": "[ди АБ-шпра-хе]",
                 "sentence": "Unsere Absprache ist perfekt.",
                 "sentenceTranslation": "Наш сговор совершенен.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bündnis",
+                    "planen",
+                    "teilen"
+                ],
                 "wordFamily": [
                     "Основа: die Absprache",
                     "Множественное число (пример): die Absprache",
@@ -1661,8 +1718,12 @@
                 "transcription": "[фер-АЙН-ба-рен]",
                 "sentence": "Wir vereinbaren gemeinsame Grausamkeit.",
                 "sentenceTranslation": "Мы договариваемся о совместной жестокости.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bündnis",
+                    "planen",
+                    "teilen"
+                ],
                 "wordFamily": [
                     "Инфинитив: vereinbaren",
                     "Презенс: ich vereinbare",
@@ -1681,8 +1742,12 @@
                 "transcription": "[ди штра-те-ГИ]",
                 "sentence": "Unsere Strategie wird ihn brechen.",
                 "sentenceTranslation": "Наша стратегия сломает его.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bündnis",
+                    "planen",
+                    "teilen"
+                ],
                 "wordFamily": [
                     "Основа: die Strategie",
                     "Множественное число (пример): die Strategie",
@@ -1729,8 +1794,15 @@
                 "transcription": "[ФОЛЬ-терн]",
                 "sentence": "Ich foltere ihn mit kalten Worten.",
                 "sentenceTranslation": "Я пытаю его холодными словами.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Инфинитив: foltern",
                     "Презенс: ich foltere",
@@ -1750,8 +1822,15 @@
                 "transcription": "[ер-НИД-ри-ген]",
                 "sentence": "Ich erniedrige den einst mächtigen König.",
                 "sentenceTranslation": "Я унижаю некогда могущественного короля.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Инфинитив: erniedrigen",
                     "Презенс: ich erniedrige",
@@ -1772,8 +1851,15 @@
                 "transcription": "[фер-ХЁ-нен]",
                 "sentence": "Ich verhöhne seine väterliche Liebe.",
                 "sentenceTranslation": "Я насмехаюсь над его отцовской любовью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Инфинитив: verhöhnen",
                     "Презенс: ich verhöhne",
@@ -1795,8 +1881,15 @@
                 "transcription": "[ди БОС-хайт]",
                 "sentence": "Meine Bosheit kennt kein Erbarmen.",
                 "sentenceTranslation": "Моя злоба не знает милосердия.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Основа: die Bosheit",
                     "Множественное число (пример): die Bosheiten",
@@ -1816,8 +1909,12 @@
                 "transcription": "[МИС-хан-дельн]",
                 "sentence": "Ich misshandle den alten Mann.",
                 "sentenceTranslation": "Я жестоко обращаюсь со стариком.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Инфинитив: misshandeln",
                     "Презенс: ich misshandele",
@@ -1837,8 +1934,15 @@
                 "transcription": "[ди ХЕР-те]",
                 "sentence": "Mit eiserner Härte stoße ich ihn fort.",
                 "sentenceTranslation": "С железной жёсткостью я отталкиваю его.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Основа: die Härte",
                     "Множественное число (пример): die Härte",
@@ -1859,8 +1963,12 @@
                 "transcription": "[АБ-вай-зен]",
                 "sentence": "Ich weise alle seine Bitten ab.",
                 "sentenceTranslation": "Я отвергаю все его просьбы.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
                 "wordFamily": [
                     "Инфинитив: abweisen",
                     "Презенс: ich weise ab",
@@ -1880,8 +1988,20 @@
                 "transcription": "[ди ГРАУ-зам-кайт]",
                 "sentence": "Meine Grausamkeit übertrifft die meiner Schwester.",
                 "sentenceTranslation": "Моя жестокость превосходит жестокость сестры.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "Verzweiflung",
+                    "blenden",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen",
+                    "verlassen",
+                    "verraten",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основа: die Grausamkeit",
                     "Множественное число (пример): die Grausamkeiten",
@@ -1931,8 +2051,10 @@
                 "transcription": "[БЛЕН-ден]",
                 "sentence": "Wir blenden den treuen Grafen Gloucester.",
                 "sentenceTranslation": "Мы ослепляем верного графа Глостера.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: blenden",
                     "Презенс: ich blende",
@@ -1955,8 +2077,14 @@
                 "transcription": "[дер за-ДИС-мус]",
                 "sentence": "Mein Sadismus findet Befriedigung.",
                 "sentenceTranslation": "Мой садизм находит удовлетворение.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
                 "wordFamily": [
                     "Основа: der Sadismus",
                     "Множественное число (пример): die Sadismuse",
@@ -1976,8 +2104,12 @@
                 "transcription": "[ге-НИ-сен]",
                 "sentence": "Ich genieße jeden Schrei des Schmerzes.",
                 "sentenceTranslation": "Я наслаждаюсь каждым криком боли.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
                 "wordFamily": [
                     "Инфинитив: genießen",
                     "Презенс: ich genieße",
@@ -1996,8 +2128,14 @@
                 "transcription": "[АУС-ште-хен]",
                 "sentence": "Stecht ihm beide Augen aus!",
                 "sentenceTranslation": "Выколите ему оба глаза!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
                 "wordFamily": [
                     "Инфинитив: ausstechen",
                     "Презенс: ich steche aus",
@@ -2017,8 +2155,17 @@
                 "transcription": "[ди ФОЛЬ-тер]",
                 "sentence": "Die Folter ist meine Unterhaltung.",
                 "sentenceTranslation": "Пытка - моё развлечение.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Schmerz",
+                    "blenden",
+                    "genießen",
+                    "verraten"
+                ],
                 "wordFamily": [
                     "Основа: die Folter",
                     "Множественное число (пример): die Folter",
@@ -2040,8 +2187,17 @@
                 "transcription": "[ер-БАР-мунгс-лос]",
                 "sentence": "Ich bin erbarmungslos in meiner Rache.",
                 "sentenceTranslation": "Я беспощадна в своей мести.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Sturm",
+                    "blenden",
+                    "genießen",
+                    "gnadenlos",
+                    "verraten",
+                    "verstoßen"
+                ],
                 "wordFamily": [
                     "Основная форма: erbarmungslos",
                     "Сравнительная степень: erbarmungsloser",
@@ -2062,8 +2218,12 @@
                 "transcription": "[ди бру-та-ли-ТЕТ]",
                 "sentence": "Meine Brutalität erschreckt sogar Cornwall.",
                 "sentenceTranslation": "Моя брутальность пугает даже Корнуолла.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
                 "wordFamily": [
                     "Основа: die Brutalität",
                     "Множественное число (пример): die Brutalitäte",
@@ -2082,8 +2242,12 @@
                 "transcription": "[цер-ТРЕ-тен]",
                 "sentence": "Ich zertrete seine Augen unter meinem Fuß.",
                 "sentenceTranslation": "Я растаптываю его глаза под ногой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
                 "wordFamily": [
                     "Инфинитив: zertreten",
                     "Презенс: ich zertrete",
@@ -2130,8 +2294,12 @@
                 "transcription": "[ди ВИТ-ве]",
                 "sentence": "Als Witwe bin ich endlich frei.",
                 "sentenceTranslation": "Как вдова я наконец свободна.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Witwe",
+                    "begehren",
+                    "verführen"
+                ],
                 "wordFamily": [
                     "Основа: die Witwe",
                     "Множественное число (пример): die Witwe",
@@ -2150,8 +2318,10 @@
                 "transcription": "[бе-ГЕ-рен]",
                 "sentence": "Ich begehre Edmund mit brennender Lust.",
                 "sentenceTranslation": "Я вожделею Эдмунда с пылающей страстью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: begehren",
                     "Презенс: ich begehre",
@@ -2176,8 +2346,15 @@
                 "transcription": "[фер-ФЮ-рен]",
                 "sentence": "Ich will Edmund verführen und besitzen.",
                 "sentenceTranslation": "Я хочу соблазнить и завладеть Эдмундом.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Macht",
+                    "Witwe",
+                    "begehren",
+                    "erobern",
+                    "verbünden",
+                    "verführen"
+                ],
                 "wordFamily": [
                     "Инфинитив: verführen",
                     "Презенс: ich verführe",
@@ -2197,8 +2374,12 @@
                 "transcription": "[ди бе-ГИР-де]",
                 "sentence": "Meine Begierde brennt wie Feuer.",
                 "sentenceTranslation": "Моё вожделение горит как огонь.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Witwe",
+                    "begehren",
+                    "verführen"
+                ],
                 "wordFamily": [
                     "Основа: die Begierde",
                     "Множественное число (пример): die Begierde",
@@ -2217,8 +2398,12 @@
                 "transcription": "[ЛО-кен]",
                 "sentence": "Ich locke ihn mit Versprechungen.",
                 "sentenceTranslation": "Я заманиваю его обещаниями.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Witwe",
+                    "begehren",
+                    "verführen"
+                ],
                 "wordFamily": [
                     "Инфинитив: locken",
                     "Презенс: ich locke",
@@ -2237,8 +2422,15 @@
                 "transcription": "[ди ЛУСТ]",
                 "sentence": "Die Lust macht mich blind für Gefahr.",
                 "sentenceTranslation": "Похоть делает меня слепой к опасности.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "Witwe",
+                    "begehren",
+                    "spielen",
+                    "verführen"
+                ],
                 "wordFamily": [
                     "Основа: die Lust",
                     "Множественное число (пример): die Luste",
@@ -2258,8 +2450,10 @@
                 "transcription": "[ВЕР-бен]",
                 "sentence": "Ich werbe schamlos um seine Gunst.",
                 "sentenceTranslation": "Я бесстыдно добиваюсь его благосклонности.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: werben",
                     "Презенс: ich werbe",
@@ -2308,8 +2502,12 @@
                 "transcription": "[ВЕТ-кемп-фен]",
                 "sentence": "Wir wettkämpfen um Edmunds Liebe.",
                 "sentenceTranslation": "Мы соревнуемся за любовь Эдмунда.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "bedrohen",
+                    "hassen",
+                    "wettkämpfen"
+                ],
                 "wordFamily": [
                     "Инфинитив: wettkämpfen",
                     "Презенс: ich wettkämpfe",
@@ -2328,8 +2526,10 @@
                 "transcription": "[ХА-сен]",
                 "sentence": "Ich hasse meine Schwester mehr als je zuvor.",
                 "sentenceTranslation": "Я ненавижу сестру больше, чем когда-либо.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: hassen",
                     "Презенс: ich hasse",
@@ -2350,8 +2550,12 @@
                 "transcription": "[бе-ДРО-ен]",
                 "sentence": "Ich bedrohe sie mit dem Tod.",
                 "sentenceTranslation": "Я угрожаю ей смертью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "bedrohen",
+                    "hassen",
+                    "wettkämpfen"
+                ],
                 "wordFamily": [
                     "Инфинитив: bedrohen",
                     "Презенс: ich bedrohe",
@@ -2371,8 +2575,15 @@
                 "transcription": "[ди ри-ва-ли-ТЕТ]",
                 "sentence": "Unsere Rivalität wird tödlich enden.",
                 "sentenceTranslation": "Наше соперничество закончится смертью.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "bedrohen",
+                    "hassen",
+                    "spielen",
+                    "wettkämpfen"
+                ],
                 "wordFamily": [
                     "Основа: die Rivalität",
                     "Множественное число (пример): die Rivalitäte",
@@ -2392,8 +2603,12 @@
                 "transcription": "[бе-КЕМП-фен]",
                 "sentence": "Ich bekämpfe sie mit allen Mitteln.",
                 "sentenceTranslation": "Я борюсь с ней всеми средствами.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "bedrohen",
+                    "hassen",
+                    "wettkämpfen"
+                ],
                 "wordFamily": [
                     "Инфинитив: bekämpfen",
                     "Презенс: ich bekämpfe",
@@ -2413,8 +2628,10 @@
                 "transcription": "[МИС-трау-ен]",
                 "sentence": "Ich misstraue jedem ihrer Worte.",
                 "sentenceTranslation": "Я не доверяю ни одному её слову.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: misstrauen",
                     "Презенс: ich misstraue",
@@ -2438,8 +2655,12 @@
                 "transcription": "[АРГ-вё-нен]",
                 "sentence": "Ich argwöhne Gift in meinem Wein.",
                 "sentenceTranslation": "Я подозреваю яд в моём вине.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "bedrohen",
+                    "hassen",
+                    "wettkämpfen"
+                ],
                 "wordFamily": [
                     "Инфинитив: argwöhnen",
                     "Презенс: ich argwöhne",
@@ -2487,8 +2708,12 @@
                 "transcription": "[фер-ГИФ-тет]",
                 "sentence": "Ich bin von meiner eigenen Schwester vergiftet.",
                 "sentenceTranslation": "Я отравлена собственной сестрой.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
                 "wordFamily": [
                     "Основная форма: vergiftet",
                     "Сравнительная степень: vergifteter",
@@ -2507,8 +2732,10 @@
                 "transcription": "[ЛАЙ-ден]",
                 "sentence": "Ich leide furchtbare Qualen.",
                 "sentenceTranslation": "Я страдаю от ужасных мук.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "король лир"
+                ],
                 "wordFamily": [
                     "Инфинитив: leiden",
                     "Презенс: ich leide",
@@ -2532,8 +2759,15 @@
                 "transcription": "[фер-ЕН-ден]",
                 "sentence": "Wie ein Tier verende ich elend.",
                 "sentenceTranslation": "Как зверь я издыхаю жалко.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Ende",
+                    "Tod",
+                    "Vergeltung",
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
                 "wordFamily": [
                     "Инфинитив: verenden",
                     "Презенс: ich verende",
@@ -2552,8 +2786,15 @@
                 "transcription": "[ди КВАЛЬ]",
                 "sentence": "Die Qual des Giftes zerreißt mich.",
                 "sentenceTranslation": "Мучение от яда разрывает меня.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
                 "wordFamily": [
                     "Основа: die Qual",
                     "Множественное число (пример): die Quale",
@@ -2574,8 +2815,12 @@
                 "transcription": "[фер-ВЮН-шен]",
                 "sentence": "Ich verwünsche meine Schwester mit letzter Kraft.",
                 "sentenceTranslation": "Я проклинаю сестру последними силами.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
                 "wordFamily": [
                     "Инфинитив: verwünschen",
                     "Презенс: ich verwünsche",
@@ -2596,8 +2841,12 @@
                 "transcription": "[дас фер-ХЕНГ-нис]",
                 "sentence": "Das Verhängnis ereilt mich gerecht.",
                 "sentenceTranslation": "Рок настигает меня справедливо.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
                 "wordFamily": [
                     "Основа: das Verhängnis",
                     "Множественное число (пример): die Verhängnise",
@@ -2616,8 +2865,12 @@
                 "transcription": "[БЮ-сен]",
                 "sentence": "Ich büße für all meine Grausamkeiten.",
                 "sentenceTranslation": "Я расплачиваюсь за все свои жестокости.",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
                 "wordFamily": [
                     "Инфинитив: büßen",
                     "Презенс: ich büße",
@@ -2636,8 +2889,12 @@
                 "transcription": "[фер-ФЛУХТ]",
                 "sentence": "Verflucht sei unser böses Blut!",
                 "sentenceTranslation": "Проклята наша злая кровь!",
-                "visual_hint": "",
-                "themes": [],
+                "visual_hint": "📚",
+                "themes": [
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
                 "wordFamily": [
                     "Основная форма: verflucht",
                     "Сравнительная степень: verfluchter",


### PR DESCRIPTION
## Summary
- copy visual hints and thematic tags from the shared vocabulary into character vocab items when they are missing
- ensure every entry in the shared vocabulary file has a default visual hint so enrichments always provide a value
- regenerate the journey pages so phase vocabularies expose the new hints and themes for the front-end

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68cd932d1e808320bc0b8bb23d2a9b3b