### PR TITLE
Track quiz results and surface journey stats

### DIFF
--- a/templates/journey.html
+++ b/templates/journey.html
@@ -119,6 +119,17 @@
 
         {% if quizzes %}
         <div class="quiz-section" data-quiz-map='{{ quizzes_json | safe }}'>
+            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>{{ first_phase_title or '—' }}</span></h3>
+                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                <div class="quiz-progress-row">
+                    <span class="quiz-progress-label">Прогресс:</span>
+                    <span class="quiz-progress-value" data-quiz-progress>—</span>
+                </div>
+                <div class="quiz-errors-container" data-quiz-errors>
+                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                </div>
+            </div>
             <h2>🧠 Викторина по фазам</h2>
             <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">{% if quizzes and quizzes[0].questions %}{{ quizzes[0].questions | length }}{% else %}0{% endif %}</span> вопрос(ов).</p>
 


### PR DESCRIPTION
## Summary
- persist quiz attempts per phase in localStorage and expose helpers to compute stats and queue review items
- update quiz flow to record each answer, update progress, and emit a phase completion event with error details
- add a statistics panel to the journey template to display progress and current mistakes for the active phase

## Testing
- pytest *(fails: scripts/test_mobile_navigation.py expects a Windows-specific path)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9b8693188320a618f68d6e74b757