### PR TITLE
Add vocabulary visual hints to training pages

### DIFF
--- a/static/css/training.css
+++ b/static/css/training.css
@@ -71,9 +71,22 @@ body {
     gap: 1.5rem;
 }
 
-.word-emoji {
+.word-illustrations {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    align-items: center;
+}
+
+.word-emoji,
+.word-visual-hint {
     font-size: 2.75rem;
     filter: drop-shadow(0 10px 20px rgba(15, 23, 42, 0.5));
+}
+
+.word-visual-hint {
+    font-size: 2rem;
+    opacity: 0.9;
 }
 
 .word-article {
@@ -101,6 +114,64 @@ body {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+}
+
+.word-highlights {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.word-highlight {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.65rem 0.95rem;
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(56, 189, 248, 0.05));
+    border: 1px solid rgba(56, 189, 248, 0.35);
+    box-shadow: 0 12px 26px rgba(8, 47, 73, 0.35);
+}
+
+.word-highlight-icon {
+    font-size: 2rem;
+    line-height: 1;
+}
+
+.word-highlight-label {
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    color: #e0f2fe;
+}
+
+.word-highlight--themes {
+    align-items: flex-start;
+}
+
+.word-highlight--themes .word-highlight-label {
+    margin-top: 0.1rem;
+}
+
+.theme-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.theme-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.2rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(14, 116, 144, 0.35);
+    border: 1px solid rgba(56, 189, 248, 0.35);
+    color: #f0f9ff;
+    font-size: 0.75rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
 }
 
 .tag {

--- a/templates/trainings/word.html
+++ b/templates/trainings/word.html
@@ -12,12 +12,37 @@
         <header class="training-header">
             <a class="back-link" href="../index.html">← На главную</a>
             <div class="word-title">
-                <div class="word-emoji" aria-hidden="true">{{ word.emoji or "📘" }}</div>
+                <div class="word-illustrations" aria-hidden="true">
+                    <div class="word-emoji">{{ word.emoji or "📘" }}</div>
+                    {% if word.visual_hint %}
+                    <div class="word-visual-hint">{{ word.visual_hint }}</div>
+                    {% endif %}
+                </div>
                 <div>
                     <p class="word-article">{{ word.article }}</p>
                     <h1>{{ word.word }}</h1>
                     {% if translations.ru or translations.en %}
                     <p class="word-translation">{{ translations.ru or translations.en }}</p>
+                    {% endif %}
+                    {% if word.visual_hint or word.themes %}
+                    <div class="word-highlights" role="list">
+                        {% if word.visual_hint %}
+                        <div class="word-highlight" role="listitem">
+                            <span class="word-highlight-icon" aria-hidden="true">{{ word.visual_hint }}</span>
+                            <span class="word-highlight-label">Образ слова</span>
+                        </div>
+                        {% endif %}
+                        {% if word.themes %}
+                        <div class="word-highlight word-highlight--themes" role="listitem">
+                            <span class="word-highlight-label">Темы:</span>
+                            <div class="theme-badges">
+                                {% for theme in word.themes %}
+                                <span class="theme-badge">{{ theme }}</span>
+                                {% endfor %}
+                            </div>
+                        </div>
+                        {% endif %}
+                    </div>
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- load visual hints and theme tags for each vocabulary word from the extended vocabulary dataset
- render the additional emoji cue and theme badges beside the training page title
- style the new lexical hint blocks to group the vocabulary visually

## Testing
- pytest *(fails: scripts/test_mobile_navigation.py expects Windows-specific path)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9bf9487c83208bc8ac60b73480e4