### PR TITLE
Add story context to vocabulary sentences

### DIFF
--- a/data/characters/albany.json
+++ b/data/characters/albany.json
@@ -14,57 +14,57 @@
           "german": "das Schweigen",
           "russian": "молчание",
           "transcription": "[дас ШВАЙ-ген]",
-          "sentence": "Mein Schweigen macht mich zum Mitschuldigen.",
-          "sentence_translation": "Моё молчание делает меня соучастником."
+          "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Mein Schweigen macht mich zum Mitschuldigen.",
+          "sentence_translation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Моё молчание делает меня соучастником."
         },
         {
           "german": "die Schwäche",
           "russian": "слабость",
           "transcription": "[ди ШВЕ-хе]",
-          "sentence": "Meine Schwäche erlaubt das Böse zu wachsen.",
-          "sentence_translation": "Моя слабость позволяет злу расти."
+          "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Meine Schwäche erlaubt das Böse zu wachsen.",
+          "sentence_translation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Моя слабость позволяет злу расти."
         },
         {
           "german": "die Ehe",
           "russian": "брак",
           "transcription": "[ди Э-е]",
-          "sentence": "Die Ehe bindet mich an eine grausame Frau.",
-          "sentence_translation": "Брак связывает меня с жестокой женой."
+          "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Die Ehe bindet mich an eine grausame Frau.",
+          "sentence_translation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Брак связывает меня с жестокой женой."
         },
         {
           "german": "dulden",
           "russian": "терпеть",
           "transcription": "[ДУЛЬ-ден]",
-          "sentence": "Ich dulde ihre Grausamkeit zu lange.",
-          "sentence_translation": "Я слишком долго терплю её жестокость."
+          "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Ich dulde ihre Grausamkeit zu lange.",
+          "sentence_translation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Я слишком долго терплю её жестокость."
         },
         {
           "german": "passiv",
           "russian": "пассивный",
           "transcription": "[па-СИФ]",
-          "sentence": "Passiv schaue ich dem Unrecht zu.",
-          "sentence_translation": "Пассивно я наблюдаю за несправедливостью."
+          "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Passiv schaue ich dem Unrecht zu.",
+          "sentence_translation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Пассивно я наблюдаю за несправедливостью."
         },
         {
           "german": "nachgeben",
           "russian": "уступать",
           "transcription": "[НАХ-ге-бен]",
-          "sentence": "Zu oft gebe ich ihrem Willen nach.",
-          "sentence_translation": "Слишком часто я уступаю её воле."
+          "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Zu oft gebe ich ihrem Willen nach.",
+          "sentence_translation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Слишком часто я уступаю её воле."
         },
         {
           "german": "zögern",
           "russian": "колебаться",
           "transcription": "[ЦЁ-герн]",
-          "sentence": "Ich zögere, wenn ich handeln sollte.",
-          "sentence_translation": "Я колеблюсь, когда должен действовать."
+          "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Ich zögere, wenn ich handeln sollte.",
+          "sentence_translation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Я колеблюсь, когда должен действовать."
         },
         {
           "german": "mild",
           "russian": "мягкий",
           "transcription": "[МИЛЬД]",
-          "sentence": "Meine milde Art wird als Schwäche gesehen.",
-          "sentence_translation": "Моя мягкость воспринимается как слабость."
+          "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Meine milde Art wird als Schwäche gesehen.",
+          "sentence_translation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Моя мягкость воспринимается как слабость."
         }
       ],
       "theatrical_scene": {
@@ -107,50 +107,50 @@
           "german": "der Zweifel",
           "russian": "сомнение",
           "transcription": "[дер ЦВАЙ-фель]",
-          "sentence": "Der Zweifel an ihrer Güte wächst in mir.",
-          "sentence_translation": "Сомнение в её доброте растёт во мне."
+          "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Der Zweifel an ihrer Güte wächst in mir.",
+          "sentence_translation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Сомнение в её доброте растёт во мне."
         },
         {
           "german": "das Gewissen",
           "russian": "совесть",
           "transcription": "[дас ге-ВИ-сен]",
-          "sentence": "Mein Gewissen beginnt mich zu quälen.",
-          "sentence_translation": "Моя совесть начинает мучить меня."
+          "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Mein Gewissen beginnt mich zu quälen.",
+          "sentence_translation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Моя совесть начинает мучить меня."
         },
         {
           "german": "das Unbehagen",
           "russian": "беспокойство",
           "transcription": "[дас УН-бе-ха-ген]",
-          "sentence": "Ein tiefes Unbehagen erfüllt meine Seele.",
-          "sentence_translation": "Глубокое беспокойство наполняет мою душу."
+          "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Ein tiefes Unbehagen erfüllt meine Seele.",
+          "sentence_translation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Глубокое беспокойство наполняет мою душу."
         },
         {
           "german": "hinterfragen",
           "russian": "подвергать сомнению",
           "transcription": "[ХИН-тер-фра-ген]",
-          "sentence": "Ich beginne ihre Taten zu hinterfragen.",
-          "sentence_translation": "Я начинаю подвергать сомнению её поступки."
+          "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Ich beginne ihre Taten zu hinterfragen.",
+          "sentence_translation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Я начинаю подвергать сомнению её поступки."
         },
         {
           "german": "beunruhigen",
           "russian": "тревожить",
           "transcription": "[бе-УН-ру-и-ген]",
-          "sentence": "Ihre Grausamkeit beunruhigt mich zunehmend.",
-          "sentence_translation": "Её жестокость всё больше тревожит меня."
+          "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Ihre Grausamkeit beunruhigt mich zunehmend.",
+          "sentence_translation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Её жестокость всё больше тревожит меня."
         },
         {
           "german": "unsicher",
           "russian": "неуверенный",
           "transcription": "[УН-зи-хер]",
-          "sentence": "Ich werde unsicher in meinem Schweigen.",
-          "sentence_translation": "Я становлюсь неуверенным в своём молчании."
+          "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Ich werde unsicher in meinem Schweigen.",
+          "sentence_translation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Я становлюсь неуверенным в своём молчании."
         },
         {
           "german": "grübeln",
           "russian": "размышлять",
           "transcription": "[ГРЮ-бельн]",
-          "sentence": "Nachts grüble ich über richtig und falsch.",
-          "sentence_translation": "Ночами я размышляю о правильном и неправильном."
+          "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Nachts grüble ich über richtig und falsch.",
+          "sentence_translation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Ночами я размышляю о правильном и неправильном."
         }
       ],
       "theatrical_scene": {
@@ -193,57 +193,57 @@
           "german": "die Erkenntnis",
           "russian": "осознание",
           "transcription": "[ди ер-КЕНТ-нис]",
-          "sentence": "Die Erkenntnis ihrer Bosheit erschüttert mich.",
-          "sentence_translation": "Осознание её злобы потрясает меня."
+          "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Die Erkenntnis ihrer Bosheit erschüttert mich.",
+          "sentence_translation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Осознание её злобы потрясает меня."
         },
         {
           "german": "das Entsetzen",
           "russian": "ужас",
           "transcription": "[дас энт-ЗЕ-цен]",
-          "sentence": "Mit Entsetzen sehe ich ihr wahres Gesicht.",
-          "sentence_translation": "С ужасом я вижу её истинное лицо."
+          "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Mit Entsetzen sehe ich ihr wahres Gesicht.",
+          "sentence_translation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: С ужасом я вижу её истинное лицо."
         },
         {
           "german": "erwachen",
           "russian": "пробуждаться",
           "transcription": "[ер-ВА-хен]",
-          "sentence": "Endlich erwache ich aus meiner Blindheit.",
-          "sentence_translation": "Наконец я пробуждаюсь от своей слепоты."
+          "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Endlich erwache ich aus meiner Blindheit.",
+          "sentence_translation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Наконец я пробуждаюсь от своей слепоты."
         },
         {
           "german": "begreifen",
           "russian": "понимать",
           "transcription": "[бе-ГРАЙ-фен]",
-          "sentence": "Ich begreife das Ausmaß ihrer Grausamkeit.",
-          "sentence_translation": "Я понимаю масштаб её жестокости."
+          "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Ich begreife das Ausmaß ihrer Grausamkeit.",
+          "sentence_translation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Я понимаю масштаб её жестокости."
         },
         {
           "german": "erschrecken",
           "russian": "пугаться",
           "transcription": "[ер-ШРЕК-кен]",
-          "sentence": "Ihre Taten erschrecken mein gutes Herz.",
-          "sentence_translation": "Её поступки пугают моё доброе сердце."
+          "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Ihre Taten erschrecken mein gutes Herz.",
+          "sentence_translation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Её поступки пугают моё доброе сердце."
         },
         {
           "german": "aufwachen",
           "russian": "просыпаться",
           "transcription": "[АУФ-ва-хен]",
-          "sentence": "Ich wache auf aus meinem langen Schlaf.",
-          "sentence_translation": "Я просыпаюсь от долгого сна."
+          "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Ich wache auf aus meinem langen Schlaf.",
+          "sentence_translation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Я просыпаюсь от долгого сна."
         },
         {
           "german": "klar sehen",
           "russian": "ясно видеть",
           "transcription": "[КЛАР ЗЕ-ен]",
-          "sentence": "Zum ersten Mal sehe ich klar.",
-          "sentence_translation": "Впервые я вижу ясно."
+          "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Zum ersten Mal sehe ich klar.",
+          "sentence_translation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Впервые я вижу ясно."
         },
         {
           "german": "die Verwandlung",
           "russian": "превращение",
           "transcription": "[ди фер-ВАНД-лунг]",
-          "sentence": "Eine Verwandlung beginnt in meiner Seele.",
-          "sentence_translation": "Превращение начинается в моей душе."
+          "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Eine Verwandlung beginnt in meiner Seele.",
+          "sentence_translation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Превращение начинается в моей душе."
         }
       ],
       "theatrical_scene": {
@@ -286,50 +286,50 @@
           "german": "der Streit",
           "russian": "спор",
           "transcription": "[дер ШТРАЙТ]",
-          "sentence": "Der Streit mit meiner Frau eskaliert.",
-          "sentence_translation": "Спор с моей женой обостряется."
+          "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Der Streit mit meiner Frau eskaliert.",
+          "sentence_translation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Спор с моей женой обостряется."
         },
         {
           "german": "der Mut",
           "russian": "мужество",
           "transcription": "[дер МУТ]",
-          "sentence": "Endlich finde ich den Mut zu widersprechen.",
-          "sentence_translation": "Наконец я нахожу мужество возражать."
+          "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Endlich finde ich den Mut zu widersprechen.",
+          "sentence_translation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Наконец я нахожу мужество возражать."
         },
         {
           "german": "der Widerstand",
           "russian": "сопротивление",
           "transcription": "[дер ВИ-дер-штанд]",
-          "sentence": "Mein Widerstand gegen das Böse beginnt.",
-          "sentence_translation": "Моё сопротивление злу начинается."
+          "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Mein Widerstand gegen das Böse beginnt.",
+          "sentence_translation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Моё сопротивление злу начинается."
         },
         {
           "german": "konfrontieren",
           "russian": "противостоять",
           "transcription": "[кон-фрон-ТИ-рен]",
-          "sentence": "Ich konfrontiere sie mit ihrer Grausamkeit.",
-          "sentence_translation": "Я противостою ей с её жестокостью."
+          "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Ich konfrontiere sie mit ihrer Grausamkeit.",
+          "sentence_translation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Я противостою ей с её жестокостью."
         },
         {
           "german": "anklagen",
           "russian": "обвинять",
           "transcription": "[АН-кла-ген]",
-          "sentence": "Ich klage sie ihrer Unmenschlichkeit an.",
-          "sentence_translation": "Я обвиняю её в бесчеловечности."
+          "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Ich klage sie ihrer Unmenschlichkeit an.",
+          "sentence_translation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Я обвиняю её в бесчеловечности."
         },
         {
           "german": "sich wehren",
           "russian": "защищаться",
           "transcription": "[зих ВЕ-рен]",
-          "sentence": "Ich wehre mich gegen ihre Tyrannei.",
-          "sentence_translation": "Я защищаюсь от её тирании."
+          "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Ich wehre mich gegen ihre Tyrannei.",
+          "sentence_translation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Я защищаюсь от её тирании."
         },
         {
           "german": "aufbegehren",
           "russian": "восставать",
           "transcription": "[АУФ-бе-ге-рен]",
-          "sentence": "Ich begehre auf gegen das Unrecht.",
-          "sentence_translation": "Я восстаю против несправедливости."
+          "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Ich begehre auf gegen das Unrecht.",
+          "sentence_translation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Я восстаю против несправедливости."
         }
       ],
       "theatrical_scene": {
@@ -372,57 +372,57 @@
           "german": "die Moral",
           "russian": "мораль",
           "transcription": "[ди мо-РАЛЬ]",
-          "sentence": "Die Moral leitet nun meine Entscheidungen.",
-          "sentence_translation": "Мораль теперь руководит моими решениями."
+          "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Die Moral leitet nun meine Entscheidungen.",
+          "sentence_translation": "Перед потрясёнными придворными Лира Олбани заявляет: Мораль теперь руководит моими решениями."
         },
         {
           "german": "die Gerechtigkeit",
           "russian": "справедливость",
           "transcription": "[ди ге-РЕХ-тиг-кайт]",
-          "sentence": "Für Gerechtigkeit will ich kämpfen.",
-          "sentence_translation": "За справедливость я хочу бороться."
+          "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Für Gerechtigkeit will ich kämpfen.",
+          "sentence_translation": "Перед потрясёнными придворными Лира Олбани заявляет: За справедливость я хочу бороться."
         },
         {
           "german": "die Entscheidung",
           "russian": "решение",
           "transcription": "[ди энт-ШАЙ-дунг]",
-          "sentence": "Meine Entscheidung steht fest: ich wähle das Gute.",
-          "sentence_translation": "Моё решение твёрдо: я выбираю добро."
+          "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Meine Entscheidung steht fest: ich wähle das Gute.",
+          "sentence_translation": "Перед потрясёнными придворными Лира Олбани заявляет: Моё решение твёрдо: я выбираю добро."
         },
         {
           "german": "wählen",
           "russian": "выбирать",
           "transcription": "[ВЕ-лен]",
-          "sentence": "Ich wähle den schweren Weg der Tugend.",
-          "sentence_translation": "Я выбираю трудный путь добродетели."
+          "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Ich wähle den schweren Weg der Tugend.",
+          "sentence_translation": "Перед потрясёнными придворными Лира Олбани заявляет: Я выбираю трудный путь добродетели."
         },
         {
           "german": "rechtschaffen",
           "russian": "праведный",
           "transcription": "[РЕХТ-ша-фен]",
-          "sentence": "Ich will rechtschaffen leben und handeln.",
-          "sentence_translation": "Я хочу жить и действовать праведно."
+          "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Ich will rechtschaffen leben und handeln.",
+          "sentence_translation": "Перед потрясёнными придворными Лира Олбани заявляет: Я хочу жить и действовать праведно."
         },
         {
           "german": "das Prinzip",
           "russian": "принцип",
           "transcription": "[дас прин-ЦИП]",
-          "sentence": "Meine Prinzipien sind wichtiger als meine Ehe.",
-          "sentence_translation": "Мои принципы важнее моего брака."
+          "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Meine Prinzipien sind wichtiger als meine Ehe.",
+          "sentence_translation": "Перед потрясёнными придворными Лира Олбани заявляет: Мои принципы важнее моего брака."
         },
         {
           "german": "edel",
           "russian": "благородный",
           "transcription": "[Э-дель]",
-          "sentence": "Ich strebe nach edlen Taten.",
-          "sentence_translation": "Я стремлюсь к благородным поступкам."
+          "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Ich strebe nach edlen Taten.",
+          "sentence_translation": "Перед потрясёнными придворными Лира Олбани заявляет: Я стремлюсь к благородным поступкам."
         },
         {
           "german": "die Tugend",
           "russian": "добродетель",
           "transcription": "[ди ТУ-генд]",
-          "sentence": "Die Tugend wird mein Leitstern sein.",
-          "sentence_translation": "Добродетель будет моей путеводной звездой."
+          "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Die Tugend wird mein Leitstern sein.",
+          "sentence_translation": "Перед потрясёнными придворными Лира Олбани заявляет: Добродетель будет моей путеводной звездой."
         }
       ],
       "theatrical_scene": {
@@ -465,50 +465,50 @@
           "german": "der Kampf",
           "russian": "борьба",
           "transcription": "[дер КАМПФ]",
-          "sentence": "Der Kampf für das Recht beginnt jetzt.",
-          "sentence_translation": "Борьба за право начинается сейчас."
+          "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Der Kampf für das Recht beginnt jetzt.",
+          "sentence_translation": "При опустевшем дворе Лира Олбани собирает верных: Борьба за право начинается сейчас."
         },
         {
           "german": "das Recht",
           "russian": "право",
           "transcription": "[дас РЕХТ]",
-          "sentence": "Das Recht muss über das Unrecht siegen.",
-          "sentence_translation": "Право должно победить неправду."
+          "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Das Recht muss über das Unrecht siegen.",
+          "sentence_translation": "При опустевшем дворе Лира Олбани собирает верных: Право должно победить неправду."
         },
         {
           "german": "die Güte",
           "russian": "доброта",
           "transcription": "[ди ГЮ-те]",
-          "sentence": "Mit Güte will ich das Böse besiegen.",
-          "sentence_translation": "Добротой я хочу победить зло."
+          "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Mit Güte will ich das Böse besiegen.",
+          "sentence_translation": "При опустевшем дворе Лира Олбани собирает верных: Добротой я хочу победить зло."
         },
         {
           "german": "strafen",
           "russian": "наказывать",
           "transcription": "[ШТРА-фен]",
-          "sentence": "Die Schuldigen müssen bestraft werden.",
-          "sentence_translation": "Виновные должны быть наказаны."
+          "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Die Schuldigen müssen bestraft werden.",
+          "sentence_translation": "При опустевшем дворе Лира Олбани собирает верных: Виновные должны быть наказаны."
         },
         {
           "german": "richten",
           "russian": "судить",
           "transcription": "[РИХ-тен]",
-          "sentence": "Gerecht will ich über die Verbrecher richten.",
-          "sentence_translation": "Справедливо я хочу судить преступников."
+          "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Gerecht will ich über die Verbrecher richten.",
+          "sentence_translation": "При опустевшем дворе Лира Олбани собирает верных: Справедливо я хочу судить преступников."
         },
         {
           "german": "beschützen",
           "russian": "защищать",
           "transcription": "[бе-ШЮ-цен]",
-          "sentence": "Die Unschuldigen will ich beschützen.",
-          "sentence_translation": "Невинных я хочу защитить."
+          "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Die Unschuldigen will ich beschützen.",
+          "sentence_translation": "При опустевшем дворе Лира Олбани собирает верных: Невинных я хочу защитить."
         },
         {
           "german": "eingreifen",
           "russian": "вмешиваться",
           "transcription": "[АЙН-грай-фен]",
-          "sentence": "Ich greife ein, um das Schlimmste zu verhindern.",
-          "sentence_translation": "Я вмешиваюсь, чтобы предотвратить худшее."
+          "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Ich greife ein, um das Schlimmste zu verhindern.",
+          "sentence_translation": "При опустевшем дворе Лира Олбани собирает верных: Я вмешиваюсь, чтобы предотвратить худшее."
         }
       ],
       "theatrical_scene": {
@@ -551,57 +551,57 @@
           "german": "die Herrschaft",
           "russian": "правление",
           "transcription": "[ди ХЕР-шафт]",
-          "sentence": "Die Herrschaft fällt nun in meine Hände.",
-          "sentence_translation": "Правление теперь переходит в мои руки."
+          "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Die Herrschaft fällt nun in meine Hände.",
+          "sentence_translation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Правление теперь переходит в мои руки."
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
-          "sentence": "Mit Weisheit will ich das Land führen.",
-          "sentence_translation": "С мудростью я хочу вести страну."
+          "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Mit Weisheit will ich das Land führen.",
+          "sentence_translation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: С мудростью я хочу вести страну."
         },
         {
           "german": "der Neuanfang",
           "russian": "новое начало",
           "transcription": "[дер НОЙ-ан-фанг]",
-          "sentence": "Ein Neuanfang für das Königreich beginnt.",
-          "sentence_translation": "Новое начало для королевства начинается."
+          "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Ein Neuanfang für das Königreich beginnt.",
+          "sentence_translation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Новое начало для королевства начинается."
         },
         {
           "german": "lenken",
           "russian": "направлять",
           "transcription": "[ЛЕН-кен]",
-          "sentence": "Ich lenke das Land in eine bessere Zukunft.",
-          "sentence_translation": "Я направляю страну в лучшее будущее."
+          "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Ich lenke das Land in eine bessere Zukunft.",
+          "sentence_translation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Я направляю страну в лучшее будущее."
         },
         {
           "german": "aufbauen",
           "russian": "строить",
           "transcription": "[АУФ-бау-ен]",
-          "sentence": "Ich baue auf, was zerstört wurde.",
-          "sentence_translation": "Я строю то, что было разрушено."
+          "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Ich baue auf, was zerstört wurde.",
+          "sentence_translation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Я строю то, что было разрушено."
         },
         {
           "german": "erneuern",
           "russian": "обновлять",
           "transcription": "[ер-НОЙ-ерн]",
-          "sentence": "Das Reich will ich erneuern und heilen.",
-          "sentence_translation": "Королевство я хочу обновить и исцелить."
+          "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Das Reich will ich erneuern und heilen.",
+          "sentence_translation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Королевство я хочу обновить и исцелить."
         },
         {
           "german": "versöhnen",
           "russian": "примирять",
           "transcription": "[фер-ЗЁ-нен]",
-          "sentence": "Ich will die Getrennten versöhnen.",
-          "sentence_translation": "Я хочу примирить разделённых."
+          "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Ich will die Getrennten versöhnen.",
+          "sentence_translation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Я хочу примирить разделённых."
         },
         {
           "german": "der Friede",
           "russian": "мир",
           "transcription": "[дер ФРИ-де]",
-          "sentence": "Der Friede soll wieder ins Land kommen.",
-          "sentence_translation": "Мир должен вернуться в страну."
+          "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Der Friede soll wieder ins Land kommen.",
+          "sentence_translation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Мир должен вернуться в страну."
         }
       ],
       "theatrical_scene": {

--- a/data/characters/cordelia.json
+++ b/data/characters/cordelia.json
@@ -20,57 +20,57 @@
           "german": "die Wahrheit",
           "russian": "правда",
           "transcription": "[ди ВАР-хайт]",
-          "sentence": "Die Wahrheit war vor meinen Augen verborgen.",
-          "sentence_translation": "Правда была скрыта от моих глаз."
+          "sentence": "Im Thronsaal von König Lear spricht Cordelia: Die Wahrheit war vor meinen Augen verborgen.",
+          "sentence_translation": "В тронном зале короля Лира Корделия говорит: Правда была скрыта от моих глаз."
         },
         {
           "german": "die Zeremonie",
           "russian": "церемония",
           "transcription": "[ди це-ре-мо-НИ]",
-          "sentence": "Die Zeremonie beginnt im prächtigen Thronsaal.",
-          "sentence_translation": "Церемония начинается в великолепном тронном зале."
+          "sentence": "Im Thronsaal von König Lear spricht Cordelia: Die Zeremonie beginnt im prächtigen Thronsaal.",
+          "sentence_translation": "В тронном зале короля Лира Корделия говорит: Церемония начинается в великолепном тронном зале."
         },
         {
           "german": "verkünden",
           "russian": "провозглашать",
           "transcription": "[фер-КЮН-ден]",
-          "sentence": "Ich verkünde nur die Wahrheit meines Herzens.",
-          "sentence_translation": "Я провозглашаю только правду моего сердца."
+          "sentence": "Im Thronsaal von König Lear spricht Cordelia: Ich verkünde nur die Wahrheit meines Herzens.",
+          "sentence_translation": "В тронном зале короля Лира Корделия говорит: Я провозглашаю только правду моего сердца."
         },
         {
           "german": "die Macht",
           "russian": "власть",
           "transcription": "[ди МАХТ]",
-          "sentence": "Die Macht bedeutet nichts ohne wahre Liebe.",
-          "sentence_translation": "Власть ничего не значит без истинной любви."
+          "sentence": "Im Thronsaal von König Lear spricht Cordelia: Die Macht bedeutet nichts ohne wahre Liebe.",
+          "sentence_translation": "В тронном зале короля Лира Корделия говорит: Власть ничего не значит без истинной любви."
         },
         {
           "german": "gehorchen",
           "russian": "повиноваться",
           "transcription": "[ге-ХОР-хен]",
-          "sentence": "Ich kann der Lüge nicht gehorchen.",
-          "sentence_translation": "Я не могу повиноваться лжи."
+          "sentence": "Im Thronsaal von König Lear spricht Cordelia: Ich kann der Lüge nicht gehorchen.",
+          "sentence_translation": "В тронном зале короля Лира Корделия говорит: Я не могу повиноваться лжи."
         },
         {
           "german": "die Pflicht",
           "russian": "долг",
           "transcription": "[ди ПФЛИХТ]",
-          "sentence": "Meine Pflicht ist es, ehrlich zu sein.",
-          "sentence_translation": "Мой долг - быть честной."
+          "sentence": "Im Thronsaal von König Lear spricht Cordelia: Meine Pflicht ist es, ehrlich zu sein.",
+          "sentence_translation": "В тронном зале короля Лира Корделия говорит: Мой долг - быть честной."
         },
         {
           "german": "feierlich",
           "russian": "торжественный",
           "transcription": "[ФАЙ-ер-лих]",
-          "sentence": "Dieser feierliche Moment wird zur Tragödie.",
-          "sentence_translation": "Этот торжественный момент становится трагедией."
+          "sentence": "Im Thronsaal von König Lear spricht Cordelia: Dieser feierliche Moment wird zur Tragödie.",
+          "sentence_translation": "В тронном зале короля Лира Корделия говорит: Этот торжественный момент становится трагедией."
         },
         {
           "german": "die Treue",
           "russian": "верность",
           "transcription": "[ди ТРОЙ-е]",
-          "sentence": "Meine Treue gilt der Wahrheit und der echten Liebe.",
-          "sentence_translation": "Моя верность принадлежит правде и истинной любви."
+          "sentence": "Im Thronsaal von König Lear spricht Cordelia: Meine Treue gilt der Wahrheit und der echten Liebe.",
+          "sentence_translation": "В тронном зале короля Лира Корделия говорит: Моя верность принадлежит правде и истинной любви."
         }
       ],
       "quizzes": [
@@ -113,57 +113,57 @@
           "german": "verstoßen",
           "russian": "изгонять",
           "transcription": "[фер-ШТО-сен]",
-          "sentence": "Der König verstößt mich aus seinem Herzen.",
-          "sentence_translation": "Король изгоняет меня из своего сердца."
+          "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Der König verstößt mich aus seinem Herzen.",
+          "sentence_translation": "На причале перед отъездом во Францию Корделия клянётся: Король изгоняет меня из своего сердца."
         },
         {
           "german": "verlassen",
           "russian": "покидать",
           "transcription": "[фер-ЛА-сен]",
-          "sentence": "Schweren Herzens verlasse ich mein Vaterland.",
-          "sentence_translation": "С тяжёлым сердцем я покидаю родину."
+          "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Schweren Herzens verlasse ich mein Vaterland.",
+          "sentence_translation": "На причале перед отъездом во Францию Корделия клянётся: С тяжёлым сердцем я покидаю родину."
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
-          "sentence": "Sein Zorn ist grenzenlos und blind.",
-          "sentence_translation": "Его гнев безграничен и слеп."
+          "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Sein Zorn ist grenzenlos und blind.",
+          "sentence_translation": "На причале перед отъездом во Францию Корделия клянётся: Его гнев безграничен и слеп."
         },
         {
           "german": "die Strafe",
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
-          "sentence": "Diese Strafe ist der Preis für meine Ehrlichkeit.",
-          "sentence_translation": "Это наказание - цена моей честности."
+          "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Diese Strafe ist der Preis für meine Ehrlichkeit.",
+          "sentence_translation": "На причале перед отъездом во Францию Корделия клянётся: Это наказание - цена моей честности."
         },
         {
           "german": "fremd",
           "russian": "чужой",
           "transcription": "[ФРЕМД]",
-          "sentence": "Ich bin jetzt fremd in meinem eigenen Land.",
-          "sentence_translation": "Я теперь чужая в своей собственной стране."
+          "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Ich bin jetzt fremd in meinem eigenen Land.",
+          "sentence_translation": "На причале перед отъездом во Францию Корделия клянётся: Я теперь чужая в своей собственной стране."
         },
         {
           "german": "die Mitgift",
           "russian": "приданое",
           "transcription": "[ди МИТ-гифт]",
-          "sentence": "Ohne Mitgift bin ich reicher an Ehre.",
-          "sentence_translation": "Без приданого я богаче честью."
+          "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Ohne Mitgift bin ich reicher an Ehre.",
+          "sentence_translation": "На причале перед отъездом во Францию Корделия клянётся: Без приданого я богаче честью."
         },
         {
           "german": "aufnehmen",
           "russian": "принимать",
           "transcription": "[АУФ-не-мен]",
-          "sentence": "Der König von Frankreich nimmt mich liebevoll auf.",
-          "sentence_translation": "Король Франции принимает меня с любовью."
+          "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Der König von Frankreich nimmt mich liebevoll auf.",
+          "sentence_translation": "На причале перед отъездом во Францию Корделия клянётся: Король Франции принимает меня с любовью."
         },
         {
           "german": "die Hoffnung",
           "russian": "надежда",
           "transcription": "[ди ХОФ-нунг]",
-          "sentence": "Die Hoffnung auf Versöhnung stirbt nie in meinem Herzen.",
-          "sentence_translation": "Надежда на примирение никогда не умирает в моём сердце."
+          "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Die Hoffnung auf Versöhnung stirbt nie in meinem Herzen.",
+          "sentence_translation": "На причале перед отъездом во Францию Корделия клянётся: Надежда на примирение никогда не умирает в моём сердце."
         }
       ],
       "quizzes": [
@@ -206,57 +206,57 @@
           "german": "die Sorge",
           "russian": "забота",
           "transcription": "[ди ЗОР-ге]",
-          "sentence": "Die Sorge um meinen Vater lässt mich nicht schlafen.",
-          "sentence_translation": "Забота об отце не даёт мне спать."
+          "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Die Sorge um meinen Vater lässt mich nicht schlafen.",
+          "sentence_translation": "Во французском изгнании Корделия вспоминает Лира: Забота об отце не даёт мне спать."
         },
         {
           "german": "die Einsamkeit",
           "russian": "одиночество",
           "transcription": "[ди АЙН-зам-кайт]",
-          "sentence": "In der Einsamkeit denke ich an ihn.",
-          "sentence_translation": "В одиночестве я думаю о нём."
+          "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: In der Einsamkeit denke ich an ihn.",
+          "sentence_translation": "Во французском изгнании Корделия вспоминает Лира: В одиночестве я думаю о нём."
         },
         {
           "german": "die Nachricht",
           "russian": "известие",
           "transcription": "[ди НАХ-рихт]",
-          "sentence": "Schreckliche Nachrichten erreichen mich aus England.",
-          "sentence_translation": "Ужасные известия доходят до меня из Англии."
+          "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Schreckliche Nachrichten erreichen mich aus England.",
+          "sentence_translation": "Во французском изгнании Корделия вспоминает Лира: Ужасные известия доходят до меня из Англии."
         },
         {
           "german": "die Angst",
           "russian": "страх",
           "transcription": "[ди АНГСТ]",
-          "sentence": "Die Angst um meinen Vater wächst täglich.",
-          "sentence_translation": "Страх за отца растёт с каждым днём."
+          "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Die Angst um meinen Vater wächst täglich.",
+          "sentence_translation": "Во французском изгнании Корделия вспоминает Лира: Страх за отца растёт с каждым днём."
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
-          "sentence": "Er muss furchtbar leiden ohne mich.",
-          "sentence_translation": "Он должно быть ужасно страдает без меня."
+          "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Er muss furchtbar leiden ohne mich.",
+          "sentence_translation": "Во французском изгнании Корделия вспоминает Лира: Он должно быть ужасно страдает без меня."
         },
         {
           "german": "beschützen",
           "russian": "защищать",
           "transcription": "[бе-ШЮ-цен]",
-          "sentence": "Ich kann ihn aus der Ferne nicht beschützen.",
-          "sentence_translation": "Я не могу защитить его издалека."
+          "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Ich kann ihn aus der Ferne nicht beschützen.",
+          "sentence_translation": "Во французском изгнании Корделия вспоминает Лира: Я не могу защитить его издалека."
         },
         {
           "german": "die Sehnsucht",
           "russian": "тоска",
           "transcription": "[ди ЗЕН-зухт]",
-          "sentence": "Die Sehnsucht nach Versöhnung erfüllt mein Herz.",
-          "sentence_translation": "Тоска по примирению наполняет моё сердце."
+          "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Die Sehnsucht nach Versöhnung erfüllt mein Herz.",
+          "sentence_translation": "Во французском изгнании Корделия вспоминает Лира: Тоска по примирению наполняет моё сердце."
         },
         {
           "german": "beten",
           "russian": "молиться",
           "transcription": "[БЕ-тен]",
-          "sentence": "Jeden Tag bete ich für seine Sicherheit.",
-          "sentence_translation": "Каждый день я молюсь за его безопасность."
+          "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Jeden Tag bete ich für seine Sicherheit.",
+          "sentence_translation": "Во французском изгнании Корделия вспоминает Лира: Каждый день я молюсь за его безопасность."
         }
       ],
       "quizzes": [
@@ -299,57 +299,57 @@
           "german": "zurückkehren",
           "russian": "возвращаться",
           "transcription": "[цу-РЮК-ке-рен]",
-          "sentence": "Mit einer Armee kehre ich zurück, meinen Vater zu retten.",
-          "sentence_translation": "С армией я возвращаюсь спасти моего отца."
+          "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Mit einer Armee kehre ich zurück, meinen Vater zu retten.",
+          "sentence_translation": "Во главе французской армии у Дувра Корделия восклицает: С армией я возвращаюсь спасти моего отца."
         },
         {
           "german": "der Kampf",
           "russian": "борьба",
           "transcription": "[дер КАМПФ]",
-          "sentence": "Dieser Kampf ist für die Ehre meines Vaters.",
-          "sentence_translation": "Эта борьба за честь моего отца."
+          "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Dieser Kampf ist für die Ehre meines Vaters.",
+          "sentence_translation": "Во главе французской армии у Дувра Корделия восклицает: Эта борьба за честь моего отца."
         },
         {
           "german": "retten",
           "russian": "спасать",
           "transcription": "[РЕ-тен]",
-          "sentence": "Ich muss meinen Vater vor seinen grausamen Töchtern retten.",
-          "sentence_translation": "Я должна спасти отца от его жестоких дочерей."
+          "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Ich muss meinen Vater vor seinen grausamen Töchtern retten.",
+          "sentence_translation": "Во главе французской армии у Дувра Корделия восклицает: Я должна спасти отца от его жестоких дочерей."
         },
         {
           "german": "die Schlacht",
           "russian": "битва",
           "transcription": "[ди ШЛАХТ]",
-          "sentence": "Diese Schlacht entscheidet über das Schicksal des Königreichs.",
-          "sentence_translation": "Эта битва решает судьбу королевства."
+          "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Diese Schlacht entscheidet über das Schicksal des Königreichs.",
+          "sentence_translation": "Во главе французской армии у Дувра Корделия восклицает: Эта битва решает судьбу королевства."
         },
         {
           "german": "mutig",
           "russian": "храбрый",
           "transcription": "[МУ-тиг]",
-          "sentence": "Sei mutig, mein Herz, für die gerechte Sache.",
-          "sentence_translation": "Будь храбрым, моё сердце, ради правого дела."
+          "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Sei mutig, mein Herz, für die gerechte Sache.",
+          "sentence_translation": "Во главе французской армии у Дувра Корделия восклицает: Будь храбрым, моё сердце, ради правого дела."
         },
         {
           "german": "die Gerechtigkeit",
           "russian": "справедливость",
           "transcription": "[ди ге-РЕХ-тиг-кайт]",
-          "sentence": "Die Gerechtigkeit führt meine Klinge.",
-          "sentence_translation": "Справедливость ведёт мой клинок."
+          "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Die Gerechtigkeit führt meine Klinge.",
+          "sentence_translation": "Во главе французской армии у Дувра Корделия восклицает: Справедливость ведёт мой клинок."
         },
         {
           "german": "siegen",
           "russian": "побеждать",
           "transcription": "[ЗИ-ген]",
-          "sentence": "Die Liebe wird über den Hass siegen.",
-          "sentence_translation": "Любовь победит ненависть."
+          "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Die Liebe wird über den Hass siegen.",
+          "sentence_translation": "Во главе французской армии у Дувра Корделия восклицает: Любовь победит ненависть."
         },
         {
           "german": "die Armee",
           "russian": "армия",
           "transcription": "[ди ар-МЭ]",
-          "sentence": "Diese Armee kämpft für Gerechtigkeit und Liebe.",
-          "sentence_translation": "Эта армия сражается за справедливость и любовь."
+          "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Diese Armee kämpft für Gerechtigkeit und Liebe.",
+          "sentence_translation": "Во главе французской армии у Дувра Корделия восклицает: Эта армия сражается за справедливость и любовь."
         }
       ],
       "quizzes": [
@@ -392,57 +392,57 @@
           "german": "verzeihen",
           "russian": "прощать",
           "transcription": "[фер-ЦАЙ-ен]",
-          "sentence": "Ich verzeihe dir alles, mein lieber Vater.",
-          "sentence_translation": "Я прощаю тебе всё, мой дорогой отец."
+          "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Ich verzeihe dir alles, mein lieber Vater.",
+          "sentence_translation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Я прощаю тебе всё, мой дорогой отец."
         },
         {
           "german": "die Tränen",
           "russian": "слёзы",
           "transcription": "[ди ТРЕ-нен]",
-          "sentence": "Unsere Tränen waschen den Schmerz fort.",
-          "sentence_translation": "Наши слёзы смывают боль."
+          "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Unsere Tränen waschen den Schmerz fort.",
+          "sentence_translation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Наши слёзы смывают боль."
         },
         {
           "german": "umarmen",
           "russian": "обнимать",
           "transcription": "[ум-АР-мен]",
-          "sentence": "Lass mich dich umarmen und deine Tränen trocknen.",
-          "sentence_translation": "Позволь мне обнять тебя и вытереть твои слёзы."
+          "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Lass mich dich umarmen und deine Tränen trocknen.",
+          "sentence_translation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Позволь мне обнять тебя и вытереть твои слёзы."
         },
         {
           "german": "erkennen",
           "russian": "узнавать",
           "transcription": "[ер-КЕН-нен]",
-          "sentence": "Erkennst du mich, dein Kind Cordelia?",
-          "sentence_translation": "Узнаёшь ли ты меня, твоё дитя Корделия?"
+          "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Erkennst du mich, dein Kind Cordelia?",
+          "sentence_translation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Узнаёшь ли ты меня, твоё дитя Корделия?"
         },
         {
           "german": "heilen",
           "russian": "исцелять",
           "transcription": "[ХАЙ-лен]",
-          "sentence": "Meine Liebe wird deine Wunden heilen.",
-          "sentence_translation": "Моя любовь исцелит твои раны."
+          "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Meine Liebe wird deine Wunden heilen.",
+          "sentence_translation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Моя любовь исцелит твои раны."
         },
         {
           "german": "die Reue",
           "russian": "раскаяние",
           "transcription": "[ди РОЙ-е]",
-          "sentence": "Deine Reue ist nicht nötig, nur deine Liebe.",
-          "sentence_translation": "Твоё раскаяние не нужно, только твоя любовь."
+          "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Deine Reue ist nicht nötig, nur deine Liebe.",
+          "sentence_translation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Твоё раскаяние не нужно, только твоя любовь."
         },
         {
           "german": "sanft",
           "russian": "нежный",
           "transcription": "[ЗАНФТ]",
-          "sentence": "Sei sanft zu dir selbst, lieber Vater.",
-          "sentence_translation": "Будь нежен к себе, дорогой отец."
+          "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Sei sanft zu dir selbst, lieber Vater.",
+          "sentence_translation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Будь нежен к себе, дорогой отец."
         },
         {
           "german": "die Vergebung",
           "russian": "прощение",
           "transcription": "[ди фер-ГЕ-бунг]",
-          "sentence": "Die Vergebung ist der Schlüssel zum Frieden.",
-          "sentence_translation": "Прощение - ключ к покою."
+          "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Die Vergebung ist der Schlüssel zum Frieden.",
+          "sentence_translation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Прощение - ключ к покою."
         }
       ],
       "quizzes": [
@@ -485,57 +485,57 @@
           "german": "gefangen",
           "russian": "пленный",
           "transcription": "[ге-ФАН-ген]",
-          "sentence": "Obwohl gefangen, bin ich frei in meinem Herzen.",
-          "sentence_translation": "Хотя я в плену, в сердце я свободна."
+          "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Obwohl gefangen, bin ich frei in meinem Herzen.",
+          "sentence_translation": "После поражения на поле под Дувром Корделия говорит как пленница: Хотя я в плену, в сердце я свободна."
         },
         {
           "german": "das Gefängnis",
           "russian": "тюрьма",
           "transcription": "[дас ге-ФЭНГ-нис]",
-          "sentence": "Dieses Gefängnis kann meine Liebe nicht einsperren.",
-          "sentence_translation": "Эта тюрьма не может запереть мою любовь."
+          "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Dieses Gefängnis kann meine Liebe nicht einsperren.",
+          "sentence_translation": "После поражения на поле под Дувром Корделия говорит как пленница: Эта тюрьма не может запереть мою любовь."
         },
         {
           "german": "die Würde",
           "russian": "достоинство",
           "transcription": "[ди ВЮР-де]",
-          "sentence": "Mit Würde trage ich mein Schicksal.",
-          "sentence_translation": "С достоинством я несу свою судьбу."
+          "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Mit Würde trage ich mein Schicksal.",
+          "sentence_translation": "После поражения на поле под Дувром Корделия говорит как пленница: С достоинством я несу свою судьбу."
         },
         {
           "german": "trösten",
           "russian": "утешать",
           "transcription": "[ТРЁС-тен]",
-          "sentence": "Lass mich dich trösten in dieser dunklen Stunde.",
-          "sentence_translation": "Позволь мне утешить тебя в этот тёмный час."
+          "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Lass mich dich trösten in dieser dunklen Stunde.",
+          "sentence_translation": "После поражения на поле под Дувром Корделия говорит как пленница: Позволь мне утешить тебя в этот тёмный час."
         },
         {
           "german": "tapfer",
           "russian": "отважный",
           "transcription": "[ТАП-фер]",
-          "sentence": "Ich bleibe tapfer für dich, Vater.",
-          "sentence_translation": "Я остаюсь отважной ради тебя, отец."
+          "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Ich bleibe tapfer für dich, Vater.",
+          "sentence_translation": "После поражения на поле под Дувром Корделия говорит как пленница: Я остаюсь отважной ради тебя, отец."
         },
         {
           "german": "die Demut",
           "russian": "смирение",
           "transcription": "[ди ДЕ-мут]",
-          "sentence": "In der Demut finden wir wahre Größe.",
-          "sentence_translation": "В смирении мы находим истинное величие."
+          "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: In der Demut finden wir wahre Größe.",
+          "sentence_translation": "После поражения на поле под Дувром Корделия говорит как пленница: В смирении мы находим истинное величие."
         },
         {
           "german": "das Schicksal",
           "russian": "судьба",
           "transcription": "[дас ШИК-заль]",
-          "sentence": "Unser Schicksal ist miteinander verwoben.",
-          "sentence_translation": "Наши судьбы переплетены."
+          "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Unser Schicksal ist miteinander verwoben.",
+          "sentence_translation": "После поражения на поле под Дувром Корделия говорит как пленница: Наши судьбы переплетены."
         },
         {
           "german": "die Ehre",
           "russian": "честь",
           "transcription": "[ди Э-ре]",
-          "sentence": "Unsere Ehre bleibt unbefleckt.",
-          "sentence_translation": "Наша честь остаётся незапятнанной."
+          "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Unsere Ehre bleibt unbefleckt.",
+          "sentence_translation": "После поражения на поле под Дувром Корделия говорит как пленница: Наша честь остаётся незапятнанной."
         }
       ],
       "quizzes": [
@@ -578,57 +578,57 @@
           "german": "der Tod",
           "russian": "смерть",
           "transcription": "[дер ТОД]",
-          "sentence": "Der Tod trennt uns nur für kurze Zeit.",
-          "sentence_translation": "Смерть разлучает нас лишь ненадолго."
+          "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Der Tod trennt uns nur für kurze Zeit.",
+          "sentence_translation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Смерть разлучает нас лишь ненадолго."
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
-          "sentence": "Wenn ich sterben muss, sterbe ich mit reinem Herzen.",
-          "sentence_translation": "Если я должна умереть, я умру с чистым сердцем."
+          "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Wenn ich sterben muss, sterbe ich mit reinem Herzen.",
+          "sentence_translation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Если я должна умереть, я умру с чистым сердцем."
         },
         {
           "german": "das Opfer",
           "russian": "жертва",
           "transcription": "[дас ОП-фер]",
-          "sentence": "Ich bin das Opfer der Wahrheit und Liebe.",
-          "sentence_translation": "Я жертва правды и любви."
+          "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Ich bin das Opfer der Wahrheit und Liebe.",
+          "sentence_translation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Я жертва правды и любви."
         },
         {
           "german": "die Seele",
           "russian": "душа",
           "transcription": "[ди ЗЕ-ле]",
-          "sentence": "Meine Seele ist rein vor Gott.",
-          "sentence_translation": "Моя душа чиста перед Богом."
+          "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Meine Seele ist rein vor Gott.",
+          "sentence_translation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Моя душа чиста перед Богом."
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЕН-де]",
-          "sentence": "Dies ist nicht das Ende, nur ein Übergang.",
-          "sentence_translation": "Это не конец, только переход."
+          "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Dies ist nicht das Ende, nur ein Übergang.",
+          "sentence_translation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Это не конец, только переход."
         },
         {
           "german": "ewig",
           "russian": "вечный",
           "transcription": "[Э-виг]",
-          "sentence": "Unsere Liebe ist ewig, Vater.",
-          "sentence_translation": "Наша любовь вечна, отец."
+          "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Unsere Liebe ist ewig, Vater.",
+          "sentence_translation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Наша любовь вечна, отец."
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
-          "sentence": "Unser Abschied ist nur vorübergehend.",
-          "sentence_translation": "Наше прощание лишь временно."
+          "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Unser Abschied ist nur vorübergehend.",
+          "sentence_translation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Наше прощание лишь временно."
         },
         {
           "german": "die Erlösung",
           "russian": "спасение",
           "transcription": "[ди ер-ЛЁ-зунг]",
-          "sentence": "Im Tod finde ich Erlösung und Frieden.",
-          "sentence_translation": "В смерти я нахожу спасение и покой."
+          "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Im Tod finde ich Erlösung und Frieden.",
+          "sentence_translation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: В смерти я нахожу спасение и покой."
         }
       ],
       "quizzes": [

--- a/data/characters/cornwall.json
+++ b/data/characters/cornwall.json
@@ -14,57 +14,57 @@
           "german": "der Ehrgeiz",
           "russian": "честолюбие",
           "transcription": "[дер ЭР-гайц]",
-          "sentence": "Mein Ehrgeiz kennt keine Grenzen mehr.",
-          "sentence_translation": "Моё честолюбие не знает больше границ."
+          "sentence": "In Glosters Schloss plant Herzog Cornwall: Mein Ehrgeiz kennt keine Grenzen mehr.",
+          "sentence_translation": "В замке Глостера герцог Корнуолл замышляет: Моё честолюбие не знает больше границ."
         },
         {
           "german": "die Gier",
           "russian": "жадность",
           "transcription": "[ди ГИР]",
-          "sentence": "Die Gier nach Macht verzehrt meine Seele.",
-          "sentence_translation": "Жадность к власти пожирает мою душу."
+          "sentence": "In Glosters Schloss plant Herzog Cornwall: Die Gier nach Macht verzehrt meine Seele.",
+          "sentence_translation": "В замке Глостера герцог Корнуолл замышляет: Жадность к власти пожирает мою душу."
         },
         {
           "german": "streben",
           "russian": "стремиться",
           "transcription": "[ШТРЕ-бен]",
-          "sentence": "Ich strebe nach absoluter Kontrolle.",
-          "sentence_translation": "Я стремлюсь к абсолютному контролю."
+          "sentence": "In Glosters Schloss plant Herzog Cornwall: Ich strebe nach absoluter Kontrolle.",
+          "sentence_translation": "В замке Глостера герцог Корнуолл замышляет: Я стремлюсь к абсолютному контролю."
         },
         {
           "german": "verlangen",
           "russian": "желать",
           "transcription": "[фер-ЛАН-ген]",
-          "sentence": "Ich verlange mehr als mir zusteht.",
-          "sentence_translation": "Я желаю больше, чем мне положено."
+          "sentence": "In Glosters Schloss plant Herzog Cornwall: Ich verlange mehr als mir zusteht.",
+          "sentence_translation": "В замке Глостера герцог Корнуолл замышляет: Я желаю больше, чем мне положено."
         },
         {
           "german": "begehren",
           "russian": "вожделеть",
           "transcription": "[бе-ГЕ-рен]",
-          "sentence": "Ich begehre die Krone für mich selbst.",
-          "sentence_translation": "Я вожделею корону для себя."
+          "sentence": "In Glosters Schloss plant Herzog Cornwall: Ich begehre die Krone für mich selbst.",
+          "sentence_translation": "В замке Глостера герцог Корнуолл замышляет: Я вожделею корону для себя."
         },
         {
           "german": "gierig",
           "russian": "жадный",
           "transcription": "[ГИ-риг]",
-          "sentence": "Gierig greife ich nach jedem Stück Macht.",
-          "sentence_translation": "Жадно я хватаюсь за каждый кусок власти."
+          "sentence": "In Glosters Schloss plant Herzog Cornwall: Gierig greife ich nach jedem Stück Macht.",
+          "sentence_translation": "В замке Глостера герцог Корнуолл замышляет: Жадно я хватаюсь за каждый кусок власти."
         },
         {
           "german": "die Herrschsucht",
           "russian": "властолюбие",
           "transcription": "[ди ХЕР-зухт]",
-          "sentence": "Die Herrschsucht bestimmt all meine Taten.",
-          "sentence_translation": "Властолюбие определяет все мои поступки."
+          "sentence": "In Glosters Schloss plant Herzog Cornwall: Die Herrschsucht bestimmt all meine Taten.",
+          "sentence_translation": "В замке Глостера герцог Корнуолл замышляет: Властолюбие определяет все мои поступки."
         },
         {
           "german": "ergreifen",
           "russian": "захватывать",
           "transcription": "[ер-ГРАЙ-фен]",
-          "sentence": "Ich ergreife jede Gelegenheit zur Macht.",
-          "sentence_translation": "Я захватываю каждую возможность власти."
+          "sentence": "In Glosters Schloss plant Herzog Cornwall: Ich ergreife jede Gelegenheit zur Macht.",
+          "sentence_translation": "В замке Глостера герцог Корнуолл замышляет: Я захватываю каждую возможность власти."
         }
       ],
       "theatrical_scene": {
@@ -107,50 +107,50 @@
           "german": "die Grausamkeit",
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
-          "sentence": "Die Grausamkeit meiner Frau gefällt mir.",
-          "sentence_translation": "Жестокость моей жены мне нравится."
+          "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Die Grausamkeit meiner Frau gefällt mir.",
+          "sentence_translation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Жестокость моей жены мне нравится."
         },
         {
           "german": "die Bosheit",
           "russian": "злоба",
           "transcription": "[ди БОС-хайт]",
-          "sentence": "Unsere Bosheit macht uns zum perfekten Paar.",
-          "sentence_translation": "Наша злоба делает нас идеальной парой."
+          "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Unsere Bosheit macht uns zum perfekten Paar.",
+          "sentence_translation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Наша злоба делает нас идеальной парой."
         },
         {
           "german": "billigen",
           "russian": "одобрять",
           "transcription": "[БИ-ли-ген]",
-          "sentence": "Ich billige alle ihre grausamen Pläne.",
-          "sentence_translation": "Я одобряю все её жестокие планы."
+          "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Ich billige alle ihre grausamen Pläne.",
+          "sentence_translation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Я одобряю все её жестокие планы."
         },
         {
           "german": "unterstützen",
           "russian": "поддерживать",
           "transcription": "[ун-тер-ШТЮ-цен]",
-          "sentence": "Ich unterstütze ihre Unmenschlichkeit.",
-          "sentence_translation": "Я поддерживаю её бесчеловечность."
+          "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Ich unterstütze ihre Unmenschlichkeit.",
+          "sentence_translation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Я поддерживаю её бесчеловечность."
         },
         {
           "german": "anstacheln",
           "russian": "подстрекать",
           "transcription": "[АН-шта-хельн]",
-          "sentence": "Ich stachle sie zu größerer Grausamkeit an.",
-          "sentence_translation": "Я подстрекаю её к большей жестокости."
+          "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Ich stachle sie zu größerer Grausamkeit an.",
+          "sentence_translation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Я подстрекаю её к большей жестокости."
         },
         {
           "german": "ermutigen",
           "russian": "поощрять",
           "transcription": "[ер-МУ-ти-ген]",
-          "sentence": "Ich ermutige ihre dunkelsten Impulse.",
-          "sentence_translation": "Я поощряю её самые тёмные импульсы."
+          "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Ich ermutige ihre dunkelsten Impulse.",
+          "sentence_translation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Я поощряю её самые тёмные импульсы."
         },
         {
           "german": "die Härte",
           "russian": "суровость",
           "transcription": "[ди ХЕР-те]",
-          "sentence": "Mit eiserner Härte regieren wir zusammen.",
-          "sentence_translation": "С железной суровостью мы правим вместе."
+          "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Mit eiserner Härte regieren wir zusammen.",
+          "sentence_translation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: С железной суровостью мы правим вместе."
         }
       ],
       "theatrical_scene": {
@@ -193,57 +193,57 @@
           "german": "die Tyrannei",
           "russian": "тирания",
           "transcription": "[ди тю-ра-НАЙ]",
-          "sentence": "Meine Tyrannei erstickt jeden Widerstand.",
-          "sentence_translation": "Моя тирания душит любое сопротивление."
+          "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Meine Tyrannei erstickt jeden Widerstand.",
+          "sentence_translation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Моя тирания душит любое сопротивление."
         },
         {
           "german": "die Unterdrückung",
           "russian": "угнетение",
           "transcription": "[ди ун-тер-ДРЮ-кунг]",
-          "sentence": "Die Unterdrückung ist mein Herrschaftsmittel.",
-          "sentence_translation": "Угнетение - моё средство правления."
+          "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Die Unterdrückung ist mein Herrschaftsmittel.",
+          "sentence_translation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Угнетение - моё средство правления."
         },
         {
           "german": "die Furcht",
           "russian": "страх",
           "transcription": "[ди ФУРХТ]",
-          "sentence": "Durch Furcht halte ich alle unter Kontrolle.",
-          "sentence_translation": "Страхом я держу всех под контролем."
+          "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Durch Furcht halte ich alle unter Kontrolle.",
+          "sentence_translation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Страхом я держу всех под контролем."
         },
         {
           "german": "unterdrücken",
           "russian": "подавлять",
           "transcription": "[ун-тер-ДРЮ-кен]",
-          "sentence": "Ich unterdrücke jeden freien Gedanken.",
-          "sentence_translation": "Я подавляю любую свободную мысль."
+          "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Ich unterdrücke jeden freien Gedanken.",
+          "sentence_translation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Я подавляю любую свободную мысль."
         },
         {
           "german": "knechten",
           "russian": "порабощать",
           "transcription": "[КНЕХ-тен]",
-          "sentence": "Ich knechte alle, die mir unterstehen.",
-          "sentence_translation": "Я порабощаю всех, кто мне подчинён."
+          "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Ich knechte alle, die mir unterstehen.",
+          "sentence_translation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Я порабощаю всех, кто мне подчинён."
         },
         {
           "german": "zwingen",
           "russian": "принуждать",
           "transcription": "[ЦВИН-ген]",
-          "sentence": "Ich zwinge alle zu absolutem Gehorsam.",
-          "sentence_translation": "Я принуждаю всех к абсолютному послушанию."
+          "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Ich zwinge alle zu absolutem Gehorsam.",
+          "sentence_translation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Я принуждаю всех к абсолютному послушанию."
         },
         {
           "german": "die Willkür",
           "russian": "произвол",
           "transcription": "[ди ВИЛЬ-кюр]",
-          "sentence": "Meine Willkür ist das einzige Gesetz.",
-          "sentence_translation": "Мой произвол - единственный закон."
+          "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Meine Willkür ist das einzige Gesetz.",
+          "sentence_translation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Мой произвол - единственный закон."
         },
         {
           "german": "brutal",
           "russian": "брутальный",
           "transcription": "[бру-ТАЛЬ]",
-          "sentence": "Brutal zerschlage ich jeden Widerstand.",
-          "sentence_translation": "Брутально я сокрушаю любое сопротивление."
+          "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Brutal zerschlage ich jeden Widerstand.",
+          "sentence_translation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Брутально я сокрушаю любое сопротивление."
         }
       ],
       "theatrical_scene": {
@@ -286,50 +286,50 @@
           "german": "die Strafe",
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
-          "sentence": "Die Strafe für Widerspruch ist hart.",
-          "sentence_translation": "Наказание за возражение сурово."
+          "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Die Strafe für Widerspruch ist hart.",
+          "sentence_translation": "Перед стенами замка Глостера Корнуолл приказывает: Наказание за возражение сурово."
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
-          "sentence": "Mein Zorn kennt keine Barmherzigkeit.",
-          "sentence_translation": "Мой гнев не знает милосердия."
+          "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Mein Zorn kennt keine Barmherzigkeit.",
+          "sentence_translation": "Перед стенами замка Глостера Корнуолл приказывает: Мой гнев не знает милосердия."
         },
         {
           "german": "bestrafen",
           "russian": "карать",
           "transcription": "[бе-ШТРА-фен]",
-          "sentence": "Ich bestrafe Kent für seine Frechheit.",
-          "sentence_translation": "Я караю Кента за его дерзость."
+          "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Ich bestrafe Kent für seine Frechheit.",
+          "sentence_translation": "Перед стенами замка Глостера Корнуолл приказывает: Я караю Кента за его дерзость."
         },
         {
           "german": "züchtigen",
           "russian": "наказывать",
           "transcription": "[ЦЮХ-ти-ген]",
-          "sentence": "Öffentlich züchtige ich die Widerspenstigen.",
-          "sentence_translation": "Публично я наказываю непокорных."
+          "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Öffentlich züchtige ich die Widerspenstigen.",
+          "sentence_translation": "Перед стенами замка Глостера Корнуолл приказывает: Публично я наказываю непокорных."
         },
         {
           "german": "demütigen",
           "russian": "унижать",
           "transcription": "[де-МЮ-ти-ген]",
-          "sentence": "Ich demütige ihn vor aller Augen.",
-          "sentence_translation": "Я унижаю его на глазах у всех."
+          "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Ich demütige ihn vor aller Augen.",
+          "sentence_translation": "Перед стенами замка Глостера Корнуолл приказывает: Я унижаю его на глазах у всех."
         },
         {
           "german": "erniedrigen",
           "russian": "унижать",
           "transcription": "[ер-НИД-ри-ген]",
-          "sentence": "Ich erniedrige den treuen Diener.",
-          "sentence_translation": "Я унижаю верного слугу."
+          "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Ich erniedrige den treuen Diener.",
+          "sentence_translation": "Перед стенами замка Глостера Корнуолл приказывает: Я унижаю верного слугу."
         },
         {
           "german": "quälen",
           "russian": "мучить",
           "transcription": "[КВЕ-лен]",
-          "sentence": "Es bereitet mir Freude, ihn zu quälen.",
-          "sentence_translation": "Мне доставляет радость мучить его."
+          "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Es bereitet mir Freude, ihn zu quälen.",
+          "sentence_translation": "Перед стенами замка Глостера Корнуолл приказывает: Мне доставляет радость мучить его."
         }
       ],
       "theatrical_scene": {
@@ -372,57 +372,57 @@
           "german": "die Folter",
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
-          "sentence": "Die Folter ist mein liebstes Werkzeug.",
-          "sentence_translation": "Пытка - мой любимый инструмент."
+          "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Die Folter ist mein liebstes Werkzeug.",
+          "sentence_translation": "В застенках Глостера Корнуолл готовит пытку: Пытка - мой любимый инструмент."
         },
         {
           "german": "der Sadismus",
           "russian": "садизм",
           "transcription": "[дер за-ДИС-мус]",
-          "sentence": "Mein Sadismus kennt keine Grenzen.",
-          "sentence_translation": "Мой садизм не знает границ."
+          "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Mein Sadismus kennt keine Grenzen.",
+          "sentence_translation": "В застенках Глостера Корнуолл готовит пытку: Мой садизм не знает границ."
         },
         {
           "german": "das Blut",
           "russian": "кровь",
           "transcription": "[дас БЛУТ]",
-          "sentence": "Das Blut des Grafen befleckt meine Hände.",
-          "sentence_translation": "Кровь графа пятнает мои руки."
+          "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Das Blut des Grafen befleckt meine Hände.",
+          "sentence_translation": "В застенках Глостера Корнуолл готовит пытку: Кровь графа пятнает мои руки."
         },
         {
           "german": "foltern",
           "russian": "пытать",
           "transcription": "[ФОЛЬ-терн]",
-          "sentence": "Mit Lust foltere ich den alten Mann.",
-          "sentence_translation": "С наслаждением я пытаю старика."
+          "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Mit Lust foltere ich den alten Mann.",
+          "sentence_translation": "В застенках Глостера Корнуолл готовит пытку: С наслаждением я пытаю старика."
         },
         {
           "german": "verstümmeln",
           "russian": "калечить",
           "transcription": "[фер-ШТЮМ-мельн]",
-          "sentence": "Ich verstümmle ihn ohne Erbarmen.",
-          "sentence_translation": "Я калечу его без милосердия."
+          "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Ich verstümmle ihn ohne Erbarmen.",
+          "sentence_translation": "В застенках Глостера Корнуолл готовит пытку: Я калечу его без милосердия."
         },
         {
           "german": "blenden",
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
-          "sentence": "Eigenhändig blende ich Gloucester.",
-          "sentence_translation": "Собственноручно я ослепляю Глостера."
+          "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Eigenhändig blende ich Gloucester.",
+          "sentence_translation": "В застенках Глостера Корнуолл готовит пытку: Собственноручно я ослепляю Глостера."
         },
         {
           "german": "ausstechen",
           "russian": "выкалывать",
           "transcription": "[АУС-ште-хен]",
-          "sentence": "Seine Augen steche ich mit Freude aus.",
-          "sentence_translation": "Его глаза я выкалываю с радостью."
+          "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Seine Augen steche ich mit Freude aus.",
+          "sentence_translation": "В застенках Глостера Корнуолл готовит пытку: Его глаза я выкалываю с радостью."
         },
         {
           "german": "die Qual",
           "russian": "мука",
           "transcription": "[ди КВАЛЬ]",
-          "sentence": "Seine Qual bereitet mir Vergnügen.",
-          "sentence_translation": "Его мука доставляет мне удовольствие."
+          "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Seine Qual bereitet mir Vergnügen.",
+          "sentence_translation": "В застенках Глостера Корнуолл готовит пытку: Его мука доставляет мне удовольствие."
         }
       ],
       "theatrical_scene": {
@@ -465,50 +465,50 @@
           "german": "die Wunde",
           "russian": "рана",
           "transcription": "[ди ВУН-де]",
-          "sentence": "Die Wunde brennt wie Feuer in meinem Leib.",
-          "sentence_translation": "Рана горит как огонь в моём теле."
+          "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Die Wunde brennt wie Feuer in meinem Leib.",
+          "sentence_translation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Рана горит как огонь в моём теле."
         },
         {
           "german": "der Schmerz",
           "russian": "боль",
           "transcription": "[дер ШМЕРЦ]",
-          "sentence": "Der Schmerz durchbohrt meinen Körper.",
-          "sentence_translation": "Боль пронзает моё тело."
+          "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Der Schmerz durchbohrt meinen Körper.",
+          "sentence_translation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Боль пронзает моё тело."
         },
         {
           "german": "die Überraschung",
           "russian": "удивление",
           "transcription": "[ди ю-бер-РА-шунг]",
-          "sentence": "Die Überraschung des Angriffs schockiert mich.",
-          "sentence_translation": "Неожиданность нападения шокирует меня."
+          "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Die Überraschung des Angriffs schockiert mich.",
+          "sentence_translation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Неожиданность нападения шокирует меня."
         },
         {
           "german": "bluten",
           "russian": "кровоточить",
           "transcription": "[БЛУ-тен]",
-          "sentence": "Ich blute wie ein geschlachtetes Schwein.",
-          "sentence_translation": "Я кровоточу как зарезанная свинья."
+          "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Ich blute wie ein geschlachtetes Schwein.",
+          "sentence_translation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Я кровоточу как зарезанная свинья."
         },
         {
           "german": "verwundet",
           "russian": "раненый",
           "transcription": "[фер-ВУН-дет]",
-          "sentence": "Schwer verwundet sinke ich zu Boden.",
-          "sentence_translation": "Тяжело раненый я падаю на землю."
+          "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Schwer verwundet sinke ich zu Boden.",
+          "sentence_translation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Тяжело раненый я падаю на землю."
         },
         {
           "german": "schwächen",
           "russian": "ослаблять",
           "transcription": "[ШВЕ-хен]",
-          "sentence": "Die Verletzung schwächt meinen starken Körper.",
-          "sentence_translation": "Ранение ослабляет моё сильное тело."
+          "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Die Verletzung schwächt meinen starken Körper.",
+          "sentence_translation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Ранение ослабляет моё сильное тело."
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
-          "sentence": "Zum ersten Mal leide ich selbst.",
-          "sentence_translation": "Впервые я сам страдаю."
+          "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Zum ersten Mal leide ich selbst.",
+          "sentence_translation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Впервые я сам страдаю."
         }
       ],
       "theatrical_scene": {
@@ -551,57 +551,57 @@
           "german": "der Tod",
           "russian": "смерть",
           "transcription": "[дер ТОД]",
-          "sentence": "Der Tod kommt für mich zu früh.",
-          "sentence_translation": "Смерть приходит ко мне слишком рано."
+          "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Der Tod kommt für mich zu früh.",
+          "sentence_translation": "Умирая в покоях Реганы, Корнуолл рычит: Смерть приходит ко мне слишком рано."
         },
         {
           "german": "die Vergeltung",
           "russian": "возмездие",
           "transcription": "[ди фер-ГЕЛЬ-тунг]",
-          "sentence": "Die Vergeltung ereilt mich unerwartet.",
-          "sentence_translation": "Возмездие настигает меня неожиданно."
+          "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Die Vergeltung ereilt mich unerwartet.",
+          "sentence_translation": "Умирая в покоях Реганы, Корнуолл рычит: Возмездие настигает меня неожиданно."
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЕН-де]",
-          "sentence": "Mein Ende kommt durch eines Dieners Hand.",
-          "sentence_translation": "Мой конец приходит от руки слуги."
+          "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Mein Ende kommt durch eines Dieners Hand.",
+          "sentence_translation": "Умирая в покоях Реганы, Корнуолл рычит: Мой конец приходит от руки слуги."
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
-          "sentence": "Ich sterbe ohne Reue für meine Taten.",
-          "sentence_translation": "Я умираю без раскаяния за свои дела."
+          "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Ich sterbe ohne Reue für meine Taten.",
+          "sentence_translation": "Умирая в покоях Реганы, Корнуолл рычит: Я умираю без раскаяния за свои дела."
         },
         {
           "german": "verenden",
           "russian": "издыхать",
           "transcription": "[фер-ЕН-ден]",
-          "sentence": "Wie ein Tier verende ich elend.",
-          "sentence_translation": "Как зверь я издыхаю жалко."
+          "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Wie ein Tier verende ich elend.",
+          "sentence_translation": "Умирая в покоях Реганы, Корнуолл рычит: Как зверь я издыхаю жалко."
         },
         {
           "german": "verfluchen",
           "russian": "проклинать",
           "transcription": "[фер-ФЛУ-хен]",
-          "sentence": "Sterbend verfluche ich meine Mörder.",
-          "sentence_translation": "Умирая, я проклинаю своих убийц."
+          "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Sterbend verfluche ich meine Mörder.",
+          "sentence_translation": "Умирая в покоях Реганы, Корнуолл рычит: Умирая, я проклинаю своих убийц."
         },
         {
           "german": "röcheln",
           "russian": "хрипеть",
           "transcription": "[РЁ-хельн]",
-          "sentence": "Röchelnd hauche ich mein Leben aus.",
-          "sentence_translation": "Хрипя, я испускаю дух."
+          "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Röchelnd hauche ich mein Leben aus.",
+          "sentence_translation": "Умирая в покоях Реганы, Корнуолл рычит: Хрипя, я испускаю дух."
         },
         {
           "german": "die Strafe",
           "russian": "кара",
           "transcription": "[ди ШТРА-фе]",
-          "sentence": "Dies ist die gerechte Strafe für meine Grausamkeit.",
-          "sentence_translation": "Это справедливая кара за мою жестокость."
+          "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Dies ist die gerechte Strafe für meine Grausamkeit.",
+          "sentence_translation": "Умирая в покоях Реганы, Корнуолл рычит: Это справедливая кара за мою жестокость."
         }
       ],
       "theatrical_scene": {

--- a/data/characters/edgar.json
+++ b/data/characters/edgar.json
@@ -20,57 +20,57 @@
           "german": "der Adel",
           "russian": "знать",
           "transcription": "[дер А-дель]",
-          "sentence": "Der Adel erwartet von mir ehrenhaftes Verhalten.",
-          "sentence_translation": "Знать ожидает от меня достойного поведения."
+          "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Der Adel erwartet von mir ehrenhaftes Verhalten.",
+          "sentence_translation": "В зале Глостера Эдгар обещает отцу: Знать ожидает от меня достойного поведения."
         },
         {
           "german": "der Erbe",
           "russian": "наследник",
           "transcription": "[дер ЕР-бе]",
-          "sentence": "Als rechtmäßiger Erbe habe ich Pflichten.",
-          "sentence_translation": "Как законный наследник, у меня есть обязанности."
+          "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Als rechtmäßiger Erbe habe ich Pflichten.",
+          "sentence_translation": "В зале Глостера Эдгар обещает отцу: Как законный наследник, у меня есть обязанности."
         },
         {
           "german": "das Königreich",
           "russian": "королевство",
           "transcription": "[дас КЁ-ниг-райх]",
-          "sentence": "Ich diene dem Königreich mit Ehre.",
-          "sentence_translation": "Я служу королевству с честью."
+          "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Ich diene dem Königreich mit Ehre.",
+          "sentence_translation": "В зале Глостера Эдгар обещает отцу: Я служу королевству с честью."
         },
         {
           "german": "vertrauen",
           "russian": "доверять",
           "transcription": "[фер-ТРАУ-ен]",
-          "sentence": "Mein Vater vertraut mir vollkommen.",
-          "sentence_translation": "Мой отец полностью мне доверяет."
+          "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Mein Vater vertraut mir vollkommen.",
+          "sentence_translation": "В зале Глостера Эдгар обещает отцу: Мой отец полностью мне доверяет."
         },
         {
           "german": "die Ehre",
           "russian": "честь",
           "transcription": "[ди Э-ре]",
-          "sentence": "Die Ehre der Familie liegt in meinen Händen.",
-          "sentence_translation": "Честь семьи в моих руках."
+          "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Die Ehre der Familie liegt in meinen Händen.",
+          "sentence_translation": "В зале Глостера Эдгар обещает отцу: Честь семьи в моих руках."
         },
         {
           "german": "legitim",
           "russian": "законный",
           "transcription": "[ле-ги-ТИМ]",
-          "sentence": "Ich bin der legitime Sohn des Grafen.",
-          "sentence_translation": "Я законный сын графа."
+          "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Ich bin der legitime Sohn des Grafen.",
+          "sentence_translation": "В зале Глостера Эдгар обещает отцу: Я законный сын графа."
         },
         {
           "german": "der Graf",
           "russian": "граф",
           "transcription": "[дер ГРАФ]",
-          "sentence": "Mein Vater, der Graf, ist ein edler Mann.",
-          "sentence_translation": "Мой отец, граф, благородный человек."
+          "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Mein Vater, der Graf, ist ein edler Mann.",
+          "sentence_translation": "В зале Глостера Эдгар обещает отцу: Мой отец, граф, благородный человек."
         },
         {
           "german": "ahnungslos",
           "russian": "ничего не подозревающий",
           "transcription": "[А-нунгс-лос]",
-          "sentence": "Ahnungslos vertraue ich meinem Bruder.",
-          "sentence_translation": "Ничего не подозревая, я доверяю брату."
+          "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Ahnungslos vertraue ich meinem Bruder.",
+          "sentence_translation": "В зале Глостера Эдгар обещает отцу: Ничего не подозревая, я доверяю брату."
         }
       ],
       "quizzes": [
@@ -113,57 +113,57 @@
           "german": "fliehen",
           "russian": "бежать",
           "transcription": "[ФЛИ-ен]",
-          "sentence": "Ich muss vor falschen Anschuldigungen fliehen.",
-          "sentence_translation": "Я должен бежать от ложных обвинений."
+          "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Ich muss vor falschen Anschuldigungen fliehen.",
+          "sentence_translation": "После предательства Эдмунда Эдгар бежит через лес: Я должен бежать от ложных обвинений."
         },
         {
           "german": "der Verrat",
           "russian": "предательство",
           "transcription": "[дер фер-РАТ]",
-          "sentence": "Der Verrat meines Bruders zerstört mein Leben.",
-          "sentence_translation": "Предательство моего брата разрушает мою жизнь."
+          "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Der Verrat meines Bruders zerstört mein Leben.",
+          "sentence_translation": "После предательства Эдмунда Эдгар бежит через лес: Предательство моего брата разрушает мою жизнь."
         },
         {
           "german": "die Gefahr",
           "russian": "опасность",
           "transcription": "[ди ге-ФАР]",
-          "sentence": "Die Gefahr lauert überall um mich herum.",
-          "sentence_translation": "Опасность подстерегает меня повсюду."
+          "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Die Gefahr lauert überall um mich herum.",
+          "sentence_translation": "После предательства Эдмунда Эдгар бежит через лес: Опасность подстерегает меня повсюду."
         },
         {
           "german": "verfolgen",
           "russian": "преследовать",
           "transcription": "[фер-ФОЛЬ-ген]",
-          "sentence": "Die Soldaten verfolgen mich wie einen Verbrecher.",
-          "sentence_translation": "Солдаты преследуют меня как преступника."
+          "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Die Soldaten verfolgen mich wie einen Verbrecher.",
+          "sentence_translation": "После предательства Эдмунда Эдгар бежит через лес: Солдаты преследуют меня как преступника."
         },
         {
           "german": "verstecken",
           "russian": "прятаться",
           "transcription": "[фер-ШТЕ-кен]",
-          "sentence": "Ich muss mich in den Wäldern verstecken.",
-          "sentence_translation": "Я должен прятаться в лесах."
+          "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Ich muss mich in den Wäldern verstecken.",
+          "sentence_translation": "После предательства Эдмунда Эдгар бежит через лес: Я должен прятаться в лесах."
         },
         {
           "german": "die Intrige",
           "russian": "интрига",
           "transcription": "[ди ин-ТРИ-ге]",
-          "sentence": "Edmunds Intrige hat mich zum Geächteten gemacht.",
-          "sentence_translation": "Интрига Эдмунда сделала меня изгоем."
+          "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Edmunds Intrige hat mich zum Geächteten gemacht.",
+          "sentence_translation": "После предательства Эдмунда Эдгар бежит через лес: Интрига Эдмунда сделала меня изгоем."
         },
         {
           "german": "der Betrug",
           "russian": "обман",
           "transcription": "[дер бе-ТРУГ]",
-          "sentence": "Dieser Betrug wird eines Tages aufgedeckt.",
-          "sentence_translation": "Этот обман однажды раскроется."
+          "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Dieser Betrug wird eines Tages aufgedeckt.",
+          "sentence_translation": "После предательства Эдмунда Эдгар бежит через лес: Этот обман однажды раскроется."
         },
         {
           "german": "verbannen",
           "russian": "изгнать",
           "transcription": "[фер-БАН-нен]",
-          "sentence": "Mein Vater will mich aus dem Land verbannen.",
-          "sentence_translation": "Мой отец хочет изгнать меня из страны."
+          "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Mein Vater will mich aus dem Land verbannen.",
+          "sentence_translation": "После предательства Эдмунда Эдгар бежит через лес: Мой отец хочет изгнать меня из страны."
         }
       ],
       "quizzes": [
@@ -206,57 +206,57 @@
           "german": "der Wahnsinn",
           "russian": "безумие",
           "transcription": "[дер ВАН-зин]",
-          "sentence": "Ich spiele den Wahnsinn, um zu überleben.",
-          "sentence_translation": "Я играю безумие, чтобы выжить."
+          "sentence": "Als armer Tom auf der Heide erklärt Edgar: Ich spiele den Wahnsinn, um zu überleben.",
+          "sentence_translation": "Под видом бедного Тома на пустоши Эдгар объясняет: Я играю безумие, чтобы выжить."
         },
         {
           "german": "der Bettler",
           "russian": "нищий",
           "transcription": "[дер БЕТ-лер]",
-          "sentence": "Als Bettler bin ich unsichtbar für meine Feinde.",
-          "sentence_translation": "Как нищий, я невидим для врагов."
+          "sentence": "Als armer Tom auf der Heide erklärt Edgar: Als Bettler bin ich unsichtbar für meine Feinde.",
+          "sentence_translation": "Под видом бедного Тома на пустоши Эдгар объясняет: Как нищий, я невидим для врагов."
         },
         {
           "german": "die Verkleidung",
           "russian": "маскировка",
           "transcription": "[ди фер-КЛАЙ-дунг]",
-          "sentence": "Diese Verkleidung ist meine einzige Rettung.",
-          "sentence_translation": "Эта маскировка - моё единственное спасение."
+          "sentence": "Als armer Tom auf der Heide erklärt Edgar: Diese Verkleidung ist meine einzige Rettung.",
+          "sentence_translation": "Под видом бедного Тома на пустоши Эдгар объясняет: Эта маскировка - моё единственное спасение."
         },
         {
           "german": "nackt",
           "russian": "голый",
           "transcription": "[НАКТ]",
-          "sentence": "Fast nackt wandere ich durch die Wildnis.",
-          "sentence_translation": "Почти голый, я брожу по дикой местности."
+          "sentence": "Als armer Tom auf der Heide erklärt Edgar: Fast nackt wandere ich durch die Wildnis.",
+          "sentence_translation": "Под видом бедного Тома на пустоши Эдгар объясняет: Почти голый, я брожу по дикой местности."
         },
         {
           "german": "murmeln",
           "russian": "бормотать",
           "transcription": "[МУР-мельн]",
-          "sentence": "Ich murmle Unsinn, um verrückt zu wirken.",
-          "sentence_translation": "Я бормочу чепуху, чтобы казаться сумасшедшим."
+          "sentence": "Als armer Tom auf der Heide erklärt Edgar: Ich murmle Unsinn, um verrückt zu wirken.",
+          "sentence_translation": "Под видом бедного Тома на пустоши Эдгар объясняет: Я бормочу чепуху, чтобы казаться сумасшедшим."
         },
         {
           "german": "zittern",
           "russian": "дрожать",
           "transcription": "[ЦИ-терн]",
-          "sentence": "Vor Kälte und Angst zittere ich ständig.",
-          "sentence_translation": "От холода и страха я постоянно дрожу."
+          "sentence": "Als armer Tom auf der Heide erklärt Edgar: Vor Kälte und Angst zittere ich ständig.",
+          "sentence_translation": "Под видом бедного Тома на пустоши Эдгар объясняет: От холода и страха я постоянно дрожу."
         },
         {
           "german": "das Elend",
           "russian": "нищета",
           "transcription": "[дас Э-ленд]",
-          "sentence": "Im Elend lerne ich die wahre Natur des Menschen.",
-          "sentence_translation": "В нищете я познаю истинную природу человека."
+          "sentence": "Als armer Tom auf der Heide erklärt Edgar: Im Elend lerne ich die wahre Natur des Menschen.",
+          "sentence_translation": "Под видом бедного Тома на пустоши Эдгар объясняет: В нищете я познаю истинную природу человека."
         },
         {
           "german": "wahnsinnig",
           "russian": "безумный",
           "transcription": "[ВАН-зи-ниг]",
-          "sentence": "Ich gebe vor, wahnsinnig zu sein.",
-          "sentence_translation": "Я притворяюсь безумным."
+          "sentence": "Als armer Tom auf der Heide erklärt Edgar: Ich gebe vor, wahnsinnig zu sein.",
+          "sentence_translation": "Под видом бедного Тома на пустоши Эдгар объясняет: Я притворяюсь безумным."
         }
       ],
       "quizzes": [
@@ -299,57 +299,57 @@
           "german": "der Sturm",
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
-          "sentence": "Der Sturm tobt über unseren Köpfen.",
-          "sentence_translation": "Буря бушует над нашими головами."
+          "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Der Sturm tobt über unseren Köpfen.",
+          "sentence_translation": "В штормовую ночь Лира Эдгар сопровождает короля: Буря бушует над нашими головами."
         },
         {
           "german": "frieren",
           "russian": "мёрзнуть",
           "transcription": "[ФРИ-рен]",
-          "sentence": "Wir frieren gemeinsam in dieser kalten Nacht.",
-          "sentence_translation": "Мы мёрзнем вместе в эту холодную ночь."
+          "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Wir frieren gemeinsam in dieser kalten Nacht.",
+          "sentence_translation": "В штормовую ночь Лира Эдгар сопровождает короля: Мы мёрзнем вместе в эту холодную ночь."
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
-          "sentence": "Der König leidet mehr als ich jemals gelitten habe.",
-          "sentence_translation": "Король страдает больше, чем я когда-либо страдал."
+          "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Der König leidet mehr als ich jemals gelitten habe.",
+          "sentence_translation": "В штормовую ночь Лира Эдгар сопровождает короля: Король страдает больше, чем я когда-либо страдал."
         },
         {
           "german": "die Hütte",
           "russian": "хижина",
           "transcription": "[ди ХЮ-те]",
-          "sentence": "In dieser armseligen Hütte finden wir Zuflucht.",
-          "sentence_translation": "В этой жалкой хижине мы находим убежище."
+          "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: In dieser armseligen Hütte finden wir Zuflucht.",
+          "sentence_translation": "В штормовую ночь Лира Эдгар сопровождает короля: В этой жалкой хижине мы находим убежище."
         },
         {
           "german": "beschützen",
           "russian": "защищать",
           "transcription": "[бе-ШЮ-цен]",
-          "sentence": "Heimlich beschütze ich den wahnsinnigen König.",
-          "sentence_translation": "Тайно я защищаю безумного короля."
+          "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Heimlich beschütze ich den wahnsinnigen König.",
+          "sentence_translation": "В штормовую ночь Лира Эдгар сопровождает короля: Тайно я защищаю безумного короля."
         },
         {
           "german": "begleiten",
           "russian": "сопровождать",
           "transcription": "[бе-ГЛАЙ-тен]",
-          "sentence": "Als Tom begleite ich Lear durch seine dunkelste Stunde.",
-          "sentence_translation": "Как Том, я сопровождаю Лира в его самый тёмный час."
+          "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Als Tom begleite ich Lear durch seine dunkelste Stunde.",
+          "sentence_translation": "В штормовую ночь Лира Эдгар сопровождает короля: Как Том, я сопровождаю Лира в его самый тёмный час."
         },
         {
           "german": "der Donner",
           "russian": "гром",
           "transcription": "[дер ДО-нер]",
-          "sentence": "Der Donner übertönt unsere Schreie.",
-          "sentence_translation": "Гром заглушает наши крики."
+          "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Der Donner übertönt unsere Schreie.",
+          "sentence_translation": "В штормовую ночь Лира Эдгар сопровождает короля: Гром заглушает наши крики."
         },
         {
           "german": "der Blitz",
           "russian": "молния",
           "transcription": "[дер БЛИЦ]",
-          "sentence": "Die Blitze erhellen unser Elend.",
-          "sentence_translation": "Молнии освещают нашу нищету."
+          "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Die Blitze erhellen unser Elend.",
+          "sentence_translation": "В штормовую ночь Лира Эдгар сопровождает короля: Молнии освещают нашу нищету."
         }
       ],
       "quizzes": [
@@ -392,57 +392,57 @@
           "german": "blind",
           "russian": "слепой",
           "transcription": "[БЛИНД]",
-          "sentence": "Mein blinder Vater erkennt mich nicht.",
-          "sentence_translation": "Мой слепой отец не узнаёт меня."
+          "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Mein blinder Vater erkennt mich nicht.",
+          "sentence_translation": "Перед хижиной Эдгар ведёт слепого Глостера: Мой слепой отец не узнаёт меня."
         },
         {
           "german": "führen",
           "russian": "вести",
           "transcription": "[ФЮ-рен]",
-          "sentence": "Ich führe ihn sicher durch die Dunkelheit.",
-          "sentence_translation": "Я веду его безопасно сквозь тьму."
+          "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Ich führe ihn sicher durch die Dunkelheit.",
+          "sentence_translation": "Перед хижиной Эдгар ведёт слепого Глостера: Я веду его безопасно сквозь тьму."
         },
         {
           "german": "die Klippe",
           "russian": "утёс",
           "transcription": "[ди КЛИ-пе]",
-          "sentence": "Er glaubt, wir stehen am Rand der Klippe.",
-          "sentence_translation": "Он думает, мы стоим на краю утёса."
+          "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Er glaubt, wir stehen am Rand der Klippe.",
+          "sentence_translation": "Перед хижиной Эдгар ведёт слепого Глостера: Он думает, мы стоим на краю утёса."
         },
         {
           "german": "täuschen",
           "russian": "обманывать",
           "transcription": "[ТОЙ-шен]",
-          "sentence": "Ich täusche ihn, um sein Leben zu retten.",
-          "sentence_translation": "Я обманываю его, чтобы спасти его жизнь."
+          "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Ich täusche ihn, um sein Leben zu retten.",
+          "sentence_translation": "Перед хижиной Эдгар ведёт слепого Глостера: Я обманываю его, чтобы спасти его жизнь."
         },
         {
           "german": "retten",
           "russian": "спасать",
           "transcription": "[РЕ-тен]",
-          "sentence": "Mit List will ich meinen Vater retten.",
-          "sentence_translation": "Хитростью я хочу спасти отца."
+          "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Mit List will ich meinen Vater retten.",
+          "sentence_translation": "Перед хижиной Эдгар ведёт слепого Глостера: Хитростью я хочу спасти отца."
         },
         {
           "german": "die List",
           "russian": "хитрость",
           "transcription": "[ди ЛИСТ]",
-          "sentence": "Meine List bewahrt ihn vor dem Selbstmord.",
-          "sentence_translation": "Моя хитрость спасает его от самоубийства."
+          "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Meine List bewahrt ihn vor dem Selbstmord.",
+          "sentence_translation": "Перед хижиной Эдгар ведёт слепого Глостера: Моя хитрость спасает его от самоубийства."
         },
         {
           "german": "trösten",
           "russian": "утешать",
           "transcription": "[ТРЁС-тен]",
-          "sentence": "Als Fremder tröste ich meinen eigenen Vater.",
-          "sentence_translation": "Как чужой, я утешаю собственного отца."
+          "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Als Fremder tröste ich meinen eigenen Vater.",
+          "sentence_translation": "Перед хижиной Эдгар ведёт слепого Глостера: Как чужой, я утешаю собственного отца."
         },
         {
           "german": "die Verzweiflung",
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
-          "sentence": "Seine Verzweiflung bricht mir das Herz.",
-          "sentence_translation": "Его отчаяние разбивает мне сердце."
+          "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Seine Verzweiflung bricht mir das Herz.",
+          "sentence_translation": "Перед хижиной Эдгар ведёт слепого Глостера: Его отчаяние разбивает мне сердце."
         }
       ],
       "quizzes": [
@@ -485,57 +485,57 @@
           "german": "der Kampf",
           "russian": "бой",
           "transcription": "[дер КАМПФ]",
-          "sentence": "Der Kampf gegen meinen Bruder ist unvermeidlich.",
-          "sentence_translation": "Бой с моим братом неизбежен."
+          "sentence": "Auf den Klippen von Dover schwört Edgar: Der Kampf gegen meinen Bruder ist unvermeidlich.",
+          "sentence_translation": "На утёсах Дувра Эдгар клянётся: Бой с моим братом неизбежен."
         },
         {
           "german": "das Duell",
           "russian": "дуэль",
           "transcription": "[дас ду-ЭЛЬ]",
-          "sentence": "In diesem Duell kämpfe ich für die Gerechtigkeit.",
-          "sentence_translation": "В этой дуэли я сражаюсь за справедливость."
+          "sentence": "Auf den Klippen von Dover schwört Edgar: In diesem Duell kämpfe ich für die Gerechtigkeit.",
+          "sentence_translation": "На утёсах Дувра Эдгар клянётся: В этой дуэли я сражаюсь за справедливость."
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
-          "sentence": "Nicht Rache, sondern Gerechtigkeit leitet meine Klinge.",
-          "sentence_translation": "Не месть, а справедливость ведёт мой клинок."
+          "sentence": "Auf den Klippen von Dover schwört Edgar: Nicht Rache, sondern Gerechtigkeit leitet meine Klinge.",
+          "sentence_translation": "На утёсах Дувра Эдгар клянётся: Не месть, а справедливость ведёт мой клинок."
         },
         {
           "german": "enthüllen",
           "russian": "разоблачать",
           "transcription": "[энт-ХЮ-лен]",
-          "sentence": "Ich enthülle meine wahre Identität.",
-          "sentence_translation": "Я разоблачаю свою истинную личность."
+          "sentence": "Auf den Klippen von Dover schwört Edgar: Ich enthülle meine wahre Identität.",
+          "sentence_translation": "На утёсах Дувра Эдгар клянётся: Я разоблачаю свою истинную личность."
         },
         {
           "german": "siegen",
           "russian": "побеждать",
           "transcription": "[ЗИ-ген]",
-          "sentence": "Die Wahrheit wird über die Lüge siegen.",
-          "sentence_translation": "Правда победит ложь."
+          "sentence": "Auf den Klippen von Dover schwört Edgar: Die Wahrheit wird über die Lüge siegen.",
+          "sentence_translation": "На утёсах Дувра Эдгар клянётся: Правда победит ложь."
         },
         {
           "german": "die Gerechtigkeit",
           "russian": "справедливость",
           "transcription": "[ди ге-РЕХ-тиг-кайт]",
-          "sentence": "Die Gerechtigkeit fordert diesen Kampf.",
-          "sentence_translation": "Справедливость требует этого боя."
+          "sentence": "Auf den Klippen von Dover schwört Edgar: Die Gerechtigkeit fordert diesen Kampf.",
+          "sentence_translation": "На утёсах Дувра Эдгар клянётся: Справедливость требует этого боя."
         },
         {
           "german": "das Schwert",
           "russian": "меч",
           "transcription": "[дас ШВЕРТ]",
-          "sentence": "Mein Schwert ist die Waffe der Wahrheit.",
-          "sentence_translation": "Мой меч - оружие правды."
+          "sentence": "Auf den Klippen von Dover schwört Edgar: Mein Schwert ist die Waffe der Wahrheit.",
+          "sentence_translation": "На утёсах Дувра Эдгар клянётся: Мой меч - оружие правды."
         },
         {
           "german": "der Bruder",
           "russian": "брат",
           "transcription": "[дер БРУ-дер]",
-          "sentence": "Mein Bruder muss für seine Verbrechen büßen.",
-          "sentence_translation": "Мой брат должен поплатиться за свои преступления."
+          "sentence": "Auf den Klippen von Dover schwört Edgar: Mein Bruder muss für seine Verbrechen büßen.",
+          "sentence_translation": "На утёсах Дувра Эдгар клянётся: Мой брат должен поплатиться за свои преступления."
         }
       ],
       "quizzes": [
@@ -578,57 +578,57 @@
           "german": "überleben",
           "russian": "выживать",
           "transcription": "[ю-бер-ЛЕ-бен]",
-          "sentence": "Ich habe alle Prüfungen überlebt.",
-          "sentence_translation": "Я пережил все испытания."
+          "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Ich habe alle Prüfungen überlebt.",
+          "sentence_translation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Я пережил все испытания."
         },
         {
           "german": "erben",
           "russian": "наследовать",
           "transcription": "[ЭР-бен]",
-          "sentence": "Nun erbe ich Titel und Verantwortung.",
-          "sentence_translation": "Теперь я наследую титул и ответственность."
+          "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Nun erbe ich Titel und Verantwortung.",
+          "sentence_translation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Теперь я наследую титул и ответственность."
         },
         {
           "german": "die Zukunft",
           "russian": "будущее",
           "transcription": "[ди ЦУ-кунфт]",
-          "sentence": "Die Zukunft des Königreichs liegt in unseren Händen.",
-          "sentence_translation": "Будущее королевства в наших руках."
+          "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Die Zukunft des Königreichs liegt in unseren Händen.",
+          "sentence_translation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Будущее королевства в наших руках."
         },
         {
           "german": "regieren",
           "russian": "править",
           "transcription": "[ре-ГИ-рен]",
-          "sentence": "Mit Weisheit werde ich regieren.",
-          "sentence_translation": "С мудростью я буду править."
+          "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Mit Weisheit werde ich regieren.",
+          "sentence_translation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: С мудростью я буду править."
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
-          "sentence": "Durch Leiden habe ich Weisheit erlangt.",
-          "sentence_translation": "Через страдания я обрёл мудрость."
+          "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Durch Leiden habe ich Weisheit erlangt.",
+          "sentence_translation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Через страдания я обрёл мудрость."
         },
         {
           "german": "die Ordnung",
           "russian": "порядок",
           "transcription": "[ди ОРД-нунг]",
-          "sentence": "Neue Ordnung muss aus dem Chaos entstehen.",
-          "sentence_translation": "Новый порядок должен возникнуть из хаоса."
+          "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Neue Ordnung muss aus dem Chaos entstehen.",
+          "sentence_translation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Новый порядок должен возникнуть из хаоса."
         },
         {
           "german": "die Verantwortung",
           "russian": "ответственность",
           "transcription": "[ди фер-АНТ-вор-тунг]",
-          "sentence": "Die Verantwortung für alle wiegt schwer.",
-          "sentence_translation": "Ответственность за всех тяжела."
+          "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Die Verantwortung für alle wiegt schwer.",
+          "sentence_translation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Ответственность за всех тяжела."
         },
         {
           "german": "neu",
           "russian": "новый",
           "transcription": "[НОЙ]",
-          "sentence": "Eine neue Ära beginnt für unser Land.",
-          "sentence_translation": "Новая эра начинается для нашей страны."
+          "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Eine neue Ära beginnt für unser Land.",
+          "sentence_translation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Новая эра начинается для нашей страны."
         }
       ],
       "quizzes": [

--- a/data/characters/edmund.json
+++ b/data/characters/edmund.json
@@ -20,57 +20,57 @@
           "german": "der Bastard",
           "russian": "бастард",
           "transcription": "[дер БАС-тард]",
-          "sentence": "Als Bastard habe ich keine Rechte.",
-          "sentence_translation": "Как бастард я не имею прав."
+          "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Als Bastard habe ich keine Rechte.",
+          "sentence_translation": "В замке Глостера Эдмунд тайно клянётся: Как бастард я не имею прав."
         },
         {
           "german": "der Neid",
           "russian": "зависть",
           "transcription": "[дер НАЙД]",
-          "sentence": "Der Neid auf Edgar verzehrt mich.",
-          "sentence_translation": "Зависть к Эдгару пожирает меня."
+          "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Der Neid auf Edgar verzehrt mich.",
+          "sentence_translation": "В замке Глостера Эдмунд тайно клянётся: Зависть к Эдгару пожирает меня."
         },
         {
           "german": "die Ambition",
           "russian": "амбиция",
           "transcription": "[ди ам-би-ЦИ-он]",
-          "sentence": "Meine Ambition kennt keine Grenzen.",
-          "sentence_translation": "Моя амбиция не знает границ."
+          "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Meine Ambition kennt keine Grenzen.",
+          "sentence_translation": "В замке Глостера Эдмунд тайно клянётся: Моя амбиция не знает границ."
         },
         {
           "german": "benachteiligt",
           "russian": "обделённый",
           "transcription": "[бе-НАХ-тай-лигт]",
-          "sentence": "Ich bin von Geburt an benachteiligt.",
-          "sentence_translation": "Я обделён с рождения."
+          "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Ich bin von Geburt an benachteiligt.",
+          "sentence_translation": "В замке Глостера Эдмунд тайно клянётся: Я обделён с рождения."
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
-          "sentence": "Die Rache an der Gesellschaft ist mein Ziel.",
-          "sentence_translation": "Месть обществу - моя цель."
+          "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Die Rache an der Gesellschaft ist mein Ziel.",
+          "sentence_translation": "В замке Глостера Эдмунд тайно клянётся: Месть обществу - моя цель."
         },
         {
           "german": "aufsteigen",
           "russian": "возвышаться",
           "transcription": "[АУФ-штай-ген]",
-          "sentence": "Ich will über alle aufsteigen.",
-          "sentence_translation": "Я хочу возвыситься над всеми."
+          "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Ich will über alle aufsteigen.",
+          "sentence_translation": "В замке Глостера Эдмунд тайно клянётся: Я хочу возвыситься над всеми."
         },
         {
           "german": "unehelich",
           "russian": "внебрачный",
           "transcription": "[УН-э-е-лих]",
-          "sentence": "Meine uneheliche Geburt ist mein Fluch.",
-          "sentence_translation": "Моё внебрачное рождение - мой проклятие."
+          "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Meine uneheliche Geburt ist mein Fluch.",
+          "sentence_translation": "В замке Глостера Эдмунд тайно клянётся: Моё внебрачное рождение - мой проклятие."
         },
         {
           "german": "die Natur",
           "russian": "природа",
           "transcription": "[ди на-ТУР]",
-          "sentence": "Die Natur ist meine Göttin, nicht das Gesetz.",
-          "sentence_translation": "Природа - моя богиня, не закон."
+          "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Die Natur ist meine Göttin, nicht das Gesetz.",
+          "sentence_translation": "В замке Глостера Эдмунд тайно клянётся: Природа - моя богиня, не закон."
         }
       ],
       "quizzes": [
@@ -113,57 +113,57 @@
           "german": "fälschen",
           "russian": "подделывать",
           "transcription": "[ФЕЛЬ-шен]",
-          "sentence": "Ich fälsche Edgars Brief perfekt.",
-          "sentence_translation": "Я идеально подделываю письмо Эдгара."
+          "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Ich fälsche Edgars Brief perfekt.",
+          "sentence_translation": "В своей комнате Эдмунд подписывает фальшивое письмо: Я идеально подделываю письмо Эдгара."
         },
         {
           "german": "intrigieren",
           "russian": "интриговать",
           "transcription": "[ин-три-ГИ-рен]",
-          "sentence": "Ich intrigiere gegen meinen Bruder.",
-          "sentence_translation": "Я интригую против брата."
+          "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Ich intrigiere gegen meinen Bruder.",
+          "sentence_translation": "В своей комнате Эдмунд подписывает фальшивое письмо: Я интригую против брата."
         },
         {
           "german": "beschuldigen",
           "russian": "обвинять",
           "transcription": "[бе-ШУЛЬ-ди-ген]",
-          "sentence": "Ich beschuldige Edgar des Verrats.",
-          "sentence_translation": "Я обвиняю Эдгара в предательстве."
+          "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Ich beschuldige Edgar des Verrats.",
+          "sentence_translation": "В своей комнате Эдмунд подписывает фальшивое письмо: Я обвиняю Эдгара в предательстве."
         },
         {
           "german": "der Plan",
           "russian": "план",
           "transcription": "[дер ПЛАН]",
-          "sentence": "Mein Plan wird perfekt ausgeführt.",
-          "sentence_translation": "Мой план выполняется идеально."
+          "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Mein Plan wird perfekt ausgeführt.",
+          "sentence_translation": "В своей комнате Эдмунд подписывает фальшивое письмо: Мой план выполняется идеально."
         },
         {
           "german": "manipulieren",
           "russian": "манипулировать",
           "transcription": "[ма-ни-пу-ЛИ-рен]",
-          "sentence": "Ich manipuliere meinen Vater geschickt.",
-          "sentence_translation": "Я ловко манипулирую отцом."
+          "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Ich manipuliere meinen Vater geschickt.",
+          "sentence_translation": "В своей комнате Эдмунд подписывает фальшивое письмо: Я ловко манипулирую отцом."
         },
         {
           "german": "der Brief",
           "russian": "письмо",
           "transcription": "[дер БРИФ]",
-          "sentence": "Der gefälschte Brief ist mein Beweis.",
-          "sentence_translation": "Поддельное письмо - моё доказательство."
+          "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Der gefälschte Brief ist mein Beweis.",
+          "sentence_translation": "В своей комнате Эдмунд подписывает фальшивое письмо: Поддельное письмо - моё доказательство."
         },
         {
           "german": "lügen",
           "russian": "лгать",
           "transcription": "[ЛЮ-ген]",
-          "sentence": "Ich lüge ohne mit der Wimper zu zucken.",
-          "sentence_translation": "Я лгу не моргнув глазом."
+          "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Ich lüge ohne mit der Wimper zu zucken.",
+          "sentence_translation": "В своей комнате Эдмунд подписывает фальшивое письмо: Я лгу не моргнув глазом."
         },
         {
           "german": "die Täuschung",
           "russian": "обман",
           "transcription": "[ди ТОЙ-шунг]",
-          "sentence": "Die Täuschung ist vollkommen.",
-          "sentence_translation": "Обман совершенен."
+          "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Die Täuschung ist vollkommen.",
+          "sentence_translation": "В своей комнате Эдмунд подписывает фальшивое письмо: Обман совершенен."
         }
       ],
       "quizzes": [
@@ -206,57 +206,57 @@
           "german": "vertreiben",
           "russian": "изгонять",
           "transcription": "[фер-ТРАЙ-бен]",
-          "sentence": "Ich vertreibe Edgar aus seinem Erbe.",
-          "sentence_translation": "Я изгоняю Эдгара из его наследства."
+          "sentence": "Im Saal, den Regan hält, prahlt Edmund: Ich vertreibe Edgar aus seinem Erbe.",
+          "sentence_translation": "В зале, который удерживает Регана, Эдмунд хвастается: Я изгоняю Эдгара из его наследства."
         },
         {
           "german": "triumphieren",
           "russian": "торжествовать",
           "transcription": "[три-ум-ФИ-рен]",
-          "sentence": "Ich triumphiere über meinen Bruder.",
-          "sentence_translation": "Я торжествую над братом."
+          "sentence": "Im Saal, den Regan hält, prahlt Edmund: Ich triumphiere über meinen Bruder.",
+          "sentence_translation": "В зале, который удерживает Регана, Эдмунд хвастается: Я торжествую над братом."
         },
         {
           "german": "erben",
           "russian": "наследовать",
           "transcription": "[ЭР-бен]",
-          "sentence": "Nun erbe ich alles, was Edgar zustand.",
-          "sentence_translation": "Теперь я наследую всё, что полагалось Эдгару."
+          "sentence": "Im Saal, den Regan hält, prahlt Edmund: Nun erbe ich alles, was Edgar zustand.",
+          "sentence_translation": "В зале, который удерживает Регана, Эдмунд хвастается: Теперь я наследую всё, что полагалось Эдгару."
         },
         {
           "german": "der Erfolg",
           "russian": "успех",
           "transcription": "[дер эр-ФОЛЬГ]",
-          "sentence": "Mein Erfolg ist vollkommen.",
-          "sentence_translation": "Мой успех полный."
+          "sentence": "Im Saal, den Regan hält, prahlt Edmund: Mein Erfolg ist vollkommen.",
+          "sentence_translation": "В зале, который удерживает Регана, Эдмунд хвастается: Мой успех полный."
         },
         {
           "german": "gewinnen",
           "russian": "выигрывать",
           "transcription": "[ге-ВИН-нен]",
-          "sentence": "Ich gewinne alles durch List.",
-          "sentence_translation": "Я выигрываю всё хитростью."
+          "sentence": "Im Saal, den Regan hält, prahlt Edmund: Ich gewinne alles durch List.",
+          "sentence_translation": "В зале, который удерживает Регана, Эдмунд хвастается: Я выигрываю всё хитростью."
         },
         {
           "german": "die Belohnung",
           "russian": "награда",
           "transcription": "[ди бе-ЛО-нунг]",
-          "sentence": "Die Belohnung für meine Intrige ist groß.",
-          "sentence_translation": "Награда за мою интригу велика."
+          "sentence": "Im Saal, den Regan hält, prahlt Edmund: Die Belohnung für meine Intrige ist groß.",
+          "sentence_translation": "В зале, который удерживает Регана, Эдмунд хвастается: Награда за мою интригу велика."
         },
         {
           "german": "verdrängen",
           "russian": "вытеснять",
           "transcription": "[фер-ДРЕН-ген]",
-          "sentence": "Ich verdränge den rechtmäßigen Erben.",
-          "sentence_translation": "Я вытесняю законного наследника."
+          "sentence": "Im Saal, den Regan hält, prahlt Edmund: Ich verdränge den rechtmäßigen Erben.",
+          "sentence_translation": "В зале, который удерживает Регана, Эдмунд хвастается: Я вытесняю законного наследника."
         },
         {
           "german": "der Sieg",
           "russian": "победа",
           "transcription": "[дер ЗИГ]",
-          "sentence": "Der Sieg über Edgar ist süß.",
-          "sentence_translation": "Победа над Эдгаром сладка."
+          "sentence": "Im Saal, den Regan hält, prahlt Edmund: Der Sieg über Edgar ist süß.",
+          "sentence_translation": "В зале, который удерживает Регана, Эдмунд хвастается: Победа над Эдгаром сладка."
         }
       ],
       "quizzes": [
@@ -299,57 +299,57 @@
           "german": "verbünden",
           "russian": "объединяться",
           "transcription": "[фер-БЮН-ден]",
-          "sentence": "Ich verbünde mich mit den bösen Schwestern.",
-          "sentence_translation": "Я объединяюсь со злыми сёстрами."
+          "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Ich verbünde mich mit den bösen Schwestern.",
+          "sentence_translation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Я объединяюсь со злыми сёстрами."
         },
         {
           "german": "die Macht",
           "russian": "власть",
           "transcription": "[ди МАХТ]",
-          "sentence": "Die Macht über das Königreich ist nah.",
-          "sentence_translation": "Власть над королевством близка."
+          "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Die Macht über das Königreich ist nah.",
+          "sentence_translation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Власть над королевством близка."
         },
         {
           "german": "erobern",
           "russian": "завоёвывать",
           "transcription": "[эр-О-берн]",
-          "sentence": "Wir erobern das Reich gemeinsam.",
-          "sentence_translation": "Мы завоёвываем королевство вместе."
+          "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Wir erobern das Reich gemeinsam.",
+          "sentence_translation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Мы завоёвываем королевство вместе."
         },
         {
           "german": "das Bündnis",
           "russian": "союз",
           "transcription": "[дас БЮНД-нис]",
-          "sentence": "Unser Bündnis ist stark und grausam.",
-          "sentence_translation": "Наш союз силён и жесток."
+          "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Unser Bündnis ist stark und grausam.",
+          "sentence_translation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Наш союз силён и жесток."
         },
         {
           "german": "verführen",
           "russian": "соблазнять",
           "transcription": "[фер-ФЮ-рен]",
-          "sentence": "Ich verführe beide Schwestern gleichzeitig.",
-          "sentence_translation": "Я соблазняю обеих сестёр одновременно."
+          "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Ich verführe beide Schwestern gleichzeitig.",
+          "sentence_translation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Я соблазняю обеих сестёр одновременно."
         },
         {
           "german": "die Eroberung",
           "russian": "завоевание",
           "transcription": "[ди эр-О-бе-рунг]",
-          "sentence": "Die Eroberung des Throns ist mein Ziel.",
-          "sentence_translation": "Завоевание трона - моя цель."
+          "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Die Eroberung des Throns ist mein Ziel.",
+          "sentence_translation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Завоевание трона - моя цель."
         },
         {
           "german": "beherrschen",
           "russian": "господствовать",
           "transcription": "[бе-ХЕР-шен]",
-          "sentence": "Ich beherrsche das Spiel der Macht.",
-          "sentence_translation": "Я господствую в игре власти."
+          "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Ich beherrsche das Spiel der Macht.",
+          "sentence_translation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Я господствую в игре власти."
         },
         {
           "german": "die Allianz",
           "russian": "альянс",
           "transcription": "[ди а-ли-АНЦС]",
-          "sentence": "Unsere Allianz wird alle Feinde vernichten.",
-          "sentence_translation": "Наш альянс уничтожит всех врагов."
+          "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Unsere Allianz wird alle Feinde vernichten.",
+          "sentence_translation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Наш альянс уничтожит всех врагов."
         }
       ],
       "quizzes": [
@@ -392,57 +392,57 @@
           "german": "verraten",
           "russian": "предавать",
           "transcription": "[фер-РА-тен]",
-          "sentence": "Ich verrate meinen eigenen Vater.",
-          "sentence_translation": "Я предаю собственного отца."
+          "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Ich verrate meinen eigenen Vater.",
+          "sentence_translation": "Перед воротами Глостера Эдмунд продаёт отца: Я предаю собственного отца."
         },
         {
           "german": "blenden",
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
-          "sentence": "Sie blenden ihn auf meinen Hinweis.",
-          "sentence_translation": "Они ослепляют его по моей наводке."
+          "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Sie blenden ihn auf meinen Hinweis.",
+          "sentence_translation": "Перед воротами Глостера Эдмунд продаёт отца: Они ослепляют его по моей наводке."
         },
         {
           "german": "die Grausamkeit",
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
-          "sentence": "Meine Grausamkeit kennt keine Grenzen.",
-          "sentence_translation": "Моя жестокость не знает границ."
+          "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Meine Grausamkeit kennt keine Grenzen.",
+          "sentence_translation": "Перед воротами Глостера Эдмунд продаёт отца: Моя жестокость не знает границ."
         },
         {
           "german": "denunzieren",
           "russian": "доносить",
           "transcription": "[де-нун-ЦИ-рен]",
-          "sentence": "Ich denunziere meinen Vater als Verräter.",
-          "sentence_translation": "Я доношу на отца как на предателя."
+          "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Ich denunziere meinen Vater als Verräter.",
+          "sentence_translation": "Перед воротами Глостера Эдмунд продаёт отца: Я доношу на отца как на предателя."
         },
         {
           "german": "ausliefern",
           "russian": "выдавать",
           "transcription": "[АУС-ли-ферн]",
-          "sentence": "Ich liefere ihn seinen Feinden aus.",
-          "sentence_translation": "Я выдаю его врагам."
+          "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Ich liefere ihn seinen Feinden aus.",
+          "sentence_translation": "Перед воротами Глостера Эдмунд продаёт отца: Я выдаю его врагам."
         },
         {
           "german": "die Folter",
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
-          "sentence": "Die Folter meines Vaters stört mich nicht.",
-          "sentence_translation": "Пытка моего отца меня не тревожит."
+          "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Die Folter meines Vaters stört mich nicht.",
+          "sentence_translation": "Перед воротами Глостера Эдмунд продаёт отца: Пытка моего отца меня не тревожит."
         },
         {
           "german": "opfern",
           "russian": "жертвовать",
           "transcription": "[ОП-ферн]",
-          "sentence": "Ich opfere ihn für meine Ambitionen.",
-          "sentence_translation": "Я жертвую им ради своих амбиций."
+          "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Ich opfere ihn für meine Ambitionen.",
+          "sentence_translation": "Перед воротами Глостера Эдмунд продаёт отца: Я жертвую им ради своих амбиций."
         },
         {
           "german": "erbarmungslos",
           "russian": "беспощадный",
           "transcription": "[эр-БАР-мунгс-лос]",
-          "sentence": "Erbarmungslos verfolge ich mein Ziel.",
-          "sentence_translation": "Беспощадно я преследую свою цель."
+          "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Erbarmungslos verfolge ich mein Ziel.",
+          "sentence_translation": "Перед воротами Глостера Эдмунд продаёт отца: Беспощадно я преследую свою цель."
         }
       ],
       "quizzes": [
@@ -485,57 +485,57 @@
           "german": "die Liebschaft",
           "russian": "любовная связь",
           "transcription": "[ди ЛИБ-шафт]",
-          "sentence": "Meine Liebschaft mit beiden Schwestern ist gefährlich.",
-          "sentence_translation": "Моя любовная связь с обеими сёстрами опасна."
+          "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Meine Liebschaft mit beiden Schwestern ist gefährlich.",
+          "sentence_translation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Моя любовная связь с обеими сёстрами опасна."
         },
         {
           "german": "die Rivalität",
           "russian": "соперничество",
           "transcription": "[ди ри-ва-ли-ТЕТ]",
-          "sentence": "Ihre Rivalität spielt mir in die Hände.",
-          "sentence_translation": "Их соперничество играет мне на руку."
+          "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ihre Rivalität spielt mir in die Hände.",
+          "sentence_translation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Их соперничество играет мне на руку."
         },
         {
           "german": "spielen",
           "russian": "играть",
           "transcription": "[ШПИ-лен]",
-          "sentence": "Ich spiele mit ihren Gefühlen.",
-          "sentence_translation": "Я играю с их чувствами."
+          "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ich spiele mit ihren Gefühlen.",
+          "sentence_translation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Я играю с их чувствами."
         },
         {
           "german": "verlocken",
           "russian": "завлекать",
           "transcription": "[фер-ЛО-кен]",
-          "sentence": "Ich verlocke sie mit falschen Versprechen.",
-          "sentence_translation": "Я завлекаю их ложными обещаниями."
+          "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ich verlocke sie mit falschen Versprechen.",
+          "sentence_translation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Я завлекаю их ложными обещаниями."
         },
         {
           "german": "die Lust",
           "russian": "похоть",
           "transcription": "[ди ЛУСТ]",
-          "sentence": "Ihre Lust macht sie blind.",
-          "sentence_translation": "Их похоть делает их слепыми."
+          "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ihre Lust macht sie blind.",
+          "sentence_translation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Их похоть делает их слепыми."
         },
         {
           "german": "ausnutzen",
           "russian": "использовать",
           "transcription": "[АУС-нут-цен]",
-          "sentence": "Ich nutze ihre Leidenschaft aus.",
-          "sentence_translation": "Я использую их страсть."
+          "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ich nutze ihre Leidenschaft aus.",
+          "sentence_translation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Я использую их страсть."
         },
         {
           "german": "jonglieren",
           "russian": "жонглировать",
           "transcription": "[жон-ГЛИ-рен]",
-          "sentence": "Ich jongliere mit zwei gefährlichen Frauen.",
-          "sentence_translation": "Я жонглирую двумя опасными женщинами."
+          "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ich jongliere mit zwei gefährlichen Frauen.",
+          "sentence_translation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Я жонглирую двумя опасными женщинами."
         },
         {
           "german": "die Affäre",
           "russian": "интрига",
           "transcription": "[ди а-ФЕ-ре]",
-          "sentence": "Diese Affäre wird tödlich enden.",
-          "sentence_translation": "Эта интрига закончится смертью."
+          "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Diese Affäre wird tödlich enden.",
+          "sentence_translation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Эта интрига закончится смертью."
         }
       ],
       "quizzes": [
@@ -578,57 +578,57 @@
           "german": "das Duell",
           "russian": "дуэль",
           "transcription": "[дас ду-ЭЛЬ]",
-          "sentence": "Das Duell mit Edgar ist mein Ende.",
-          "sentence_translation": "Дуэль с Эдгаром - мой конец."
+          "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Das Duell mit Edgar ist mein Ende.",
+          "sentence_translation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Дуэль с Эдгаром - мой конец."
         },
         {
           "german": "fallen",
           "russian": "падать",
           "transcription": "[ФАЛ-лен]",
-          "sentence": "Ich falle von seinem gerechten Schwert.",
-          "sentence_translation": "Я падаю от его справедливого меча."
+          "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Ich falle von seinem gerechten Schwert.",
+          "sentence_translation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Я падаю от его справедливого меча."
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
-          "sentence": "Am Ende bereue ich meine Taten.",
-          "sentence_translation": "В конце я сожалею о своих делах."
+          "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Am Ende bereue ich meine Taten.",
+          "sentence_translation": "В лагере Олбани перед дуэлью Эдмунд признаёт: В конце я сожалею о своих делах."
         },
         {
           "german": "die Niederlage",
           "russian": "поражение",
           "transcription": "[ди НИ-дер-ла-ге]",
-          "sentence": "Die Niederlage ist vollkommen.",
-          "sentence_translation": "Поражение полное."
+          "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Die Niederlage ist vollkommen.",
+          "sentence_translation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Поражение полное."
         },
         {
           "german": "verlieren",
           "russian": "проигрывать",
           "transcription": "[фер-ЛИ-рен]",
-          "sentence": "Ich verliere alles, was ich gewann.",
-          "sentence_translation": "Я проигрываю всё, что выиграл."
+          "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Ich verliere alles, was ich gewann.",
+          "sentence_translation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Я проигрываю всё, что выиграл."
         },
         {
           "german": "der Untergang",
           "russian": "падение",
           "transcription": "[дер УН-тер-ганг]",
-          "sentence": "Mein Untergang ist gerecht.",
-          "sentence_translation": "Моё падение справедливо."
+          "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Mein Untergang ist gerecht.",
+          "sentence_translation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Моё падение справедливо."
         },
         {
           "german": "gestehen",
           "russian": "признаваться",
           "transcription": "[ге-ШТЕ-ен]",
-          "sentence": "Ich gestehe alle meine Verbrechen.",
-          "sentence_translation": "Я признаюсь во всех преступлениях."
+          "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Ich gestehe alle meine Verbrechen.",
+          "sentence_translation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Я признаюсь во всех преступлениях."
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЭН-де]",
-          "sentence": "Das Ende kommt schnell und gerecht.",
-          "sentence_translation": "Конец приходит быстро и справедливо."
+          "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Das Ende kommt schnell und gerecht.",
+          "sentence_translation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Конец приходит быстро и справедливо."
         }
       ],
       "quizzes": [

--- a/data/characters/fool.json
+++ b/data/characters/fool.json
@@ -14,57 +14,57 @@
           "german": "der Narr",
           "russian": "шут",
           "transcription": "[дер НАР]",
-          "sentence": "Als Narr sage ich die Wahrheit durch Scherze.",
-          "sentence_translation": "Как шут я говорю правду через шутки."
+          "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Als Narr sage ich die Wahrheit durch Scherze.",
+          "sentence_translation": "В тронном зале Лира шут пляшет рядом с Корделией: Как шут я говорю правду через шутки."
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
-          "sentence": "Hinter meinen Späßen verbirgt sich Weisheit.",
-          "sentence_translation": "За моими шутками скрывается мудрость."
+          "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Hinter meinen Späßen verbirgt sich Weisheit.",
+          "sentence_translation": "В тронном зале Лира шут пляшет рядом с Корделией: За моими шутками скрывается мудрость."
         },
         {
           "german": "die Trauer",
           "russian": "печаль",
           "transcription": "[ди ТРАУ-ер]",
-          "sentence": "Die Trauer um Корделия macht mich stumm.",
-          "sentence_translation": "Печаль о Корделии делает меня немым."
+          "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Die Trauer um Корделия macht mich stumm.",
+          "sentence_translation": "В тронном зале Лира шут пляшет рядом с Корделией: Печаль о Корделии делает меня немым."
         },
         {
           "german": "scherzen",
           "russian": "шутить",
           "transcription": "[ШЕР-цен]",
-          "sentence": "Ich scherze, um den Schmerz zu verbergen.",
-          "sentence_translation": "Я шучу, чтобы скрыть боль."
+          "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Ich scherze, um den Schmerz zu verbergen.",
+          "sentence_translation": "В тронном зале Лира шут пляшет рядом с Корделией: Я шучу, чтобы скрыть боль."
         },
         {
           "german": "der Spaß",
           "russian": "забава",
           "transcription": "[дер ШПАС]",
-          "sentence": "Der Spaß ist meine Maske vor der Welt.",
-          "sentence_translation": "Забава - моя маска перед миром."
+          "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Der Spaß ist meine Maske vor der Welt.",
+          "sentence_translation": "В тронном зале Лира шут пляшет рядом с Корделией: Забава - моя маска перед миром."
         },
         {
           "german": "klug",
           "russian": "умный",
           "transcription": "[КЛУГ]",
-          "sentence": "Ich bin klüger als alle bei Hofe.",
-          "sentence_translation": "Я умнее всех при дворе."
+          "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Ich bin klüger als alle bei Hofe.",
+          "sentence_translation": "В тронном зале Лира шут пляшет рядом с Корделией: Я умнее всех при дворе."
         },
         {
           "german": "vermissen",
           "russian": "скучать",
           "transcription": "[фер-МИ-сен]",
-          "sentence": "Ich vermisse die süße Корделия sehr.",
-          "sentence_translation": "Я очень скучаю по милой Корделии."
+          "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Ich vermisse die süße Корделия sehr.",
+          "sentence_translation": "В тронном зале Лира шут пляшет рядом с Корделией: Я очень скучаю по милой Корделии."
         },
         {
           "german": "der Witz",
           "russian": "остроумие",
           "transcription": "[дер ВИТЦ]",
-          "sentence": "Mein Witz ist scharf wie ein Schwert.",
-          "sentence_translation": "Моё остроумие остро как меч."
+          "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Mein Witz ist scharf wie ein Schwert.",
+          "sentence_translation": "В тронном зале Лира шут пляшет рядом с Корделией: Моё остроумие остро как меч."
         }
       ],
       "theatrical_scene": {
@@ -107,50 +107,50 @@
           "german": "die Wahrheit",
           "russian": "правда",
           "transcription": "[ди ВАР-хайт]",
-          "sentence": "Die Wahrheit verpacke ich in lustige Lieder.",
-          "sentence_translation": "Правду я заворачиваю в весёлые песни."
+          "sentence": "Unter Gonerils kaltem Blick singt der Narr: Die Wahrheit verpacke ich in lustige Lieder.",
+          "sentence_translation": "Под холодным взглядом Гонериль шут поёт: Правду я заворачиваю в весёлые песни."
         },
         {
           "german": "der Scherz",
           "russian": "шутка",
           "transcription": "[дер ШЕРЦ]",
-          "sentence": "Jeder Scherz enthält eine bittere Lehre.",
-          "sentence_translation": "Каждая шутка содержит горький урок."
+          "sentence": "Unter Gonerils kaltem Blick singt der Narr: Jeder Scherz enthält eine bittere Lehre.",
+          "sentence_translation": "Под холодным взглядом Гонериль шут поёт: Каждая шутка содержит горький урок."
         },
         {
           "german": "die Warnung",
           "russian": "предупреждение",
           "transcription": "[ди ВАР-нунг]",
-          "sentence": "Meine Warnung kommt als Rätsel verkleidet.",
-          "sentence_translation": "Моё предупреждение приходит замаскированным под загадку."
+          "sentence": "Unter Gonerils kaltem Blick singt der Narr: Meine Warnung kommt als Rätsel verkleidet.",
+          "sentence_translation": "Под холодным взглядом Гонериль шут поёт: Моё предупреждение приходит замаскированным под загадку."
         },
         {
           "german": "bitter",
           "russian": "горький",
           "transcription": "[БИ-тер]",
-          "sentence": "Die Wahrheit schmeckt bitter wie Galle.",
-          "sentence_translation": "Правда горька как желчь."
+          "sentence": "Unter Gonerils kaltem Blick singt der Narr: Die Wahrheit schmeckt bitter wie Galle.",
+          "sentence_translation": "Под холодным взглядом Гонериль шут поёт: Правда горька как желчь."
         },
         {
           "german": "spotten",
           "russian": "насмехаться",
           "transcription": "[ШПО-тен]",
-          "sentence": "Ich spotte über die Torheit der Mächtigen.",
-          "sentence_translation": "Я насмехаюсь над глупостью сильных."
+          "sentence": "Unter Gonerils kaltem Blick singt der Narr: Ich spotte über die Torheit der Mächtigen.",
+          "sentence_translation": "Под холодным взглядом Гонериль шут поёт: Я насмехаюсь над глупостью сильных."
         },
         {
           "german": "necken",
           "russian": "дразнить",
           "transcription": "[НЕ-кен]",
-          "sentence": "Ich necke den König mit der Wahrheit.",
-          "sentence_translation": "Я дразню короля правдой."
+          "sentence": "Unter Gonerils kaltem Blick singt der Narr: Ich necke den König mit der Wahrheit.",
+          "sentence_translation": "Под холодным взглядом Гонериль шут поёт: Я дразню короля правдой."
         },
         {
           "german": "enthüllen",
           "russian": "раскрывать",
           "transcription": "[энт-ХЮ-лен]",
-          "sentence": "Spielerisch enthülle ich seine Fehler.",
-          "sentence_translation": "Играючи я раскрываю его ошибки."
+          "sentence": "Unter Gonerils kaltem Blick singt der Narr: Spielerisch enthülle ich seine Fehler.",
+          "sentence_translation": "Под холодным взглядом Гонериль шут поёт: Играючи я раскрываю его ошибки."
         }
       ],
       "theatrical_scene": {
@@ -193,57 +193,57 @@
           "german": "die Prophezeiung",
           "russian": "пророчество",
           "transcription": "[ди про-фе-ЦАЙ-унг]",
-          "sentence": "Meine Prophezeiung wird wahr werden.",
-          "sentence_translation": "Моё пророчество сбудется."
+          "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Meine Prophezeiung wird wahr werden.",
+          "sentence_translation": "На продуваемой бурей пустоши шут пророчит: Моё пророчество сбудется."
         },
         {
           "german": "das Rätsel",
           "russian": "загадка",
           "transcription": "[дас РЕТ-зель]",
-          "sentence": "In Rätseln spreche ich von der Zukunft.",
-          "sentence_translation": "В загадках я говорю о будущем."
+          "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: In Rätseln spreche ich von der Zukunft.",
+          "sentence_translation": "На продуваемой бурей пустоши шут пророчит: В загадках я говорю о будущем."
         },
         {
           "german": "die Vorahnung",
           "russian": "предчувствие",
           "transcription": "[ди ФОР-а-нунг]",
-          "sentence": "Eine dunkle Vorahnung erfüllt mein Herz.",
-          "sentence_translation": "Тёмное предчувствие наполняет моё сердце."
+          "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Eine dunkle Vorahnung erfüllt mein Herz.",
+          "sentence_translation": "На продуваемой бурей пустоши шут пророчит: Тёмное предчувствие наполняет моё сердце."
         },
         {
           "german": "vorhersagen",
           "russian": "предсказывать",
           "transcription": "[ФОР-хер-за-ген]",
-          "sentence": "Ich sage das kommende Unheil vorher.",
-          "sentence_translation": "Я предсказываю грядущую беду."
+          "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Ich sage das kommende Unheil vorher.",
+          "sentence_translation": "На продуваемой бурей пустоши шут пророчит: Я предсказываю грядущую беду."
         },
         {
           "german": "deuten",
           "russian": "толковать",
           "transcription": "[ДОЙ-тен]",
-          "sentence": "Die Zeichen deute ich besser als alle.",
-          "sentence_translation": "Знаки я толкую лучше всех."
+          "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Die Zeichen deute ich besser als alle.",
+          "sentence_translation": "На продуваемой бурей пустоши шут пророчит: Знаки я толкую лучше всех."
         },
         {
           "german": "ahnen",
           "russian": "предчувствовать",
           "transcription": "[А-нен]",
-          "sentence": "Ich ahne das schlimme Ende voraus.",
-          "sentence_translation": "Я предчувствую плохой конец."
+          "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Ich ahne das schlimme Ende voraus.",
+          "sentence_translation": "На продуваемой бурей пустоши шут пророчит: Я предчувствую плохой конец."
         },
         {
           "german": "das Omen",
           "russian": "знамение",
           "transcription": "[дас О-мен]",
-          "sentence": "Jedes Omen zeigt auf Untergang.",
-          "sentence_translation": "Каждое знамение указывает на гибель."
+          "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Jedes Omen zeigt auf Untergang.",
+          "sentence_translation": "На продуваемой бурей пустоши шут пророчит: Каждое знамение указывает на гибель."
         },
         {
           "german": "rätselhaft",
           "russian": "загадочный",
           "transcription": "[РЕТ-зель-хафт]",
-          "sentence": "Meine Worte bleiben rätselhaft und wahr.",
-          "sentence_translation": "Мои слова остаются загадочными и правдивыми."
+          "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Meine Worte bleiben rätselhaft und wahr.",
+          "sentence_translation": "На продуваемой бурей пустоши шут пророчит: Мои слова остаются загадочными и правдивыми."
         }
       ],
       "theatrical_scene": {
@@ -286,50 +286,50 @@
           "german": "der Wahnsinn",
           "russian": "безумие",
           "transcription": "[дер ВАН-зин]",
-          "sentence": "Im Wahnsinn finden wir uns als Brüder.",
-          "sentence_translation": "В безумии мы находим друг друга как братья."
+          "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Im Wahnsinn finden wir uns als Brüder.",
+          "sentence_translation": "В хижине шут разделяет безумие Лира: В безумии мы находим друг друга как братья."
         },
         {
           "german": "die Freundschaft",
           "russian": "дружба",
           "transcription": "[ди ФРОЙНД-шафт]",
-          "sentence": "Unsere Freundschaft überdauert den Sturm.",
-          "sentence_translation": "Наша дружба переживёт бурю."
+          "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Unsere Freundschaft überdauert den Sturm.",
+          "sentence_translation": "В хижине шут разделяет безумие Лира: Наша дружба переживёт бурю."
         },
         {
           "german": "begleiten",
           "russian": "сопровождать",
           "transcription": "[бе-ГЛАЙ-тен]",
-          "sentence": "Treu begleite ich meinen verrückten König.",
-          "sentence_translation": "Верно я сопровождаю своего безумного короля."
+          "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Treu begleite ich meinen verrückten König.",
+          "sentence_translation": "В хижине шут разделяет безумие Лира: Верно я сопровождаю своего безумного короля."
         },
         {
           "german": "frieren",
           "russian": "мёрзнуть",
           "transcription": "[ФРИ-рен]",
-          "sentence": "Wir frieren gemeinsam in der kalten Nacht.",
-          "sentence_translation": "Мы мёрзнем вместе в холодную ночь."
+          "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Wir frieren gemeinsam in der kalten Nacht.",
+          "sentence_translation": "В хижине шут разделяет безумие Лира: Мы мёрзнем вместе в холодную ночь."
         },
         {
           "german": "singen",
           "russian": "петь",
           "transcription": "[ЗИН-ген]",
-          "sentence": "Ich singe, um seine Angst zu lindern.",
-          "sentence_translation": "Я пою, чтобы облегчить его страх."
+          "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Ich singe, um seine Angst zu lindern.",
+          "sentence_translation": "В хижине шут разделяет безумие Лира: Я пою, чтобы облегчить его страх."
         },
         {
           "german": "zittern",
           "russian": "дрожать",
           "transcription": "[ЦИ-терн]",
-          "sentence": "Vor Kälte zittern wir wie Espenlaub.",
-          "sentence_translation": "От холода мы дрожим как осиновый лист."
+          "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Vor Kälte zittern wir wie Espenlaub.",
+          "sentence_translation": "В хижине шут разделяет безумие Лира: От холода мы дрожим как осиновый лист."
         },
         {
           "german": "treu",
           "russian": "верный",
           "transcription": "[ТРОЙ]",
-          "sentence": "Ich bleibe treu, wenn alle anderen fliehen.",
-          "sentence_translation": "Я остаюсь верным, когда все остальные бегут."
+          "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Ich bleibe treu, wenn alle anderen fliehen.",
+          "sentence_translation": "В хижине шут разделяет безумие Лира: Я остаюсь верным, когда все остальные бегут."
         }
       ],
       "theatrical_scene": {
@@ -372,57 +372,57 @@
           "german": "das Lied",
           "russian": "песня",
           "transcription": "[дас ЛИД]",
-          "sentence": "Mein Lied erzählt von vergangenen Tagen.",
-          "sentence_translation": "Моя песня рассказывает о прошлых днях."
+          "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Mein Lied erzählt von vergangenen Tagen.",
+          "sentence_translation": "Во время возвращения Корделии в Дувр шут тихо поёт: Моя песня рассказывает о прошлых днях."
         },
         {
           "german": "der Trost",
           "russian": "утешение",
           "transcription": "[дер ТРОСТ]",
-          "sentence": "Mit Liedern bringe ich kleinen Trost.",
-          "sentence_translation": "Песнями я приношу малое утешение."
+          "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Mit Liedern bringe ich kleinen Trost.",
+          "sentence_translation": "Во время возвращения Корделии в Дувр шут тихо поёт: Песнями я приношу малое утешение."
         },
         {
           "german": "die Ironie",
           "russian": "ирония",
           "transcription": "[ди и-ро-НИ]",
-          "sentence": "Die Ironie ist meine letzte Waffe.",
-          "sentence_translation": "Ирония - моё последнее оружие."
+          "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Die Ironie ist meine letzte Waffe.",
+          "sentence_translation": "Во время возвращения Корделии в Дувр шут тихо поёт: Ирония - моё последнее оружие."
         },
         {
           "german": "summen",
           "russian": "напевать",
           "transcription": "[ЗУ-мен]",
-          "sentence": "Leise summe ich alte Melodien.",
-          "sentence_translation": "Тихо я напеваю старые мелодии."
+          "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Leise summe ich alte Melodien.",
+          "sentence_translation": "Во время возвращения Корделии в Дувр шут тихо поёт: Тихо я напеваю старые мелодии."
         },
         {
           "german": "die Melodie",
           "russian": "мелодия",
           "transcription": "[ди ме-ло-ДИ]",
-          "sentence": "Die Melodie erinnert an bessere Zeiten.",
-          "sentence_translation": "Мелодия напоминает о лучших временах."
+          "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Die Melodie erinnert an bessere Zeiten.",
+          "sentence_translation": "Во время возвращения Корделии в Дувр шут тихо поёт: Мелодия напоминает о лучших временах."
         },
         {
           "german": "pfeifen",
           "russian": "свистеть",
           "transcription": "[ПФАЙ-фен]",
-          "sentence": "Ich pfeife gegen die Dunkelheit an.",
-          "sentence_translation": "Я свищу против темноты."
+          "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Ich pfeife gegen die Dunkelheit an.",
+          "sentence_translation": "Во время возвращения Корделии в Дувр шут тихо поёт: Я свищу против темноты."
         },
         {
           "german": "der Reim",
           "russian": "рифма",
           "transcription": "[дер РАЙМ]",
-          "sentence": "Jeder Reim verbirgt eine tiefe Wahrheit.",
-          "sentence_translation": "Каждая рифма скрывает глубокую правду."
+          "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Jeder Reim verbirgt eine tiefe Wahrheit.",
+          "sentence_translation": "Во время возвращения Корделии в Дувр шут тихо поёт: Каждая рифма скрывает глубокую правду."
         },
         {
           "german": "klingen",
           "russian": "звучать",
           "transcription": "[КЛИН-ген]",
-          "sentence": "Meine Worte klingen lustig, doch sind traurig.",
-          "sentence_translation": "Мои слова звучат весело, но печальны."
+          "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Meine Worte klingen lustig, doch sind traurig.",
+          "sentence_translation": "Во время возвращения Корделии в Дувр шут тихо поёт: Мои слова звучат весело, но печальны."
         }
       ],
       "theatrical_scene": {
@@ -465,50 +465,50 @@
           "german": "die Philosophie",
           "russian": "философия",
           "transcription": "[ди фи-ло-зо-ФИ]",
-          "sentence": "Meine Philosophie ist einfach: Alles ist Narretei.",
-          "sentence_translation": "Моя философия проста: всё - глупость."
+          "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Meine Philosophie ist einfach: Alles ist Narretei.",
+          "sentence_translation": "После перехода в Дувр шут размышляет: Моя философия проста: всё - глупость."
         },
         {
           "german": "das Schicksal",
           "russian": "судьба",
           "transcription": "[дас ШИК-заль]",
-          "sentence": "Das Schicksal macht Narren aus uns allen.",
-          "sentence_translation": "Судьба делает дураков из всех нас."
+          "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Das Schicksal macht Narren aus uns allen.",
+          "sentence_translation": "После перехода в Дувр шут размышляет: Судьба делает дураков из всех нас."
         },
         {
           "german": "die Vergänglichkeit",
           "russian": "бренность",
           "transcription": "[ди фер-ГЕНГ-лих-кайт]",
-          "sentence": "Die Vergänglichkeit der Macht ist offenbar.",
-          "sentence_translation": "Бренность власти очевидна."
+          "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Die Vergänglichkeit der Macht ist offenbar.",
+          "sentence_translation": "После перехода в Дувр шут размышляет: Бренность власти очевидна."
         },
         {
           "german": "nachdenken",
           "russian": "размышлять",
           "transcription": "[НАХ-ден-кен]",
-          "sentence": "Ich denke nach über des Lebens Sinn.",
-          "sentence_translation": "Я размышляю о смысле жизни."
+          "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Ich denke nach über des Lebens Sinn.",
+          "sentence_translation": "После перехода в Дувр шут размышляет: Я размышляю о смысле жизни."
         },
         {
           "german": "erkennen",
           "russian": "познавать",
           "transcription": "[ер-КЕН-нен]",
-          "sentence": "Ich erkenne die Wahrheit hinter dem Schein.",
-          "sentence_translation": "Я познаю правду за видимостью."
+          "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Ich erkenne die Wahrheit hinter dem Schein.",
+          "sentence_translation": "После перехода в Дувр шут размышляет: Я познаю правду за видимостью."
         },
         {
           "german": "der Sinn",
           "russian": "смысл",
           "transcription": "[дер ЗИН]",
-          "sentence": "Der Sinn des Lebens ist ein schlechter Witz.",
-          "sentence_translation": "Смысл жизни - плохая шутка."
+          "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Der Sinn des Lebens ist ein schlechter Witz.",
+          "sentence_translation": "После перехода в Дувр шут размышляет: Смысл жизни - плохая шутка."
         },
         {
           "german": "vergänglich",
           "russian": "преходящий",
           "transcription": "[фер-ГЕНГ-лих]",
-          "sentence": "Alles ist vergänglich, nur die Torheit bleibt.",
-          "sentence_translation": "Всё преходяще, только глупость остаётся."
+          "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Alles ist vergänglich, nur die Torheit bleibt.",
+          "sentence_translation": "После перехода в Дувр шут размышляет: Всё преходяще, только глупость остаётся."
         }
       ],
       "theatrical_scene": {
@@ -551,57 +551,57 @@
           "german": "verschwinden",
           "russian": "исчезать",
           "transcription": "[фер-ШВИН-ден]",
-          "sentence": "Ich verschwinde wie ein Traum im Morgen.",
-          "sentence_translation": "Я исчезаю как сон поутру."
+          "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Ich verschwinde wie ein Traum im Morgen.",
+          "sentence_translation": "Незадолго до пленения Корделии шут исчезает: Я исчезаю как сон поутру."
         },
         {
           "german": "das Geheimnis",
           "russian": "тайна",
           "transcription": "[дас ге-ХАЙМ-нис]",
-          "sentence": "Mein Verschwinden bleibt ein ewiges Geheimnis.",
-          "sentence_translation": "Моё исчезновение остаётся вечной тайной."
+          "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Mein Verschwinden bleibt ein ewiges Geheimnis.",
+          "sentence_translation": "Незадолго до пленения Корделии шут исчезает: Моё исчезновение остаётся вечной тайной."
         },
         {
           "german": "die Leere",
           "russian": "пустота",
           "transcription": "[ди ЛЕ-ре]",
-          "sentence": "Ich hinterlasse nur Leere und Erinnerung.",
-          "sentence_translation": "Я оставляю только пустоту и воспоминание."
+          "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Ich hinterlasse nur Leere und Erinnerung.",
+          "sentence_translation": "Незадолго до пленения Корделии шут исчезает: Я оставляю только пустоту и воспоминание."
         },
         {
           "german": "sich auflösen",
           "russian": "растворяться",
           "transcription": "[зих АУФ-лё-зен]",
-          "sentence": "Ich löse mich auf wie Nebel im Wind.",
-          "sentence_translation": "Я растворяюсь как туман на ветру."
+          "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Ich löse mich auf wie Nebel im Wind.",
+          "sentence_translation": "Незадолго до пленения Корделии шут исчезает: Я растворяюсь как туман на ветру."
         },
         {
           "german": "spurlos",
           "russian": "бесследно",
           "transcription": "[ШПУР-лос]",
-          "sentence": "Spurlos gehe ich aus dieser Welt.",
-          "sentence_translation": "Бесследно я ухожу из этого мира."
+          "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Spurlos gehe ich aus dieser Welt.",
+          "sentence_translation": "Незадолго до пленения Корделии шут исчезает: Бесследно я ухожу из этого мира."
         },
         {
           "german": "der Nebel",
           "russian": "туман",
           "transcription": "[дер НЕ-бель]",
-          "sentence": "Im Nebel verliere ich mich für immer.",
-          "sentence_translation": "В тумане я теряюсь навсегда."
+          "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Im Nebel verliere ich mich für immer.",
+          "sentence_translation": "Незадолго до пленения Корделии шут исчезает: В тумане я теряюсь навсегда."
         },
         {
           "german": "rätselhaft",
           "russian": "загадочный",
           "transcription": "[РЕТ-зель-хафт]",
-          "sentence": "Mein Ende bleibt rätselhaft und stumm.",
-          "sentence_translation": "Мой конец остаётся загадочным и немым."
+          "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Mein Ende bleibt rätselhaft und stumm.",
+          "sentence_translation": "Незадолго до пленения Корделии шут исчезает: Мой конец остаётся загадочным и немым."
         },
         {
           "german": "fortgehen",
           "russian": "уходить",
           "transcription": "[ФОРТ-ге-ен]",
-          "sentence": "Ich gehe fort, wenn keiner es bemerkt.",
-          "sentence_translation": "Я ухожу, когда никто не замечает."
+          "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Ich gehe fort, wenn keiner es bemerkt.",
+          "sentence_translation": "Незадолго до пленения Корделии шут исчезает: Я ухожу, когда никто не замечает."
         }
       ],
       "theatrical_scene": {

--- a/data/characters/gloucester.json
+++ b/data/characters/gloucester.json
@@ -14,57 +14,57 @@
           "german": "der Adel",
           "russian": "знать",
           "transcription": "[дер А-дель]",
-          "sentence": "Als Adel diene ich meinem König treu.",
-          "sentence_translation": "Как знать я верно служу своему королю."
+          "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Als Adel diene ich meinem König treu.",
+          "sentence_translation": "В замке Глостера старый граф уверяет короля Лира: Как знать я верно служу своему королю."
         },
         {
           "german": "dienen",
           "russian": "служить",
           "transcription": "[ДИ-нен]",
-          "sentence": "Ich diene dem König seit vielen Jahren.",
-          "sentence_translation": "Я служу королю много лет."
+          "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Ich diene dem König seit vielen Jahren.",
+          "sentence_translation": "В замке Глостера старый граф уверяет короля Лира: Я служу королю много лет."
         },
         {
           "german": "vertrauen",
           "russian": "доверять",
           "transcription": "[фер-ТРАУ-ен]",
-          "sentence": "Ich vertraue beiden Söhnen gleich.",
-          "sentence_translation": "Я доверяю обоим сыновьям одинаково."
+          "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Ich vertraue beiden Söhnen gleich.",
+          "sentence_translation": "В замке Глостера старый граф уверяет короля Лира: Я доверяю обоим сыновьям одинаково."
         },
         {
           "german": "der Graf",
           "russian": "граф",
           "transcription": "[дер ГРАФ]",
-          "sentence": "Als Graf habe ich große Verantwortung.",
-          "sentence_translation": "Как граф я несу большую ответственность."
+          "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Als Graf habe ich große Verantwortung.",
+          "sentence_translation": "В замке Глостера старый граф уверяет короля Лира: Как граф я несу большую ответственность."
         },
         {
           "german": "die Ehre",
           "russian": "честь",
           "transcription": "[ди Э-ре]",
-          "sentence": "Meine Ehre ist mein höchstes Gut.",
-          "sentence_translation": "Моя честь - моё высшее благо."
+          "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Meine Ehre ist mein höchstes Gut.",
+          "sentence_translation": "В замке Глостера старый граф уверяет короля Лира: Моя честь - моё высшее благо."
         },
         {
           "german": "rechtschaffen",
           "russian": "праведный",
           "transcription": "[РЕХТ-ша-фен]",
-          "sentence": "Ich bin ein rechtschaffener Mann.",
-          "sentence_translation": "Я праведный человек."
+          "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Ich bin ein rechtschaffener Mann.",
+          "sentence_translation": "В замке Глостера старый граф уверяет короля Лира: Я праведный человек."
         },
         {
           "german": "die Pflicht",
           "russian": "долг",
           "transcription": "[ди ПФЛИХТ]",
-          "sentence": "Meine Pflicht ruft mich zum König.",
-          "sentence_translation": "Мой долг зовёт меня к королю."
+          "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Meine Pflicht ruft mich zum König.",
+          "sentence_translation": "В замке Глостера старый граф уверяет короля Лира: Мой долг зовёт меня к королю."
         },
         {
           "german": "achten",
           "russian": "уважать",
           "transcription": "[АХ-тен]",
-          "sentence": "Ich achte beide Söhne, Edgar und Edmund.",
-          "sentence_translation": "Я уважаю обоих сыновей, Эдгара и Эдмунда."
+          "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Ich achte beide Söhne, Edgar und Edmund.",
+          "sentence_translation": "В замке Глостера старый граф уверяет короля Лира: Я уважаю обоих сыновей, Эдгара и Эдмунда."
         }
       ],
       "theatrical_scene": {
@@ -107,57 +107,57 @@
           "german": "der Brief",
           "russian": "письмо",
           "transcription": "[дер БРИФ]",
-          "sentence": "Dieser Brief beweist Edgars Verrat.",
-          "sentence_translation": "Это письмо доказывает предательство Эдгара."
+          "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Dieser Brief beweist Edgars Verrat.",
+          "sentence_translation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Это письмо доказывает предательство Эдгара."
         },
         {
           "german": "glauben",
           "russian": "верить",
           "transcription": "[ГЛАУ-бен]",
-          "sentence": "Ich glaube Edmunds Lügen sofort.",
-          "sentence_translation": "Я сразу верю лжи Эдмунда."
+          "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich glaube Edmunds Lügen sofort.",
+          "sentence_translation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я сразу верю лжи Эдмунда."
         },
         {
           "german": "täuschen",
           "russian": "обманывать",
           "transcription": "[ТОЙ-шен]",
-          "sentence": "Edmund täuscht mich mit falschen Beweisen.",
-          "sentence_translation": "Эдмунд обманывает меня ложными доказательствами."
+          "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Edmund täuscht mich mit falschen Beweisen.",
+          "sentence_translation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Эдмунд обманывает меня ложными доказательствами."
         },
         {
           "german": "der Betrug",
           "russian": "обман",
           "transcription": "[дер бе-ТРУГ]",
-          "sentence": "Ich erkenne den Betrug nicht.",
-          "sentence_translation": "Я не распознаю обман."
+          "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich erkenne den Betrug nicht.",
+          "sentence_translation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я не распознаю обман."
         },
         {
           "german": "arglos",
           "russian": "простодушный",
           "transcription": "[АРГ-лос]",
-          "sentence": "Ich bin zu arglos für solche Intrigen.",
-          "sentence_translation": "Я слишком простодушен для таких интриг."
+          "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich bin zu arglos für solche Intrigen.",
+          "sentence_translation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я слишком простодушен для таких интриг."
         },
         {
           "german": "verdächtigen",
           "russian": "подозревать",
           "transcription": "[фер-ДЕХ-ти-ген]",
-          "sentence": "Ich verdächtige meinen guten Sohn Edgar.",
-          "sentence_translation": "Я подозреваю моего доброго сына Эдгара."
+          "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich verdächtige meinen guten Sohn Edgar.",
+          "sentence_translation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я подозреваю моего доброго сына Эдгара."
         },
         {
           "german": "leichtgläubig",
           "russian": "легковерный",
           "transcription": "[ЛАЙХТ-глой-биг]",
-          "sentence": "Ich bin zu leichtgläubig für diese Welt.",
-          "sentence_translation": "Я слишком легковерен для этого мира."
+          "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich bin zu leichtgläubig für diese Welt.",
+          "sentence_translation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я слишком легковерен для этого мира."
         },
         {
           "german": "die Falle",
           "russian": "ловушка",
           "transcription": "[ди ФА-ле]",
-          "sentence": "Ich tappe blind in Edmunds Falle.",
-          "sentence_translation": "Я слепо попадаю в ловушку Эдмунда."
+          "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich tappe blind in Edmunds Falle.",
+          "sentence_translation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я слепо попадаю в ловушку Эдмунда."
         }
       ],
       "theatrical_scene": {
@@ -200,50 +200,50 @@
           "german": "verstoßen",
           "russian": "изгонять",
           "transcription": "[фер-ШТО-сен]",
-          "sentence": "Ich verstoße meinen unschuldigen Sohn.",
-          "sentence_translation": "Я изгоняю своего невинного сына."
+          "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Ich verstoße meinen unschuldigen Sohn.",
+          "sentence_translation": "Во дворе замка Реганы Глостер проклинает сына: Я изгоняю своего невинного сына."
         },
         {
           "german": "verfluchen",
           "russian": "проклинать",
           "transcription": "[фер-ФЛУ-хен]",
-          "sentence": "Im Zorn verfluche ich Edgar.",
-          "sentence_translation": "В гневе я проклинаю Эдгара."
+          "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Im Zorn verfluche ich Edgar.",
+          "sentence_translation": "Во дворе замка Реганы Глостер проклинает сына: В гневе я проклинаю Эдгара."
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
-          "sentence": "Später werde ich diese Tat bitter bereuen.",
-          "sentence_translation": "Позже я горько пожалею об этом поступке."
+          "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Später werde ich diese Tat bitter bereuen.",
+          "sentence_translation": "Во дворе замка Реганы Глостер проклинает сына: Позже я горько пожалею об этом поступке."
         },
         {
           "german": "der Irrtum",
           "russian": "заблуждение",
           "transcription": "[дер ИР-тум]",
-          "sentence": "Mein Irrtum zerstört meine Familie.",
-          "sentence_translation": "Моё заблуждение разрушает мою семью."
+          "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Mein Irrtum zerstört meine Familie.",
+          "sentence_translation": "Во дворе замка Реганы Глостер проклинает сына: Моё заблуждение разрушает мою семью."
         },
         {
           "german": "blind",
           "russian": "слепой",
           "transcription": "[БЛИНД]",
-          "sentence": "Ich bin blind für die Wahrheit.",
-          "sentence_translation": "Я слеп к правде."
+          "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Ich bin blind für die Wahrheit.",
+          "sentence_translation": "Во дворе замка Реганы Глостер проклинает сына: Я слеп к правде."
         },
         {
           "german": "jagen",
           "russian": "гнать",
           "transcription": "[Я-ген]",
-          "sentence": "Ich jage meinen Sohn fort wie einen Verbrecher.",
-          "sentence_translation": "Я гоню сына прочь как преступника."
+          "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Ich jage meinen Sohn fort wie einen Verbrecher.",
+          "sentence_translation": "Во дворе замка Реганы Глостер проклинает сына: Я гоню сына прочь как преступника."
         },
         {
           "german": "die Ungerechtigkeit",
           "russian": "несправедливость",
           "transcription": "[ди УН-ге-рех-тиг-кайт]",
-          "sentence": "Ich begehe große Ungerechtigkeit.",
-          "sentence_translation": "Я совершаю большую несправедливость."
+          "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Ich begehe große Ungerechtigkeit.",
+          "sentence_translation": "Во дворе замка Реганы Глостер проклинает сына: Я совершаю большую несправедливость."
         }
       ],
       "theatrical_scene": {
@@ -286,57 +286,57 @@
           "german": "helfen",
           "russian": "помогать",
           "transcription": "[ХЕЛЬ-фен]",
-          "sentence": "Heimlich helfe ich dem verstoßenen König.",
-          "sentence_translation": "Тайно я помогаю изгнанному королю."
+          "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Heimlich helfe ich dem verstoßenen König.",
+          "sentence_translation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Тайно я помогаю изгнанному королю."
         },
         {
           "german": "das Mitleid",
           "russian": "сострадание",
           "transcription": "[дас МИТ-лайд]",
-          "sentence": "Mitleid erfüllt mein Herz für Lear.",
-          "sentence_translation": "Сострадание наполняет моё сердце к Лиру."
+          "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Mitleid erfüllt mein Herz für Lear.",
+          "sentence_translation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Сострадание наполняет моё сердце к Лиру."
         },
         {
           "german": "riskieren",
           "russian": "рисковать",
           "transcription": "[рис-КИ-рен]",
-          "sentence": "Ich riskiere alles für den alten König.",
-          "sentence_translation": "Я рискую всем ради старого короля."
+          "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Ich riskiere alles für den alten König.",
+          "sentence_translation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Я рискую всем ради старого короля."
         },
         {
           "german": "die Gefahr",
           "russian": "опасность",
           "transcription": "[ди ге-ФАР]",
-          "sentence": "Die Gefahr der Entdeckung ist groß.",
-          "sentence_translation": "Опасность разоблачения велика."
+          "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Die Gefahr der Entdeckung ist groß.",
+          "sentence_translation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Опасность разоблачения велика."
         },
         {
           "german": "heimlich",
           "russian": "тайно",
           "transcription": "[ХАЙМ-лих]",
-          "sentence": "Ich handle heimlich gegen die neuen Herrscher.",
-          "sentence_translation": "Я действую тайно против новых правителей."
+          "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Ich handle heimlich gegen die neuen Herrscher.",
+          "sentence_translation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Я действую тайно против новых правителей."
         },
         {
           "german": "schützen",
           "russian": "защищать",
           "transcription": "[ШЮ-цен]",
-          "sentence": "Ich will den wahnsinnigen König schützen.",
-          "sentence_translation": "Я хочу защитить безумного короля."
+          "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Ich will den wahnsinnigen König schützen.",
+          "sentence_translation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Я хочу защитить безумного короля."
         },
         {
           "german": "der Verrat",
           "russian": "измена",
           "transcription": "[дер фер-РАТ]",
-          "sentence": "Meine Hilfe gilt als Verrat.",
-          "sentence_translation": "Моя помощь считается изменой."
+          "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Meine Hilfe gilt als Verrat.",
+          "sentence_translation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Моя помощь считается изменой."
         },
         {
           "german": "wagen",
           "russian": "осмеливаться",
           "transcription": "[ВА-ген]",
-          "sentence": "Ich wage es, gegen die Töchter zu handeln.",
-          "sentence_translation": "Я осмеливаюсь действовать против дочерей."
+          "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Ich wage es, gegen die Töchter zu handeln.",
+          "sentence_translation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Я осмеливаюсь действовать против дочерей."
         }
       ],
       "theatrical_scene": {
@@ -379,50 +379,50 @@
           "german": "blenden",
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
-          "sentence": "Sie blenden mich für meinen Verrat.",
-          "sentence_translation": "Они ослепляют меня за мою измену."
+          "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Sie blenden mich für meinen Verrat.",
+          "sentence_translation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Они ослепляют меня за мою измену."
         },
         {
           "german": "die Folter",
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
-          "sentence": "Die Folter ist grausam und erbarmungslos.",
-          "sentence_translation": "Пытка жестока и беспощадна."
+          "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Die Folter ist grausam und erbarmungslos.",
+          "sentence_translation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Пытка жестока и беспощадна."
         },
         {
           "german": "der Schmerz",
           "russian": "боль",
           "transcription": "[дер ШМЕРЦ]",
-          "sentence": "Der Schmerz durchbohrt meine Seele.",
-          "sentence_translation": "Боль пронзает мою душу."
+          "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Der Schmerz durchbohrt meine Seele.",
+          "sentence_translation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Боль пронзает мою душу."
         },
         {
           "german": "die Dunkelheit",
           "russian": "темнота",
           "transcription": "[ди ДУН-кель-хайт]",
-          "sentence": "Ewige Dunkelheit umgibt mich nun.",
-          "sentence_translation": "Вечная темнота окружает меня теперь."
+          "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Ewige Dunkelheit umgibt mich nun.",
+          "sentence_translation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Вечная темнота окружает меня теперь."
         },
         {
           "german": "schreien",
           "russian": "кричать",
           "transcription": "[ШРАЙ-ен]",
-          "sentence": "Ich schreie vor unerträglichem Schmerz.",
-          "sentence_translation": "Я кричу от невыносимой боли."
+          "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Ich schreie vor unerträglichem Schmerz.",
+          "sentence_translation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Я кричу от невыносимой боли."
         },
         {
           "german": "erblinden",
           "russian": "слепнуть",
           "transcription": "[ер-БЛИН-ден]",
-          "sentence": "Ich erblinde durch ihre Grausamkeit.",
-          "sentence_translation": "Я слепну от их жестокости."
+          "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Ich erblinde durch ihre Grausamkeit.",
+          "sentence_translation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Я слепну от их жестокости."
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
-          "sentence": "Dies ist ihre Rache für meine Treue.",
-          "sentence_translation": "Это их месть за мою верность."
+          "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Dies ist ihre Rache für meine Treue.",
+          "sentence_translation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Это их месть за мою верность."
         }
       ],
       "theatrical_scene": {
@@ -465,57 +465,57 @@
           "german": "die Verzweiflung",
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
-          "sentence": "Die Verzweiflung treibt mich zum Abgrund.",
-          "sentence_translation": "Отчаяние гонит меня к пропасти."
+          "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Die Verzweiflung treibt mich zum Abgrund.",
+          "sentence_translation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Отчаяние гонит меня к пропасти."
         },
         {
           "german": "springen",
           "russian": "прыгать",
           "transcription": "[ШПРИН-ген]",
-          "sentence": "Ich will von den Klippen springen.",
-          "sentence_translation": "Я хочу прыгнуть со скал."
+          "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Ich will von den Klippen springen.",
+          "sentence_translation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Я хочу прыгнуть со скал."
         },
         {
           "german": "die Täuschung",
           "russian": "обман",
           "transcription": "[ди ТОЙ-шунг]",
-          "sentence": "Edgars liebevolle Täuschung rettet mich.",
-          "sentence_translation": "Любящий обман Эдгара спасает меня."
+          "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Edgars liebevolle Täuschung rettet mich.",
+          "sentence_translation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Любящий обман Эдгара спасает меня."
         },
         {
           "german": "der Abgrund",
           "russian": "пропасть",
           "transcription": "[дер АБ-грунд]",
-          "sentence": "Der Abgrund ruft nach mir.",
-          "sentence_translation": "Пропасть зовёт меня."
+          "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Der Abgrund ruft nach mir.",
+          "sentence_translation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Пропасть зовёт меня."
         },
         {
           "german": "aufgeben",
           "russian": "сдаваться",
           "transcription": "[АУФ-ге-бен]",
-          "sentence": "Ich will das Leben aufgeben.",
-          "sentence_translation": "Я хочу отказаться от жизни."
+          "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Ich will das Leben aufgeben.",
+          "sentence_translation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Я хочу отказаться от жизни."
         },
         {
           "german": "die Hoffnungslosigkeit",
           "russian": "безнадёжность",
           "transcription": "[ди ХОФ-нунгс-ло-зиг-кайт]",
-          "sentence": "Die Hoffnungslosigkeit erdrückt mich.",
-          "sentence_translation": "Безнадёжность давит меня."
+          "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Die Hoffnungslosigkeit erdrückt mich.",
+          "sentence_translation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Безнадёжность давит меня."
         },
         {
           "german": "stürzen",
           "russian": "падать",
           "transcription": "[ШТЮР-цен]",
-          "sentence": "Ich glaube, von hohen Klippen zu stürzen.",
-          "sentence_translation": "Я верю, что падаю с высоких скал."
+          "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Ich glaube, von hohen Klippen zu stürzen.",
+          "sentence_translation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Я верю, что падаю с высоких скал."
         },
         {
           "german": "erlösen",
           "russian": "избавлять",
           "transcription": "[ер-ЛЁ-зен]",
-          "sentence": "Der Tod soll mich von der Schuld erlösen.",
-          "sentence_translation": "Смерть должна избавить меня от вины."
+          "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Der Tod soll mich von der Schuld erlösen.",
+          "sentence_translation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Смерть должна избавить меня от вины."
         }
       ],
       "theatrical_scene": {
@@ -558,57 +558,57 @@
           "german": "erkennen",
           "russian": "узнавать",
           "transcription": "[ер-КЕН-нен]",
-          "sentence": "Endlich erkenne ich meinen treuen Edgar.",
-          "sentence_translation": "Наконец я узнаю моего верного Эдгара."
+          "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Endlich erkenne ich meinen treuen Edgar.",
+          "sentence_translation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Наконец я узнаю моего верного Эдгара."
         },
         {
           "german": "vergeben",
           "russian": "прощать",
           "transcription": "[фер-ГЕ-бен]",
-          "sentence": "Edgar vergibt mir meine Blindheit.",
-          "sentence_translation": "Эдгар прощает мне мою слепоту."
+          "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Edgar vergibt mir meine Blindheit.",
+          "sentence_translation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Эдгар прощает мне мою слепоту."
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
-          "sentence": "Ich sterbe vor Freude und Kummer.",
-          "sentence_translation": "Я умираю от радости и горя."
+          "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Ich sterbe vor Freude und Kummer.",
+          "sentence_translation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Я умираю от радости и горя."
         },
         {
           "german": "die Erkenntnis",
           "russian": "осознание",
           "transcription": "[ди ер-КЕНТ-нис]",
-          "sentence": "Die späte Erkenntnis bricht mein Herz.",
-          "sentence_translation": "Позднее осознание разбивает моё сердце."
+          "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Die späte Erkenntnis bricht mein Herz.",
+          "sentence_translation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Позднее осознание разбивает моё сердце."
         },
         {
           "german": "die Reue",
           "russian": "раскаяние",
           "transcription": "[ди РОЙ-е]",
-          "sentence": "Die Reue überwältigt meine Seele.",
-          "sentence_translation": "Раскаяние переполняет мою душу."
+          "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Die Reue überwältigt meine Seele.",
+          "sentence_translation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Раскаяние переполняет мою душу."
         },
         {
           "german": "umarmen",
           "russian": "обнимать",
           "transcription": "[ум-АР-мен]",
-          "sentence": "Ein letztes Mal umarme ich meinen Sohn.",
-          "sentence_translation": "В последний раз я обнимаю сына."
+          "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Ein letztes Mal umarme ich meinen Sohn.",
+          "sentence_translation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: В последний раз я обнимаю сына."
         },
         {
           "german": "die Versöhnung",
           "russian": "примирение",
           "transcription": "[ди фер-ЗЁ-нунг]",
-          "sentence": "Die Versöhnung kommt zu spät.",
-          "sentence_translation": "Примирение приходит слишком поздно."
+          "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Die Versöhnung kommt zu spät.",
+          "sentence_translation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Примирение приходит слишком поздно."
         },
         {
           "german": "das Herz",
           "russian": "сердце",
           "transcription": "[дас ХЕРЦ]",
-          "sentence": "Mein Herz zerbricht vor Glück und Leid.",
-          "sentence_translation": "Моё сердце разрывается от счастья и горя."
+          "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Mein Herz zerbricht vor Glück und Leid.",
+          "sentence_translation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Моё сердце разрывается от счастья и горя."
         }
       ],
       "theatrical_scene": {

--- a/data/characters/goneril.json
+++ b/data/characters/goneril.json
@@ -20,57 +20,57 @@
           "german": "die Lüge",
           "russian": "ложь",
           "transcription": "[ди ЛЮ-ге]",
-          "sentence": "Die Lüge klingt süßer als die Wahrheit.",
-          "sentence_translation": "Ложь звучит слаще правды."
+          "sentence": "Im Thronsaal von König Lear haucht Goneril: Die Lüge klingt süßer als die Wahrheit.",
+          "sentence_translation": "В тронном зале короля Лира Гонериль шепчет: Ложь звучит слаще правды."
         },
         {
           "german": "schwören",
           "russian": "клясться",
           "transcription": "[ШВЁ-рен]",
-          "sentence": "Ich schwöre, dass ich Euch mehr liebe als mein Leben.",
-          "sentence_translation": "Я клянусь, что люблю вас больше жизни."
+          "sentence": "Im Thronsaal von König Lear haucht Goneril: Ich schwöre, dass ich Euch mehr liebe als mein Leben.",
+          "sentence_translation": "В тронном зале короля Лира Гонериль шепчет: Я клянусь, что люблю вас больше жизни."
         },
         {
           "german": "das Erbe",
           "russian": "наследство",
           "transcription": "[дас ЕР-бе]",
-          "sentence": "Das Erbe ist endlich mein.",
-          "sentence_translation": "Наследство наконец моё."
+          "sentence": "Im Thronsaal von König Lear haucht Goneril: Das Erbe ist endlich mein.",
+          "sentence_translation": "В тронном зале короля Лира Гонериль шепчет: Наследство наконец моё."
         },
         {
           "german": "heucheln",
           "russian": "лицемерить",
           "transcription": "[ХОЙ-хельн]",
-          "sentence": "Ich muss vor meinem Vater heucheln.",
-          "sentence_translation": "Я должна лицемерить перед отцом."
+          "sentence": "Im Thronsaal von König Lear haucht Goneril: Ich muss vor meinem Vater heucheln.",
+          "sentence_translation": "В тронном зале короля Лира Гонериль шепчет: Я должна лицемерить перед отцом."
         },
         {
           "german": "die Gier",
           "russian": "жадность",
           "transcription": "[ди ГИР]",
-          "sentence": "Die Gier nach Macht treibt mich an.",
-          "sentence_translation": "Жадность к власти движет мной."
+          "sentence": "Im Thronsaal von König Lear haucht Goneril: Die Gier nach Macht treibt mich an.",
+          "sentence_translation": "В тронном зале короля Лира Гонериль шепчет: Жадность к власти движет мной."
         },
         {
           "german": "täuschen",
           "russian": "обманывать",
           "transcription": "[ТОЙ-шен]",
-          "sentence": "Ich täusche meinen alten Vater leicht.",
-          "sentence_translation": "Я легко обманываю старого отца."
+          "sentence": "Im Thronsaal von König Lear haucht Goneril: Ich täusche meinen alten Vater leicht.",
+          "sentence_translation": "В тронном зале короля Лира Гонериль шепчет: Я легко обманываю старого отца."
         },
         {
           "german": "schmeicheln",
           "russian": "льстить",
           "transcription": "[ШМАЙ-хельн]",
-          "sentence": "Mit süßen Worten schmeichle ich ihm.",
-          "sentence_translation": "Сладкими словами я льщу ему."
+          "sentence": "Im Thronsaal von König Lear haucht Goneril: Mit süßen Worten schmeichle ich ihm.",
+          "sentence_translation": "В тронном зале короля Лира Гонериль шепчет: Сладкими словами я льщу ему."
         },
         {
           "german": "das Vermögen",
           "russian": "состояние",
           "transcription": "[дас фер-МЁ-ген]",
-          "sentence": "Sein ganzes Vermögen wird mir gehören.",
-          "sentence_translation": "Всё его состояние будет моим."
+          "sentence": "Im Thronsaal von König Lear haucht Goneril: Sein ganzes Vermögen wird mir gehören.",
+          "sentence_translation": "В тронном зале короля Лира Гонериль шепчет: Всё его состояние будет моим."
         }
       ],
       "quizzes": [
@@ -113,57 +113,57 @@
           "german": "die Macht",
           "russian": "власть",
           "transcription": "[ди МАХТ]",
-          "sentence": "Die Macht über das halbe Königreich ist mein.",
-          "sentence_translation": "Власть над половиной королевства моя."
+          "sentence": "In ihrem Palast in Albany prahlt Goneril: Die Macht über das halbe Königreich ist mein.",
+          "sentence_translation": "В своём дворце в Олбани Гонериль хвастается: Власть над половиной королевства моя."
         },
         {
           "german": "herrschen",
           "russian": "править",
           "transcription": "[ХЕР-шен]",
-          "sentence": "Jetzt herrsche ich über meine Länder.",
-          "sentence_translation": "Теперь я правлю своими землями."
+          "sentence": "In ihrem Palast in Albany prahlt Goneril: Jetzt herrsche ich über meine Länder.",
+          "sentence_translation": "В своём дворце в Олбани Гонериль хвастается: Теперь я правлю своими землями."
         },
         {
           "german": "befehlen",
           "russian": "приказывать",
           "transcription": "[бе-ФЕ-лен]",
-          "sentence": "Ich befehle, und alle gehorchen mir.",
-          "sentence_translation": "Я приказываю, и все подчиняются мне."
+          "sentence": "In ihrem Palast in Albany prahlt Goneril: Ich befehle, und alle gehorchen mir.",
+          "sentence_translation": "В своём дворце в Олбани Гонериль хвастается: Я приказываю, и все подчиняются мне."
         },
         {
           "german": "der Thron",
           "russian": "трон",
           "transcription": "[дер ТРОН]",
-          "sentence": "Der Thron meines Vaters wird bald leer sein.",
-          "sentence_translation": "Трон моего отца скоро опустеет."
+          "sentence": "In ihrem Palast in Albany prahlt Goneril: Der Thron meines Vaters wird bald leer sein.",
+          "sentence_translation": "В своём дворце в Олбани Гонериль хвастается: Трон моего отца скоро опустеет."
         },
         {
           "german": "erobern",
           "russian": "завоёвывать",
           "transcription": "[ер-О-берн]",
-          "sentence": "Ich erobere, was mir zusteht.",
-          "sentence_translation": "Я завоёвываю то, что мне положено."
+          "sentence": "In ihrem Palast in Albany prahlt Goneril: Ich erobere, was mir zusteht.",
+          "sentence_translation": "В своём дворце в Олбани Гонериль хвастается: Я завоёвываю то, что мне положено."
         },
         {
           "german": "die Herrschaft",
           "russian": "господство",
           "transcription": "[ди ХЕР-шафт]",
-          "sentence": "Die Herrschaft über alle ist mein Ziel.",
-          "sentence_translation": "Господство над всеми - моя цель."
+          "sentence": "In ihrem Palast in Albany prahlt Goneril: Die Herrschaft über alle ist mein Ziel.",
+          "sentence_translation": "В своём дворце в Олбани Гонериль хвастается: Господство над всеми - моя цель."
         },
         {
           "german": "regieren",
           "russian": "управлять",
           "transcription": "[ре-ГИ-рен]",
-          "sentence": "Ich werde mit eiserner Hand regieren.",
-          "sentence_translation": "Я буду управлять железной рукой."
+          "sentence": "In ihrem Palast in Albany prahlt Goneril: Ich werde mit eiserner Hand regieren.",
+          "sentence_translation": "В своём дворце в Олбани Гонериль хвастается: Я буду управлять железной рукой."
         },
         {
           "german": "unterwerfen",
           "russian": "подчинять",
           "transcription": "[ун-тер-ВЕР-фен]",
-          "sentence": "Alle müssen sich mir unterwerfen.",
-          "sentence_translation": "Все должны мне подчиниться."
+          "sentence": "In ihrem Palast in Albany prahlt Goneril: Alle müssen sich mir unterwerfen.",
+          "sentence_translation": "В своём дворце в Олбани Гонериль хвастается: Все должны мне подчиниться."
         }
       ],
       "quizzes": [
@@ -206,57 +206,57 @@
           "german": "demütigen",
           "russian": "унижать",
           "transcription": "[де-МЮ-ти-ген]",
-          "sentence": "Ich demütige meinen alten Vater ohne Mitleid.",
-          "sentence_translation": "Я унижаю старого отца без жалости."
+          "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich demütige meinen alten Vater ohne Mitleid.",
+          "sentence_translation": "Когда Лир квартирует у неё, Гонериль приказывает: Я унижаю старого отца без жалости."
         },
         {
           "german": "grausam",
           "russian": "жестокий",
           "transcription": "[ГРАУ-зам]",
-          "sentence": "Ich bin grausam zu dem, der mir alles gab.",
-          "sentence_translation": "Я жестока к тому, кто дал мне всё."
+          "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich bin grausam zu dem, der mir alles gab.",
+          "sentence_translation": "Когда Лир квартирует у неё, Гонериль приказывает: Я жестока к тому, кто дал мне всё."
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
-          "sentence": "Die Rache für Jahre der Unterwerfung.",
-          "sentence_translation": "Месть за годы подчинения."
+          "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Die Rache für Jahre der Unterwerfung.",
+          "sentence_translation": "Когда Лир квартирует у неё, Гонериль приказывает: Месть за годы подчинения."
         },
         {
           "german": "vertreiben",
           "russian": "изгонять",
           "transcription": "[фер-ТРАЙ-бен]",
-          "sentence": "Ich vertreibe ihn aus meinem Haus.",
-          "sentence_translation": "Я изгоняю его из моего дома."
+          "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich vertreibe ihn aus meinem Haus.",
+          "sentence_translation": "Когда Лир квартирует у неё, Гонериль приказывает: Я изгоняю его из моего дома."
         },
         {
           "german": "verachten",
           "russian": "презирать",
           "transcription": "[фер-АХ-тен]",
-          "sentence": "Ich verachte seine Schwäche und sein Alter.",
-          "sentence_translation": "Я презираю его слабость и старость."
+          "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich verachte seine Schwäche und sein Alter.",
+          "sentence_translation": "Когда Лир квартирует у неё, Гонериль приказывает: Я презираю его слабость и старость."
         },
         {
           "german": "verweigern",
           "russian": "отказывать",
           "transcription": "[фер-ВАЙ-герн]",
-          "sentence": "Ich verweigere ihm jeden Komfort.",
-          "sentence_translation": "Я отказываю ему в любом комфорте."
+          "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich verweigere ihm jeden Komfort.",
+          "sentence_translation": "Когда Лир квартирует у неё, Гонериль приказывает: Я отказываю ему в любом комфорте."
         },
         {
           "german": "quälen",
           "russian": "мучить",
           "transcription": "[КВЕ-лен]",
-          "sentence": "Es macht mir Freude, ihn zu quälen.",
-          "sentence_translation": "Мне доставляет радость мучить его."
+          "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Es macht mir Freude, ihn zu quälen.",
+          "sentence_translation": "Когда Лир квартирует у неё, Гонериль приказывает: Мне доставляет радость мучить его."
         },
         {
           "german": "beschränken",
           "russian": "ограничивать",
           "transcription": "[бе-ШРЕН-кен]",
-          "sentence": "Ich beschränke seine Dienerschaft auf null.",
-          "sentence_translation": "Я ограничиваю его свиту до нуля."
+          "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich beschränke seine Dienerschaft auf null.",
+          "sentence_translation": "Когда Лир квартирует у неё, Гонериль приказывает: Я ограничиваю его свиту до нуля."
         }
       ],
       "quizzes": [
@@ -299,50 +299,50 @@
           "german": "verstoßen",
           "russian": "отвергать",
           "transcription": "[фер-ШТО-сен]",
-          "sentence": "Ich verstoße meinen Vater in die Nacht.",
-          "sentence_translation": "Я отвергаю отца в ночь."
+          "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Ich verstoße meinen Vater in die Nacht.",
+          "sentence_translation": "Перед воротами своего замка Гонериль выталкивает отца: Я отвергаю отца в ночь."
         },
         {
           "german": "der Sturm",
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
-          "sentence": "Der Sturm soll sein neues Zuhause sein.",
-          "sentence_translation": "Буря пусть будет его новым домом."
+          "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Der Sturm soll sein neues Zuhause sein.",
+          "sentence_translation": "Перед воротами своего замка Гонериль выталкивает отца: Буря пусть будет его новым домом."
         },
         {
           "german": "gnadenlos",
           "russian": "безжалостный",
           "transcription": "[ГНА-ден-лос]",
-          "sentence": "Ich bin gnadenlos wie der Winter.",
-          "sentence_translation": "Я безжалостна как зима."
+          "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Ich bin gnadenlos wie der Winter.",
+          "sentence_translation": "Перед воротами своего замка Гонериль выталкивает отца: Я безжалостна как зима."
         },
         {
           "german": "verschließen",
           "russian": "запирать",
           "transcription": "[фер-ШЛИ-сен]",
-          "sentence": "Ich verschließe meine Türen vor ihm.",
-          "sentence_translation": "Я запираю двери перед ним."
+          "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Ich verschließe meine Türen vor ihm.",
+          "sentence_translation": "Перед воротами своего замка Гонериль выталкивает отца: Я запираю двери перед ним."
         },
         {
           "german": "die Kälte",
           "russian": "холод",
           "transcription": "[ди КЕЛ-те]",
-          "sentence": "Die Kälte meines Herzens übertrifft den Winter.",
-          "sentence_translation": "Холод моего сердца превосходит зиму."
+          "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Die Kälte meines Herzens übertrifft den Winter.",
+          "sentence_translation": "Перед воротами своего замка Гонериль выталкивает отца: Холод моего сердца превосходит зиму."
         },
         {
           "german": "erbarmungslos",
           "russian": "беспощадный",
           "transcription": "[ер-БАР-мунгс-лос]",
-          "sentence": "Erbarmungslos werfe ich ihn hinaus.",
-          "sentence_translation": "Беспощадно я выбрасываю его."
+          "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Erbarmungslos werfe ich ihn hinaus.",
+          "sentence_translation": "Перед воротами своего замка Гонериль выталкивает отца: Беспощадно я выбрасываю его."
         },
         {
           "german": "verhärten",
           "russian": "ожесточаться",
           "transcription": "[фер-ХЕР-тен]",
-          "sentence": "Mein Herz verhärtet sich gegen alle Bitten.",
-          "sentence_translation": "Моё сердце ожесточается против всех просьб."
+          "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Mein Herz verhärtet sich gegen alle Bitten.",
+          "sentence_translation": "Перед воротами своего замка Гонериль выталкивает отца: Моё сердце ожесточается против всех просьб."
         }
       ],
       "quizzes": [
@@ -385,57 +385,57 @@
           "german": "streiten",
           "russian": "ссориться",
           "transcription": "[ШТРАЙ-тен]",
-          "sentence": "Ich streite mit meinem schwachen Mann.",
-          "sentence_translation": "Я ссорюсь со своим слабым мужем."
+          "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Ich streite mit meinem schwachen Mann.",
+          "sentence_translation": "В военном лагере Олбани Гонериль ссорится с мужем: Я ссорюсь со своим слабым мужем."
         },
         {
           "german": "verraten",
           "russian": "предавать",
           "transcription": "[фер-РА-тен]",
-          "sentence": "Ich verrate meinen Mann für Edmund.",
-          "sentence_translation": "Я предаю мужа ради Эдмунда."
+          "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Ich verrate meinen Mann für Edmund.",
+          "sentence_translation": "В военном лагере Олбани Гонериль ссорится с мужем: Я предаю мужа ради Эдмунда."
         },
         {
           "german": "die Zwietracht",
           "russian": "раздор",
           "transcription": "[ди ЦВИ-трахт]",
-          "sentence": "Die Zwietracht zerstört unsere Ehe.",
-          "sentence_translation": "Раздор разрушает наш брак."
+          "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Die Zwietracht zerstört unsere Ehe.",
+          "sentence_translation": "В военном лагере Олбани Гонериль ссорится с мужем: Раздор разрушает наш брак."
         },
         {
           "german": "hassen",
           "russian": "ненавидеть",
           "transcription": "[ХА-сен]",
-          "sentence": "Ich hasse seine Schwäche und Güte.",
-          "sentence_translation": "Я ненавижу его слабость и доброту."
+          "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Ich hasse seine Schwäche und Güte.",
+          "sentence_translation": "В военном лагере Олбани Гонериль ссорится с мужем: Я ненавижу его слабость и доброту."
         },
         {
           "german": "betrügen",
           "russian": "изменять",
           "transcription": "[бе-ТРЮ-ген]",
-          "sentence": "Ich betrüge ihn mit Edmund.",
-          "sentence_translation": "Я изменяю ему с Эдмундом."
+          "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Ich betrüge ihn mit Edmund.",
+          "sentence_translation": "В военном лагере Олбани Гонериль ссорится с мужем: Я изменяю ему с Эдмундом."
         },
         {
           "german": "die Verachtung",
           "russian": "презрение",
           "transcription": "[ди фер-АХ-тунг]",
-          "sentence": "Meine Verachtung für ihn wächst täglich.",
-          "sentence_translation": "Моё презрение к нему растёт ежедневно."
+          "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Meine Verachtung für ihn wächst täglich.",
+          "sentence_translation": "В военном лагере Олбани Гонериль ссорится с мужем: Моё презрение к нему растёт ежедневно."
         },
         {
           "german": "zerstören",
           "russian": "разрушать",
           "transcription": "[цер-ШТЁ-рен]",
-          "sentence": "Ich zerstöre alles, was uns verband.",
-          "sentence_translation": "Я разрушаю всё, что нас связывало."
+          "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Ich zerstöre alles, was uns verband.",
+          "sentence_translation": "В военном лагере Олбани Гонериль ссорится с мужем: Я разрушаю всё, что нас связывало."
         },
         {
           "german": "die Leidenschaft",
           "russian": "страсть",
           "transcription": "[ди ЛАЙ-ден-шафт]",
-          "sentence": "Meine Leidenschaft gilt nur Edmund.",
-          "sentence_translation": "Моя страсть принадлежит только Эдмунду."
+          "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Meine Leidenschaft gilt nur Edmund.",
+          "sentence_translation": "В военном лагере Олбани Гонериль ссорится с мужем: Моя страсть принадлежит только Эдмунду."
         }
       ],
       "quizzes": [
@@ -478,57 +478,57 @@
           "german": "die Eifersucht",
           "russian": "ревность",
           "transcription": "[ди АЙ-фер-зухт]",
-          "sentence": "Die Eifersucht verzehrt mich von innen.",
-          "sentence_translation": "Ревность пожирает меня изнутри."
+          "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Die Eifersucht verzehrt mich von innen.",
+          "sentence_translation": "В поле под Дувром Гонериль злится на Регану: Ревность пожирает меня изнутри."
         },
         {
           "german": "rivalisieren",
           "russian": "соперничать",
           "transcription": "[ри-ва-ли-ЗИ-рен]",
-          "sentence": "Ich rivalisiere mit meiner Schwester um Edmund.",
-          "sentence_translation": "Я соперничаю с сестрой за Эдмунда."
+          "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Ich rivalisiere mit meiner Schwester um Edmund.",
+          "sentence_translation": "В поле под Дувром Гонериль злится на Регану: Я соперничаю с сестрой за Эдмунда."
         },
         {
           "german": "kämpfen",
           "russian": "бороться",
           "transcription": "[КЕМП-фен]",
-          "sentence": "Ich kämpfe um das, was ich begehre.",
-          "sentence_translation": "Я борюсь за то, чего желаю."
+          "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Ich kämpfe um das, was ich begehre.",
+          "sentence_translation": "В поле под Дувром Гонериль злится на Регану: Я борюсь за то, чего желаю."
         },
         {
           "german": "begehren",
           "russian": "желать",
           "transcription": "[бе-ГЕ-рен]",
-          "sentence": "Ich begehre Edmund mehr als mein Leben.",
-          "sentence_translation": "Я желаю Эдмунда больше жизни."
+          "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Ich begehre Edmund mehr als mein Leben.",
+          "sentence_translation": "В поле под Дувром Гонериль злится на Регану: Я желаю Эдмунда больше жизни."
         },
         {
           "german": "beseitigen",
           "russian": "устранять",
           "transcription": "[бе-ЗАЙ-ти-ген]",
-          "sentence": "Ich muss meine Schwester beseitigen.",
-          "sentence_translation": "Я должна устранить свою сестру."
+          "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Ich muss meine Schwester beseitigen.",
+          "sentence_translation": "В поле под Дувром Гонериль злится на Регану: Я должна устранить свою сестру."
         },
         {
           "german": "das Gift",
           "russian": "яд",
           "transcription": "[дас ГИФТ]",
-          "sentence": "Das Gift ist bereit für meine Schwester.",
-          "sentence_translation": "Яд готов для моей сестры."
+          "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Das Gift ist bereit für meine Schwester.",
+          "sentence_translation": "В поле под Дувром Гонериль злится на Регану: Яд готов для моей сестры."
         },
         {
           "german": "die Intrige",
           "russian": "интрига",
           "transcription": "[ди ин-ТРИ-ге]",
-          "sentence": "Meine Intrige wird sie vernichten.",
-          "sentence_translation": "Моя интрига уничтожит её."
+          "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Meine Intrige wird sie vernichten.",
+          "sentence_translation": "В поле под Дувром Гонериль злится на Регану: Моя интрига уничтожит её."
         },
         {
           "german": "morden",
           "russian": "убивать",
           "transcription": "[МОР-ден]",
-          "sentence": "Ich bin bereit zu morden für meine Lust.",
-          "sentence_translation": "Я готова убивать ради своей страсти."
+          "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Ich bin bereit zu morden für meine Lust.",
+          "sentence_translation": "В поле под Дувром Гонериль злится на Регану: Я готова убивать ради своей страсти."
         }
       ],
       "quizzes": [
@@ -571,57 +571,57 @@
           "german": "vergiften",
           "russian": "отравлять",
           "transcription": "[фер-ГИФ-тен]",
-          "sentence": "Ich vergifte erst meine Schwester, dann mich selbst.",
-          "sentence_translation": "Я отравляю сначала сестру, потом себя."
+          "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Ich vergifte erst meine Schwester, dann mich selbst.",
+          "sentence_translation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Я отравляю сначала сестру, потом себя."
         },
         {
           "german": "die Verzweiflung",
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
-          "sentence": "Die Verzweiflung führt mich zum Tod.",
-          "sentence_translation": "Отчаяние ведёт меня к смерти."
+          "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Die Verzweiflung führt mich zum Tod.",
+          "sentence_translation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Отчаяние ведёт меня к смерти."
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
-          "sentence": "Ich sterbe durch meine eigene Hand.",
-          "sentence_translation": "Я умираю от своей собственной руки."
+          "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Ich sterbe durch meine eigene Hand.",
+          "sentence_translation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Я умираю от своей собственной руки."
         },
         {
           "german": "die Schuld",
           "russian": "вина",
           "transcription": "[ди ШУЛЬД]",
-          "sentence": "Die Schuld erdrückt mich am Ende.",
-          "sentence_translation": "Вина давит меня в конце."
+          "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Die Schuld erdrückt mich am Ende.",
+          "sentence_translation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Вина давит меня в конце."
         },
         {
           "german": "vernichten",
           "russian": "уничтожать",
           "transcription": "[фер-НИХ-тен]",
-          "sentence": "Ich vernichte mich selbst durch meine Bosheit.",
-          "sentence_translation": "Я уничтожаю себя своим злом."
+          "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Ich vernichte mich selbst durch meine Bosheit.",
+          "sentence_translation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Я уничтожаю себя своим злом."
         },
         {
           "german": "das Verderben",
           "russian": "погибель",
           "transcription": "[дас фер-ДЕР-бен]",
-          "sentence": "Das Verderben holt mich ein.",
-          "sentence_translation": "Погибель настигает меня."
+          "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Das Verderben holt mich ein.",
+          "sentence_translation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Погибель настигает меня."
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
-          "sentence": "Zu spät bereue ich meine Taten.",
-          "sentence_translation": "Слишком поздно я сожалею о своих делах."
+          "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Zu spät bereue ich meine Taten.",
+          "sentence_translation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Слишком поздно я сожалею о своих делах."
         },
         {
           "german": "die Hölle",
           "russian": "ад",
           "transcription": "[ди ХЁ-ле]",
-          "sentence": "Die Hölle wartet auf meine schwarze Seele.",
-          "sentence_translation": "Ад ждёт мою чёрную душу."
+          "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Die Hölle wartet auf meine schwarze Seele.",
+          "sentence_translation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Ад ждёт мою чёрную душу."
         }
       ],
       "quizzes": [

--- a/data/characters/kent.json
+++ b/data/characters/kent.json
@@ -14,57 +14,57 @@
           "german": "die Treue",
           "russian": "верность",
           "transcription": "[ди ТРОЙ-е]",
-          "sentence": "Die Treue zu meinem König ist unerschütterlich.",
-          "sentence_translation": "Верность моему королю непоколебима."
+          "sentence": "Im Thronsaal von Lear kniet Kent: Die Treue zu meinem König ist unerschütterlich.",
+          "sentence_translation": "В тронном зале Лира Кент преклоняется: Верность моему королю непоколебима."
         },
         {
           "german": "der Mut",
           "russian": "мужество",
           "transcription": "[дер МУТ]",
-          "sentence": "Der Mut fordert mich, die Wahrheit zu sagen.",
-          "sentence_translation": "Мужество требует от меня говорить правду."
+          "sentence": "Im Thronsaal von Lear kniet Kent: Der Mut fordert mich, die Wahrheit zu sagen.",
+          "sentence_translation": "В тронном зале Лира Кент преклоняется: Мужество требует от меня говорить правду."
         },
         {
           "german": "widersprechen",
           "russian": "возражать",
           "transcription": "[ВИ-дер-шпре-хен]",
-          "sentence": "Ich widerspreche dem König für seine eigene Ehre.",
-          "sentence_translation": "Я возражаю королю ради его же чести."
+          "sentence": "Im Thronsaal von Lear kniet Kent: Ich widerspreche dem König für seine eigene Ehre.",
+          "sentence_translation": "В тронном зале Лира Кент преклоняется: Я возражаю королю ради его же чести."
         },
         {
           "german": "verteidigen",
           "russian": "защищать",
           "transcription": "[фер-ТАЙ-ди-ген]",
-          "sentence": "Ich verteidige Корделия gegen Ungerechtigkeit.",
-          "sentence_translation": "Я защищаю Корделию от несправедливости."
+          "sentence": "Im Thronsaal von Lear kniet Kent: Ich verteidige Корделия gegen Ungerechtigkeit.",
+          "sentence_translation": "В тронном зале Лира Кент преклоняется: Я защищаю Корделию от несправедливости."
         },
         {
           "german": "aufrichtig",
           "russian": "искренний",
           "transcription": "[АУФ-рих-тиг]",
-          "sentence": "Ich bin aufrichtig, auch wenn es gefährlich ist.",
-          "sentence_translation": "Я искренен, даже если это опасно."
+          "sentence": "Im Thronsaal von Lear kniet Kent: Ich bin aufrichtig, auch wenn es gefährlich ist.",
+          "sentence_translation": "В тронном зале Лира Кент преклоняется: Я искренен, даже если это опасно."
         },
         {
           "german": "der Diener",
           "russian": "слуга",
           "transcription": "[дер ДИ-нер]",
-          "sentence": "Als treuer Diener spreche ich offen.",
-          "sentence_translation": "Как верный слуга, я говорю открыто."
+          "sentence": "Im Thronsaal von Lear kniet Kent: Als treuer Diener spreche ich offen.",
+          "sentence_translation": "В тронном зале Лира Кент преклоняется: Как верный слуга, я говорю открыто."
         },
         {
           "german": "warnen",
           "russian": "предупреждать",
           "transcription": "[ВАР-нен]",
-          "sentence": "Ich warne den König vor seinem Fehler.",
-          "sentence_translation": "Я предупреждаю короля об его ошибке."
+          "sentence": "Im Thronsaal von Lear kniet Kent: Ich warne den König vor seinem Fehler.",
+          "sentence_translation": "В тронном зале Лира Кент преклоняется: Я предупреждаю короля об его ошибке."
         },
         {
           "german": "gerecht",
           "russian": "справедливый",
           "transcription": "[ге-РЕХТ]",
-          "sentence": "Ich kämpfe für das, was gerecht ist.",
-          "sentence_translation": "Я борюсь за то, что справедливо."
+          "sentence": "Im Thronsaal von Lear kniet Kent: Ich kämpfe für das, was gerecht ist.",
+          "sentence_translation": "В тронном зале Лира Кент преклоняется: Я борюсь за то, что справедливо."
         }
       ],
       "theatrical_scene": {
@@ -107,50 +107,50 @@
           "german": "die Verbannung",
           "russian": "изгнание",
           "transcription": "[ди фер-БА-нунг]",
-          "sentence": "Die Verbannung ist der Preis für meine Ehrlichkeit.",
-          "sentence_translation": "Изгнание - цена моей честности."
+          "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Die Verbannung ist der Preis für meine Ehrlichkeit.",
+          "sentence_translation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Изгнание - цена моей честности."
         },
         {
           "german": "die Ungerechtigkeit",
           "russian": "несправедливость",
           "transcription": "[ди УН-ге-рех-тиг-кайт]",
-          "sentence": "Diese Ungerechtigkeit werde ich nicht akzeptieren.",
-          "sentence_translation": "Эту несправедливость я не приму."
+          "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Diese Ungerechtigkeit werde ich nicht akzeptieren.",
+          "sentence_translation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Эту несправедливость я не приму."
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
-          "sentence": "Der Zorn des Königs trifft mich ungerecht.",
-          "sentence_translation": "Гнев короля поражает меня несправедливо."
+          "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Der Zorn des Königs trifft mich ungerecht.",
+          "sentence_translation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Гнев короля поражает меня несправедливо."
         },
         {
           "german": "verbannt",
           "russian": "изгнанный",
           "transcription": "[фер-БАНТ]",
-          "sentence": "Verbannt aus dem Land, das ich liebe.",
-          "sentence_translation": "Изгнан из страны, которую люблю."
+          "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Verbannt aus dem Land, das ich liebe.",
+          "sentence_translation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Изгнан из страны, которую люблю."
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
-          "sentence": "Der Abschied vom Hof schmerzt mich tief.",
-          "sentence_translation": "Прощание с двором глубоко ранит меня."
+          "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Der Abschied vom Hof schmerzt mich tief.",
+          "sentence_translation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Прощание с двором глубоко ранит меня."
         },
         {
           "german": "die Strafe",
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
-          "sentence": "Diese Strafe nehme ich mit Würde an.",
-          "sentence_translation": "Это наказание я принимаю с достоинством."
+          "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Diese Strafe nehme ich mit Würde an.",
+          "sentence_translation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Это наказание я принимаю с достоинством."
         },
         {
           "german": "zurückkehren",
           "russian": "возвращаться",
           "transcription": "[цу-РЮК-ке-рен]",
-          "sentence": "Ich schwöre, verkleidet zurückzukehren.",
-          "sentence_translation": "Я клянусь вернуться переодетым."
+          "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Ich schwöre, verkleidet zurückzukehren.",
+          "sentence_translation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Я клянусь вернуться переодетым."
         }
       ],
       "theatrical_scene": {
@@ -193,57 +193,57 @@
           "german": "die Verkleidung",
           "russian": "переодевание",
           "transcription": "[ди фер-КЛАЙ-дунг]",
-          "sentence": "In Verkleidung diene ich meinem König weiter.",
-          "sentence_translation": "В переодевании я продолжаю служить королю."
+          "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: In Verkleidung diene ich meinem König weiter.",
+          "sentence_translation": "Перед замком Гонериль Кент надевает своё маскировочное платье: В переодевании я продолжаю служить королю."
         },
         {
           "german": "die List",
           "russian": "хитрость",
           "transcription": "[ди ЛИСТ]",
-          "sentence": "Mit List kehre ich an den Hof zurück.",
-          "sentence_translation": "Хитростью я возвращаюсь ко двору."
+          "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Mit List kehre ich an den Hof zurück.",
+          "sentence_translation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Хитростью я возвращаюсь ко двору."
         },
         {
           "german": "unerkannt",
           "russian": "неузнанный",
           "transcription": "[УН-ер-кант]",
-          "sentence": "Unerkannt bleibe ich an seiner Seite.",
-          "sentence_translation": "Неузнанным я остаюсь рядом с ним."
+          "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Unerkannt bleibe ich an seiner Seite.",
+          "sentence_translation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Неузнанным я остаюсь рядом с ним."
         },
         {
           "german": "vorgeben",
           "russian": "притворяться",
           "transcription": "[ФОР-ге-бен]",
-          "sentence": "Ich gebe vor, ein einfacher Mann zu sein.",
-          "sentence_translation": "Я притворяюсь простым человеком."
+          "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Ich gebe vor, ein einfacher Mann zu sein.",
+          "sentence_translation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Я притворяюсь простым человеком."
         },
         {
           "german": "verstellen",
           "russian": "изменять",
           "transcription": "[фер-ШТЕ-лен]",
-          "sentence": "Ich verstelle meine Stimme und Haltung.",
-          "sentence_translation": "Я изменяю свой голос и осанку."
+          "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Ich verstelle meine Stimme und Haltung.",
+          "sentence_translation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Я изменяю свой голос и осанку."
         },
         {
           "german": "der Bart",
           "russian": "борода",
           "transcription": "[дер БАРТ]",
-          "sentence": "Mit falschem Bart bin ich nicht zu erkennen.",
-          "sentence_translation": "С фальшивой бородой меня не узнать."
+          "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Mit falschem Bart bin ich nicht zu erkennen.",
+          "sentence_translation": "Перед замком Гонериль Кент надевает своё маскировочное платье: С фальшивой бородой меня не узнать."
         },
         {
           "german": "anheuern",
           "russian": "наниматься",
           "transcription": "[АН-хой-ерн]",
-          "sentence": "Als Кай heuere ich beim König an.",
-          "sentence_translation": "Как Кай я нанимаюсь к королю."
+          "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Als Кай heuere ich beim König an.",
+          "sentence_translation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Как Кай я нанимаюсь к королю."
         },
         {
           "german": "treu",
           "russian": "верный",
           "transcription": "[ТРОЙ]",
-          "sentence": "Treu bleibe ich trotz der Verkleidung.",
-          "sentence_translation": "Верным остаюсь несмотря на переодевание."
+          "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Treu bleibe ich trotz der Verkleidung.",
+          "sentence_translation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Верным остаюсь несмотря на переодевание."
         }
       ],
       "theatrical_scene": {
@@ -286,50 +286,50 @@
           "german": "der Dienst",
           "russian": "служба",
           "transcription": "[дер ДИНСТ]",
-          "sentence": "Mein Dienst geht über die Verbannung hinaus.",
-          "sentence_translation": "Моя служба идёт дальше изгнания."
+          "sentence": "Als Diener Caius an Lears Seite schwört Kent: Mein Dienst geht über die Verbannung hinaus.",
+          "sentence_translation": "В облике слуги Кая при Лире Кент клянётся: Моя служба идёт дальше изгнания."
         },
         {
           "german": "der Schutz",
           "russian": "защита",
           "transcription": "[дер ШУТЦ]",
-          "sentence": "Ich biete Schutz, ohne erkannt zu werden.",
-          "sentence_translation": "Я предоставляю защиту, не будучи узнанным."
+          "sentence": "Als Diener Caius an Lears Seite schwört Kent: Ich biete Schutz, ohne erkannt zu werden.",
+          "sentence_translation": "В облике слуги Кая при Лире Кент клянётся: Я предоставляю защиту, не будучи узнанным."
         },
         {
           "german": "die Gefahr",
           "russian": "опасность",
           "transcription": "[ди ге-ФАР]",
-          "sentence": "Trotz Gefahr bleibe ich beim König.",
-          "sentence_translation": "Несмотря на опасность, я остаюсь с королём."
+          "sentence": "Als Diener Caius an Lears Seite schwört Kent: Trotz Gefahr bleibe ich beim König.",
+          "sentence_translation": "В облике слуги Кая при Лире Кент клянётся: Несмотря на опасность, я остаюсь с королём."
         },
         {
           "german": "bewachen",
           "russian": "охранять",
           "transcription": "[бе-ВА-хен]",
-          "sentence": "Heimlich bewache ich meinen alten Herrn.",
-          "sentence_translation": "Тайно я охраняю своего старого господина."
+          "sentence": "Als Diener Caius an Lears Seite schwört Kent: Heimlich bewache ich meinen alten Herrn.",
+          "sentence_translation": "В облике слуги Кая при Лире Кент клянётся: Тайно я охраняю своего старого господина."
         },
         {
           "german": "kämpfen",
           "russian": "сражаться",
           "transcription": "[КЕМП-фен]",
-          "sentence": "Ich kämpfe gegen alle seine Feinde.",
-          "sentence_translation": "Я сражаюсь против всех его врагов."
+          "sentence": "Als Diener Caius an Lears Seite schwört Kent: Ich kämpfe gegen alle seine Feinde.",
+          "sentence_translation": "В облике слуги Кая при Лире Кент клянётся: Я сражаюсь против всех его врагов."
         },
         {
           "german": "raten",
           "russian": "советовать",
           "transcription": "[РА-тен]",
-          "sentence": "Als Кай rate ich ihm zur Vorsicht.",
-          "sentence_translation": "Как Кай я советую ему осторожность."
+          "sentence": "Als Diener Caius an Lears Seite schwört Kent: Als Кай rate ich ihm zur Vorsicht.",
+          "sentence_translation": "В облике слуги Кая при Лире Кент клянётся: Как Кай я советую ему осторожность."
         },
         {
           "german": "die Wache",
           "russian": "стража",
           "transcription": "[ди ВА-хе]",
-          "sentence": "Ich halte Wache über seinen Schlaf.",
-          "sentence_translation": "Я держу стражу над его сном."
+          "sentence": "Als Diener Caius an Lears Seite schwört Kent: Ich halte Wache über seinen Schlaf.",
+          "sentence_translation": "В облике слуги Кая при Лире Кент клянётся: Я держу стражу над его сном."
         }
       ],
       "theatrical_scene": {
@@ -372,57 +372,57 @@
           "german": "die Strafe",
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
-          "sentence": "Diese Strafe erdulde ich für meinen König.",
-          "sentence_translation": "Это наказание я терплю ради короля."
+          "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Diese Strafe erdulde ich für meinen König.",
+          "sentence_translation": "Во дворе замка Реганы Кент сидит в колодках: Это наказание я терплю ради короля."
         },
         {
           "german": "die Demütigung",
           "russian": "унижение",
           "transcription": "[ди де-МЮ-ти-гунг]",
-          "sentence": "Die Demütigung macht mich nur stärker.",
-          "sentence_translation": "Унижение делает меня только сильнее."
+          "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Die Demütigung macht mich nur stärker.",
+          "sentence_translation": "Во дворе замка Реганы Кент сидит в колодках: Унижение делает меня только сильнее."
         },
         {
           "german": "die Standhaftigkeit",
           "russian": "стойкость",
           "transcription": "[ди ШТАНД-хаф-тиг-кайт]",
-          "sentence": "Mit Standhaftigkeit ertrage ich die Schmach.",
-          "sentence_translation": "Со стойкостью я переношу позор."
+          "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Mit Standhaftigkeit ertrage ich die Schmach.",
+          "sentence_translation": "Во дворе замка Реганы Кент сидит в колодках: Со стойкостью я переношу позор."
         },
         {
           "german": "fesseln",
           "russian": "сковывать",
           "transcription": "[ФЕ-сельн]",
-          "sentence": "Sie fesseln mich wie einen gemeinen Dieb.",
-          "sentence_translation": "Они сковывают меня как обычного вора."
+          "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Sie fesseln mich wie einen gemeinen Dieb.",
+          "sentence_translation": "Во дворе замка Реганы Кент сидит в колодках: Они сковывают меня как обычного вора."
         },
         {
           "german": "erdulden",
           "russian": "терпеть",
           "transcription": "[ер-ДУЛЬ-ден]",
-          "sentence": "Ich erdulde die Schande ohne Klage.",
-          "sentence_translation": "Я терплю позор без жалоб."
+          "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Ich erdulde die Schande ohne Klage.",
+          "sentence_translation": "Во дворе замка Реганы Кент сидит в колодках: Я терплю позор без жалоб."
         },
         {
           "german": "der Stock",
           "russian": "колодка",
           "transcription": "[дер ШТОК]",
-          "sentence": "Im Stock sitze ich die ganze Nacht.",
-          "sentence_translation": "В колодке я сижу всю ночь."
+          "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Im Stock sitze ich die ganze Nacht.",
+          "sentence_translation": "Во дворе замка Реганы Кент сидит в колодках: В колодке я сижу всю ночь."
         },
         {
           "german": "ausharren",
           "russian": "выдерживать",
           "transcription": "[АУС-ха-рен]",
-          "sentence": "Ich harre aus bis zur Befreiung.",
-          "sentence_translation": "Я выдерживаю до освобождения."
+          "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Ich harre aus bis zur Befreiung.",
+          "sentence_translation": "Во дворе замка Реганы Кент сидит в колодках: Я выдерживаю до освобождения."
         },
         {
           "german": "die Schande",
           "russian": "позор",
           "transcription": "[ди ШАН-де]",
-          "sentence": "Diese Schande ist Cornwall's, nicht meine.",
-          "sentence_translation": "Этот позор Корнуолла, не мой."
+          "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Diese Schande ist Cornwall's, nicht meine.",
+          "sentence_translation": "Во дворе замка Реганы Кент сидит в колодках: Этот позор Корнуолла, не мой."
         }
       ],
       "theatrical_scene": {
@@ -465,50 +465,50 @@
           "german": "der Sturm",
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
-          "sentence": "Im Sturm bleibe ich bei meinem König.",
-          "sentence_translation": "В буре я остаюсь с моим королём."
+          "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Im Sturm bleibe ich bei meinem König.",
+          "sentence_translation": "На пустоши в бурю Кент поддерживает старого короля: В буре я остаюсь с моим королём."
         },
         {
           "german": "der Beistand",
           "russian": "поддержка",
           "transcription": "[дер БАЙ-штанд]",
-          "sentence": "Mein Beistand ist alles, was ich bieten kann.",
-          "sentence_translation": "Моя поддержка - всё, что я могу предложить."
+          "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Mein Beistand ist alles, was ich bieten kann.",
+          "sentence_translation": "На пустоши в бурю Кент поддерживает старого короля: Моя поддержка - всё, что я могу предложить."
         },
         {
           "german": "begleiten",
           "russian": "сопровождать",
           "transcription": "[бе-ГЛАЙ-тен]",
-          "sentence": "Ich begleite ihn durch Wind und Regen.",
-          "sentence_translation": "Я сопровождаю его сквозь ветер и дождь."
+          "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Ich begleite ihn durch Wind und Regen.",
+          "sentence_translation": "На пустоши в бурю Кент поддерживает старого короля: Я сопровождаю его сквозь ветер и дождь."
         },
         {
           "german": "trösten",
           "russian": "утешать",
           "transcription": "[ТРЁС-тен]",
-          "sentence": "Mit Worten tröste ich den wahnsinnigen König.",
-          "sentence_translation": "Словами я утешаю безумного короля."
+          "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Mit Worten tröste ich den wahnsinnigen König.",
+          "sentence_translation": "На пустоши в бурю Кент поддерживает старого короля: Словами я утешаю безумного короля."
         },
         {
           "german": "die Zuflucht",
           "russian": "убежище",
           "transcription": "[ди ЦУ-флухт]",
-          "sentence": "Ich suche Zuflucht für uns beide.",
-          "sentence_translation": "Я ищу убежище для нас обоих."
+          "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Ich suche Zuflucht für uns beide.",
+          "sentence_translation": "На пустоши в бурю Кент поддерживает старого короля: Я ищу убежище для нас обоих."
         },
         {
           "german": "durchhalten",
           "russian": "выдерживать",
           "transcription": "[ДУРХ-халь-тен]",
-          "sentence": "Gemeinsam werden wir durchhalten.",
-          "sentence_translation": "Вместе мы выдержим."
+          "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Gemeinsam werden wir durchhalten.",
+          "sentence_translation": "На пустоши в бурю Кент поддерживает старого короля: Вместе мы выдержим."
         },
         {
           "german": "die Kälte",
           "russian": "холод",
           "transcription": "[ди КЕЛ-те]",
-          "sentence": "Die Kälte dringt in unsere Knochen.",
-          "sentence_translation": "Холод проникает в наши кости."
+          "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Die Kälte dringt in unsere Knochen.",
+          "sentence_translation": "На пустоши в бурю Кент поддерживает старого короля: Холод проникает в наши кости."
         }
       ],
       "theatrical_scene": {
@@ -551,57 +551,57 @@
           "german": "der Tod",
           "russian": "смерть",
           "transcription": "[дер ТОД]",
-          "sentence": "Bis zum Tod bleibe ich an seiner Seite.",
-          "sentence_translation": "До смерти я остаюсь рядом с ним."
+          "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Bis zum Tod bleibe ich an seiner Seite.",
+          "sentence_translation": "Перед телом Корделии в Дувре Кент отвергает корону: До смерти я остаюсь рядом с ним."
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
-          "sentence": "Der Abschied von meinem König bricht mein Herz.",
-          "sentence_translation": "Прощание с моим королём разбивает моё сердце."
+          "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Der Abschied von meinem König bricht mein Herz.",
+          "sentence_translation": "Перед телом Корделии в Дувре Кент отвергает корону: Прощание с моим королём разбивает моё сердце."
         },
         {
           "german": "ewig",
           "russian": "вечный",
           "transcription": "[Э-виг]",
-          "sentence": "Meine Treue ist ewig, über den Tod hinaus.",
-          "sentence_translation": "Моя верность вечна, за пределами смерти."
+          "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Meine Treue ist ewig, über den Tod hinaus.",
+          "sentence_translation": "Перед телом Корделии в Дувре Кент отвергает корону: Моя верность вечна, за пределами смерти."
         },
         {
           "german": "weinen",
           "russian": "плакать",
           "transcription": "[ВАЙ-нен]",
-          "sentence": "Ich weine um meinen gefallenen König.",
-          "sentence_translation": "Я плачу о моём павшем короле."
+          "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Ich weine um meinen gefallenen König.",
+          "sentence_translation": "Перед телом Корделии в Дувре Кент отвергает корону: Я плачу о моём павшем короле."
         },
         {
           "german": "die Erschöpfung",
           "russian": "истощение",
           "transcription": "[ди ер-ШЁП-фунг]",
-          "sentence": "Die Erschöpfung überwältigt meinen alten Körper.",
-          "sentence_translation": "Истощение одолевает моё старое тело."
+          "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Die Erschöpfung überwältigt meinen alten Körper.",
+          "sentence_translation": "Перед телом Корделии в Дувре Кент отвергает корону: Истощение одолевает моё старое тело."
         },
         {
           "german": "aufgeben",
           "russian": "сдаваться",
           "transcription": "[АУФ-ге-бен]",
-          "sentence": "Ich gebe auf, nachdem mein Herr gestorben ist.",
-          "sentence_translation": "Я сдаюсь после смерти моего господина."
+          "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Ich gebe auf, nachdem mein Herr gestorben ist.",
+          "sentence_translation": "Перед телом Корделии в Дувре Кент отвергает корону: Я сдаюсь после смерти моего господина."
         },
         {
           "german": "die Trauer",
           "russian": "скорбь",
           "transcription": "[ди ТРАУ-ер]",
-          "sentence": "Die Trauer ist zu schwer zu ertragen.",
-          "sentence_translation": "Скорбь слишком тяжела, чтобы вынести."
+          "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Die Trauer ist zu schwer zu ertragen.",
+          "sentence_translation": "Перед телом Корделии в Дувре Кент отвергает корону: Скорбь слишком тяжела, чтобы вынести."
         },
         {
           "german": "folgen",
           "russian": "следовать",
           "transcription": "[ФОЛЬ-ген]",
-          "sentence": "Bald folge ich meinem König ins Jenseits.",
-          "sentence_translation": "Скоро я последую за королём в иной мир."
+          "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Bald folge ich meinem König ins Jenseits.",
+          "sentence_translation": "Перед телом Корделии в Дувре Кент отвергает корону: Скоро я последую за королём в иной мир."
         }
       ],
       "theatrical_scene": {

--- a/data/characters/king_lear.json
+++ b/data/characters/king_lear.json
@@ -20,57 +20,57 @@
           "german": "der Thron",
           "russian": "трон",
           "transcription": "[дер ТРОН]",
-          "sentence": "Vom Thron herab verkünde ich meinen Willen.",
-          "sentence_translation": "С трона я провозглашаю свою волю."
+          "sentence": "Im prunkvollen Thronsaal ruft König Lear: Vom Thron herab verkünde ich meinen Willen.",
+          "sentence_translation": "В роскошном тронном зале восклицает король Лир: С трона я провозглашаю свою волю."
         },
         {
           "german": "das Königreich",
           "russian": "королевство",
           "transcription": "[дас КЁ-ниг-райх]",
-          "sentence": "Mein Königreich teile ich unter meinen Töchtern.",
-          "sentence_translation": "Моё королевство я делю между дочерьми."
+          "sentence": "Im prunkvollen Thronsaal ruft König Lear: Mein Königreich teile ich unter meinen Töchtern.",
+          "sentence_translation": "В роскошном тронном зале восклицает король Лир: Моё королевство я делю между дочерьми."
         },
         {
           "german": "die Macht",
           "russian": "власть",
           "transcription": "[ди МАХТ]",
-          "sentence": "Die Macht gebe ich an jene, die mich am meisten liebt.",
-          "sentence_translation": "Власть я отдаю той, кто любит меня больше всех."
+          "sentence": "Im prunkvollen Thronsaal ruft König Lear: Die Macht gebe ich an jene, die mich am meisten liebt.",
+          "sentence_translation": "В роскошном тронном зале восклицает король Лир: Власть я отдаю той, кто любит меня больше всех."
         },
         {
           "german": "herrschen",
           "russian": "править",
           "transcription": "[ХЕР-шен]",
-          "sentence": "Ich habe lange genug geherrscht.",
-          "sentence_translation": "Я правил достаточно долго."
+          "sentence": "Im prunkvollen Thronsaal ruft König Lear: Ich habe lange genug geherrscht.",
+          "sentence_translation": "В роскошном тронном зале восклицает король Лир: Я правил достаточно долго."
         },
         {
           "german": "verkünden",
           "russian": "провозглашать",
           "transcription": "[фер-КЮН-ден]",
-          "sentence": "Ich verkünde die Teilung meines Reiches.",
-          "sentence_translation": "Я провозглашаю раздел моего королевства."
+          "sentence": "Im prunkvollen Thronsaal ruft König Lear: Ich verkünde die Teilung meines Reiches.",
+          "sentence_translation": "В роскошном тронном зале восклицает король Лир: Я провозглашаю раздел моего королевства."
         },
         {
           "german": "die Krone",
           "russian": "корона",
           "transcription": "[ди КРО-не]",
-          "sentence": "Diese Krone ist schwer geworden für mein altes Haupt.",
-          "sentence_translation": "Эта корона стала тяжела для моей старой головы."
+          "sentence": "Im prunkvollen Thronsaal ruft König Lear: Diese Krone ist schwer geworden für mein altes Haupt.",
+          "sentence_translation": "В роскошном тронном зале восклицает король Лир: Эта корона стала тяжела для моей старой головы."
         },
         {
           "german": "die Zeremonie",
           "russian": "церемония",
           "transcription": "[ди це-ре-мо-НИ]",
-          "sentence": "Die Zeremonie der Teilung beginnt jetzt.",
-          "sentence_translation": "Церемония раздела начинается сейчас."
+          "sentence": "Im prunkvollen Thronsaal ruft König Lear: Die Zeremonie der Teilung beginnt jetzt.",
+          "sentence_translation": "В роскошном тронном зале восклицает король Лир: Церемония раздела начинается сейчас."
         },
         {
           "german": "prächtig",
           "russian": "великолепный",
           "transcription": "[ПРЕХ-тиг]",
-          "sentence": "Ein prächtiger Tag für eine verhängnisvolle Entscheidung.",
-          "sentence_translation": "Великолепный день для рокового решения."
+          "sentence": "Im prunkvollen Thronsaal ruft König Lear: Ein prächtiger Tag für eine verhängnisvolle Entscheidung.",
+          "sentence_translation": "В роскошном тронном зале восклицает король Лир: Великолепный день для рокового решения."
         }
       ],
       "quizzes": [
@@ -113,57 +113,57 @@
           "german": "demütigen",
           "russian": "унижать",
           "transcription": "[де-МЮ-ти-ген]",
-          "sentence": "Meine eigene Tochter will mich demütigen!",
-          "sentence_translation": "Моя собственная дочь хочет меня унизить!"
+          "sentence": "In Gonerils Palast fühlt Lear: Meine eigene Tochter will mich demütigen!",
+          "sentence_translation": "Во дворце Гонериль Лир ощущает: Моя собственная дочь хочет меня унизить!"
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
-          "sentence": "Mein Zorn brennt wie Feuer in meiner Brust!",
-          "sentence_translation": "Мой гнев горит как огонь в моей груди!"
+          "sentence": "In Gonerils Palast fühlt Lear: Mein Zorn brennt wie Feuer in meiner Brust!",
+          "sentence_translation": "Во дворце Гонериль Лир ощущает: Мой гнев горит как огонь в моей груди!"
         },
         {
           "german": "die Undankbarkeit",
           "russian": "неблагодарность",
           "transcription": "[ди УН-данк-бар-кайт]",
-          "sentence": "Die Undankbarkeit ist schärfer als der Zahn einer Schlange!",
-          "sentence_translation": "Неблагодарность острее змеиного зуба!"
+          "sentence": "In Gonerils Palast fühlt Lear: Die Undankbarkeit ist schärfer als der Zahn einer Schlange!",
+          "sentence_translation": "Во дворце Гонериль Лир ощущает: Неблагодарность острее змеиного зуба!"
         },
         {
           "german": "verfluchen",
           "russian": "проклинать",
           "transcription": "[фер-ФЛУ-хен]",
-          "sentence": "Ich verfluche dich bei allen Sternen!",
-          "sentence_translation": "Я проклинаю тебя всеми звёздами!"
+          "sentence": "In Gonerils Palast fühlt Lear: Ich verfluche dich bei allen Sternen!",
+          "sentence_translation": "Во дворце Гонериль Лир ощущает: Я проклинаю тебя всеми звёздами!"
         },
         {
           "german": "vertreiben",
           "russian": "изгонять",
           "transcription": "[фер-ТРАЙ-бен]",
-          "sentence": "Aus meinem eigenen Haus will sie mich vertreiben!",
-          "sentence_translation": "Из моего собственного дома она хочет меня изгнать!"
+          "sentence": "In Gonerils Palast fühlt Lear: Aus meinem eigenen Haus will sie mich vertreiben!",
+          "sentence_translation": "Во дворце Гонериль Лир ощущает: Из моего собственного дома она хочет меня изгнать!"
         },
         {
           "german": "die Kränkung",
           "russian": "обида",
           "transcription": "[ди КРЭН-кунг]",
-          "sentence": "Diese Kränkung werde ich nicht vergessen!",
-          "sentence_translation": "Эту обиду я не забуду!"
+          "sentence": "In Gonerils Palast fühlt Lear: Diese Kränkung werde ich nicht vergessen!",
+          "sentence_translation": "Во дворце Гонериль Лир ощущает: Эту обиду я не забуду!"
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
-          "sentence": "Sie wird ihre Grausamkeit bereuen!",
-          "sentence_translation": "Она пожалеет о своей жестокости!"
+          "sentence": "In Gonerils Palast fühlt Lear: Sie wird ihre Grausamkeit bereuen!",
+          "sentence_translation": "Во дворце Гонериль Лир ощущает: Она пожалеет о своей жестокости!"
         },
         {
           "german": "der Fluch",
           "russian": "проклятие",
           "transcription": "[дер ФЛУХ]",
-          "sentence": "Mein Fluch soll über dich kommen!",
-          "sentence_translation": "Моё проклятие падёт на тебя!"
+          "sentence": "In Gonerils Palast fühlt Lear: Mein Fluch soll über dich kommen!",
+          "sentence_translation": "Во дворце Гонериль Лир ощущает: Моё проклятие падёт на тебя!"
         }
       ],
       "quizzes": [
@@ -206,57 +206,57 @@
           "german": "verlassen",
           "russian": "покидать",
           "transcription": "[фер-ЛА-сен]",
-          "sentence": "Auch Regan will mich verlassen und verstoßen!",
-          "sentence_translation": "И Регана хочет меня покинуть и отвергнуть!"
+          "sentence": "Auf dem Hof von Regans Burg fleht Lear: Auch Regan will mich verlassen und verstoßen!",
+          "sentence_translation": "На дворе замка Реганы Лир умоляет: И Регана хочет меня покинуть и отвергнуть!"
         },
         {
           "german": "verstoßen",
           "russian": "отвергать",
           "transcription": "[фер-ШТО-сен]",
-          "sentence": "Meine Töchter verstoßen mich wie einen Bettler!",
-          "sentence_translation": "Мои дочери отвергают меня как нищего!"
+          "sentence": "Auf dem Hof von Regans Burg fleht Lear: Meine Töchter verstoßen mich wie einen Bettler!",
+          "sentence_translation": "На дворе замка Реганы Лир умоляет: Мои дочери отвергают меня как нищего!"
         },
         {
           "german": "die Grausamkeit",
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
-          "sentence": "Ihre Grausamkeit übertrifft die ihrer Schwester!",
-          "sentence_translation": "Её жестокость превосходит жестокость сестры!"
+          "sentence": "Auf dem Hof von Regans Burg fleht Lear: Ihre Grausamkeit übertrifft die ihrer Schwester!",
+          "sentence_translation": "На дворе замка Реганы Лир умоляет: Её жестокость превосходит жестокость сестры!"
         },
         {
           "german": "die Verzweiflung",
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
-          "sentence": "Die Verzweiflung packt mein altes Herz!",
-          "sentence_translation": "Отчаяние охватывает моё старое сердце!"
+          "sentence": "Auf dem Hof von Regans Burg fleht Lear: Die Verzweiflung packt mein altes Herz!",
+          "sentence_translation": "На дворе замка Реганы Лир умоляет: Отчаяние охватывает моё старое сердце!"
         },
         {
           "german": "betteln",
           "russian": "просить",
           "transcription": "[БЕ-тельн]",
-          "sentence": "Muss ich um Unterkunft betteln bei meinen eigenen Kindern?",
-          "sentence_translation": "Должен ли я просить крова у собственных детей?"
+          "sentence": "Auf dem Hof von Regans Burg fleht Lear: Muss ich um Unterkunft betteln bei meinen eigenen Kindern?",
+          "sentence_translation": "На дворе замка Реганы Лир умоляет: Должен ли я просить крова у собственных детей?"
         },
         {
           "german": "die Einsamkeit",
           "russian": "одиночество",
           "transcription": "[ди АЙН-зам-кайт]",
-          "sentence": "Die Einsamkeit umgibt mich wie ein kalter Mantel.",
-          "sentence_translation": "Одиночество окружает меня как холодный плащ."
+          "sentence": "Auf dem Hof von Regans Burg fleht Lear: Die Einsamkeit umgibt mich wie ein kalter Mantel.",
+          "sentence_translation": "На дворе замка Реганы Лир умоляет: Одиночество окружает меня как холодный плащ."
         },
         {
           "german": "die Träne",
           "russian": "слеза",
           "transcription": "[ди ТРЭ-не]",
-          "sentence": "Keine Träne will ich für diese Undankbaren vergießen!",
-          "sentence_translation": "Ни одной слезы я не пролью за этих неблагодарных!"
+          "sentence": "Auf dem Hof von Regans Burg fleht Lear: Keine Träne will ich für diese Undankbaren vergießen!",
+          "sentence_translation": "На дворе замка Реганы Лир умоляет: Ни одной слезы я не пролью за этих неблагодарных!"
         },
         {
           "german": "die Not",
           "russian": "нужда",
           "transcription": "[ди НОТ]",
-          "sentence": "In meiner Not erkennen sie mich nicht als Vater.",
-          "sentence_translation": "В моей нужде они не признают меня отцом."
+          "sentence": "Auf dem Hof von Regans Burg fleht Lear: In meiner Not erkennen sie mich nicht als Vater.",
+          "sentence_translation": "На дворе замка Реганы Лир умоляет: В моей нужде они не признают меня отцом."
         }
       ],
       "quizzes": [
@@ -299,57 +299,57 @@
           "german": "der Sturm",
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
-          "sentence": "Der Sturm in meinem Kopf ist schlimmer als draußen!",
-          "sentence_translation": "Буря в моей голове хуже, чем снаружи!"
+          "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Der Sturm in meinem Kopf ist schlimmer als draußen!",
+          "sentence_translation": "На пустоши под хлещущим дождём Лир кричит: Буря в моей голове хуже, чем снаружи!"
         },
         {
           "german": "der Wahnsinn",
           "russian": "безумие",
           "transcription": "[дер ВАН-зин]",
-          "sentence": "Der Wahnsinn ist gnädiger als die Vernunft!",
-          "sentence_translation": "Безумие милосерднее разума!"
+          "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Der Wahnsinn ist gnädiger als die Vernunft!",
+          "sentence_translation": "На пустоши под хлещущим дождём Лир кричит: Безумие милосерднее разума!"
         },
         {
           "german": "toben",
           "russian": "бушевать",
           "transcription": "[ТО-бен]",
-          "sentence": "Lasst die Winde toben und die Blitze fallen!",
-          "sentence_translation": "Пусть ветры бушуют и молнии падают!"
+          "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Lasst die Winde toben und die Blitze fallen!",
+          "sentence_translation": "На пустоши под хлещущим дождём Лир кричит: Пусть ветры бушуют и молнии падают!"
         },
         {
           "german": "der Donner",
           "russian": "гром",
           "transcription": "[дер ДО-нер]",
-          "sentence": "Der Donner ist die Stimme der Götter!",
-          "sentence_translation": "Гром - это голос богов!"
+          "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Der Donner ist die Stimme der Götter!",
+          "sentence_translation": "На пустоши под хлещущим дождём Лир кричит: Гром - это голос богов!"
         },
         {
           "german": "der Blitz",
           "russian": "молния",
           "transcription": "[дер БЛИЦ]",
-          "sentence": "Die Blitze sollen meine weißen Haare verbrennen!",
-          "sentence_translation": "Пусть молнии сожгут мои седые волосы!"
+          "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Die Blitze sollen meine weißen Haare verbrennen!",
+          "sentence_translation": "На пустоши под хлещущим дождём Лир кричит: Пусть молнии сожгут мои седые волосы!"
         },
         {
           "german": "schreien",
           "russian": "кричать",
           "transcription": "[ШРАЙ-ен]",
-          "sentence": "Ich schreie in den Wind meine Wut hinaus!",
-          "sentence_translation": "Я кричу в ветер свою ярость!"
+          "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Ich schreie in den Wind meine Wut hinaus!",
+          "sentence_translation": "На пустоши под хлещущим дождём Лир кричит: Я кричу в ветер свою ярость!"
         },
         {
           "german": "nackt",
           "russian": "голый",
           "transcription": "[НАКТ]",
-          "sentence": "Nackt kam ich auf die Welt, nackt gehe ich!",
-          "sentence_translation": "Голым я пришёл в мир, голым и уйду!"
+          "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Nackt kam ich auf die Welt, nackt gehe ich!",
+          "sentence_translation": "На пустоши под хлещущим дождём Лир кричит: Голым я пришёл в мир, голым и уйду!"
         },
         {
           "german": "das Chaos",
           "russian": "хаос",
           "transcription": "[дас ХА-ос]",
-          "sentence": "Das Chaos in der Natur spiegelt meine Seele!",
-          "sentence_translation": "Хаос в природе отражает мою душу!"
+          "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Das Chaos in der Natur spiegelt meine Seele!",
+          "sentence_translation": "На пустоши под хлещущим дождём Лир кричит: Хаос в природе отражает мою душу!"
         }
       ],
       "quizzes": [
@@ -392,57 +392,57 @@
           "german": "das Elend",
           "russian": "нищета",
           "transcription": "[дас Э-ленд]",
-          "sentence": "Im Elend erkenne ich die Wahrheit der Welt.",
-          "sentence_translation": "В нищете я познаю истину мира."
+          "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Im Elend erkenne ich die Wahrheit der Welt.",
+          "sentence_translation": "В полуразвалившейся хижине у Глостера Лир бредит: В нищете я познаю истину мира."
         },
         {
           "german": "der Bettler",
           "russian": "нищий",
           "transcription": "[дер БЕТ-лер]",
-          "sentence": "Dieser Bettler ist glücklicher als ich, der König!",
-          "sentence_translation": "Этот нищий счастливее меня, короля!"
+          "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Dieser Bettler ist glücklicher als ich, der König!",
+          "sentence_translation": "В полуразвалившейся хижине у Глостера Лир бредит: Этот нищий счастливее меня, короля!"
         },
         {
           "german": "arm",
           "russian": "бедный",
           "transcription": "[АРМ]",
-          "sentence": "Die Armen leiden mehr als Könige jemals wissen.",
-          "sentence_translation": "Бедные страдают больше, чем короли когда-либо узнают."
+          "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Die Armen leiden mehr als Könige jemals wissen.",
+          "sentence_translation": "В полуразвалившейся хижине у Глостера Лир бредит: Бедные страдают больше, чем короли когда-либо узнают."
         },
         {
           "german": "frieren",
           "russian": "мёрзнуть",
           "transcription": "[ФРИ-рен]",
-          "sentence": "Wir alle frieren in dieser kalten Welt.",
-          "sentence_translation": "Мы все мёрзнем в этом холодном мире."
+          "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Wir alle frieren in dieser kalten Welt.",
+          "sentence_translation": "В полуразвалившейся хижине у Глостера Лир бредит: Мы все мёрзнем в этом холодном мире."
         },
         {
           "german": "die Hütte",
           "russian": "хижина",
           "transcription": "[ди ХЮ-те]",
-          "sentence": "Diese Hütte ist ein Palast für die Verlassenen.",
-          "sentence_translation": "Эта хижина - дворец для покинутых."
+          "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Diese Hütte ist ein Palast für die Verlassenen.",
+          "sentence_translation": "В полуразвалившейся хижине у Глостера Лир бредит: Эта хижина - дворец для покинутых."
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
-          "sentence": "Wer nicht gelitten hat, kennt das Leben nicht.",
-          "sentence_translation": "Кто не страдал, не знает жизни."
+          "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Wer nicht gelitten hat, kennt das Leben nicht.",
+          "sentence_translation": "В полуразвалившейся хижине у Глостера Лир бредит: Кто не страдал, не знает жизни."
         },
         {
           "german": "der Narr",
           "russian": "шут",
           "transcription": "[дер НАР]",
-          "sentence": "Mein Narr ist weiser als ich je war.",
-          "sentence_translation": "Мой шут мудрее, чем я когда-либо был."
+          "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Mein Narr ist weiser als ich je war.",
+          "sentence_translation": "В полуразвалившейся хижине у Глостера Лир бредит: Мой шут мудрее, чем я когда-либо был."
         },
         {
           "german": "die Erkenntnis",
           "russian": "познание",
           "transcription": "[ди ер-КЕНТ-нис]",
-          "sentence": "Die Erkenntnis kommt durch Schmerz und Verlust.",
-          "sentence_translation": "Познание приходит через боль и утрату."
+          "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Die Erkenntnis kommt durch Schmerz und Verlust.",
+          "sentence_translation": "В полуразвалившейся хижине у Глостера Лир бредит: Познание приходит через боль и утрату."
         }
       ],
       "quizzes": [
@@ -485,57 +485,57 @@
           "german": "erkennen",
           "russian": "узнавать",
           "transcription": "[эр-КЕ-нен]",
-          "sentence": "Ich erkenne dich, meine treue Cordelia!",
-          "sentence_translation": "Я узнаю тебя, моя верная Корделия!"
+          "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Ich erkenne dich, meine treue Cordelia!",
+          "sentence_translation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Я узнаю тебя, моя верная Корделия!"
         },
         {
           "german": "verstehen",
           "russian": "понимать",
           "transcription": "[фер-ШТЕ-ен]",
-          "sentence": "Jetzt verstehe ich, wer mich wirklich liebte.",
-          "sentence_translation": "Теперь я понимаю, кто действительно меня любил."
+          "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Jetzt verstehe ich, wer mich wirklich liebte.",
+          "sentence_translation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Теперь я понимаю, кто действительно меня любил."
         },
         {
           "german": "die Wahrheit",
           "russian": "правда",
           "transcription": "[ди ВАР-хайт]",
-          "sentence": "Die Wahrheit war immer in deinen Worten, Kind.",
-          "sentence_translation": "Правда всегда была в твоих словах, дитя."
+          "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Die Wahrheit war immer in deinen Worten, Kind.",
+          "sentence_translation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Правда всегда была в твоих словах, дитя."
         },
         {
           "german": "die Reue",
           "russian": "раскаяние",
           "transcription": "[ди РОЙ-е]",
-          "sentence": "Die Reue brennt heißer als alle Feuer der Hölle.",
-          "sentence_translation": "Раскаяние жжёт горячее всех адских огней."
+          "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Die Reue brennt heißer als alle Feuer der Hölle.",
+          "sentence_translation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Раскаяние жжёт горячее всех адских огней."
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
-          "sentence": "Die Weisheit kommt zu spät zu mir.",
-          "sentence_translation": "Мудрость приходит ко мне слишком поздно."
+          "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Die Weisheit kommt zu spät zu mir.",
+          "sentence_translation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Мудрость приходит ко мне слишком поздно."
         },
         {
           "german": "vergeben",
           "russian": "прощать",
           "transcription": "[фер-ГЕ-бен]",
-          "sentence": "Kannst du einem törichten alten Mann vergeben?",
-          "sentence_translation": "Можешь ли ты простить глупого старика?"
+          "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Kannst du einem törichten alten Mann vergeben?",
+          "sentence_translation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Можешь ли ты простить глупого старика?"
         },
         {
           "german": "die Einsicht",
           "russian": "прозрение",
           "transcription": "[ди АЙН-зихт]",
-          "sentence": "Die Einsicht verbrennt meine Seele.",
-          "sentence_translation": "Прозрение сжигает мою душу."
+          "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Die Einsicht verbrennt meine Seele.",
+          "sentence_translation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Прозрение сжигает мою душу."
         },
         {
           "german": "schuldig",
           "russian": "виновный",
           "transcription": "[ШУЛЬ-диг]",
-          "sentence": "Ich bin schuldig vor meiner Tochter.",
-          "sentence_translation": "Я виновен перед своей дочерью."
+          "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Ich bin schuldig vor meiner Tochter.",
+          "sentence_translation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Я виновен перед своей дочерью."
         }
       ],
       "quizzes": [
@@ -578,57 +578,57 @@
           "german": "verzeihen",
           "russian": "прощать",
           "transcription": "[фер-ЦАЙ-ен]",
-          "sentence": "Verzeih mir, ich bin nur ein törichter alter Mann.",
-          "sentence_translation": "Прости меня, я всего лишь глупый старик."
+          "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Verzeih mir, ich bin nur ein törichter alter Mann.",
+          "sentence_translation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Прости меня, я всего лишь глупый старик."
         },
         {
           "german": "der Tod",
           "russian": "смерть",
           "transcription": "[дер ТОД]",
-          "sentence": "Der Tod ist gnädiger als das Leben ohne dich.",
-          "sentence_translation": "Смерть милосерднее жизни без тебя."
+          "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Der Tod ist gnädiger als das Leben ohne dich.",
+          "sentence_translation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Смерть милосерднее жизни без тебя."
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
-          "sentence": "Lass mich an deiner Seite sterben, Cordelia.",
-          "sentence_translation": "Позволь мне умереть рядом с тобой, Корделия."
+          "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Lass mich an deiner Seite sterben, Cordelia.",
+          "sentence_translation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Позволь мне умереть рядом с тобой, Корделия."
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЕН-де]",
-          "sentence": "Das Ende kommt, aber mit dir bin ich nicht allein.",
-          "sentence_translation": "Конец приходит, но с тобой я не одинок."
+          "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Das Ende kommt, aber mit dir bin ich nicht allein.",
+          "sentence_translation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Конец приходит, но с тобой я не одинок."
         },
         {
           "german": "das Herz",
           "russian": "сердце",
           "transcription": "[дас ХЕРЦ]",
-          "sentence": "Mein Herz bricht vor Schmerz und Liebe.",
-          "sentence_translation": "Моё сердце разбивается от боли и любви."
+          "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Mein Herz bricht vor Schmerz und Liebe.",
+          "sentence_translation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Моё сердце разбивается от боли и любви."
         },
         {
           "german": "die Trauer",
           "russian": "скорбь",
           "transcription": "[ди ТРАУ-ер]",
-          "sentence": "Die Trauer überwältigt meine Seele.",
-          "sentence_translation": "Скорбь переполняет мою душу."
+          "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Die Trauer überwältigt meine Seele.",
+          "sentence_translation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Скорбь переполняет мою душу."
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
-          "sentence": "Das ist unser letzter Abschied, mein Kind.",
-          "sentence_translation": "Это наше последнее прощание, дитя моё."
+          "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Das ist unser letzter Abschied, mein Kind.",
+          "sentence_translation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Это наше последнее прощание, дитя моё."
         },
         {
           "german": "ewig",
           "russian": "вечный",
           "transcription": "[Э-виг]",
-          "sentence": "Unsere Liebe wird ewig dauern, mein Kind.",
-          "sentence_translation": "Наша любовь будет вечной, дитя моё."
+          "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Unsere Liebe wird ewig dauern, mein Kind.",
+          "sentence_translation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Наша любовь будет вечной, дитя моё."
         }
       ],
       "quizzes": [

--- a/data/characters/oswald.json
+++ b/data/characters/oswald.json
@@ -14,57 +14,57 @@
           "german": "der Diener",
           "russian": "слуга",
           "transcription": "[дер ДИ-нер]",
-          "sentence": "Als Diener gehorche ich meiner Herrin blind.",
-          "sentence_translation": "Как слуга я слепо подчиняюсь своей госпоже."
+          "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Als Diener gehorche ich meiner Herrin blind.",
+          "sentence_translation": "В доме Гонериль Освальд распоряжается как управляющий: Как слуга я слепо подчиняюсь своей госпоже."
         },
         {
           "german": "der Gehorsam",
           "russian": "послушание",
           "transcription": "[дер ге-ХОР-зам]",
-          "sentence": "Mein Gehorsam kennt keine Fragen.",
-          "sentence_translation": "Моё послушание не знает вопросов."
+          "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Mein Gehorsam kennt keine Fragen.",
+          "sentence_translation": "В доме Гонериль Освальд распоряжается как управляющий: Моё послушание не знает вопросов."
         },
         {
           "german": "die Ergebenheit",
           "russian": "преданность",
           "transcription": "[ди ер-ГЕ-бен-хайт]",
-          "sentence": "Meine Ergebenheit gilt nur Lady Goneril.",
-          "sentence_translation": "Моя преданность принадлежит только леди Гонерилье."
+          "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Meine Ergebenheit gilt nur Lady Goneril.",
+          "sentence_translation": "В доме Гонериль Освальд распоряжается как управляющий: Моя преданность принадлежит только леди Гонерилье."
         },
         {
           "german": "dienen",
           "russian": "служить",
           "transcription": "[ДИ-нен]",
-          "sentence": "Ich diene ohne Gewissen oder Ehre.",
-          "sentence_translation": "Я служу без совести и чести."
+          "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Ich diene ohne Gewissen oder Ehre.",
+          "sentence_translation": "В доме Гонериль Освальд распоряжается как управляющий: Я служу без совести и чести."
         },
         {
           "german": "der Verwalter",
           "russian": "управляющий",
           "transcription": "[дер фер-ВАЛЬ-тер]",
-          "sentence": "Als Verwalter kontrolliere ich den Haushalt.",
-          "sentence_translation": "Как управляющий я контролирую дом."
+          "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Als Verwalter kontrolliere ich den Haushalt.",
+          "sentence_translation": "В доме Гонериль Освальд распоряжается как управляющий: Как управляющий я контролирую дом."
         },
         {
           "german": "ergeben",
           "russian": "покорный",
           "transcription": "[ер-ГЕ-бен]",
-          "sentence": "Ergeben folge ich jedem Befehl.",
-          "sentence_translation": "Покорно я следую каждому приказу."
+          "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Ergeben folge ich jedem Befehl.",
+          "sentence_translation": "В доме Гонериль Освальд распоряжается как управляющий: Покорно я следую каждому приказу."
         },
         {
           "german": "unterwürfig",
           "russian": "раболепный",
           "transcription": "[УН-тер-вюр-фиг]",
-          "sentence": "Unterwürfig krieche ich vor meiner Herrin.",
-          "sentence_translation": "Раболепно я пресмыкаюсь перед госпожой."
+          "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Unterwürfig krieche ich vor meiner Herrin.",
+          "sentence_translation": "В доме Гонериль Освальд распоряжается как управляющий: Раболепно я пресмыкаюсь перед госпожой."
         },
         {
           "german": "befolgen",
           "russian": "исполнять",
           "transcription": "[бе-ФОЛЬ-ген]",
-          "sentence": "Jeden Befehl befolge ich sofort.",
-          "sentence_translation": "Каждый приказ я исполняю немедленно."
+          "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Jeden Befehl befolge ich sofort.",
+          "sentence_translation": "В доме Гонериль Освальд распоряжается как управляющий: Каждый приказ я исполняю немедленно."
         }
       ],
       "theatrical_scene": {
@@ -107,50 +107,50 @@
           "german": "der Bote",
           "russian": "гонец",
           "transcription": "[дер БО-те]",
-          "sentence": "Als Bote überbringe ich böse Nachrichten.",
-          "sentence_translation": "Как гонец я приношу дурные вести."
+          "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Als Bote überbringe ich böse Nachrichten.",
+          "sentence_translation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Как гонец я приношу дурные вести."
         },
         {
           "german": "der Auftrag",
           "russian": "поручение",
           "transcription": "[дер АУФ-траг]",
-          "sentence": "Jeden Auftrag erfülle ich gewissenhaft.",
-          "sentence_translation": "Каждое поручение я выполняю добросовестно."
+          "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Jeden Auftrag erfülle ich gewissenhaft.",
+          "sentence_translation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Каждое поручение я выполняю добросовестно."
         },
         {
           "german": "die Eile",
           "russian": "спешка",
           "transcription": "[ди АЙ-ле]",
-          "sentence": "In großer Eile renne ich hin und her.",
-          "sentence_translation": "В большой спешке я бегаю туда-сюда."
+          "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: In großer Eile renne ich hin und her.",
+          "sentence_translation": "Между дворцом Гонериль и замком Реганы Освальд бегает: В большой спешке я бегаю туда-сюда."
         },
         {
           "german": "überbringen",
           "russian": "передавать",
           "transcription": "[ю-бер-БРИН-ген]",
-          "sentence": "Ich überbringe Befehle an alle Diener.",
-          "sentence_translation": "Я передаю приказы всем слугам."
+          "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Ich überbringe Befehle an alle Diener.",
+          "sentence_translation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Я передаю приказы всем слугам."
         },
         {
           "german": "hasten",
           "russian": "спешить",
           "transcription": "[ХАС-тен]",
-          "sentence": "Ich haste von einem Ort zum anderen.",
-          "sentence_translation": "Я спешу с места на место."
+          "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Ich haste von einem Ort zum anderen.",
+          "sentence_translation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Я спешу с места на место."
         },
         {
           "german": "die Botschaft",
           "russian": "послание",
           "transcription": "[ди БОТ-шафт]",
-          "sentence": "Die Botschaft meiner Herrin ist grausam.",
-          "sentence_translation": "Послание моей госпожи жестоко."
+          "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Die Botschaft meiner Herrin ist grausam.",
+          "sentence_translation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Послание моей госпожи жестоко."
         },
         {
           "german": "eilen",
           "russian": "торопиться",
           "transcription": "[АЙ-лен]",
-          "sentence": "Ich eile, um ihre Wünsche zu erfüllen.",
-          "sentence_translation": "Я тороплюсь исполнить её желания."
+          "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Ich eile, um ihre Wünsche zu erfüllen.",
+          "sentence_translation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Я тороплюсь исполнить её желания."
         }
       ],
       "theatrical_scene": {
@@ -193,57 +193,57 @@
           "german": "die Beleidigung",
           "russian": "оскорбление",
           "transcription": "[ди бе-ЛАЙ-ди-гунг]",
-          "sentence": "Jede Beleidigung spreche ich mit Genuss aus.",
-          "sentence_translation": "Каждое оскорбление я произношу с наслаждением."
+          "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Jede Beleidigung spreche ich mit Genuss aus.",
+          "sentence_translation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Каждое оскорбление я произношу с наслаждением."
         },
         {
           "german": "die Respektlosigkeit",
           "russian": "неуважение",
           "transcription": "[ди рес-ПЕКТ-ло-зиг-кайт]",
-          "sentence": "Meine Respektlosigkeit kennt keine Grenzen.",
-          "sentence_translation": "Моё неуважение не знает границ."
+          "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Meine Respektlosigkeit kennt keine Grenzen.",
+          "sentence_translation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Моё неуважение не знает границ."
         },
         {
           "german": "die Feigheit",
           "russian": "трусость",
           "transcription": "[ди ФАЙГ-хайт]",
-          "sentence": "Aus Feigheit greife ich nur Schwache an.",
-          "sentence_translation": "Из трусости я нападаю только на слабых."
+          "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Aus Feigheit greife ich nur Schwache an.",
+          "sentence_translation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Из трусости я нападаю только на слабых."
         },
         {
           "german": "beleidigen",
           "russian": "оскорблять",
           "transcription": "[бе-ЛАЙ-ди-ген]",
-          "sentence": "Ich beleidige den alten König ohne Scham.",
-          "sentence_translation": "Я оскорбляю старого короля без стыда."
+          "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Ich beleidige den alten König ohne Scham.",
+          "sentence_translation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Я оскорбляю старого короля без стыда."
         },
         {
           "german": "verhöhnen",
           "russian": "высмеивать",
           "transcription": "[фер-ХЁ-нен]",
-          "sentence": "Ich verhöhne seine königliche Würde.",
-          "sentence_translation": "Я высмеиваю его королевское достоинство."
+          "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Ich verhöhne seine königliche Würde.",
+          "sentence_translation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Я высмеиваю его королевское достоинство."
         },
         {
           "german": "frech",
           "russian": "дерзкий",
           "transcription": "[ФРЕХ]",
-          "sentence": "Frech widerspreche ich dem alten Mann.",
-          "sentence_translation": "Дерзко я возражаю старику."
+          "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Frech widerspreche ich dem alten Mann.",
+          "sentence_translation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Дерзко я возражаю старику."
         },
         {
           "german": "missachten",
           "russian": "пренебрегать",
           "transcription": "[МИС-ах-тен]",
-          "sentence": "Ich missachte seinen früheren Rang.",
-          "sentence_translation": "Я пренебрегаю его прежним рангом."
+          "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Ich missachte seinen früheren Rang.",
+          "sentence_translation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Я пренебрегаю его прежним рангом."
         },
         {
           "german": "feige",
           "russian": "трусливый",
           "transcription": "[ФАЙ-ге]",
-          "sentence": "Feige verstecke ich mich hinter meiner Herrin.",
-          "sentence_translation": "Трусливо я прячусь за своей госпожой."
+          "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Feige verstecke ich mich hinter meiner Herrin.",
+          "sentence_translation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Трусливо я прячусь за своей госпожой."
         }
       ],
       "theatrical_scene": {
@@ -286,50 +286,50 @@
           "german": "der Spion",
           "russian": "шпион",
           "transcription": "[дер шпи-ОН]",
-          "sentence": "Als Spion lausche ich an jeder Tür.",
-          "sentence_translation": "Как шпион я подслушиваю у каждой двери."
+          "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Als Spion lausche ich an jeder Tür.",
+          "sentence_translation": "В коридорах замка Олбани Освальд крадётся: Как шпион я подслушиваю у каждой двери."
         },
         {
           "german": "der Verrat",
           "russian": "предательство",
           "transcription": "[дер фер-РАТ]",
-          "sentence": "Der Verrat ist mein tägliches Geschäft.",
-          "sentence_translation": "Предательство - моё ежедневное дело."
+          "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Der Verrat ist mein tägliches Geschäft.",
+          "sentence_translation": "В коридорах замка Олбани Освальд крадётся: Предательство - моё ежедневное дело."
         },
         {
           "german": "die Heimlichkeit",
           "russian": "скрытность",
           "transcription": "[ди ХАЙМ-лих-кайт]",
-          "sentence": "In Heimlichkeit sammle ich Informationen.",
-          "sentence_translation": "В скрытности я собираю информацию."
+          "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: In Heimlichkeit sammle ich Informationen.",
+          "sentence_translation": "В коридорах замка Олбани Освальд крадётся: В скрытности я собираю информацию."
         },
         {
           "german": "spionieren",
           "russian": "шпионить",
           "transcription": "[шпи-о-НИ-рен]",
-          "sentence": "Ich spioniere für meine böse Herrin.",
-          "sentence_translation": "Я шпионю для моей злой госпожи."
+          "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Ich spioniere für meine böse Herrin.",
+          "sentence_translation": "В коридорах замка Олбани Освальд крадётся: Я шпионю для моей злой госпожи."
         },
         {
           "german": "lauschen",
           "russian": "подслушивать",
           "transcription": "[ЛАУ-шен]",
-          "sentence": "Heimlich lausche ich allen Gesprächen.",
-          "sentence_translation": "Тайно я подслушиваю все разговоры."
+          "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Heimlich lausche ich allen Gesprächen.",
+          "sentence_translation": "В коридорах замка Олбани Освальд крадётся: Тайно я подслушиваю все разговоры."
         },
         {
           "german": "verraten",
           "russian": "выдавать",
           "transcription": "[фер-РА-тен]",
-          "sentence": "Ich verrate jeden an meine Herrin.",
-          "sentence_translation": "Я выдаю каждого своей госпоже."
+          "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Ich verrate jeden an meine Herrin.",
+          "sentence_translation": "В коридорах замка Олбани Освальд крадётся: Я выдаю каждого своей госпоже."
         },
         {
           "german": "schnüffeln",
           "russian": "вынюхивать",
           "transcription": "[ШНЮФ-фельн]",
-          "sentence": "Überall schnüffle ich nach Geheimnissen.",
-          "sentence_translation": "Везде я вынюхиваю секреты."
+          "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Überall schnüffle ich nach Geheimnissen.",
+          "sentence_translation": "В коридорах замка Олбани Освальд крадётся: Везде я вынюхиваю секреты."
         }
       ],
       "theatrical_scene": {
@@ -372,57 +372,57 @@
           "german": "die Intrige",
           "russian": "интрига",
           "transcription": "[ди ин-ТРИ-ге]",
-          "sentence": "Jede Intrige spinne ich mit Freude.",
-          "sentence_translation": "Каждую интригу я плету с радостью."
+          "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Jede Intrige spinne ich mit Freude.",
+          "sentence_translation": "На ночных советах с Гонериль Освальд планирует: Каждую интригу я плету с радостью."
         },
         {
           "german": "der Plan",
           "russian": "план",
           "transcription": "[дер ПЛАН]",
-          "sentence": "Mein hinterhältiger Plan wird funktionieren.",
-          "sentence_translation": "Мой коварный план сработает."
+          "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Mein hinterhältiger Plan wird funktionieren.",
+          "sentence_translation": "На ночных советах с Гонериль Освальд планирует: Мой коварный план сработает."
         },
         {
           "german": "die Hinterlist",
           "russian": "коварство",
           "transcription": "[ди ХИН-тер-лист]",
-          "sentence": "Mit Hinterlist verfolge ich meine Ziele.",
-          "sentence_translation": "С коварством я преследую свои цели."
+          "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Mit Hinterlist verfolge ich meine Ziele.",
+          "sentence_translation": "На ночных советах с Гонериль Освальд планирует: С коварством я преследую свои цели."
         },
         {
           "german": "schmieden",
           "russian": "ковать",
           "transcription": "[ШМИ-ден]",
-          "sentence": "Ich schmiede Pläne gegen alle Feinde.",
-          "sentence_translation": "Я кую планы против всех врагов."
+          "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Ich schmiede Pläne gegen alle Feinde.",
+          "sentence_translation": "На ночных советах с Гонериль Освальд планирует: Я кую планы против всех врагов."
         },
         {
           "german": "hintergehen",
           "russian": "обманывать",
           "transcription": "[ХИН-тер-ге-ен]",
-          "sentence": "Ich hintergehe jeden, der mir traut.",
-          "sentence_translation": "Я обманываю каждого, кто мне доверяет."
+          "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Ich hintergehe jeden, der mir traut.",
+          "sentence_translation": "На ночных советах с Гонериль Освальд планирует: Я обманываю каждого, кто мне доверяет."
         },
         {
           "german": "tückisch",
           "russian": "коварный",
           "transcription": "[ТЮ-киш]",
-          "sentence": "Tückisch plane ich meinen nächsten Schritt.",
-          "sentence_translation": "Коварно я планирую свой следующий шаг."
+          "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Tückisch plane ich meinen nächsten Schritt.",
+          "sentence_translation": "На ночных советах с Гонериль Освальд планирует: Коварно я планирую свой следующий шаг."
         },
         {
           "german": "verschlagen",
           "russian": "хитрый",
           "transcription": "[фер-ШЛАГ-ен]",
-          "sentence": "Verschlagen verberge ich meine wahren Absichten.",
-          "sentence_translation": "Хитро я скрываю свои истинные намерения."
+          "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Verschlagen verberge ich meine wahren Absichten.",
+          "sentence_translation": "На ночных советах с Гонериль Освальд планирует: Хитро я скрываю свои истинные намерения."
         },
         {
           "german": "die Falle",
           "russian": "ловушка",
           "transcription": "[ди ФА-ле]",
-          "sentence": "Ich stelle Fallen für die Ahnungslosen.",
-          "sentence_translation": "Я ставлю ловушки для ничего не подозревающих."
+          "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Ich stelle Fallen für die Ahnungslosen.",
+          "sentence_translation": "На ночных советах с Гонериль Освальд планирует: Я ставлю ловушки для ничего не подозревающих."
         }
       ],
       "theatrical_scene": {
@@ -465,50 +465,50 @@
           "german": "die Verfolgung",
           "russian": "преследование",
           "transcription": "[ди фер-ФОЛЬ-гунг]",
-          "sentence": "Die Verfolgung des blinden Grafen beginnt.",
-          "sentence_translation": "Преследование слепого графа начинается."
+          "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Die Verfolgung des blinden Grafen beginnt.",
+          "sentence_translation": "На полях близ Дувра Освальд гонится за слепым Глостером: Преследование слепого графа начинается."
         },
         {
           "german": "die Jagd",
           "russian": "охота",
           "transcription": "[ди ЯГДТ]",
-          "sentence": "Die Jagd auf Gloucester macht mir Spaß.",
-          "sentence_translation": "Охота на Глостера доставляет мне удовольствие."
+          "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Die Jagd auf Gloucester macht mir Spaß.",
+          "sentence_translation": "На полях близ Дувра Освальд гонится за слепым Глостером: Охота на Глостера доставляет мне удовольствие."
         },
         {
           "german": "verfolgen",
           "russian": "преследовать",
           "transcription": "[фер-ФОЛЬ-ген]",
-          "sentence": "Gnadenlos verfolge ich den alten Mann.",
-          "sentence_translation": "Безжалостно я преследую старика."
+          "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Gnadenlos verfolge ich den alten Mann.",
+          "sentence_translation": "На полях близ Дувра Освальд гонится за слепым Глостером: Безжалостно я преследую старика."
         },
         {
           "german": "jagen",
           "russian": "гнаться",
           "transcription": "[Я-ген]",
-          "sentence": "Wie ein Hund jage ich meine Beute.",
-          "sentence_translation": "Как собака я гонюсь за добычей."
+          "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Wie ein Hund jage ich meine Beute.",
+          "sentence_translation": "На полях близ Дувра Освальд гонится за слепым Глостером: Как собака я гонюсь за добычей."
         },
         {
           "german": "aufspüren",
           "russian": "выслеживать",
           "transcription": "[АУФ-шпю-рен]",
-          "sentence": "Ich spüre den Flüchtling überall auf.",
-          "sentence_translation": "Я выслеживаю беглеца повсюду."
+          "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Ich spüre den Flüchtling überall auf.",
+          "sentence_translation": "На полях близ Дувра Освальд гонится за слепым Глостером: Я выслеживаю беглеца повсюду."
         },
         {
           "german": "hetzen",
           "russian": "травить",
           "transcription": "[ХЕ-цен]",
-          "sentence": "Ich hetze ihn bis zum Ende.",
-          "sentence_translation": "Я травлю его до конца."
+          "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Ich hetze ihn bis zum Ende.",
+          "sentence_translation": "На полях близ Дувра Освальд гонится за слепым Глостером: Я травлю его до конца."
         },
         {
           "german": "die Beute",
           "russian": "добыча",
           "transcription": "[ди БОЙ-те]",
-          "sentence": "Der Graf ist meine leichte Beute.",
-          "sentence_translation": "Граф - моя лёгкая добыча."
+          "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Der Graf ist meine leichte Beute.",
+          "sentence_translation": "На полях близ Дувра Освальд гонится за слепым Глостером: Граф - моя лёгкая добыча."
         }
       ],
       "theatrical_scene": {
@@ -551,57 +551,57 @@
           "german": "der Tod",
           "russian": "смерть",
           "transcription": "[дер ТОД]",
-          "sentence": "Der Tod ereilt mich durch Эдгars Hand.",
-          "sentence_translation": "Смерть настигает меня от руки Эдгара."
+          "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Der Tod ereilt mich durch Эдгars Hand.",
+          "sentence_translation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Смерть настигает меня от руки Эдгара."
         },
         {
           "german": "die Feigheit",
           "russian": "трусость",
           "transcription": "[ди ФАЙГ-хайт]",
-          "sentence": "Meine Feigheit führt zu meinem Ende.",
-          "sentence_translation": "Моя трусость приводит к моему концу."
+          "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Meine Feigheit führt zu meinem Ende.",
+          "sentence_translation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Моя трусость приводит к моему концу."
         },
         {
           "german": "die Niederlage",
           "russian": "поражение",
           "transcription": "[ди НИ-дер-ла-ге]",
-          "sentence": "Die Niederlage ist mein letztes Schicksal.",
-          "sentence_translation": "Поражение - моя последняя судьба."
+          "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Die Niederlage ist mein letztes Schicksal.",
+          "sentence_translation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Поражение - моя последняя судьба."
         },
         {
           "german": "fallen",
           "russian": "падать",
           "transcription": "[ФА-лен]",
-          "sentence": "Ich falle wie der Feigling, der ich bin.",
-          "sentence_translation": "Я падаю как трус, которым являюсь."
+          "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Ich falle wie der Feigling, der ich bin.",
+          "sentence_translation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Я падаю как трус, которым являюсь."
         },
         {
           "german": "unterliegen",
           "russian": "проигрывать",
           "transcription": "[ун-тер-ЛИ-ген]",
-          "sentence": "Ich unterliege dem edlen Edgar.",
-          "sentence_translation": "Я проигрываю благородному Эдгару."
+          "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Ich unterliege dem edlen Edgar.",
+          "sentence_translation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Я проигрываю благородному Эдгару."
         },
         {
           "german": "wimmern",
           "russian": "хныкать",
           "transcription": "[ВИМ-мерн]",
-          "sentence": "Wimmernd bitte ich um Gnade.",
-          "sentence_translation": "Хныкая, я прошу о пощаде."
+          "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Wimmernd bitte ich um Gnade.",
+          "sentence_translation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Хныкая, я прошу о пощаде."
         },
         {
           "german": "betteln",
           "russian": "умолять",
           "transcription": "[БЕ-тельн]",
-          "sentence": "Um mein Leben bettle ich vergeblich.",
-          "sentence_translation": "О жизни я умоляю напрасно."
+          "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Um mein Leben bettle ich vergeblich.",
+          "sentence_translation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: О жизни я умоляю напрасно."
         },
         {
           "german": "erbärmlich",
           "russian": "жалкий",
           "transcription": "[ер-БЕРМ-лих]",
-          "sentence": "Erbärmlich ende ich wie ich gelebt habe.",
-          "sentence_translation": "Жалко я заканчиваю, как и жил."
+          "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Erbärmlich ende ich wie ich gelebt habe.",
+          "sentence_translation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Жалко я заканчиваю, как и жил."
         }
       ],
       "theatrical_scene": {

--- a/data/characters/regan.json
+++ b/data/characters/regan.json
@@ -20,57 +20,57 @@
           "german": "vortäuschen",
           "russian": "притворяться",
           "transcription": "[ФОР-той-шен]",
-          "sentence": "Ich täusche Liebe vor, die nie existierte.",
-          "sentence_translation": "Я притворяюсь в любви, которой никогда не было."
+          "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Ich täusche Liebe vor, die nie existierte.",
+          "sentence_translation": "В тронном зале Лира Регана соперничает с сестрой: Я притворяюсь в любви, которой никогда не было."
         },
         {
           "german": "übertreffen",
           "russian": "превосходить",
           "transcription": "[ю-бер-ТРЕ-фен]",
-          "sentence": "Ich will meine Schwester in der Lüge übertreffen.",
-          "sentence_translation": "Я хочу превзойти сестру во лжи."
+          "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Ich will meine Schwester in der Lüge übertreffen.",
+          "sentence_translation": "В тронном зале Лира Регана соперничает с сестрой: Я хочу превзойти сестру во лжи."
         },
         {
           "german": "wetteifern",
           "russian": "состязаться",
           "transcription": "[ВЕТ-ай-ферн]",
-          "sentence": "Wir wetteifern um das größte Erbe.",
-          "sentence_translation": "Мы состязаемся за большее наследство."
+          "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Wir wetteifern um das größte Erbe.",
+          "sentence_translation": "В тронном зале Лира Регана соперничает с сестрой: Мы состязаемся за большее наследство."
         },
         {
           "german": "die Falschheit",
           "russian": "фальшь",
           "transcription": "[ди ФАЛЬШ-хайт]",
-          "sentence": "Meine Falschheit kennt keine Grenzen.",
-          "sentence_translation": "Моя фальшь не знает границ."
+          "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Meine Falschheit kennt keine Grenzen.",
+          "sentence_translation": "В тронном зале Лира Регана соперничает с сестрой: Моя фальшь не знает границ."
         },
         {
           "german": "vorspielen",
           "russian": "разыгрывать",
           "transcription": "[ФОР-шпи-лен]",
-          "sentence": "Ich spiele ihm Töchterliebe vor.",
-          "sentence_translation": "Я разыгрываю перед ним дочернюю любовь."
+          "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Ich spiele ihm Töchterliebe vor.",
+          "sentence_translation": "В тронном зале Лира Регана соперничает с сестрой: Я разыгрываю перед ним дочернюю любовь."
         },
         {
           "german": "die List",
           "russian": "хитрость",
           "transcription": "[ди ЛИСТ]",
-          "sentence": "Mit List gewinne ich sein Vertrauen.",
-          "sentence_translation": "Хитростью я завоёвываю его доверие."
+          "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Mit List gewinne ich sein Vertrauen.",
+          "sentence_translation": "В тронном зале Лира Регана соперничает с сестрой: Хитростью я завоёвываю его доверие."
         },
         {
           "german": "erschleichen",
           "russian": "выманивать",
           "transcription": "[ер-ШЛАЙ-хен]",
-          "sentence": "Ich erschleiche mir sein Königreich.",
-          "sentence_translation": "Я выманиваю его королевство."
+          "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Ich erschleiche mir sein Königreich.",
+          "sentence_translation": "В тронном зале Лира Регана соперничает с сестрой: Я выманиваю его королевство."
         },
         {
           "german": "die Habgier",
           "russian": "алчность",
           "transcription": "[ди ХАБ-гир]",
-          "sentence": "Die Habgier treibt meine süßen Worte.",
-          "sentence_translation": "Алчность движет моими сладкими словами."
+          "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Die Habgier treibt meine süßen Worte.",
+          "sentence_translation": "В тронном зале Лира Регана соперничает с сестрой: Алчность движет моими сладкими словами."
         }
       ],
       "quizzes": [
@@ -113,50 +113,50 @@
           "german": "das Bündnis",
           "russian": "союз",
           "transcription": "[дас БЮНД-нис]",
-          "sentence": "Ein Bündnis mit Goneril gegen unseren Vater.",
-          "sentence_translation": "Союз с Гонерильей против нашего отца."
+          "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Ein Bündnis mit Goneril gegen unseren Vater.",
+          "sentence_translation": "На тайном сговоре в покоях Гонериль Регана шепчет: Союз с Гонерильей против нашего отца."
         },
         {
           "german": "teilen",
           "russian": "делить",
           "transcription": "[ТАЙ-лен]",
-          "sentence": "Wir teilen das Reich zwischen uns.",
-          "sentence_translation": "Мы делим королевство между собой."
+          "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Wir teilen das Reich zwischen uns.",
+          "sentence_translation": "На тайном сговоре в покоях Гонериль Регана шепчет: Мы делим королевство между собой."
         },
         {
           "german": "planen",
           "russian": "планировать",
           "transcription": "[ПЛА-нен]",
-          "sentence": "Wir planen den Untergang des alten Königs.",
-          "sentence_translation": "Мы планируем падение старого короля."
+          "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Wir planen den Untergang des alten Königs.",
+          "sentence_translation": "На тайном сговоре в покоях Гонериль Регана шепчет: Мы планируем падение старого короля."
         },
         {
           "german": "verschwören",
           "russian": "заговорить",
           "transcription": "[фер-ШВЁ-рен]",
-          "sentence": "Wir verschwören uns gegen ihn.",
-          "sentence_translation": "Мы составляем заговор против него."
+          "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Wir verschwören uns gegen ihn.",
+          "sentence_translation": "На тайном сговоре в покоях Гонериль Регана шепчет: Мы составляем заговор против него."
         },
         {
           "german": "die Absprache",
           "russian": "сговор",
           "transcription": "[ди АБ-шпра-хе]",
-          "sentence": "Unsere Absprache ist perfekt.",
-          "sentence_translation": "Наш сговор совершенен."
+          "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Unsere Absprache ist perfekt.",
+          "sentence_translation": "На тайном сговоре в покоях Гонериль Регана шепчет: Наш сговор совершенен."
         },
         {
           "german": "vereinbaren",
           "russian": "договариваться",
           "transcription": "[фер-АЙН-ба-рен]",
-          "sentence": "Wir vereinbaren gemeinsame Grausamkeit.",
-          "sentence_translation": "Мы договариваемся о совместной жестокости."
+          "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Wir vereinbaren gemeinsame Grausamkeit.",
+          "sentence_translation": "На тайном сговоре в покоях Гонериль Регана шепчет: Мы договариваемся о совместной жестокости."
         },
         {
           "german": "die Strategie",
           "russian": "стратегия",
           "transcription": "[ди штра-те-ГИ]",
-          "sentence": "Unsere Strategie wird ihn brechen.",
-          "sentence_translation": "Наша стратегия сломает его."
+          "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Unsere Strategie wird ihn brechen.",
+          "sentence_translation": "На тайном сговоре в покоях Гонериль Регана шепчет: Наша стратегия сломает его."
         }
       ],
       "quizzes": [
@@ -199,57 +199,57 @@
           "german": "foltern",
           "russian": "пытать",
           "transcription": "[ФОЛЬ-терн]",
-          "sentence": "Ich foltere ihn mit kalten Worten.",
-          "sentence_translation": "Я пытаю его холодными словами."
+          "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Ich foltere ihn mit kalten Worten.",
+          "sentence_translation": "В своём замке в Глостере Регана унижает короля: Я пытаю его холодными словами."
         },
         {
           "german": "erniedrigen",
           "russian": "унижать",
           "transcription": "[ер-НИД-ри-ген]",
-          "sentence": "Ich erniedrige den einst mächtigen König.",
-          "sentence_translation": "Я унижаю некогда могущественного короля."
+          "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Ich erniedrige den einst mächtigen König.",
+          "sentence_translation": "В своём замке в Глостере Регана унижает короля: Я унижаю некогда могущественного короля."
         },
         {
           "german": "verhöhnen",
           "russian": "насмехаться",
           "transcription": "[фер-ХЁ-нен]",
-          "sentence": "Ich verhöhne seine väterliche Liebe.",
-          "sentence_translation": "Я насмехаюсь над его отцовской любовью."
+          "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Ich verhöhne seine väterliche Liebe.",
+          "sentence_translation": "В своём замке в Глостере Регана унижает короля: Я насмехаюсь над его отцовской любовью."
         },
         {
           "german": "die Bosheit",
           "russian": "злоба",
           "transcription": "[ди БОС-хайт]",
-          "sentence": "Meine Bosheit kennt kein Erbarmen.",
-          "sentence_translation": "Моя злоба не знает милосердия."
+          "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Meine Bosheit kennt kein Erbarmen.",
+          "sentence_translation": "В своём замке в Глостере Регана унижает короля: Моя злоба не знает милосердия."
         },
         {
           "german": "misshandeln",
           "russian": "жестоко обращаться",
           "transcription": "[МИС-хан-дельн]",
-          "sentence": "Ich misshandle den alten Mann.",
-          "sentence_translation": "Я жестоко обращаюсь со стариком."
+          "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Ich misshandle den alten Mann.",
+          "sentence_translation": "В своём замке в Глостере Регана унижает короля: Я жестоко обращаюсь со стариком."
         },
         {
           "german": "die Härte",
           "russian": "жёсткость",
           "transcription": "[ди ХЕР-те]",
-          "sentence": "Mit eiserner Härte stoße ich ihn fort.",
-          "sentence_translation": "С железной жёсткостью я отталкиваю его."
+          "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Mit eiserner Härte stoße ich ihn fort.",
+          "sentence_translation": "В своём замке в Глостере Регана унижает короля: С железной жёсткостью я отталкиваю его."
         },
         {
           "german": "abweisen",
           "russian": "отвергать",
           "transcription": "[АБ-вай-зен]",
-          "sentence": "Ich weise alle seine Bitten ab.",
-          "sentence_translation": "Я отвергаю все его просьбы."
+          "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Ich weise alle seine Bitten ab.",
+          "sentence_translation": "В своём замке в Глостере Регана унижает короля: Я отвергаю все его просьбы."
         },
         {
           "german": "die Grausamkeit",
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
-          "sentence": "Meine Grausamkeit übertrifft die meiner Schwester.",
-          "sentence_translation": "Моя жестокость превосходит жестокость сестры."
+          "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Meine Grausamkeit übertrifft die meiner Schwester.",
+          "sentence_translation": "В своём замке в Глостере Регана унижает короля: Моя жестокость превосходит жестокость сестры."
         }
       ],
       "quizzes": [
@@ -292,57 +292,57 @@
           "german": "blenden",
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
-          "sentence": "Wir blenden den treuen Grafen Gloucester.",
-          "sentence_translation": "Мы ослепляем верного графа Глостера."
+          "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Wir blenden den treuen Grafen Gloucester.",
+          "sentence_translation": "Во время ослепления Глостера Регана приказывает: Мы ослепляем верного графа Глостера."
         },
         {
           "german": "der Sadismus",
           "russian": "садизм",
           "transcription": "[дер за-ДИС-мус]",
-          "sentence": "Mein Sadismus findet Befriedigung.",
-          "sentence_translation": "Мой садизм находит удовлетворение."
+          "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Mein Sadismus findet Befriedigung.",
+          "sentence_translation": "Во время ослепления Глостера Регана приказывает: Мой садизм находит удовлетворение."
         },
         {
           "german": "genießen",
           "russian": "наслаждаться",
           "transcription": "[ге-НИ-сен]",
-          "sentence": "Ich genieße jeden Schrei des Schmerzes.",
-          "sentence_translation": "Я наслаждаюсь каждым криком боли."
+          "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Ich genieße jeden Schrei des Schmerzes.",
+          "sentence_translation": "Во время ослепления Глостера Регана приказывает: Я наслаждаюсь каждым криком боли."
         },
         {
           "german": "ausstechen",
           "russian": "выкалывать",
           "transcription": "[АУС-ште-хен]",
-          "sentence": "Stecht ihm beide Augen aus!",
-          "sentence_translation": "Выколите ему оба глаза!"
+          "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Stecht ihm beide Augen aus!",
+          "sentence_translation": "Во время ослепления Глостера Регана приказывает: Выколите ему оба глаза!"
         },
         {
           "german": "die Folter",
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
-          "sentence": "Die Folter ist meine Unterhaltung.",
-          "sentence_translation": "Пытка - моё развлечение."
+          "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Die Folter ist meine Unterhaltung.",
+          "sentence_translation": "Во время ослепления Глостера Регана приказывает: Пытка - моё развлечение."
         },
         {
           "german": "erbarmungslos",
           "russian": "беспощадный",
           "transcription": "[ер-БАР-мунгс-лос]",
-          "sentence": "Ich bin erbarmungslos in meiner Rache.",
-          "sentence_translation": "Я беспощадна в своей мести."
+          "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Ich bin erbarmungslos in meiner Rache.",
+          "sentence_translation": "Во время ослепления Глостера Регана приказывает: Я беспощадна в своей мести."
         },
         {
           "german": "die Brutalität",
           "russian": "брутальность",
           "transcription": "[ди бру-та-ли-ТЕТ]",
-          "sentence": "Meine Brutalität erschreckt sogar Cornwall.",
-          "sentence_translation": "Моя брутальность пугает даже Корнуолла."
+          "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Meine Brutalität erschreckt sogar Cornwall.",
+          "sentence_translation": "Во время ослепления Глостера Регана приказывает: Моя брутальность пугает даже Корнуолла."
         },
         {
           "german": "zertreten",
           "russian": "растаптывать",
           "transcription": "[цер-ТРЕ-тен]",
-          "sentence": "Ich zertrete seine Augen unter meinem Fuß.",
-          "sentence_translation": "Я растаптываю его глаза под ногой."
+          "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Ich zertrete seine Augen unter meinem Fuß.",
+          "sentence_translation": "Во время ослепления Глостера Регана приказывает: Я растаптываю его глаза под ногой."
         }
       ],
       "quizzes": [
@@ -385,50 +385,50 @@
           "german": "die Witwe",
           "russian": "вдова",
           "transcription": "[ди ВИТ-ве]",
-          "sentence": "Als Witwe bin ich endlich frei.",
-          "sentence_translation": "Как вдова я наконец свободна."
+          "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Als Witwe bin ich endlich frei.",
+          "sentence_translation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Как вдова я наконец свободна."
         },
         {
           "german": "begehren",
           "russian": "вожделеть",
           "transcription": "[бе-ГЕ-рен]",
-          "sentence": "Ich begehre Edmund mit brennender Lust.",
-          "sentence_translation": "Я вожделею Эдмунда с пылающей страстью."
+          "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Ich begehre Edmund mit brennender Lust.",
+          "sentence_translation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Я вожделею Эдмунда с пылающей страстью."
         },
         {
           "german": "verführen",
           "russian": "соблазнять",
           "transcription": "[фер-ФЮ-рен]",
-          "sentence": "Ich will Edmund verführen und besitzen.",
-          "sentence_translation": "Я хочу соблазнить и завладеть Эдмундом."
+          "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Ich will Edmund verführen und besitzen.",
+          "sentence_translation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Я хочу соблазнить и завладеть Эдмундом."
         },
         {
           "german": "die Begierde",
           "russian": "вожделение",
           "transcription": "[ди бе-ГИР-де]",
-          "sentence": "Meine Begierde brennt wie Feuer.",
-          "sentence_translation": "Моё вожделение горит как огонь."
+          "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Meine Begierde brennt wie Feuer.",
+          "sentence_translation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Моё вожделение горит как огонь."
         },
         {
           "german": "locken",
           "russian": "заманивать",
           "transcription": "[ЛО-кен]",
-          "sentence": "Ich locke ihn mit Versprechungen.",
-          "sentence_translation": "Я заманиваю его обещаниями."
+          "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Ich locke ihn mit Versprechungen.",
+          "sentence_translation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Я заманиваю его обещаниями."
         },
         {
           "german": "die Lust",
           "russian": "похоть",
           "transcription": "[ди ЛУСТ]",
-          "sentence": "Die Lust macht mich blind für Gefahr.",
-          "sentence_translation": "Похоть делает меня слепой к опасности."
+          "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Die Lust macht mich blind für Gefahr.",
+          "sentence_translation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Похоть делает меня слепой к опасности."
         },
         {
           "german": "werben",
           "russian": "добиваться",
           "transcription": "[ВЕР-бен]",
-          "sentence": "Ich werbe schamlos um seine Gunst.",
-          "sentence_translation": "Я бесстыдно добиваюсь его благосклонности."
+          "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Ich werbe schamlos um seine Gunst.",
+          "sentence_translation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Я бесстыдно добиваюсь его благосклонности."
         }
       ],
       "quizzes": [
@@ -471,50 +471,50 @@
           "german": "wettkämpfen",
           "russian": "соревноваться",
           "transcription": "[ВЕТ-кемп-фен]",
-          "sentence": "Wir wettkämpfen um Edmunds Liebe.",
-          "sentence_translation": "Мы соревнуемся за любовь Эдмунда."
+          "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Wir wettkämpfen um Edmunds Liebe.",
+          "sentence_translation": "В лагере под Дувром Регана грозит сестре: Мы соревнуемся за любовь Эдмунда."
         },
         {
           "german": "hassen",
           "russian": "ненавидеть",
           "transcription": "[ХА-сен]",
-          "sentence": "Ich hasse meine Schwester mehr als je zuvor.",
-          "sentence_translation": "Я ненавижу сестру больше, чем когда-либо."
+          "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Ich hasse meine Schwester mehr als je zuvor.",
+          "sentence_translation": "В лагере под Дувром Регана грозит сестре: Я ненавижу сестру больше, чем когда-либо."
         },
         {
           "german": "bedrohen",
           "russian": "угрожать",
           "transcription": "[бе-ДРО-ен]",
-          "sentence": "Ich bedrohe sie mit dem Tod.",
-          "sentence_translation": "Я угрожаю ей смертью."
+          "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Ich bedrohe sie mit dem Tod.",
+          "sentence_translation": "В лагере под Дувром Регана грозит сестре: Я угрожаю ей смертью."
         },
         {
           "german": "die Rivalität",
           "russian": "соперничество",
           "transcription": "[ди ри-ва-ли-ТЕТ]",
-          "sentence": "Unsere Rivalität wird tödlich enden.",
-          "sentence_translation": "Наше соперничество закончится смертью."
+          "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Unsere Rivalität wird tödlich enden.",
+          "sentence_translation": "В лагере под Дувром Регана грозит сестре: Наше соперничество закончится смертью."
         },
         {
           "german": "bekämpfen",
           "russian": "бороться",
           "transcription": "[бе-КЕМП-фен]",
-          "sentence": "Ich bekämpfe sie mit allen Mitteln.",
-          "sentence_translation": "Я борюсь с ней всеми средствами."
+          "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Ich bekämpfe sie mit allen Mitteln.",
+          "sentence_translation": "В лагере под Дувром Регана грозит сестре: Я борюсь с ней всеми средствами."
         },
         {
           "german": "misstrauen",
           "russian": "не доверять",
           "transcription": "[МИС-трау-ен]",
-          "sentence": "Ich misstraue jedem ihrer Worte.",
-          "sentence_translation": "Я не доверяю ни одному её слову."
+          "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Ich misstraue jedem ihrer Worte.",
+          "sentence_translation": "В лагере под Дувром Регана грозит сестре: Я не доверяю ни одному её слову."
         },
         {
           "german": "argwöhnen",
           "russian": "подозревать",
           "transcription": "[АРГ-вё-нен]",
-          "sentence": "Ich argwöhne Gift in meinem Wein.",
-          "sentence_translation": "Я подозреваю яд в моём вине."
+          "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Ich argwöhne Gift in meinem Wein.",
+          "sentence_translation": "В лагере под Дувром Регана грозит сестре: Я подозреваю яд в моём вине."
         }
       ],
       "quizzes": [
@@ -557,57 +557,57 @@
           "german": "vergiftet",
           "russian": "отравленный",
           "transcription": "[фер-ГИФ-тет]",
-          "sentence": "Ich bin von meiner eigenen Schwester vergiftet.",
-          "sentence_translation": "Я отравлена собственной сестрой."
+          "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Ich bin von meiner eigenen Schwester vergiftet.",
+          "sentence_translation": "Отравленная Гонериль Регана умирает в своём шатре: Я отравлена собственной сестрой."
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
-          "sentence": "Ich leide furchtbare Qualen.",
-          "sentence_translation": "Я страдаю от ужасных мук."
+          "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Ich leide furchtbare Qualen.",
+          "sentence_translation": "Отравленная Гонериль Регана умирает в своём шатре: Я страдаю от ужасных мук."
         },
         {
           "german": "verenden",
           "russian": "издыхать",
           "transcription": "[фер-ЕН-ден]",
-          "sentence": "Wie ein Tier verende ich elend.",
-          "sentence_translation": "Как зверь я издыхаю жалко."
+          "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Wie ein Tier verende ich elend.",
+          "sentence_translation": "Отравленная Гонериль Регана умирает в своём шатре: Как зверь я издыхаю жалко."
         },
         {
           "german": "die Qual",
           "russian": "мучение",
           "transcription": "[ди КВАЛЬ]",
-          "sentence": "Die Qual des Giftes zerreißt mich.",
-          "sentence_translation": "Мучение от яда разрывает меня."
+          "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Die Qual des Giftes zerreißt mich.",
+          "sentence_translation": "Отравленная Гонериль Регана умирает в своём шатре: Мучение от яда разрывает меня."
         },
         {
           "german": "verwünschen",
           "russian": "проклинать",
           "transcription": "[фер-ВЮН-шен]",
-          "sentence": "Ich verwünsche meine Schwester mit letzter Kraft.",
-          "sentence_translation": "Я проклинаю сестру последними силами."
+          "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Ich verwünsche meine Schwester mit letzter Kraft.",
+          "sentence_translation": "Отравленная Гонериль Регана умирает в своём шатре: Я проклинаю сестру последними силами."
         },
         {
           "german": "das Verhängnis",
           "russian": "рок",
           "transcription": "[дас фер-ХЕНГ-нис]",
-          "sentence": "Das Verhängnis ereilt mich gerecht.",
-          "sentence_translation": "Рок настигает меня справедливо."
+          "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Das Verhängnis ereilt mich gerecht.",
+          "sentence_translation": "Отравленная Гонериль Регана умирает в своём шатре: Рок настигает меня справедливо."
         },
         {
           "german": "büßen",
           "russian": "расплачиваться",
           "transcription": "[БЮ-сен]",
-          "sentence": "Ich büße für all meine Grausamkeiten.",
-          "sentence_translation": "Я расплачиваюсь за все свои жестокости."
+          "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Ich büße für all meine Grausamkeiten.",
+          "sentence_translation": "Отравленная Гонериль Регана умирает в своём шатре: Я расплачиваюсь за все свои жестокости."
         },
         {
           "german": "verflucht",
           "russian": "проклятый",
           "transcription": "[фер-ФЛУХТ]",
-          "sentence": "Verflucht sei unser böses Blut!",
-          "sentence_translation": "Проклята наша злая кровь!"
+          "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Verflucht sei unser böses Blut!",
+          "sentence_translation": "Отравленная Гонериль Регана умирает в своём шатре: Проклята наша злая кровь!"
         }
       ],
       "quizzes": [

--- a/data/vocabulary/vocabulary.json
+++ b/data/vocabulary/vocabulary.json
@@ -51,8 +51,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich weise alle seine Bitten ab.",
-          "ru": "Я отвергаю все его просьбы."
+          "de": "Am Hof von König Lear erzählt man: Ich weise alle seine Bitten ab.",
+          "ru": "При дворе короля Лира рассказывают: Я отвергаю все его просьбы."
         }
       ],
       "word_family": [
@@ -85,8 +85,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich achte beide Söhne, Edgar und Edmund.",
-          "ru": "Я уважаю обоих сыновей, Эдгара и Эдмунда."
+          "de": "Am Hof von König Lear erzählt man: Ich achte beide Söhne, Edgar und Edmund.",
+          "ru": "При дворе короля Лира рассказывают: Я уважаю обоих сыновей, Эдгара и Эдмунда."
         }
       ],
       "word_family": [
@@ -118,8 +118,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich ahne das schlimme Ende voraus.",
-          "ru": "Я предчувствую плохой конец."
+          "de": "Am Hof von König Lear erzählt man: Ich ahne das schlimme Ende voraus.",
+          "ru": "При дворе короля Лира рассказывают: Я предчувствую плохой конец."
         }
       ],
       "word_family": [
@@ -151,8 +151,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ahnungslos vertraue ich meinem Bruder.",
-          "ru": "Ничего не подозревая, я доверяю брату."
+          "de": "Am Hof von König Lear erzählt man: Ahnungslos vertraue ich meinem Bruder.",
+          "ru": "При дворе короля Лира рассказывают: Ничего не подозревая, я доверяю брату."
         }
       ],
       "word_family": [
@@ -185,8 +185,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Angreifen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело атаковать."
+          "de": "Am Hof von König Lear erzählt man: Das Angreifen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело атаковать."
         }
       ],
       "word_family": [
@@ -218,8 +218,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Als Кай heuere ich beim König an.",
-          "ru": "Как Кай я нанимаюсь к королю."
+          "de": "Während Kent seine Verkleidung trägt, flüstert man: Als Кай heuere ich beim König an.",
+          "ru": "Пока Кент носит маскировку, шепчутся: Как Кай я нанимаюсь к королю."
         }
       ],
       "word_family": [
@@ -251,8 +251,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich klage sie ihrer Unmenschlichkeit an.",
-          "ru": "Я обвиняю её в бесчеловечности."
+          "de": "Am Hof von König Lear erzählt man: Ich klage sie ihrer Unmenschlichkeit an.",
+          "ru": "При дворе короля Лира рассказывают: Я обвиняю её в бесчеловечности."
         }
       ],
       "word_family": [
@@ -286,8 +286,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich stachle sie zu größerer Grausamkeit an.",
-          "ru": "Я подстрекаю её к большей жестокости."
+          "de": "Am Hof von König Lear erzählt man: Ich stachle sie zu größerer Grausamkeit an.",
+          "ru": "При дворе короля Лира рассказывают: Я подстрекаю её к большей жестокости."
         }
       ],
       "word_family": [
@@ -317,8 +317,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Antworten auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что отвечать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Antworten auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что отвечать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -350,8 +350,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bin zu arglos für solche Intrigen.",
-          "ru": "Я слишком простодушен для таких интриг."
+          "de": "Seit Edmund den falschen Brief schrieb, raunen die Diener: Ich bin zu arglos für solche Intrigen.",
+          "ru": "С тех пор как Эдмунд написал фальшивое письмо, слуги шепчутся: Я слишком простодушен для таких интриг."
         }
       ],
       "word_family": [
@@ -383,8 +383,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich argwöhne Gift in meinem Wein.",
-          "ru": "Я подозреваю яд в моём вине."
+          "de": "Am Hof von König Lear erzählt man: Ich argwöhne Gift in meinem Wein.",
+          "ru": "При дворе короля Лира рассказывают: Я подозреваю яд в моём вине."
         }
       ],
       "word_family": [
@@ -417,8 +417,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Armen leiden mehr als Könige jemals wissen.",
-          "ru": "Бедные страдают больше, чем короли когда-либо узнают."
+          "de": "Am Hof von König Lear erzählt man: Die Armen leiden mehr als Könige jemals wissen.",
+          "ru": "При дворе короля Лира рассказывают: Бедные страдают больше, чем короли когда-либо узнают."
         }
       ],
       "word_family": [
@@ -450,8 +450,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich baue auf, was zerstört wurde.",
-          "ru": "Я строю то, что было разрушено."
+          "de": "Am Hof von König Lear erzählt man: Ich baue auf, was zerstört wurde.",
+          "ru": "При дворе короля Лира рассказывают: Я строю то, что было разрушено."
         }
       ],
       "word_family": [
@@ -483,8 +483,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich begehre auf gegen das Unrecht.",
-          "ru": "Я восстаю против несправедливости."
+          "de": "Am Hof von König Lear erzählt man: Ich begehre auf gegen das Unrecht.",
+          "ru": "При дворе короля Лира рассказывают: Я восстаю против несправедливости."
         }
       ],
       "word_family": [
@@ -519,12 +519,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich gebe auf, nachdem mein Herr gestorben ist.",
-          "ru": "Я сдаюсь после смерти моего господина."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Ich gebe auf, nachdem mein Herr gestorben ist.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Я сдаюсь после смерти моего господина."
         },
         {
-          "de": "Ich will das Leben aufgeben.",
-          "ru": "Я хочу отказаться от жизни."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Ich will das Leben aufgeben.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Я хочу отказаться от жизни."
         }
       ],
       "word_family": [
@@ -557,8 +557,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der König von Frankreich nimmt mich liebevoll auf.",
-          "ru": "Король Франции принимает меня с любовью."
+          "de": "Im Lager der französischen Cordelia berichtet man: Der König von Frankreich nimmt mich liebevoll auf.",
+          "ru": "Во французском лагере Корделии рассказывают: Король Франции принимает меня с любовью."
         }
       ],
       "word_family": [
@@ -590,8 +590,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bin aufrichtig, auch wenn es gefährlich ist.",
-          "ru": "Я искренен, даже если это опасно."
+          "de": "Bei Cordelias treuer Umarmung sagt man: Ich bin aufrichtig, auch wenn es gefährlich ist.",
+          "ru": "У верных объятий Корделии говорят: Я искренен, даже если это опасно."
         }
       ],
       "word_family": [
@@ -623,8 +623,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich spüre den Flüchtling überall auf.",
-          "ru": "Я выслеживаю беглеца повсюду."
+          "de": "Am Hof von König Lear erzählt man: Ich spüre den Flüchtling überall auf.",
+          "ru": "При дворе короля Лира рассказывают: Я выслеживаю беглеца повсюду."
         }
       ],
       "word_family": [
@@ -656,8 +656,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich will über alle aufsteigen.",
-          "ru": "Я хочу возвыситься над всеми."
+          "de": "Im Schatten von Gloucester spricht man über den Bastard: Ich will über alle aufsteigen.",
+          "ru": "В тени Глостера говорят о бастарде: Я хочу возвыситься над всеми."
         }
       ],
       "word_family": [
@@ -689,8 +689,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich wache auf aus meinem langen Schlaf.",
-          "ru": "Я просыпаюсь от долгого сна."
+          "de": "Am Hof von König Lear erzählt man: Ich wache auf aus meinem langen Schlaf.",
+          "ru": "При дворе короля Лира рассказывают: Я просыпаюсь от долгого сна."
         }
       ],
       "word_family": [
@@ -721,8 +721,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Aufwachsen ist.",
-          "ru": "Во время бури становится понятно, насколько важно расти."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Aufwachsen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно расти."
         }
       ],
       "word_family": [
@@ -753,8 +753,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Aushalten alle verändert.",
-          "ru": "Шут чувствует, как умение выдерживать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Aushalten alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение выдерживать меняет всех."
         }
       ],
       "word_family": [
@@ -788,8 +788,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich harre aus bis zur Befreiung.",
-          "ru": "Я выдерживаю до освобождения."
+          "de": "Am Hof von König Lear erzählt man: Ich harre aus bis zur Befreiung.",
+          "ru": "При дворе короля Лира рассказывают: Я выдерживаю до освобождения."
         }
       ],
       "word_family": [
@@ -823,8 +823,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich liefere ihn seinen Feinden aus.",
-          "ru": "Я выдаю его врагам."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Ich liefere ihn seinen Feinden aus.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Я выдаю его врагам."
         }
       ],
       "word_family": [
@@ -858,8 +858,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich nutze ihre Leidenschaft aus.",
-          "ru": "Я использую их страсть."
+          "de": "Im Streitlager der Schwestern um Edmund zischt man: Ich nutze ihre Leidenschaft aus.",
+          "ru": "В спорщем лагере сестёр из-за Эдмунда шипят: Я использую их страсть."
         }
       ],
       "word_family": [
@@ -893,12 +893,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Stecht ihm beide Augen aus!",
-          "ru": "Выколите ему оба глаза!"
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Stecht ihm beide Augen aus!",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Выколите ему оба глаза!"
         },
         {
-          "de": "Seine Augen steche ich mit Freude aus.",
-          "ru": "Его глаза я выкалываю с радостью."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Seine Augen steche ich mit Freude aus.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Его глаза я выкалываю с радостью."
         }
       ],
       "word_family": [
@@ -931,8 +931,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bedrohe sie mit dem Tod.",
-          "ru": "Я угрожаю ей смертью."
+          "de": "Am Hof von König Lear erzählt man: Ich bedrohe sie mit dem Tod.",
+          "ru": "При дворе короля Лира рассказывают: Я угрожаю ей смертью."
         }
       ],
       "word_family": [
@@ -963,12 +963,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Befehlen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело приказывать."
+          "de": "Am Hof von König Lear erzählt man: Das Befehlen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело приказывать."
         },
         {
-          "de": "Ich befehle, und alle gehorchen mir.",
-          "ru": "Я приказываю, и все подчиняются мне."
+          "de": "Am Hof von König Lear erzählt man: Ich befehle, und alle gehorchen mir.",
+          "ru": "При дворе короля Лира рассказывают: Я приказываю, и все подчиняются мне."
         }
       ],
       "word_family": [
@@ -1001,8 +1001,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Jeden Befehl befolge ich sofort.",
-          "ru": "Каждый приказ я исполняю немедленно."
+          "de": "Am Hof von König Lear erzählt man: Jeden Befehl befolge ich sofort.",
+          "ru": "При дворе короля Лира рассказывают: Каждый приказ я исполняю немедленно."
         }
       ],
       "word_family": [
@@ -1033,8 +1033,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Befreien auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что освобождать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Befreien auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что освобождать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -1064,8 +1064,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Begegnen alle verändert.",
-          "ru": "Шут чувствует, как умение встречать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Begegnen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение встречать меняет всех."
         }
       ],
       "word_family": [
@@ -1095,20 +1095,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Begehren ist.",
-          "ru": "Во время бури становится понятно, насколько важно желать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Begehren ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно желать."
         },
         {
-          "de": "Ich begehre Edmund mit brennender Lust.",
-          "ru": "Я вожделею Эдмунда с пылающей страстью."
+          "de": "Am Hof von König Lear erzählt man: Ich begehre Edmund mit brennender Lust.",
+          "ru": "При дворе короля Лира рассказывают: Я вожделею Эдмунда с пылающей страстью."
         },
         {
-          "de": "Ich begehre die Krone für mich selbst.",
-          "ru": "Я вожделею корону для себя."
+          "de": "Am Hof von König Lear erzählt man: Ich begehre die Krone für mich selbst.",
+          "ru": "При дворе короля Лира рассказывают: Я вожделею корону для себя."
         },
         {
-          "de": "Ich begehre Edmund mehr als mein Leben.",
-          "ru": "Я желаю Эдмунда больше жизни."
+          "de": "Am Hof von König Lear erzählt man: Ich begehre Edmund mehr als mein Leben.",
+          "ru": "При дворе короля Лира рассказывают: Я желаю Эдмунда больше жизни."
         }
       ],
       "word_family": [
@@ -1150,16 +1150,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Als Tom begleite ich Lear durch seine dunkelste Stunde.",
-          "ru": "Как Том, я сопровождаю Лира в его самый тёмный час."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Als Tom begleite ich Lear durch seine dunkelste Stunde.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Как Том, я сопровождаю Лира в его самый тёмный час."
         },
         {
-          "de": "Ich begleite ihn durch Wind und Regen.",
-          "ru": "Я сопровождаю его сквозь ветер и дождь."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Ich begleite ihn durch Wind und Regen.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Я сопровождаю его сквозь ветер и дождь."
         },
         {
-          "de": "Treu begleite ich meinen verrückten König.",
-          "ru": "Верно я сопровождаю своего безумного короля."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Treu begleite ich meinen verrückten König.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Верно я сопровождаю своего безумного короля."
         }
       ],
       "word_family": [
@@ -1191,12 +1191,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Begreifen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело понимать."
+          "de": "Am Hof von König Lear erzählt man: Das Begreifen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело понимать."
         },
         {
-          "de": "Ich begreife das Ausmaß ihrer Grausamkeit.",
-          "ru": "Я понимаю масштаб её жестокости."
+          "de": "Am Hof von König Lear erzählt man: Ich begreife das Ausmaß ihrer Grausamkeit.",
+          "ru": "При дворе короля Лира рассказывают: Я понимаю масштаб её жестокости."
         }
       ],
       "word_family": [
@@ -1228,8 +1228,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Behalten auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что сохранять можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Behalten auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что сохранять можно и без гордыни."
         }
       ],
       "word_family": [
@@ -1259,12 +1259,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Beherrschen ist.",
-          "ru": "Во время бури становится понятно, насколько важно владеть."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Beherrschen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно владеть."
         },
         {
-          "de": "Ich beherrsche das Spiel der Macht.",
-          "ru": "Я господствую в игре власти."
+          "de": "Am Hof von König Lear erzählt man: Ich beherrsche das Spiel der Macht.",
+          "ru": "При дворе короля Лира рассказывают: Я господствую в игре власти."
         }
       ],
       "word_family": [
@@ -1298,8 +1298,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bekämpfe sie mit allen Mitteln.",
-          "ru": "Я борюсь с ней всеми средствами."
+          "de": "Am Hof von König Lear erzählt man: Ich bekämpfe sie mit allen Mitteln.",
+          "ru": "При дворе короля Лира рассказывают: Я борюсь с ней всеми средствами."
         }
       ],
       "word_family": [
@@ -1330,12 +1330,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Beleidigen alle verändert.",
-          "ru": "Шут чувствует, как умение оскорблять меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Beleidigen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение оскорблять меняет всех."
         },
         {
-          "de": "Ich beleidige den alten König ohne Scham.",
-          "ru": "Я оскорбляю старого короля без стыда."
+          "de": "Am Hof von König Lear erzählt man: Ich beleidige den alten König ohne Scham.",
+          "ru": "При дворе короля Лира рассказывают: Я оскорбляю старого короля без стыда."
         }
       ],
       "word_family": [
@@ -1366,8 +1366,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Belohnen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело награждать."
+          "de": "Am Hof von König Lear erzählt man: Das Belohnen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело награждать."
         }
       ],
       "word_family": [
@@ -1397,8 +1397,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Belügen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что лгать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Belügen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что лгать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -1431,8 +1431,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bin von Geburt an benachteiligt.",
-          "ru": "Я обделён с рождения."
+          "de": "Im Schatten von Gloucester spricht man über den Bastard: Ich bin von Geburt an benachteiligt.",
+          "ru": "В тени Глостера говорят о бастарде: Я обделён с рождения."
         }
       ],
       "word_family": [
@@ -1462,24 +1462,24 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Bereuen ist.",
-          "ru": "Во время бури становится понятно, насколько важно сожалеть."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Bereuen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно сожалеть."
         },
         {
-          "de": "Sie wird ihre Grausamkeit bereuen!",
-          "ru": "Она пожалеет о своей жестокости!"
+          "de": "Am Hof von König Lear erzählt man: Sie wird ihre Grausamkeit bereuen!",
+          "ru": "При дворе короля Лира рассказывают: Она пожалеет о своей жестокости!"
         },
         {
-          "de": "Am Ende bereue ich meine Taten.",
-          "ru": "В конце я сожалею о своих делах."
+          "de": "Am Hof von König Lear erzählt man: Am Ende bereue ich meine Taten.",
+          "ru": "При дворе короля Лира рассказывают: В конце я сожалею о своих делах."
         },
         {
-          "de": "Später werde ich diese Tat bitter bereuen.",
-          "ru": "Позже я горько пожалею об этом поступке."
+          "de": "Am Hof von König Lear erzählt man: Später werde ich diese Tat bitter bereuen.",
+          "ru": "При дворе короля Лира рассказывают: Позже я горько пожалею об этом поступке."
         },
         {
-          "de": "Zu spät bereue ich meine Taten.",
-          "ru": "Слишком поздно я сожалею о своих делах."
+          "de": "Am Hof von König Lear erzählt man: Zu spät bereue ich meine Taten.",
+          "ru": "При дворе короля Лира рассказывают: Слишком поздно я сожалею о своих делах."
         }
       ],
       "word_family": [
@@ -1515,8 +1515,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich beschränke seine Dienerschaft auf null.",
-          "ru": "Я ограничиваю его свиту до нуля."
+          "de": "Am Hof von König Lear erzählt man: Ich beschränke seine Dienerschaft auf null.",
+          "ru": "При дворе короля Лира рассказывают: Я ограничиваю его свиту до нуля."
         }
       ],
       "word_family": [
@@ -1548,8 +1548,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich beschuldige Edgar des Verrats.",
-          "ru": "Я обвиняю Эдгара в предательстве."
+          "de": "Am Hof von König Lear erzählt man: Ich beschuldige Edgar des Verrats.",
+          "ru": "При дворе короля Лира рассказывают: Я обвиняю Эдгара в предательстве."
         }
       ],
       "word_family": [
@@ -1581,20 +1581,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Beschützen alle verändert.",
-          "ru": "Шут чувствует, как умение защищать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Beschützen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение защищать меняет всех."
         },
         {
-          "de": "Die Unschuldigen will ich beschützen.",
-          "ru": "Невинных я хочу защитить."
+          "de": "Am Hof von König Lear erzählt man: Die Unschuldigen will ich beschützen.",
+          "ru": "При дворе короля Лира рассказывают: Невинных я хочу защитить."
         },
         {
-          "de": "Heimlich beschütze ich den wahnsinnigen König.",
-          "ru": "Тайно я защищаю безумного короля."
+          "de": "Am Hof von König Lear erzählt man: Heimlich beschütze ich den wahnsinnigen König.",
+          "ru": "При дворе короля Лира рассказывают: Тайно я защищаю безумного короля."
         },
         {
-          "de": "Ich kann ihn aus der Ferne nicht beschützen.",
-          "ru": "Я не могу защитить его издалека."
+          "de": "Am Hof von König Lear erzählt man: Ich kann ihn aus der Ferne nicht beschützen.",
+          "ru": "При дворе короля Лира рассказывают: Я не могу защитить его издалека."
         }
       ],
       "word_family": [
@@ -1631,8 +1631,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich muss meine Schwester beseitigen.",
-          "ru": "Я должна устранить свою сестру."
+          "de": "Am Hof von König Lear erzählt man: Ich muss meine Schwester beseitigen.",
+          "ru": "При дворе короля Лира рассказывают: Я должна устранить свою сестру."
         }
       ],
       "word_family": [
@@ -1662,12 +1662,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Bestrafen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело наказывать."
+          "de": "Am Hof von König Lear erzählt man: Das Bestrafen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело наказывать."
         },
         {
-          "de": "Ich bestrafe Kent für seine Frechheit.",
-          "ru": "Я караю Кента за его дерзость."
+          "de": "Am Hof von König Lear erzählt man: Ich bestrafe Kent für seine Frechheit.",
+          "ru": "При дворе короля Лира рассказывают: Я караю Кента за его дерзость."
         }
       ],
       "word_family": [
@@ -1703,8 +1703,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Jeden Tag bete ich für seine Sicherheit.",
-          "ru": "Каждый день я молюсь за его безопасность."
+          "de": "Am Hof von König Lear erzählt man: Jeden Tag bete ich für seine Sicherheit.",
+          "ru": "При дворе короля Лира рассказывают: Каждый день я молюсь за его безопасность."
         }
       ],
       "word_family": [
@@ -1734,12 +1734,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Betrügen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что обманывать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Betrügen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что обманывать можно и без гордыни."
         },
         {
-          "de": "Ich betrüge ihn mit Edmund.",
-          "ru": "Я изменяю ему с Эдмундом."
+          "de": "Am Hof von König Lear erzählt man: Ich betrüge ihn mit Edmund.",
+          "ru": "При дворе короля Лира рассказывают: Я изменяю ему с Эдмундом."
         }
       ],
       "word_family": [
@@ -1779,12 +1779,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Um mein Leben bettle ich vergeblich.",
-          "ru": "О жизни я умоляю напрасно."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Um mein Leben bettle ich vergeblich.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: О жизни я умоляю напрасно."
         },
         {
-          "de": "Muss ich um Unterkunft betteln bei meinen eigenen Kindern?",
-          "ru": "Должен ли я просить крова у собственных детей?"
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Muss ich um Unterkunft betteln bei meinen eigenen Kindern?",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Должен ли я просить крова у собственных детей?"
         }
       ],
       "word_family": [
@@ -1819,8 +1819,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ihre Grausamkeit beunruhigt mich zunehmend.",
-          "ru": "Её жестокость всё больше тревожит меня."
+          "de": "Am Hof von König Lear erzählt man: Ihre Grausamkeit beunruhigt mich zunehmend.",
+          "ru": "При дворе короля Лира рассказывают: Её жестокость всё больше тревожит меня."
         }
       ],
       "word_family": [
@@ -1852,8 +1852,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Heimlich bewache ich meinen alten Herrn.",
-          "ru": "Тайно я охраняю своего старого господина."
+          "de": "Am Hof von König Lear erzählt man: Heimlich bewache ich meinen alten Herrn.",
+          "ru": "При дворе короля Лира рассказывают: Тайно я охраняю своего старого господина."
         }
       ],
       "word_family": [
@@ -1883,8 +1883,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Beweinen ist.",
-          "ru": "Во время бури становится понятно, насколько важно оплакивать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Beweinen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно оплакивать."
         }
       ],
       "word_family": [
@@ -1914,8 +1914,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Beweisen alle verändert.",
-          "ru": "Шут чувствует, как умение доказывать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Beweisen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение доказывать меняет всех."
         }
       ],
       "word_family": [
@@ -1945,8 +1945,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Bezahlen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело платить."
+          "de": "Am Hof von König Lear erzählt man: Das Bezahlen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело платить."
         }
       ],
       "word_family": [
@@ -1978,8 +1978,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich billige alle ihre grausamen Pläne.",
-          "ru": "Я одобряю все её жестокие планы."
+          "de": "Am Hof von König Lear erzählt man: Ich billige alle ihre grausamen Pläne.",
+          "ru": "При дворе короля Лира рассказывают: Я одобряю все её жестокие планы."
         }
       ],
       "word_family": [
@@ -2009,8 +2009,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Bitten auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что просить можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Bitten auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что просить можно и без гордыни."
         }
       ],
       "word_family": [
@@ -2043,8 +2043,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Wahrheit schmeckt bitter wie Galle.",
-          "ru": "Правда горька как желчь."
+          "de": "Am Hof von König Lear erzählt man: Die Wahrheit schmeckt bitter wie Galle.",
+          "ru": "При дворе короля Лира рассказывают: Правда горька как желчь."
         }
       ],
       "word_family": [
@@ -2074,8 +2074,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Bleiben ist.",
-          "ru": "Во время бури становится понятно, насколько важно оставаться."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Bleiben ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно оставаться."
         }
       ],
       "word_family": [
@@ -2105,24 +2105,24 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Blenden alle verändert.",
-          "ru": "Шут чувствует, как умение ослеплять меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Blenden alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение ослеплять меняет всех."
         },
         {
-          "de": "Sie blenden ihn auf meinen Hinweis.",
-          "ru": "Они ослепляют его по моей наводке."
+          "de": "Am Hof von König Lear erzählt man: Sie blenden ihn auf meinen Hinweis.",
+          "ru": "При дворе короля Лира рассказывают: Они ослепляют его по моей наводке."
         },
         {
-          "de": "Wir blenden den treuen Grafen Gloucester.",
-          "ru": "Мы ослепляем верного графа Глостера."
+          "de": "Am Hof von König Lear erzählt man: Wir blenden den treuen Grafen Gloucester.",
+          "ru": "При дворе короля Лира рассказывают: Мы ослепляем верного графа Глостера."
         },
         {
-          "de": "Eigenhändig blende ich Gloucester.",
-          "ru": "Собственноручно я ослепляю Глостера."
+          "de": "Am Hof von König Lear erzählt man: Eigenhändig blende ich Gloucester.",
+          "ru": "При дворе короля Лира рассказывают: Собственноручно я ослепляю Глостера."
         },
         {
-          "de": "Sie blenden mich für meinen Verrat.",
-          "ru": "Они ослепляют меня за мою измену."
+          "de": "Am Hof von König Lear erzählt man: Sie blenden mich für meinen Verrat.",
+          "ru": "При дворе короля Лира рассказывают: Они ослепляют меня за мою измену."
         }
       ],
       "word_family": [
@@ -2161,12 +2161,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein blinder Vater erkennt mich nicht.",
-          "ru": "Мой слепой отец не узнаёт меня."
+          "de": "An den Klippen von Dover, wo Edgar seinen Vater führt, erinnert man sich: Mein blinder Vater erkennt mich nicht.",
+          "ru": "У утёсов Дувра, где Эдгар ведёт отца, вспоминают: Мой слепой отец не узнаёт меня."
         },
         {
-          "de": "Ich bin blind für die Wahrheit.",
-          "ru": "Я слеп к правде."
+          "de": "An den Klippen von Dover, wo Edgar seinen Vater führt, erinnert man sich: Ich bin blind für die Wahrheit.",
+          "ru": "У утёсов Дувра, где Эдгар ведёт отца, вспоминают: Я слеп к правде."
         }
       ],
       "word_family": [
@@ -2199,8 +2199,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich blute wie ein geschlachtetes Schwein.",
-          "ru": "Я кровоточу как зарезанная свинья."
+          "de": "Am Hof von König Lear erzählt man: Ich blute wie ein geschlachtetes Schwein.",
+          "ru": "При дворе короля Лира рассказывают: Я кровоточу как зарезанная свинья."
         }
       ],
       "word_family": [
@@ -2230,8 +2230,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Brechen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело ломать."
+          "de": "Am Hof von König Lear erzählt man: Das Brechen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело ломать."
         }
       ],
       "word_family": [
@@ -2263,8 +2263,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Brutal zerschlage ich jeden Widerstand.",
-          "ru": "Брутально я сокрушаю любое сопротивление."
+          "de": "Am Hof von König Lear erzählt man: Brutal zerschlage ich jeden Widerstand.",
+          "ru": "При дворе короля Лира рассказывают: Брутально я сокрушаю любое сопротивление."
         }
       ],
       "word_family": [
@@ -2296,8 +2296,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich büße für all meine Grausamkeiten.",
-          "ru": "Я расплачиваюсь за все свои жестокости."
+          "de": "Am Hof von König Lear erzählt man: Ich büße für all meine Grausamkeiten.",
+          "ru": "При дворе короля Лира рассказывают: Я расплачиваюсь за все свои жестокости."
         }
       ],
       "word_family": [
@@ -2327,8 +2327,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Danken auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что благодарить можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Danken auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что благодарить можно и без гордыни."
         }
       ],
       "word_family": [
@@ -2358,8 +2358,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt das Alter ein ständiges Thema.",
-          "ru": "Для придворных «возраст» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt das Alter ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «возраст» — постоянная тема."
         }
       ],
       "word_family": [
@@ -2390,8 +2390,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn das Asyl zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «убежище» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn das Asyl zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «убежище» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -2423,8 +2423,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über das Blatt nie.",
-          "ru": "В тронном зале постоянно звучит слово «лист»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über das Blatt nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «лист»."
         }
       ],
       "word_family": [
@@ -2455,12 +2455,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald das Blut erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «кровь»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald das Blut erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «кровь»."
         },
         {
-          "de": "Das Blut des Grafen befleckt meine Hände.",
-          "ru": "Кровь графа пятнает мои руки."
+          "de": "Am Hof von König Lear erzählt man: Das Blut des Grafen befleckt meine Hände.",
+          "ru": "При дворе короля Лира рассказывают: Кровь графа пятнает мои руки."
         }
       ],
       "word_family": [
@@ -2492,8 +2492,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie das Böse verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «зло»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie das Böse verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «зло»."
         }
       ],
       "word_family": [
@@ -2529,12 +2529,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Unser Bündnis ist stark und grausam.",
-          "ru": "Наш союз силён и жесток."
+          "de": "Am Hof von König Lear erzählt man: Unser Bündnis ist stark und grausam.",
+          "ru": "При дворе короля Лира рассказывают: Наш союз силён и жесток."
         },
         {
-          "de": "Ein Bündnis mit Goneril gegen unseren Vater.",
-          "ru": "Союз с Гонерильей против нашего отца."
+          "de": "Am Hof von König Lear erzählt man: Ein Bündnis mit Goneril gegen unseren Vater.",
+          "ru": "При дворе короля Лира рассказывают: Союз с Гонерильей против нашего отца."
         }
       ],
       "word_family": [
@@ -2565,12 +2565,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt das Chaos noch bedrückender.",
-          "ru": "Во время бури само «хаос» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt das Chaos noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «хаос» звучит ещё тяжелее."
         },
         {
-          "de": "Das Chaos in der Natur spiegelt meine Seele!",
-          "ru": "Хаос в природе отражает мою душу!"
+          "de": "Am Hof von König Lear erzählt man: Das Chaos in der Natur spiegelt meine Seele!",
+          "ru": "При дворе короля Лира рассказывают: Хаос в природе отражает мою душу!"
         }
       ],
       "word_family": [
@@ -2602,16 +2602,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt das Duell ein ständiges Thema.",
-          "ru": "Для придворных «дуэль» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt das Duell ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «дуэль» — постоянная тема."
         },
         {
-          "de": "Das Duell mit Edgar ist mein Ende.",
-          "ru": "Дуэль с Эдгаром - мой конец."
+          "de": "Am Hof von König Lear erzählt man: Das Duell mit Edgar ist mein Ende.",
+          "ru": "При дворе короля Лира рассказывают: Дуэль с Эдгаром - мой конец."
         },
         {
-          "de": "In diesem Duell kämpfe ich für die Gerechtigkeit.",
-          "ru": "В этой дуэли я сражаюсь за справедливость."
+          "de": "Am Hof von König Lear erzählt man: In diesem Duell kämpfe ich für die Gerechtigkeit.",
+          "ru": "При дворе короля Лира рассказывают: В этой дуэли я сражаюсь за справедливость."
         }
       ],
       "word_family": [
@@ -2644,8 +2644,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn das Eigentum zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «собственность» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn das Eigentum zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «собственность» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -2676,16 +2676,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über das Elend nie.",
-          "ru": "В тронном зале постоянно звучит слово «нищета»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über das Elend nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «нищета»."
         },
         {
-          "de": "Im Elend erkenne ich die Wahrheit der Welt.",
-          "ru": "В нищете я познаю истину мира."
+          "de": "Am Hof von König Lear erzählt man: Im Elend erkenne ich die Wahrheit der Welt.",
+          "ru": "При дворе короля Лира рассказывают: В нищете я познаю истину мира."
         },
         {
-          "de": "Im Elend lerne ich die wahre Natur des Menschen.",
-          "ru": "В нищете я познаю истинную природу человека."
+          "de": "Am Hof von König Lear erzählt man: Im Elend lerne ich die wahre Natur des Menschen.",
+          "ru": "При дворе короля Лира рассказывают: В нищете я познаю истинную природу человека."
         }
       ],
       "word_family": [
@@ -2718,24 +2718,24 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald das Ende erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «конец»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald das Ende erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «конец»."
         },
         {
-          "de": "Das Ende kommt, aber mit dir bin ich nicht allein.",
-          "ru": "Конец приходит, но с тобой я не одинок."
+          "de": "Am Hof von König Lear erzählt man: Das Ende kommt, aber mit dir bin ich nicht allein.",
+          "ru": "При дворе короля Лира рассказывают: Конец приходит, но с тобой я не одинок."
         },
         {
-          "de": "Das Ende kommt schnell und gerecht.",
-          "ru": "Конец приходит быстро и справедливо."
+          "de": "Am Hof von König Lear erzählt man: Das Ende kommt schnell und gerecht.",
+          "ru": "При дворе короля Лира рассказывают: Конец приходит быстро и справедливо."
         },
         {
-          "de": "Dies ist nicht das Ende, nur ein Übergang.",
-          "ru": "Это не конец, только переход."
+          "de": "Am Hof von König Lear erzählt man: Dies ist nicht das Ende, nur ein Übergang.",
+          "ru": "При дворе короля Лира рассказывают: Это не конец, только переход."
         },
         {
-          "de": "Mein Ende kommt durch eines Dieners Hand.",
-          "ru": "Мой конец приходит от руки слуги."
+          "de": "Am Hof von König Lear erzählt man: Mein Ende kommt durch eines Dieners Hand.",
+          "ru": "При дворе короля Лира рассказывают: Мой конец приходит от руки слуги."
         }
       ],
       "word_family": [
@@ -2772,8 +2772,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mit Entsetzen sehe ich ihr wahres Gesicht.",
-          "ru": "С ужасом я вижу её истинное лицо."
+          "de": "Am Hof von König Lear erzählt man: Mit Entsetzen sehe ich ihr wahres Gesicht.",
+          "ru": "При дворе короля Лира рассказывают: С ужасом я вижу её истинное лицо."
         }
       ],
       "word_family": [
@@ -2804,12 +2804,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie das Erbe verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «наследство»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie das Erbe verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «наследство»."
         },
         {
-          "de": "Das Erbe ist endlich mein.",
-          "ru": "Наследство наконец моё."
+          "de": "Am Hof von König Lear erzählt man: Das Erbe ist endlich mein.",
+          "ru": "При дворе короля Лира рассказывают: Наследство наконец моё."
         }
       ],
       "word_family": [
@@ -2841,8 +2841,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt das Erwachen noch bedrückender.",
-          "ru": "Во время бури само «пробуждение» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt das Erwachen noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «пробуждение» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -2873,8 +2873,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt das Exil ein ständiges Thema.",
-          "ru": "Для придворных «изгнание» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt das Exil ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «изгнание» — постоянная тема."
         }
       ],
       "word_family": [
@@ -2906,8 +2906,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn das Fenster zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «окно» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn das Fenster zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «окно» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -2938,8 +2938,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über das Gefolge nie.",
-          "ru": "В тронном зале постоянно звучит слово «свита»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über das Gefolge nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «свита»."
         }
       ],
       "word_family": [
@@ -2970,12 +2970,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald das Gefängnis erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «тюрьма»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald das Gefängnis erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «тюрьма»."
         },
         {
-          "de": "Dieses Gefängnis kann meine Liebe nicht einsperren.",
-          "ru": "Эта тюрьма не может запереть мою любовь."
+          "de": "Am Hof von König Lear erzählt man: Dieses Gefängnis kann meine Liebe nicht einsperren.",
+          "ru": "При дворе короля Лира рассказывают: Эта тюрьма не может запереть мою любовь."
         }
       ],
       "word_family": [
@@ -3007,12 +3007,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie das Geheimnis verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «тайна»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie das Geheimnis verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «тайна»."
         },
         {
-          "de": "Mein Verschwinden bleibt ein ewiges Geheimnis.",
-          "ru": "Моё исчезновение остаётся вечной тайной."
+          "de": "Am Hof von König Lear erzählt man: Mein Verschwinden bleibt ein ewiges Geheimnis.",
+          "ru": "При дворе короля Лира рассказывают: Моё исчезновение остаётся вечной тайной."
         }
       ],
       "word_family": [
@@ -3044,12 +3044,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt das Gewissen noch bedrückender.",
-          "ru": "Во время бури само «совесть» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt das Gewissen noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «совесть» звучит ещё тяжелее."
         },
         {
-          "de": "Mein Gewissen beginnt mich zu quälen.",
-          "ru": "Моя совесть начинает мучить меня."
+          "de": "Am Hof von König Lear erzählt man: Mein Gewissen beginnt mich zu quälen.",
+          "ru": "При дворе короля Лира рассказывают: Моя совесть начинает мучить меня."
         }
       ],
       "word_family": [
@@ -3083,8 +3083,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Gift ist bereit für meine Schwester.",
-          "ru": "Яд готов для моей сестры."
+          "de": "Am Hof von König Lear erzählt man: Das Gift ist bereit für meine Schwester.",
+          "ru": "При дворе короля Лира рассказывают: Яд готов для моей сестры."
         }
       ],
       "word_family": [
@@ -3114,8 +3114,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt das Gleichgewicht ein ständiges Thema.",
-          "ru": "Для придворных «равновесие» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt das Gleichgewicht ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «равновесие» — постоянная тема."
         }
       ],
       "word_family": [
@@ -3146,8 +3146,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn das Gold zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «золото» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn das Gold zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «золото» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -3178,8 +3178,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über das Grab nie.",
-          "ru": "В тронном зале постоянно звучит слово «могила»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über das Grab nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «могила»."
         }
       ],
       "word_family": [
@@ -3210,8 +3210,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald das Grauen erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «ужас»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald das Grauen erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «ужас»."
         }
       ],
       "word_family": [
@@ -3243,8 +3243,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie das Gute verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «добро»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie das Gute verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «добро»."
         }
       ],
       "word_family": [
@@ -3275,16 +3275,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt das Herz noch bedrückender.",
-          "ru": "Во время бури само «сердце» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt das Herz noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «сердце» звучит ещё тяжелее."
         },
         {
-          "de": "Mein Herz bricht vor Schmerz und Liebe.",
-          "ru": "Моё сердце разбивается от боли и любви."
+          "de": "Am Hof von König Lear erzählt man: Mein Herz bricht vor Schmerz und Liebe.",
+          "ru": "При дворе короля Лира рассказывают: Моё сердце разбивается от боли и любви."
         },
         {
-          "de": "Mein Herz zerbricht vor Glück und Leid.",
-          "ru": "Моё сердце разрывается от счастья и горя."
+          "de": "Am Hof von König Lear erzählt man: Mein Herz zerbricht vor Glück und Leid.",
+          "ru": "При дворе короля Лира рассказывают: Моё сердце разрывается от счастья и горя."
         }
       ],
       "word_family": [
@@ -3317,8 +3317,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt das Komplott ein ständiges Thema.",
-          "ru": "Для придворных «заговор» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt das Komplott ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «заговор» — постоянная тема."
         }
       ],
       "word_family": [
@@ -3349,16 +3349,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn das Königreich zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «королевство» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn das Königreich zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «королевство» звучит слишком близко."
         },
         {
-          "de": "Mein Königreich teile ich unter meinen Töchtern.",
-          "ru": "Моё королевство я делю между дочерьми."
+          "de": "Am Hof von König Lear erzählt man: Mein Königreich teile ich unter meinen Töchtern.",
+          "ru": "При дворе короля Лира рассказывают: Моё королевство я делю между дочерьми."
         },
         {
-          "de": "Ich diene dem Königreich mit Ehre.",
-          "ru": "Я служу королевству с честью."
+          "de": "Am Hof von König Lear erzählt man: Ich diene dem Königreich mit Ehre.",
+          "ru": "При дворе короля Лира рассказывают: Я служу королевству с честью."
         }
       ],
       "word_family": [
@@ -3391,8 +3391,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über das Land nie.",
-          "ru": "В тронном зале постоянно звучит слово «страна»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über das Land nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «страна»."
         }
       ],
       "word_family": [
@@ -3423,8 +3423,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald das Leben erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «жизнь»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald das Leben erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «жизнь»."
         }
       ],
       "word_family": [
@@ -3455,8 +3455,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie das Leid verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «страдание»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie das Leid verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «страдание»."
         }
       ],
       "word_family": [
@@ -3489,8 +3489,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Lied erzählt von vergangenen Tagen.",
-          "ru": "Моя песня рассказывает о прошлых днях."
+          "de": "Am Hof von König Lear erzählt man: Mein Lied erzählt von vergangenen Tagen.",
+          "ru": "При дворе короля Лира рассказывают: Моя песня рассказывает о прошлых днях."
         }
       ],
       "word_family": [
@@ -3520,12 +3520,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt das Mitleid noch bedrückender.",
-          "ru": "Во время бури само «сострадание» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt das Mitleid noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «сострадание» звучит ещё тяжелее."
         },
         {
-          "de": "Mitleid erfüllt mein Herz für Lear.",
-          "ru": "Сострадание наполняет моё сердце к Лиру."
+          "de": "Am Hof von König Lear erzählt man: Mitleid erfüllt mein Herz für Lear.",
+          "ru": "При дворе короля Лира рассказывают: Сострадание наполняет моё сердце к Лиру."
         }
       ],
       "word_family": [
@@ -3559,8 +3559,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Jedes Omen zeigt auf Untergang.",
-          "ru": "Каждое знамение указывает на гибель."
+          "de": "Am Hof von König Lear erzählt man: Jedes Omen zeigt auf Untergang.",
+          "ru": "При дворе короля Лира рассказывают: Каждое знамение указывает на гибель."
         }
       ],
       "word_family": [
@@ -3590,12 +3590,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt das Opfer ein ständiges Thema.",
-          "ru": "Для придворных «жертва» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt das Opfer ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «жертва» — постоянная тема."
         },
         {
-          "de": "Ich bin das Opfer der Wahrheit und Liebe.",
-          "ru": "Я жертва правды и любви."
+          "de": "Am Hof von König Lear erzählt man: Ich bin das Opfer der Wahrheit und Liebe.",
+          "ru": "При дворе короля Лира рассказывают: Я жертва правды и любви."
         }
       ],
       "word_family": [
@@ -3629,8 +3629,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Prinzipien sind wichtiger als meine Ehe.",
-          "ru": "Мои принципы важнее моего брака."
+          "de": "Am Hof von König Lear erzählt man: Meine Prinzipien sind wichtiger als meine Ehe.",
+          "ru": "При дворе короля Лира рассказывают: Мои принципы важнее моего брака."
         }
       ],
       "word_family": [
@@ -3660,12 +3660,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über das Recht nie.",
-          "ru": "В тронном зале постоянно звучит слово «право»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über das Recht nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «право»."
         },
         {
-          "de": "Das Recht muss über das Unrecht siegen.",
-          "ru": "Право должно победить неправду."
+          "de": "Am Hof von König Lear erzählt man: Das Recht muss über das Unrecht siegen.",
+          "ru": "При дворе короля Лира рассказывают: Право должно победить неправду."
         }
       ],
       "word_family": [
@@ -3697,8 +3697,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn das Reich zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «империя» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn das Reich zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «империя» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -3731,8 +3731,8 @@
       ],
       "example_sentences": [
         {
-          "de": "In Rätseln spreche ich von der Zukunft.",
-          "ru": "В загадках я говорю о будущем."
+          "de": "Am Hof von König Lear erzählt man: In Rätseln spreche ich von der Zukunft.",
+          "ru": "При дворе короля Лира рассказывают: В загадках я говорю о будущем."
         }
       ],
       "word_family": [
@@ -3762,16 +3762,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald das Schicksal erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «судьба»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald das Schicksal erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «судьба»."
         },
         {
-          "de": "Unser Schicksal ist miteinander verwoben.",
-          "ru": "Наши судьбы переплетены."
+          "de": "Am Hof von König Lear erzählt man: Unser Schicksal ist miteinander verwoben.",
+          "ru": "При дворе короля Лира рассказывают: Наши судьбы переплетены."
         },
         {
-          "de": "Das Schicksal macht Narren aus uns allen.",
-          "ru": "Судьба делает дураков из всех нас."
+          "de": "Am Hof von König Lear erzählt man: Das Schicksal macht Narren aus uns allen.",
+          "ru": "При дворе короля Лира рассказывают: Судьба делает дураков из всех нас."
         }
       ],
       "word_family": [
@@ -3804,8 +3804,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie das Schloss verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «замок»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie das Schloss verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «замок»."
         }
       ],
       "word_family": [
@@ -3838,8 +3838,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Schweigen macht mich zum Mitschuldigen.",
-          "ru": "Моё молчание делает меня соучастником."
+          "de": "Am Hof von König Lear erzählt man: Mein Schweigen macht mich zum Mitschuldigen.",
+          "ru": "При дворе короля Лира рассказывают: Моё молчание делает меня соучастником."
         }
       ],
       "word_family": [
@@ -3869,12 +3869,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt das Schwert noch bedrückender.",
-          "ru": "Во время бури само «меч» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt das Schwert noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «меч» звучит ещё тяжелее."
         },
         {
-          "de": "Mein Schwert ist die Waffe der Wahrheit.",
-          "ru": "Мой меч - оружие правды."
+          "de": "Am Hof von König Lear erzählt man: Mein Schwert ist die Waffe der Wahrheit.",
+          "ru": "При дворе короля Лира рассказывают: Мой меч - оружие правды."
         }
       ],
       "word_family": [
@@ -3908,8 +3908,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ein tiefes Unbehagen erfüllt meine Seele.",
-          "ru": "Глубокое беспокойство наполняет мою душу."
+          "de": "Am Hof von König Lear erzählt man: Ein tiefes Unbehagen erfüllt meine Seele.",
+          "ru": "При дворе короля Лира рассказывают: Глубокое беспокойство наполняет мою душу."
         }
       ],
       "word_family": [
@@ -3939,8 +3939,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt das Unglück ein ständiges Thema.",
-          "ru": "Для придворных «несчастье» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt das Unglück ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «несчастье» — постоянная тема."
         }
       ],
       "word_family": [
@@ -3971,8 +3971,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn das Urteil zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «приговор» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn das Urteil zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «приговор» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -4003,8 +4003,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über das Verbrechen nie.",
-          "ru": "В тронном зале постоянно звучит слово «преступление»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über das Verbrechen nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «преступление»."
         }
       ],
       "word_family": [
@@ -4037,8 +4037,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verderben holt mich ein.",
-          "ru": "Погибель настигает меня."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Das Verderben holt mich ein.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Погибель настигает меня."
         }
       ],
       "word_family": [
@@ -4070,8 +4070,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verhängnis ereilt mich gerecht.",
-          "ru": "Рок настигает меня справедливо."
+          "de": "Am Hof von König Lear erzählt man: Das Verhängnis ereilt mich gerecht.",
+          "ru": "При дворе короля Лира рассказывают: Рок настигает меня справедливо."
         }
       ],
       "word_family": [
@@ -4103,8 +4103,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Sein ganzes Vermögen wird mir gehören.",
-          "ru": "Всё его состояние будет моим."
+          "de": "Am Hof von König Lear erzählt man: Sein ganzes Vermögen wird mir gehören.",
+          "ru": "При дворе короля Лира рассказывают: Всё его состояние будет моим."
         }
       ],
       "word_family": [
@@ -4134,8 +4134,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald das Vertrauen erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «доверие»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald das Vertrauen erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «доверие»."
         }
       ],
       "word_family": [
@@ -4166,8 +4166,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie das Wetter verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «погода»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie das Wetter verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «погода»."
         }
       ],
       "word_family": [
@@ -4198,8 +4198,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt das Ziel noch bedrückender.",
-          "ru": "Во время бури само «цель» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt das Ziel noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «цель» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -4230,8 +4230,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt das Zuhause ein ständiges Thema.",
-          "ru": "Для придворных «дом» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt das Zuhause ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «дом» — постоянная тема."
         }
       ],
       "word_family": [
@@ -4268,16 +4268,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine eigene Tochter will mich demütigen!",
-          "ru": "Моя собственная дочь хочет меня унизить!"
+          "de": "Am Hof von König Lear erzählt man: Meine eigene Tochter will mich demütigen!",
+          "ru": "При дворе короля Лира рассказывают: Моя собственная дочь хочет меня унизить!"
         },
         {
-          "de": "Ich demütige ihn vor aller Augen.",
-          "ru": "Я унижаю его на глазах у всех."
+          "de": "Am Hof von König Lear erzählt man: Ich demütige ihn vor aller Augen.",
+          "ru": "При дворе короля Лира рассказывают: Я унижаю его на глазах у всех."
         },
         {
-          "de": "Ich demütige meinen alten Vater ohne Mitleid.",
-          "ru": "Я унижаю старого отца без жалости."
+          "de": "Am Hof von König Lear erzählt man: Ich demütige meinen alten Vater ohne Mitleid.",
+          "ru": "При дворе короля Лира рассказывают: Я унижаю старого отца без жалости."
         }
       ],
       "word_family": [
@@ -4312,8 +4312,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich denunziere meinen Vater als Verräter.",
-          "ru": "Я доношу на отца как на предателя."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Ich denunziere meinen Vater als Verräter.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Я доношу на отца как на предателя."
         }
       ],
       "word_family": [
@@ -4345,8 +4345,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Abgrund ruft nach mir.",
-          "ru": "Пропасть зовёт меня."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Der Abgrund ruft nach mir.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Пропасть зовёт меня."
         }
       ],
       "word_family": [
@@ -4386,20 +4386,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Das ist unser letzter Abschied, mein Kind.",
-          "ru": "Это наше последнее прощание, дитя моё."
+          "de": "Am Hof von König Lear erzählt man: Das ist unser letzter Abschied, mein Kind.",
+          "ru": "При дворе короля Лира рассказывают: Это наше последнее прощание, дитя моё."
         },
         {
-          "de": "Unser Abschied ist nur vorübergehend.",
-          "ru": "Наше прощание лишь временно."
+          "de": "Am Hof von König Lear erzählt man: Unser Abschied ist nur vorübergehend.",
+          "ru": "При дворе короля Лира рассказывают: Наше прощание лишь временно."
         },
         {
-          "de": "Der Abschied vom Hof schmerzt mich tief.",
-          "ru": "Прощание с двором глубоко ранит меня."
+          "de": "Am Hof von König Lear erzählt man: Der Abschied vom Hof schmerzt mich tief.",
+          "ru": "При дворе короля Лира рассказывают: Прощание с двором глубоко ранит меня."
         },
         {
-          "de": "Der Abschied von meinem König bricht mein Herz.",
-          "ru": "Прощание с моим королём разбивает моё сердце."
+          "de": "Am Hof von König Lear erzählt man: Der Abschied von meinem König bricht mein Herz.",
+          "ru": "При дворе короля Лира рассказывают: Прощание с моим королём разбивает моё сердце."
         }
       ],
       "word_family": [
@@ -4432,16 +4432,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn der Adel zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «дворянство» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn der Adel zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «дворянство» звучит слишком близко."
         },
         {
-          "de": "Der Adel erwartet von mir ehrenhaftes Verhalten.",
-          "ru": "Знать ожидает от меня достойного поведения."
+          "de": "Am Hof von König Lear erzählt man: Der Adel erwartet von mir ehrenhaftes Verhalten.",
+          "ru": "При дворе короля Лира рассказывают: Знать ожидает от меня достойного поведения."
         },
         {
-          "de": "Als Adel diene ich meinem König treu.",
-          "ru": "Как знать я верно служу своему королю."
+          "de": "Am Hof von König Lear erzählt man: Als Adel diene ich meinem König treu.",
+          "ru": "При дворе короля Лира рассказывают: Как знать я верно служу своему королю."
         }
       ],
       "word_family": [
@@ -4479,8 +4479,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Jeden Auftrag erfülle ich gewissenhaft.",
-          "ru": "Каждое поручение я выполняю добросовестно."
+          "de": "Am Hof von König Lear erzählt man: Jeden Auftrag erfülle ich gewissenhaft.",
+          "ru": "При дворе короля Лира рассказывают: Каждое поручение я выполняю добросовестно."
         }
       ],
       "word_family": [
@@ -4512,8 +4512,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mit falschem Bart bin ich nicht zu erkennen.",
-          "ru": "С фальшивой бородой меня не узнать."
+          "de": "Während Kent seine Verkleidung trägt, flüstert man: Mit falschem Bart bin ich nicht zu erkennen.",
+          "ru": "Пока Кент носит маскировку, шепчутся: С фальшивой бородой меня не узнать."
         }
       ],
       "word_family": [
@@ -4543,12 +4543,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über der Bastard nie.",
-          "ru": "В тронном зале постоянно звучит слово «бастард»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über der Bastard nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «бастард»."
         },
         {
-          "de": "Als Bastard habe ich keine Rechte.",
-          "ru": "Как бастард я не имею прав."
+          "de": "Am Hof von König Lear erzählt man: Als Bastard habe ich keine Rechte.",
+          "ru": "При дворе короля Лира рассказывают: Как бастард я не имею прав."
         }
       ],
       "word_family": [
@@ -4580,8 +4580,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald der Befehl erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «приказ»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald der Befehl erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «приказ»."
         }
       ],
       "word_family": [
@@ -4614,8 +4614,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Beistand ist alles, was ich bieten kann.",
-          "ru": "Моя поддержка - всё, что я могу предложить."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Mein Beistand ist alles, was ich bieten kann.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Моя поддержка - всё, что я могу предложить."
         }
       ],
       "word_family": [
@@ -4645,16 +4645,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie der Betrug verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «обман»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie der Betrug verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «обман»."
         },
         {
-          "de": "Dieser Betrug wird eines Tages aufgedeckt.",
-          "ru": "Этот обман однажды раскроется."
+          "de": "Am Hof von König Lear erzählt man: Dieser Betrug wird eines Tages aufgedeckt.",
+          "ru": "При дворе короля Лира рассказывают: Этот обман однажды раскроется."
         },
         {
-          "de": "Ich erkenne den Betrug nicht.",
-          "ru": "Я не распознаю обман."
+          "de": "Am Hof von König Lear erzählt man: Ich erkenne den Betrug nicht.",
+          "ru": "При дворе короля Лира рассказывают: Я не распознаю обман."
         }
       ],
       "word_family": [
@@ -4692,12 +4692,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Dieser Bettler ist glücklicher als ich, der König!",
-          "ru": "Этот нищий счастливее меня, короля!"
+          "de": "Am Hof von König Lear erzählt man: Dieser Bettler ist glücklicher als ich, der König!",
+          "ru": "При дворе короля Лира рассказывают: Этот нищий счастливее меня, короля!"
         },
         {
-          "de": "Als Bettler bin ich unsichtbar für meine Feinde.",
-          "ru": "Как нищий, я невидим для врагов."
+          "de": "Am Hof von König Lear erzählt man: Als Bettler bin ich unsichtbar für meine Feinde.",
+          "ru": "При дворе короля Лира рассказывают: Как нищий, я невидим для врагов."
         }
       ],
       "word_family": [
@@ -4728,8 +4728,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt der Beweis noch bedrückender.",
-          "ru": "Во время бури само «доказательство» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt der Beweis noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «доказательство» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -4760,16 +4760,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt der Blitz ein ständiges Thema.",
-          "ru": "Для придворных «молния» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt der Blitz ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «молния» — постоянная тема."
         },
         {
-          "de": "Die Blitze sollen meine weißen Haare verbrennen!",
-          "ru": "Пусть молнии сожгут мои седые волосы!"
+          "de": "Am Hof von König Lear erzählt man: Die Blitze sollen meine weißen Haare verbrennen!",
+          "ru": "При дворе короля Лира рассказывают: Пусть молнии сожгут мои седые волосы!"
         },
         {
-          "de": "Die Blitze erhellen unser Elend.",
-          "ru": "Молнии освещают нашу нищету."
+          "de": "Am Hof von König Lear erzählt man: Die Blitze erhellen unser Elend.",
+          "ru": "При дворе короля Лира рассказывают: Молнии освещают нашу нищету."
         }
       ],
       "word_family": [
@@ -4802,12 +4802,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn der Bote zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «посланник» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn der Bote zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «посланник» звучит слишком близко."
         },
         {
-          "de": "Als Bote überbringe ich böse Nachrichten.",
-          "ru": "Как гонец я приношу дурные вести."
+          "de": "Am Hof von König Lear erzählt man: Als Bote überbringe ich böse Nachrichten.",
+          "ru": "При дворе короля Лира рассказывают: Как гонец я приношу дурные вести."
         }
       ],
       "word_family": [
@@ -4840,16 +4840,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über der Brief nie.",
-          "ru": "В тронном зале постоянно звучит слово «письмо»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über der Brief nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «письмо»."
         },
         {
-          "de": "Der gefälschte Brief ist mein Beweis.",
-          "ru": "Поддельное письмо - моё доказательство."
+          "de": "Am Hof von König Lear erzählt man: Der gefälschte Brief ist mein Beweis.",
+          "ru": "При дворе короля Лира рассказывают: Поддельное письмо - моё доказательство."
         },
         {
-          "de": "Dieser Brief beweist Edgars Verrat.",
-          "ru": "Это письмо доказывает предательство Эдгара."
+          "de": "Am Hof von König Lear erzählt man: Dieser Brief beweist Edgars Verrat.",
+          "ru": "При дворе короля Лира рассказывают: Это письмо доказывает предательство Эдгара."
         }
       ],
       "word_family": [
@@ -4882,12 +4882,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald der Bruder erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «брат»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald der Bruder erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «брат»."
         },
         {
-          "de": "Mein Bruder muss für seine Verbrechen büßen.",
-          "ru": "Мой брат должен поплатиться за свои преступления."
+          "de": "Am Hof von König Lear erzählt man: Mein Bruder muss für seine Verbrechen büßen.",
+          "ru": "При дворе короля Лира рассказывают: Мой брат должен поплатиться за свои преступления."
         }
       ],
       "word_family": [
@@ -4919,8 +4919,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie der Dank verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «благодарность»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie der Dank verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «благодарность»."
         }
       ],
       "word_family": [
@@ -4951,16 +4951,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt der Diener noch bedrückender.",
-          "ru": "Во время бури само «слуга» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt der Diener noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «слуга» звучит ещё тяжелее."
         },
         {
-          "de": "Als Diener gehorche ich meiner Herrin blind.",
-          "ru": "Как слуга я слепо подчиняюсь своей госпоже."
+          "de": "Am Hof von König Lear erzählt man: Als Diener gehorche ich meiner Herrin blind.",
+          "ru": "При дворе короля Лира рассказывают: Как слуга я слепо подчиняюсь своей госпоже."
         },
         {
-          "de": "Als treuer Diener spreche ich offen.",
-          "ru": "Как верный слуга, я говорю открыто."
+          "de": "Am Hof von König Lear erzählt man: Als treuer Diener spreche ich offen.",
+          "ru": "При дворе короля Лира рассказывают: Как верный слуга, я говорю открыто."
         }
       ],
       "word_family": [
@@ -4995,8 +4995,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Dienst geht über die Verbannung hinaus.",
-          "ru": "Моя служба идёт дальше изгнания."
+          "de": "Am Hof von König Lear erzählt man: Mein Dienst geht über die Verbannung hinaus.",
+          "ru": "При дворе короля Лира рассказывают: Моя служба идёт дальше изгнания."
         }
       ],
       "word_family": [
@@ -5026,16 +5026,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt der Donner ein ständiges Thema.",
-          "ru": "Для придворных «гром» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt der Donner ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «гром» — постоянная тема."
         },
         {
-          "de": "Der Donner ist die Stimme der Götter!",
-          "ru": "Гром - это голос богов!"
+          "de": "Am Hof von König Lear erzählt man: Der Donner ist die Stimme der Götter!",
+          "ru": "При дворе короля Лира рассказывают: Гром - это голос богов!"
         },
         {
-          "de": "Der Donner übertönt unsere Schreie.",
-          "ru": "Гром заглушает наши крики."
+          "de": "Am Hof von König Lear erzählt man: Der Donner übertönt unsere Schreie.",
+          "ru": "При дворе короля Лира рассказывают: Гром заглушает наши крики."
         }
       ],
       "word_family": [
@@ -5068,8 +5068,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn der Dummkopf zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «дурак» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn der Dummkopf zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «дурак» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -5102,8 +5102,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Ehrgeiz kennt keine Grenzen mehr.",
-          "ru": "Моё честолюбие не знает больше границ."
+          "de": "Am Hof von König Lear erzählt man: Mein Ehrgeiz kennt keine Grenzen mehr.",
+          "ru": "При дворе короля Лира рассказывают: Моё честолюбие не знает больше границ."
         }
       ],
       "word_family": [
@@ -5133,12 +5133,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über der Erbe nie.",
-          "ru": "В тронном зале постоянно звучит слово «наследник»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über der Erbe nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «наследник»."
         },
         {
-          "de": "Als rechtmäßiger Erbe habe ich Pflichten.",
-          "ru": "Как законный наследник, у меня есть обязанности."
+          "de": "Am Hof von König Lear erzählt man: Als rechtmäßiger Erbe habe ich Pflichten.",
+          "ru": "При дворе короля Лира рассказывают: Как законный наследник, у меня есть обязанности."
         }
       ],
       "word_family": [
@@ -5172,8 +5172,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Erfolg ist vollkommen.",
-          "ru": "Мой успех полный."
+          "de": "Am Hof von König Lear erzählt man: Mein Erfolg ist vollkommen.",
+          "ru": "При дворе короля Лира рассказывают: Мой успех полный."
         }
       ],
       "word_family": [
@@ -5203,8 +5203,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald der Feind erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «враг»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald der Feind erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «враг»."
         }
       ],
       "word_family": [
@@ -5235,12 +5235,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie der Fluch verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «проклятие»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie der Fluch verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «проклятие»."
         },
         {
-          "de": "Mein Fluch soll über dich kommen!",
-          "ru": "Моё проклятие падёт на тебя!"
+          "de": "Am Hof von König Lear erzählt man: Mein Fluch soll über dich kommen!",
+          "ru": "При дворе короля Лира рассказывают: Моё проклятие падёт на тебя!"
         }
       ],
       "word_family": [
@@ -5272,8 +5272,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt der Freund noch bedrückender.",
-          "ru": "Во время бури само «друг» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt der Freund noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «друг» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -5306,8 +5306,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Friede soll wieder ins Land kommen.",
-          "ru": "Мир должен вернуться в страну."
+          "de": "Am Hof von König Lear erzählt man: Der Friede soll wieder ins Land kommen.",
+          "ru": "При дворе короля Лира рассказывают: Мир должен вернуться в страну."
         }
       ],
       "word_family": [
@@ -5338,8 +5338,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt der Gatte ein ständiges Thema.",
-          "ru": "Для придворных «супруг» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt der Gatte ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «супруг» — постоянная тема."
         }
       ],
       "word_family": [
@@ -5372,8 +5372,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Gehorsam kennt keine Fragen.",
-          "ru": "Моё послушание не знает вопросов."
+          "de": "Am Hof von König Lear erzählt man: Mein Gehorsam kennt keine Fragen.",
+          "ru": "При дворе короля Лира рассказывают: Моё послушание не знает вопросов."
         }
       ],
       "word_family": [
@@ -5403,8 +5403,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn der Geist zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «дух» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn der Geist zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «дух» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -5435,16 +5435,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über der Graf nie.",
-          "ru": "В тронном зале постоянно звучит слово «граф»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über der Graf nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «граф»."
         },
         {
-          "de": "Mein Vater, der Graf, ist ein edler Mann.",
-          "ru": "Мой отец, граф, благородный человек."
+          "de": "Am Hof von König Lear erzählt man: Mein Vater, der Graf, ist ein edler Mann.",
+          "ru": "При дворе короля Лира рассказывают: Мой отец, граф, благородный человек."
         },
         {
-          "de": "Als Graf habe ich große Verantwortung.",
-          "ru": "Как граф я несу большую ответственность."
+          "de": "Am Hof von König Lear erzählt man: Als Graf habe ich große Verantwortung.",
+          "ru": "При дворе короля Лира рассказывают: Как граф я несу большую ответственность."
         }
       ],
       "word_family": [
@@ -5477,8 +5477,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald der Grund erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «причина»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald der Grund erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «причина»."
         }
       ],
       "word_family": [
@@ -5509,8 +5509,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie der Hass verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «ненависть»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie der Hass verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «ненависть»."
         }
       ],
       "word_family": [
@@ -5541,8 +5541,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt der Herr noch bedrückender.",
-          "ru": "Во время бури само «господин» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt der Herr noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «господин» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -5573,8 +5573,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt der Herzog ein ständiges Thema.",
-          "ru": "Для придворных «герцог» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt der Herzog ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «герцог» — постоянная тема."
         }
       ],
       "word_family": [
@@ -5605,8 +5605,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn der Himmel zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «небо» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn der Himmel zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «небо» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -5637,8 +5637,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über der Hof nie.",
-          "ru": "В тронном зале постоянно звучит слово «двор»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über der Hof nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «двор»."
         }
       ],
       "word_family": [
@@ -5669,12 +5669,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald der Irrtum erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «ошибка»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald der Irrtum erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «ошибка»."
         },
         {
-          "de": "Mein Irrtum zerstört meine Familie.",
-          "ru": "Моё заблуждение разрушает мою семью."
+          "de": "Am Hof von König Lear erzählt man: Mein Irrtum zerstört meine Familie.",
+          "ru": "При дворе короля Лира рассказывают: Моё заблуждение разрушает мою семью."
         }
       ],
       "word_family": [
@@ -5707,20 +5707,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie der Kampf verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «борьба»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie der Kampf verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «борьба»."
         },
         {
-          "de": "Der Kampf für das Recht beginnt jetzt.",
-          "ru": "Борьба за право начинается сейчас."
+          "de": "Am Hof von König Lear erzählt man: Der Kampf für das Recht beginnt jetzt.",
+          "ru": "При дворе короля Лира рассказывают: Борьба за право начинается сейчас."
         },
         {
-          "de": "Der Kampf gegen meinen Bruder ist unvermeidlich.",
-          "ru": "Бой с моим братом неизбежен."
+          "de": "Am Hof von König Lear erzählt man: Der Kampf gegen meinen Bruder ist unvermeidlich.",
+          "ru": "При дворе короля Лира рассказывают: Бой с моим братом неизбежен."
         },
         {
-          "de": "Dieser Kampf ist für die Ehre meines Vaters.",
-          "ru": "Эта борьба за честь моего отца."
+          "de": "Am Hof von König Lear erzählt man: Dieser Kampf ist für die Ehre meines Vaters.",
+          "ru": "При дворе короля Лира рассказывают: Эта борьба за честь моего отца."
         }
       ],
       "word_family": [
@@ -5755,8 +5755,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt der Krieg ein ständiges Thema.",
-          "ru": "Для придворных «война» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt der Krieg ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «война» — постоянная тема."
         }
       ],
       "word_family": [
@@ -5787,8 +5787,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt der König noch bedrückender.",
-          "ru": "Во время бури само «король» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt der König noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «король» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -5819,16 +5819,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn der Mut zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «мужество» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn der Mut zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «мужество» звучит слишком близко."
         },
         {
-          "de": "Endlich finde ich den Mut zu widersprechen.",
-          "ru": "Наконец я нахожу мужество возражать."
+          "de": "Am Hof von König Lear erzählt man: Endlich finde ich den Mut zu widersprechen.",
+          "ru": "При дворе короля Лира рассказывают: Наконец я нахожу мужество возражать."
         },
         {
-          "de": "Der Mut fordert mich, die Wahrheit zu sagen.",
-          "ru": "Мужество требует от меня говорить правду."
+          "de": "Am Hof von König Lear erzählt man: Der Mut fordert mich, die Wahrheit zu sagen.",
+          "ru": "При дворе короля Лира рассказывают: Мужество требует от меня говорить правду."
         }
       ],
       "word_family": [
@@ -5861,16 +5861,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über der Narr nie.",
-          "ru": "В тронном зале постоянно звучит слово «шут»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über der Narr nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «шут»."
         },
         {
-          "de": "Mein Narr ist weiser als ich je war.",
-          "ru": "Мой шут мудрее, чем я когда-либо был."
+          "de": "Am Hof von König Lear erzählt man: Mein Narr ist weiser als ich je war.",
+          "ru": "При дворе короля Лира рассказывают: Мой шут мудрее, чем я когда-либо был."
         },
         {
-          "de": "Als Narr sage ich die Wahrheit durch Scherze.",
-          "ru": "Как шут я говорю правду через шутки."
+          "de": "Am Hof von König Lear erzählt man: Als Narr sage ich die Wahrheit durch Scherze.",
+          "ru": "При дворе короля Лира рассказывают: Как шут я говорю правду через шутки."
         }
       ],
       "word_family": [
@@ -5905,8 +5905,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Nebel verliere ich mich für immer.",
-          "ru": "В тумане я теряюсь навсегда."
+          "de": "Am Hof von König Lear erzählt man: Im Nebel verliere ich mich für immer.",
+          "ru": "При дворе короля Лира рассказывают: В тумане я теряюсь навсегда."
         }
       ],
       "word_family": [
@@ -5938,8 +5938,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Neid auf Edgar verzehrt mich.",
-          "ru": "Зависть к Эдгару пожирает меня."
+          "de": "Im Schatten von Gloucester spricht man über den Bastard: Der Neid auf Edgar verzehrt mich.",
+          "ru": "В тени Глостера говорят о бастарде: Зависть к Эдгару пожирает меня."
         }
       ],
       "word_family": [
@@ -5971,8 +5971,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ein Neuanfang für das Königreich beginnt.",
-          "ru": "Новое начало для королевства начинается."
+          "de": "Am Hof von König Lear erzählt man: Ein Neuanfang für das Königreich beginnt.",
+          "ru": "При дворе короля Лира рассказывают: Новое начало для королевства начинается."
         }
       ],
       "word_family": [
@@ -6008,12 +6008,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein hinterhältiger Plan wird funktionieren.",
-          "ru": "Мой коварный план сработает."
+          "de": "In Edmunds Intrigenzelt tuscheln die Verbündeten: Mein hinterhältiger Plan wird funktionieren.",
+          "ru": "В заговорщицком шатре Эдмунда перешёптываются союзники: Мой коварный план сработает."
         },
         {
-          "de": "Mein Plan wird perfekt ausgeführt.",
-          "ru": "Мой план выполняется идеально."
+          "de": "In Edmunds Intrigenzelt tuscheln die Verbündeten: Mein Plan wird perfekt ausgeführt.",
+          "ru": "В заговорщицком шатре Эдмунда перешёптываются союзники: Мой план выполняется идеально."
         }
       ],
       "word_family": [
@@ -6044,8 +6044,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald der Regen erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «дождь»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald der Regen erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «дождь»."
         }
       ],
       "word_family": [
@@ -6078,8 +6078,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Jeder Reim verbirgt eine tiefe Wahrheit.",
-          "ru": "Каждая рифма скрывает глубокую правду."
+          "de": "Am Hof von König Lear erzählt man: Jeder Reim verbirgt eine tiefe Wahrheit.",
+          "ru": "При дворе короля Лира рассказывают: Каждая рифма скрывает глубокую правду."
         }
       ],
       "word_family": [
@@ -6109,8 +6109,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie der Ritter verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «рыцарь»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie der Ritter verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «рыцарь»."
         }
       ],
       "word_family": [
@@ -6145,12 +6145,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Sadismus findet Befriedigung.",
-          "ru": "Мой садизм находит удовлетворение."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Mein Sadismus findet Befriedigung.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Мой садизм находит удовлетворение."
         },
         {
-          "de": "Mein Sadismus kennt keine Grenzen.",
-          "ru": "Мой садизм не знает границ."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Mein Sadismus kennt keine Grenzen.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Мой садизм не знает границ."
         }
       ],
       "word_family": [
@@ -6183,8 +6183,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Jeder Scherz enthält eine bittere Lehre.",
-          "ru": "Каждая шутка содержит горький урок."
+          "de": "Am Hof von König Lear erzählt man: Jeder Scherz enthält eine bittere Lehre.",
+          "ru": "При дворе короля Лира рассказывают: Каждая шутка содержит горький урок."
         }
       ],
       "word_family": [
@@ -6214,16 +6214,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt der Schmerz noch bedrückender.",
-          "ru": "Во время бури само «боль» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt der Schmerz noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «боль» звучит ещё тяжелее."
         },
         {
-          "de": "Der Schmerz durchbohrt meinen Körper.",
-          "ru": "Боль пронзает моё тело."
+          "de": "Am Hof von König Lear erzählt man: Der Schmerz durchbohrt meinen Körper.",
+          "ru": "При дворе короля Лира рассказывают: Боль пронзает моё тело."
         },
         {
-          "de": "Der Schmerz durchbohrt meine Seele.",
-          "ru": "Боль пронзает мою душу."
+          "de": "Am Hof von König Lear erzählt man: Der Schmerz durchbohrt meine Seele.",
+          "ru": "При дворе короля Лира рассказывают: Боль пронзает мою душу."
         }
       ],
       "word_family": [
@@ -6258,8 +6258,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich biete Schutz, ohne erkannt zu werden.",
-          "ru": "Я предоставляю защиту, не будучи узнанным."
+          "de": "Am Hof von König Lear erzählt man: Ich biete Schutz, ohne erkannt zu werden.",
+          "ru": "При дворе короля Лира рассказывают: Я предоставляю защиту, не будучи узнанным."
         }
       ],
       "word_family": [
@@ -6291,8 +6291,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Sieg über Edgar ist süß.",
-          "ru": "Победа над Эдгаром сладка."
+          "de": "Am Hof von König Lear erzählt man: Der Sieg über Edgar ist süß.",
+          "ru": "При дворе короля Лира рассказывают: Победа над Эдгаром сладка."
         }
       ],
       "word_family": [
@@ -6324,8 +6324,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Sinn des Lebens ist ein schlechter Witz.",
-          "ru": "Смысл жизни - плохая шутка."
+          "de": "Am Hof von König Lear erzählt man: Der Sinn des Lebens ist ein schlechter Witz.",
+          "ru": "При дворе короля Лира рассказывают: Смысл жизни - плохая шутка."
         }
       ],
       "word_family": [
@@ -6355,8 +6355,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt der Sohn ein ständiges Thema.",
-          "ru": "Для придворных «сын» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt der Sohn ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «сын» — постоянная тема."
         }
       ],
       "word_family": [
@@ -6389,8 +6389,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Spaß ist meine Maske vor der Welt.",
-          "ru": "Забава - моя маска перед миром."
+          "de": "Neben dem Narren, der Lear begleitet, singen wir: Der Spaß ist meine Maske vor der Welt.",
+          "ru": "Рядом с шутом, что сопровождает Лира, мы поём: Забава - моя маска перед миром."
         }
       ],
       "word_family": [
@@ -6420,8 +6420,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn der Spiegel zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «зеркало» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn der Spiegel zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «зеркало» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -6454,8 +6454,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Als Spion lausche ich an jeder Tür.",
-          "ru": "Как шпион я подслушиваю у каждой двери."
+          "de": "Am Hof von König Lear erzählt man: Als Spion lausche ich an jeder Tür.",
+          "ru": "При дворе короля Лира рассказывают: Как шпион я подслушиваю у каждой двери."
         }
       ],
       "word_family": [
@@ -6485,8 +6485,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über der Spott nie.",
-          "ru": "В тронном зале постоянно звучит слово «насмешка»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über der Spott nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «насмешка»."
         }
       ],
       "word_family": [
@@ -6519,8 +6519,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Stock sitze ich die ganze Nacht.",
-          "ru": "В колодке я сижу всю ночь."
+          "de": "Am Hof von König Lear erzählt man: Im Stock sitze ich die ganze Nacht.",
+          "ru": "При дворе короля Лира рассказывают: В колодке я сижу всю ночь."
         }
       ],
       "word_family": [
@@ -6550,8 +6550,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald der Stolz erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «гордость»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald der Stolz erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «гордость»."
         }
       ],
       "word_family": [
@@ -6584,8 +6584,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Streit mit meiner Frau eskaliert.",
-          "ru": "Спор с моей женой обостряется."
+          "de": "Am Hof von König Lear erzählt man: Der Streit mit meiner Frau eskaliert.",
+          "ru": "При дворе короля Лира рассказывают: Спор с моей женой обостряется."
         }
       ],
       "word_family": [
@@ -6615,24 +6615,24 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie der Sturm verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «буря»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie der Sturm verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «буря»."
         },
         {
-          "de": "Der Sturm in meinem Kopf ist schlimmer als draußen!",
-          "ru": "Буря в моей голове хуже, чем снаружи!"
+          "de": "Am Hof von König Lear erzählt man: Der Sturm in meinem Kopf ist schlimmer als draußen!",
+          "ru": "При дворе короля Лира рассказывают: Буря в моей голове хуже, чем снаружи!"
         },
         {
-          "de": "Der Sturm tobt über unseren Köpfen.",
-          "ru": "Буря бушует над нашими головами."
+          "de": "Am Hof von König Lear erzählt man: Der Sturm tobt über unseren Köpfen.",
+          "ru": "При дворе короля Лира рассказывают: Буря бушует над нашими головами."
         },
         {
-          "de": "Im Sturm bleibe ich bei meinem König.",
-          "ru": "В буре я остаюсь с моим королём."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm bleibe ich bei meinem König.",
+          "ru": "При дворе короля Лира рассказывают: В буре я остаюсь с моим королём."
         },
         {
-          "de": "Der Sturm soll sein neues Zuhause sein.",
-          "ru": "Буря пусть будет его новым домом."
+          "de": "Am Hof von König Lear erzählt man: Der Sturm soll sein neues Zuhause sein.",
+          "ru": "При дворе короля Лира рассказывают: Буря пусть будет его новым домом."
         }
       ],
       "word_family": [
@@ -6667,16 +6667,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt der Thron noch bedrückender.",
-          "ru": "Во время бури само «трон» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt der Thron noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «трон» звучит ещё тяжелее."
         },
         {
-          "de": "Vom Thron herab verkünde ich meinen Willen.",
-          "ru": "С трона я провозглашаю свою волю."
+          "de": "Am Hof von König Lear erzählt man: Vom Thron herab verkünde ich meinen Willen.",
+          "ru": "При дворе короля Лира рассказывают: С трона я провозглашаю свою волю."
         },
         {
-          "de": "Der Thron meines Vaters wird bald leer sein.",
-          "ru": "Трон моего отца скоро опустеет."
+          "de": "Am Hof von König Lear erzählt man: Der Thron meines Vaters wird bald leer sein.",
+          "ru": "При дворе короля Лира рассказывают: Трон моего отца скоро опустеет."
         }
       ],
       "word_family": [
@@ -6709,28 +6709,28 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt der Tod ein ständiges Thema.",
-          "ru": "Для придворных «смерть» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt der Tod ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «смерть» — постоянная тема."
         },
         {
-          "de": "Der Tod ereilt mich durch Эдгars Hand.",
-          "ru": "Смерть настигает меня от руки Эдгара."
+          "de": "Am Hof von König Lear erzählt man: Der Tod ereilt mich durch Эдгars Hand.",
+          "ru": "При дворе короля Лира рассказывают: Смерть настигает меня от руки Эдгара."
         },
         {
-          "de": "Der Tod ist gnädiger als das Leben ohne dich.",
-          "ru": "Смерть милосерднее жизни без тебя."
+          "de": "Am Hof von König Lear erzählt man: Der Tod ist gnädiger als das Leben ohne dich.",
+          "ru": "При дворе короля Лира рассказывают: Смерть милосерднее жизни без тебя."
         },
         {
-          "de": "Der Tod trennt uns nur für kurze Zeit.",
-          "ru": "Смерть разлучает нас лишь ненадолго."
+          "de": "Am Hof von König Lear erzählt man: Der Tod trennt uns nur für kurze Zeit.",
+          "ru": "При дворе короля Лира рассказывают: Смерть разлучает нас лишь ненадолго."
         },
         {
-          "de": "Bis zum Tod bleibe ich an seiner Seite.",
-          "ru": "До смерти я остаюсь рядом с ним."
+          "de": "Am Hof von König Lear erzählt man: Bis zum Tod bleibe ich an seiner Seite.",
+          "ru": "При дворе короля Лира рассказывают: До смерти я остаюсь рядом с ним."
         },
         {
-          "de": "Der Tod kommt für mich zu früh.",
-          "ru": "Смерть приходит ко мне слишком рано."
+          "de": "Am Hof von König Lear erzählt man: Der Tod kommt für mich zu früh.",
+          "ru": "При дворе короля Лира рассказывают: Смерть приходит ко мне слишком рано."
         }
       ],
       "word_family": [
@@ -6768,8 +6768,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mit Liedern bringe ich kleinen Trost.",
-          "ru": "Песнями я приношу малое утешение."
+          "de": "Am Hof von König Lear erzählt man: Mit Liedern bringe ich kleinen Trost.",
+          "ru": "При дворе короля Лира рассказывают: Песнями я приношу малое утешение."
         }
       ],
       "word_family": [
@@ -6799,8 +6799,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn der Träumer zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «мечтатель» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn der Träumer zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «мечтатель» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -6833,8 +6833,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Untergang ist gerecht.",
-          "ru": "Моё падение справедливо."
+          "de": "Vor dem Duell zwischen Edgar und Edmund erinnert man sich: Mein Untergang ist gerecht.",
+          "ru": "Перед дуэлью Эдгара и Эдмунда вспоминают: Моё падение справедливо."
         }
       ],
       "word_family": [
@@ -6864,8 +6864,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über der Vater nie.",
-          "ru": "В тронном зале постоянно звучит слово «отец»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über der Vater nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «отец»."
         }
       ],
       "word_family": [
@@ -6896,20 +6896,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald der Verrat erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «предательство»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald der Verrat erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «предательство»."
         },
         {
-          "de": "Der Verrat ist mein tägliches Geschäft.",
-          "ru": "Предательство - моё ежедневное дело."
+          "de": "Am Hof von König Lear erzählt man: Der Verrat ist mein tägliches Geschäft.",
+          "ru": "При дворе короля Лира рассказывают: Предательство - моё ежедневное дело."
         },
         {
-          "de": "Der Verrat meines Bruders zerstört mein Leben.",
-          "ru": "Предательство моего брата разрушает мою жизнь."
+          "de": "Am Hof von König Lear erzählt man: Der Verrat meines Bruders zerstört mein Leben.",
+          "ru": "При дворе короля Лира рассказывают: Предательство моего брата разрушает мою жизнь."
         },
         {
-          "de": "Meine Hilfe gilt als Verrat.",
-          "ru": "Моя помощь считается изменой."
+          "de": "Am Hof von König Lear erzählt man: Meine Hilfe gilt als Verrat.",
+          "ru": "При дворе короля Лира рассказывают: Моя помощь считается изменой."
         }
       ],
       "word_family": [
@@ -6946,8 +6946,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Als Verwalter kontrolliere ich den Haushalt.",
-          "ru": "Как управляющий я контролирую дом."
+          "de": "Am Hof von König Lear erzählt man: Als Verwalter kontrolliere ich den Haushalt.",
+          "ru": "При дворе короля Лира рассказывают: Как управляющий я контролирую дом."
         }
       ],
       "word_family": [
@@ -6977,20 +6977,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt der Wahnsinn noch bedrückender.",
-          "ru": "Во время бури само «безумие» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt der Wahnsinn noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «безумие» звучит ещё тяжелее."
         },
         {
-          "de": "Der Wahnsinn ist gnädiger als die Vernunft!",
-          "ru": "Безумие милосерднее разума!"
+          "de": "Am Hof von König Lear erzählt man: Der Wahnsinn ist gnädiger als die Vernunft!",
+          "ru": "При дворе короля Лира рассказывают: Безумие милосерднее разума!"
         },
         {
-          "de": "Ich spiele den Wahnsinn, um zu überleben.",
-          "ru": "Я играю безумие, чтобы выжить."
+          "de": "Am Hof von König Lear erzählt man: Ich spiele den Wahnsinn, um zu überleben.",
+          "ru": "При дворе короля Лира рассказывают: Я играю безумие, чтобы выжить."
         },
         {
-          "de": "Im Wahnsinn finden wir uns als Brüder.",
-          "ru": "В безумии мы находим друг друга как братья."
+          "de": "Am Hof von König Lear erzählt man: Im Wahnsinn finden wir uns als Brüder.",
+          "ru": "При дворе короля Лира рассказывают: В безумии мы находим друг друга как братья."
         }
       ],
       "word_family": [
@@ -7024,8 +7024,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie der Wald verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «лес»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie der Wald verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «лес»."
         }
       ],
       "word_family": [
@@ -7058,8 +7058,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Widerstand gegen das Böse beginnt.",
-          "ru": "Моё сопротивление злу начинается."
+          "de": "Am Hof von König Lear erzählt man: Mein Widerstand gegen das Böse beginnt.",
+          "ru": "При дворе короля Лира рассказывают: Моё сопротивление злу начинается."
         }
       ],
       "word_family": [
@@ -7089,8 +7089,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt der Wind ein ständiges Thema.",
-          "ru": "Для придворных «ветер» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt der Wind ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «ветер» — постоянная тема."
         }
       ],
       "word_family": [
@@ -7123,8 +7123,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Witz ist scharf wie ein Schwert.",
-          "ru": "Моё остроумие остро как меч."
+          "de": "Neben dem Narren, der Lear begleitet, singen wir: Mein Witz ist scharf wie ein Schwert.",
+          "ru": "Рядом с шутом, что сопровождает Лира, мы поём: Моё остроумие остро как меч."
         }
       ],
       "word_family": [
@@ -7154,24 +7154,24 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn der Zorn zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «гнев» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn der Zorn zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «гнев» звучит слишком близко."
         },
         {
-          "de": "Mein Zorn brennt wie Feuer in meiner Brust!",
-          "ru": "Мой гнев горит как огонь в моей груди!"
+          "de": "Am Hof von König Lear erzählt man: Mein Zorn brennt wie Feuer in meiner Brust!",
+          "ru": "При дворе короля Лира рассказывают: Мой гнев горит как огонь в моей груди!"
         },
         {
-          "de": "Sein Zorn ist grenzenlos und blind.",
-          "ru": "Его гнев безграничен и слеп."
+          "de": "Am Hof von König Lear erzählt man: Sein Zorn ist grenzenlos und blind.",
+          "ru": "При дворе короля Лира рассказывают: Его гнев безграничен и слеп."
         },
         {
-          "de": "Der Zorn des Königs trifft mich ungerecht.",
-          "ru": "Гнев короля поражает меня несправедливо."
+          "de": "Am Hof von König Lear erzählt man: Der Zorn des Königs trifft mich ungerecht.",
+          "ru": "При дворе короля Лира рассказывают: Гнев короля поражает меня несправедливо."
         },
         {
-          "de": "Mein Zorn kennt keine Barmherzigkeit.",
-          "ru": "Мой гнев не знает милосердия."
+          "de": "Am Hof von König Lear erzählt man: Mein Zorn kennt keine Barmherzigkeit.",
+          "ru": "При дворе короля Лира рассказывают: Мой гнев не знает милосердия."
         }
       ],
       "word_family": [
@@ -7208,8 +7208,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Zweifel an ihrer Güte wächst in mir.",
-          "ru": "Сомнение в её доброте растёт во мне."
+          "de": "Am Hof von König Lear erzählt man: Der Zweifel an ihrer Güte wächst in mir.",
+          "ru": "При дворе короля Лира рассказывают: Сомнение в её доброте растёт во мне."
         }
       ],
       "word_family": [
@@ -7241,8 +7241,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Zeichen deute ich besser als alle.",
-          "ru": "Знаки я толкую лучше всех."
+          "de": "Am Hof von König Lear erzählt man: Die Zeichen deute ich besser als alle.",
+          "ru": "При дворе короля Лира рассказывают: Знаки я толкую лучше всех."
         }
       ],
       "word_family": [
@@ -7274,8 +7274,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Unsere Absprache ist perfekt.",
-          "ru": "Наш сговор совершенен."
+          "de": "Am Hof von König Lear erzählt man: Unsere Absprache ist perfekt.",
+          "ru": "При дворе короля Лира рассказывают: Наш сговор совершенен."
         }
       ],
       "word_family": [
@@ -7307,8 +7307,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Diese Affäre wird tödlich enden.",
-          "ru": "Эта интрига закончится смертью."
+          "de": "Im Streitlager der Schwestern um Edmund zischt man: Diese Affäre wird tödlich enden.",
+          "ru": "В спорщем лагере сестёр из-за Эдмунда шипят: Эта интрига закончится смертью."
         }
       ],
       "word_family": [
@@ -7341,8 +7341,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Unsere Allianz wird alle Feinde vernichten.",
-          "ru": "Наш альянс уничтожит всех врагов."
+          "de": "Am Hof von König Lear erzählt man: Unsere Allianz wird alle Feinde vernichten.",
+          "ru": "При дворе короля Лира рассказывают: Наш альянс уничтожит всех врагов."
         }
       ],
       "word_family": [
@@ -7374,8 +7374,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Ambition kennt keine Grenzen.",
-          "ru": "Моя амбиция не знает границ."
+          "de": "Im Schatten von Gloucester spricht man über den Bastard: Meine Ambition kennt keine Grenzen.",
+          "ru": "В тени Глостера говорят о бастарде: Моя амбиция не знает границ."
         }
       ],
       "word_family": [
@@ -7405,12 +7405,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Angst nie.",
-          "ru": "В тронном зале постоянно звучит слово «страх»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Angst nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «страх»."
         },
         {
-          "de": "Die Angst um meinen Vater wächst täglich.",
-          "ru": "Страх за отца растёт с каждым днём."
+          "de": "Am Hof von König Lear erzählt man: Die Angst um meinen Vater wächst täglich.",
+          "ru": "При дворе короля Лира рассказывают: Страх за отца растёт с каждым днём."
         }
       ],
       "word_family": [
@@ -7443,8 +7443,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Antwort erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «ответ»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Antwort erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «ответ»."
         }
       ],
       "word_family": [
@@ -7477,8 +7477,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Diese Armee kämpft für Gerechtigkeit und Liebe.",
-          "ru": "Эта армия сражается за справедливость и любовь."
+          "de": "Am Hof von König Lear erzählt man: Diese Armee kämpft für Gerechtigkeit und Liebe.",
+          "ru": "При дворе короля Лира рассказывают: Эта армия сражается за справедливость и любовь."
         }
       ],
       "word_family": [
@@ -7508,8 +7508,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Aufgabe verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «задача»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Aufgabe verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «задача»."
         }
       ],
       "word_family": [
@@ -7540,8 +7540,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Bedrohung noch bedrückender.",
-          "ru": "Во время бури само «угроза» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Bedrohung noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «угроза» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -7574,8 +7574,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Begierde brennt wie Feuer.",
-          "ru": "Моё вожделение горит как огонь."
+          "de": "Am Hof von König Lear erzählt man: Meine Begierde brennt wie Feuer.",
+          "ru": "При дворе короля Лира рассказывают: Моё вожделение горит как огонь."
         }
       ],
       "word_family": [
@@ -7607,8 +7607,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Jede Beleidigung spreche ich mit Genuss aus.",
-          "ru": "Каждое оскорбление я произношу с наслаждением."
+          "de": "Am Hof von König Lear erzählt man: Jede Beleidigung spreche ich mit Genuss aus.",
+          "ru": "При дворе короля Лира рассказывают: Каждое оскорбление я произношу с наслаждением."
         }
       ],
       "word_family": [
@@ -7640,8 +7640,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Belohnung für meine Intrige ist groß.",
-          "ru": "Награда за мою интригу велика."
+          "de": "Am Hof von König Lear erzählt man: Die Belohnung für meine Intrige ist groß.",
+          "ru": "При дворе короля Лира рассказывают: Награда за мою интригу велика."
         }
       ],
       "word_family": [
@@ -7673,8 +7673,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Graf ist meine leichte Beute.",
-          "ru": "Граф - моя лёгкая добыча."
+          "de": "Am Hof von König Lear erzählt man: Der Graf ist meine leichte Beute.",
+          "ru": "При дворе короля Лира рассказывают: Граф - моя лёгкая добыча."
         }
       ],
       "word_family": [
@@ -7709,12 +7709,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Bosheit kennt kein Erbarmen.",
-          "ru": "Моя злоба не знает милосердия."
+          "de": "Am Hof von König Lear erzählt man: Meine Bosheit kennt kein Erbarmen.",
+          "ru": "При дворе короля Лира рассказывают: Моя злоба не знает милосердия."
         },
         {
-          "de": "Unsere Bosheit macht uns zum perfekten Paar.",
-          "ru": "Наша злоба делает нас идеальной парой."
+          "de": "Am Hof von König Lear erzählt man: Unsere Bosheit macht uns zum perfekten Paar.",
+          "ru": "При дворе короля Лира рассказывают: Наша злоба делает нас идеальной парой."
         }
       ],
       "word_family": [
@@ -7747,8 +7747,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Botschaft meiner Herrin ist grausam.",
-          "ru": "Послание моей госпожи жестоко."
+          "de": "Am Hof von König Lear erzählt man: Die Botschaft meiner Herrin ist grausam.",
+          "ru": "При дворе короля Лира рассказывают: Послание моей госпожи жестоко."
         }
       ],
       "word_family": [
@@ -7780,8 +7780,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Brutalität erschreckt sogar Cornwall.",
-          "ru": "Моя брутальность пугает даже Корнуолла."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Meine Brutalität erschreckt sogar Cornwall.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Моя брутальность пугает даже Корнуолла."
         }
       ],
       "word_family": [
@@ -7811,8 +7811,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Burg ein ständiges Thema.",
-          "ru": "Для придворных «крепость» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Burg ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «крепость» — постоянная тема."
         }
       ],
       "word_family": [
@@ -7845,8 +7845,8 @@
       ],
       "example_sentences": [
         {
-          "de": "In der Demut finden wir wahre Größe.",
-          "ru": "В смирении мы находим истинное величие."
+          "de": "Am Hof von König Lear erzählt man: In der Demut finden wir wahre Größe.",
+          "ru": "При дворе короля Лира рассказывают: В смирении мы находим истинное величие."
         }
       ],
       "word_family": [
@@ -7878,8 +7878,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Demütigung macht mich nur stärker.",
-          "ru": "Унижение делает меня только сильнее."
+          "de": "Am Hof von König Lear erzählt man: Die Demütigung macht mich nur stärker.",
+          "ru": "При дворе короля Лира рассказывают: Унижение делает меня только сильнее."
         }
       ],
       "word_family": [
@@ -7909,12 +7909,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Dunkelheit zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «темнота» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Dunkelheit zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «темнота» звучит слишком близко."
         },
         {
-          "de": "Ewige Dunkelheit umgibt mich nun.",
-          "ru": "Вечная темнота окружает меня теперь."
+          "de": "Am Hof von König Lear erzählt man: Ewige Dunkelheit umgibt mich nun.",
+          "ru": "При дворе короля Лира рассказывают: Вечная темнота окружает меня теперь."
         }
       ],
       "word_family": [
@@ -7948,8 +7948,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Ehe bindet mich an eine grausame Frau.",
-          "ru": "Брак связывает меня с жестокой женой."
+          "de": "Am Hof von König Lear erzählt man: Die Ehe bindet mich an eine grausame Frau.",
+          "ru": "При дворе короля Лира рассказывают: Брак связывает меня с жестокой женой."
         }
       ],
       "word_family": [
@@ -7979,20 +7979,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Ehre nie.",
-          "ru": "В тронном зале постоянно звучит слово «честь»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Ehre nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «честь»."
         },
         {
-          "de": "Die Ehre der Familie liegt in meinen Händen.",
-          "ru": "Честь семьи в моих руках."
+          "de": "Am Hof von König Lear erzählt man: Die Ehre der Familie liegt in meinen Händen.",
+          "ru": "При дворе короля Лира рассказывают: Честь семьи в моих руках."
         },
         {
-          "de": "Unsere Ehre bleibt unbefleckt.",
-          "ru": "Наша честь остаётся незапятнанной."
+          "de": "Am Hof von König Lear erzählt man: Unsere Ehre bleibt unbefleckt.",
+          "ru": "При дворе короля Лира рассказывают: Наша честь остаётся незапятнанной."
         },
         {
-          "de": "Meine Ehre ist mein höchstes Gut.",
-          "ru": "Моя честь - моё высшее благо."
+          "de": "Am Hof von König Lear erzählt man: Meine Ehre ist mein höchstes Gut.",
+          "ru": "При дворе короля Лира рассказывают: Моя честь - моё высшее благо."
         }
       ],
       "word_family": [
@@ -8026,12 +8026,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Eifersucht erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «ревность»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Eifersucht erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «ревность»."
         },
         {
-          "de": "Die Eifersucht verzehrt mich von innen.",
-          "ru": "Ревность пожирает меня изнутри."
+          "de": "Am Hof von König Lear erzählt man: Die Eifersucht verzehrt mich von innen.",
+          "ru": "При дворе короля Лира рассказывают: Ревность пожирает меня изнутри."
         }
       ],
       "word_family": [
@@ -8065,8 +8065,8 @@
       ],
       "example_sentences": [
         {
-          "de": "In großer Eile renne ich hin und her.",
-          "ru": "В большой спешке я бегаю туда-сюда."
+          "de": "Am Hof von König Lear erzählt man: In großer Eile renne ich hin und her.",
+          "ru": "При дворе короля Лира рассказывают: В большой спешке я бегаю туда-сюда."
         }
       ],
       "word_family": [
@@ -8096,16 +8096,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Einsamkeit verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «одиночество»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Einsamkeit verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «одиночество»."
         },
         {
-          "de": "Die Einsamkeit umgibt mich wie ein kalter Mantel.",
-          "ru": "Одиночество окружает меня как холодный плащ."
+          "de": "Am Hof von König Lear erzählt man: Die Einsamkeit umgibt mich wie ein kalter Mantel.",
+          "ru": "При дворе короля Лира рассказывают: Одиночество окружает меня как холодный плащ."
         },
         {
-          "de": "In der Einsamkeit denke ich an ihn.",
-          "ru": "В одиночестве я думаю о нём."
+          "de": "Am Hof von König Lear erzählt man: In der Einsamkeit denke ich an ihn.",
+          "ru": "При дворе короля Лира рассказывают: В одиночестве я думаю о нём."
         }
       ],
       "word_family": [
@@ -8140,8 +8140,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Einsicht verbrennt meine Seele.",
-          "ru": "Прозрение сжигает мою душу."
+          "de": "Am Hof von König Lear erzählt man: Die Einsicht verbrennt meine Seele.",
+          "ru": "При дворе короля Лира рассказывают: Прозрение сжигает мою душу."
         }
       ],
       "word_family": [
@@ -8171,12 +8171,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Entscheidung noch bedrückender.",
-          "ru": "Во время бури само «решение» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Entscheidung noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «решение» звучит ещё тяжелее."
         },
         {
-          "de": "Meine Entscheidung steht fest: ich wähle das Gute.",
-          "ru": "Моё решение твёрдо: я выбираю добро."
+          "de": "Am Hof von König Lear erzählt man: Meine Entscheidung steht fest: ich wähle das Gute.",
+          "ru": "При дворе короля Лира рассказывают: Моё решение твёрдо: я выбираю добро."
         }
       ],
       "word_family": [
@@ -8208,8 +8208,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Erde ein ständiges Thema.",
-          "ru": "Для придворных «земля» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Erde ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «земля» — постоянная тема."
         }
       ],
       "word_family": [
@@ -8242,8 +8242,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Ergebenheit gilt nur Lady Goneril.",
-          "ru": "Моя преданность принадлежит только леди Гонерилье."
+          "de": "Am Hof von König Lear erzählt man: Meine Ergebenheit gilt nur Lady Goneril.",
+          "ru": "При дворе короля Лира рассказывают: Моя преданность принадлежит только леди Гонерилье."
         }
       ],
       "word_family": [
@@ -8273,8 +8273,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Erinnerung nie.",
-          "ru": "В тронном зале постоянно звучит слово «воспоминание»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Erinnerung nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «воспоминание»."
         }
       ],
       "word_family": [
@@ -8305,20 +8305,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Erkenntnis zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «познание» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Erkenntnis zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «познание» звучит слишком близко."
         },
         {
-          "de": "Die Erkenntnis ihrer Bosheit erschüttert mich.",
-          "ru": "Осознание её злобы потрясает меня."
+          "de": "Am Hof von König Lear erzählt man: Die Erkenntnis ihrer Bosheit erschüttert mich.",
+          "ru": "При дворе короля Лира рассказывают: Осознание её злобы потрясает меня."
         },
         {
-          "de": "Die Erkenntnis kommt durch Schmerz und Verlust.",
-          "ru": "Познание приходит через боль и утрату."
+          "de": "Am Hof von König Lear erzählt man: Die Erkenntnis kommt durch Schmerz und Verlust.",
+          "ru": "При дворе короля Лира рассказывают: Познание приходит через боль и утрату."
         },
         {
-          "de": "Die späte Erkenntnis bricht mein Herz.",
-          "ru": "Позднее осознание разбивает моё сердце."
+          "de": "Am Hof von König Lear erzählt man: Die späte Erkenntnis bricht mein Herz.",
+          "ru": "При дворе короля Лира рассказывают: Позднее осознание разбивает моё сердце."
         }
       ],
       "word_family": [
@@ -8353,12 +8353,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Erlösung erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «спасение»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Erlösung erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «спасение»."
         },
         {
-          "de": "Im Tod finde ich Erlösung und Frieden.",
-          "ru": "В смерти я нахожу спасение и покой."
+          "de": "Am Hof von König Lear erzählt man: Im Tod finde ich Erlösung und Frieden.",
+          "ru": "При дворе короля Лира рассказывают: В смерти я нахожу спасение и покой."
         }
       ],
       "word_family": [
@@ -8392,8 +8392,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Eroberung des Throns ist mein Ziel.",
-          "ru": "Завоевание трона - моя цель."
+          "de": "Am Hof von König Lear erzählt man: Die Eroberung des Throns ist mein Ziel.",
+          "ru": "При дворе короля Лира рассказывают: Завоевание трона - моя цель."
         }
       ],
       "word_family": [
@@ -8425,8 +8425,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Erschöpfung überwältigt meinen alten Körper.",
-          "ru": "Истощение одолевает моё старое тело."
+          "de": "Am Hof von König Lear erzählt man: Die Erschöpfung überwältigt meinen alten Körper.",
+          "ru": "При дворе короля Лира рассказывают: Истощение одолевает моё старое тело."
         }
       ],
       "word_family": [
@@ -8456,8 +8456,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Ewigkeit verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «вечность»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Ewigkeit verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «вечность»."
         }
       ],
       "word_family": [
@@ -8493,12 +8493,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich stelle Fallen für die Ahnungslosen.",
-          "ru": "Я ставлю ловушки для ничего не подозревающих."
+          "de": "Seit Edmund den falschen Brief schrieb, raunen die Diener: Ich stelle Fallen für die Ahnungslosen.",
+          "ru": "С тех пор как Эдмунд написал фальшивое письмо, слуги шепчутся: Я ставлю ловушки для ничего не подозревающих."
         },
         {
-          "de": "Ich tappe blind in Edmunds Falle.",
-          "ru": "Я слепо попадаю в ловушку Эдмунда."
+          "de": "Seit Edmund den falschen Brief schrieb, raunen die Diener: Ich tappe blind in Edmunds Falle.",
+          "ru": "С тех пор как Эдмунд написал фальшивое письмо, слуги шепчутся: Я слепо попадаю в ловушку Эдмунда."
         }
       ],
       "word_family": [
@@ -8531,8 +8531,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Falschheit kennt keine Grenzen.",
-          "ru": "Моя фальшь не знает границ."
+          "de": "Am Hof von König Lear erzählt man: Meine Falschheit kennt keine Grenzen.",
+          "ru": "При дворе короля Лира рассказывают: Моя фальшь не знает границ."
         }
       ],
       "word_family": [
@@ -8562,8 +8562,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Familie noch bedrückender.",
-          "ru": "Во время бури само «семья» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Familie noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «семья» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -8598,12 +8598,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Aus Feigheit greife ich nur Schwache an.",
-          "ru": "Из трусости я нападаю только на слабых."
+          "de": "Am Hof von König Lear erzählt man: Aus Feigheit greife ich nur Schwache an.",
+          "ru": "При дворе короля Лира рассказывают: Из трусости я нападаю только на слабых."
         },
         {
-          "de": "Meine Feigheit führt zu meinem Ende.",
-          "ru": "Моя трусость приводит к моему концу."
+          "de": "Am Hof von König Lear erzählt man: Meine Feigheit führt zu meinem Ende.",
+          "ru": "При дворе короля Лира рассказывают: Моя трусость приводит к моему концу."
         }
       ],
       "word_family": [
@@ -8634,8 +8634,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Flucht ein ständiges Thema.",
-          "ru": "Для придворных «бегство» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Flucht ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «бегство» — постоянная тема."
         }
       ],
       "word_family": [
@@ -8673,20 +8673,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Folter meines Vaters stört mich nicht.",
-          "ru": "Пытка моего отца меня не тревожит."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Die Folter meines Vaters stört mich nicht.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Пытка моего отца меня не тревожит."
         },
         {
-          "de": "Die Folter ist meine Unterhaltung.",
-          "ru": "Пытка - моё развлечение."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Die Folter ist meine Unterhaltung.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Пытка - моё развлечение."
         },
         {
-          "de": "Die Folter ist mein liebstes Werkzeug.",
-          "ru": "Пытка - мой любимый инструмент."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Die Folter ist mein liebstes Werkzeug.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Пытка - мой любимый инструмент."
         },
         {
-          "de": "Die Folter ist grausam und erbarmungslos.",
-          "ru": "Пытка жестока и беспощадна."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Die Folter ist grausam und erbarmungslos.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Пытка жестока и беспощадна."
         }
       ],
       "word_family": [
@@ -8719,8 +8719,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Frage zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «вопрос» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Frage zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «вопрос» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -8751,8 +8751,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Frau nie.",
-          "ru": "В тронном зале постоянно звучит слово «женщина»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Frau nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «женщина»."
         }
       ],
       "word_family": [
@@ -8783,8 +8783,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Freiheit erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «свобода»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Freiheit erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «свобода»."
         }
       ],
       "word_family": [
@@ -8815,8 +8815,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Freude verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «радость»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Freude verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «радость»."
         }
       ],
       "word_family": [
@@ -8849,8 +8849,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Unsere Freundschaft überdauert den Sturm.",
-          "ru": "Наша дружба переживёт бурю."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Unsere Freundschaft überdauert den Sturm.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Наша дружба переживёт бурю."
         }
       ],
       "word_family": [
@@ -8882,8 +8882,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Durch Furcht halte ich alle unter Kontrolle.",
-          "ru": "Страхом я держу всех под контролем."
+          "de": "Am Hof von König Lear erzählt man: Durch Furcht halte ich alle unter Kontrolle.",
+          "ru": "При дворе короля Лира рассказывают: Страхом я держу всех под контролем."
         }
       ],
       "word_family": [
@@ -8914,8 +8914,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Gattin noch bedrückender.",
-          "ru": "Во время бури само «супруга» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Gattin noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «супруга» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -8946,20 +8946,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Gefahr ein ständiges Thema.",
-          "ru": "Для придворных «опасность» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Gefahr ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «опасность» — постоянная тема."
         },
         {
-          "de": "Die Gefahr lauert überall um mich herum.",
-          "ru": "Опасность подстерегает меня повсюду."
+          "de": "Am Hof von König Lear erzählt man: Die Gefahr lauert überall um mich herum.",
+          "ru": "При дворе короля Лира рассказывают: Опасность подстерегает меня повсюду."
         },
         {
-          "de": "Trotz Gefahr bleibe ich beim König.",
-          "ru": "Несмотря на опасность, я остаюсь с королём."
+          "de": "Am Hof von König Lear erzählt man: Trotz Gefahr bleibe ich beim König.",
+          "ru": "При дворе короля Лира рассказывают: Несмотря на опасность, я остаюсь с королём."
         },
         {
-          "de": "Die Gefahr der Entdeckung ist groß.",
-          "ru": "Опасность разоблачения велика."
+          "de": "Am Hof von König Lear erzählt man: Die Gefahr der Entdeckung ist groß.",
+          "ru": "При дворе короля Лира рассказывают: Опасность разоблачения велика."
         }
       ],
       "word_family": [
@@ -8993,20 +8993,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Gerechtigkeit zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «справедливость» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Gerechtigkeit zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «справедливость» звучит слишком близко."
         },
         {
-          "de": "Für Gerechtigkeit will ich kämpfen.",
-          "ru": "За справедливость я хочу бороться."
+          "de": "Am Hof von König Lear erzählt man: Für Gerechtigkeit will ich kämpfen.",
+          "ru": "При дворе короля Лира рассказывают: За справедливость я хочу бороться."
         },
         {
-          "de": "Die Gerechtigkeit fordert diesen Kampf.",
-          "ru": "Справедливость требует этого боя."
+          "de": "Am Hof von König Lear erzählt man: Die Gerechtigkeit fordert diesen Kampf.",
+          "ru": "При дворе короля Лира рассказывают: Справедливость требует этого боя."
         },
         {
-          "de": "Die Gerechtigkeit führt meine Klinge.",
-          "ru": "Справедливость ведёт мой клинок."
+          "de": "Am Hof von König Lear erzählt man: Die Gerechtigkeit führt meine Klinge.",
+          "ru": "При дворе короля Лира рассказывают: Справедливость ведёт мой клинок."
         }
       ],
       "word_family": [
@@ -9040,8 +9040,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Geschichte nie.",
-          "ru": "В тронном зале постоянно звучит слово «история»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Geschichte nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «история»."
         }
       ],
       "word_family": [
@@ -9072,16 +9072,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Gier erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «жадность»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Gier erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «жадность»."
         },
         {
-          "de": "Die Gier nach Macht verzehrt meine Seele.",
-          "ru": "Жадность к власти пожирает мою душу."
+          "de": "Am Hof von König Lear erzählt man: Die Gier nach Macht verzehrt meine Seele.",
+          "ru": "При дворе короля Лира рассказывают: Жадность к власти пожирает мою душу."
         },
         {
-          "de": "Die Gier nach Macht treibt mich an.",
-          "ru": "Жадность к власти движет мной."
+          "de": "Am Hof von König Lear erzählt man: Die Gier nach Macht treibt mich an.",
+          "ru": "При дворе короля Лира рассказывают: Жадность к власти движет мной."
         }
       ],
       "word_family": [
@@ -9124,20 +9124,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Ihre Grausamkeit übertrifft die ihrer Schwester!",
-          "ru": "Её жестокость превосходит жестокость сестры!"
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Ihre Grausamkeit übertrifft die ihrer Schwester!",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Её жестокость превосходит жестокость сестры!"
         },
         {
-          "de": "Meine Grausamkeit kennt keine Grenzen.",
-          "ru": "Моя жестокость не знает границ."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Meine Grausamkeit kennt keine Grenzen.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Моя жестокость не знает границ."
         },
         {
-          "de": "Meine Grausamkeit übertrifft die meiner Schwester.",
-          "ru": "Моя жестокость превосходит жестокость сестры."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Meine Grausamkeit übertrifft die meiner Schwester.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Моя жестокость превосходит жестокость сестры."
         },
         {
-          "de": "Die Grausamkeit meiner Frau gefällt mir.",
-          "ru": "Жестокость моей жены мне нравится."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Die Grausamkeit meiner Frau gefällt mir.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Жестокость моей жены мне нравится."
         }
       ],
       "word_family": [
@@ -9170,8 +9170,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Grenze verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «граница»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Grenze verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «граница»."
         }
       ],
       "word_family": [
@@ -9202,8 +9202,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Grube noch bedrückender.",
-          "ru": "Во время бури само «яма» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Grube noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «яма» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -9236,8 +9236,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mit Güte will ich das Böse besiegen.",
-          "ru": "Добротой я хочу победить зло."
+          "de": "Am Hof von König Lear erzählt man: Mit Güte will ich das Böse besiegen.",
+          "ru": "При дворе короля Лира рассказывают: Добротой я хочу победить зло."
         }
       ],
       "word_family": [
@@ -9269,8 +9269,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Habgier treibt meine süßen Worte.",
-          "ru": "Алчность движет моими сладкими словами."
+          "de": "Am Hof von König Lear erzählt man: Die Habgier treibt meine süßen Worte.",
+          "ru": "При дворе короля Лира рассказывают: Алчность движет моими сладкими словами."
         }
       ],
       "word_family": [
@@ -9300,8 +9300,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Heimat ein ständiges Thema.",
-          "ru": "Для придворных «родина» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Heimat ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «родина» — постоянная тема."
         }
       ],
       "word_family": [
@@ -9334,8 +9334,8 @@
       ],
       "example_sentences": [
         {
-          "de": "In Heimlichkeit sammle ich Informationen.",
-          "ru": "В скрытности я собираю информацию."
+          "de": "Am Hof von König Lear erzählt man: In Heimlichkeit sammle ich Informationen.",
+          "ru": "При дворе короля Лира рассказывают: В скрытности я собираю информацию."
         }
       ],
       "word_family": [
@@ -9370,12 +9370,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Herrschaft fällt nun in meine Hände.",
-          "ru": "Правление теперь переходит в мои руки."
+          "de": "Am Hof von König Lear erzählt man: Die Herrschaft fällt nun in meine Hände.",
+          "ru": "При дворе короля Лира рассказывают: Правление теперь переходит в мои руки."
         },
         {
-          "de": "Die Herrschaft über alle ist mein Ziel.",
-          "ru": "Господство над всеми - моя цель."
+          "de": "Am Hof von König Lear erzählt man: Die Herrschaft über alle ist mein Ziel.",
+          "ru": "При дворе короля Лира рассказывают: Господство над всеми - моя цель."
         }
       ],
       "word_family": [
@@ -9409,8 +9409,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Herrschsucht bestimmt all meine Taten.",
-          "ru": "Властолюбие определяет все мои поступки."
+          "de": "Am Hof von König Lear erzählt man: Die Herrschsucht bestimmt all meine Taten.",
+          "ru": "При дворе короля Лира рассказывают: Властолюбие определяет все мои поступки."
         }
       ],
       "word_family": [
@@ -9440,8 +9440,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Herzogin zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «герцогиня» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Herzogin zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «герцогиня» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -9472,8 +9472,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Heuchelei nie.",
-          "ru": "В тронном зале постоянно звучит слово «лицемерие»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Heuchelei nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «лицемерие»."
         }
       ],
       "word_family": [
@@ -9506,8 +9506,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mit Hinterlist verfolge ich meine Ziele.",
-          "ru": "С коварством я преследую свои цели."
+          "de": "In Edmunds Intrigenzelt tuscheln die Verbündeten: Mit Hinterlist verfolge ich meine Ziele.",
+          "ru": "В заговорщицком шатре Эдмунда перешёптываются союзники: С коварством я преследую свои цели."
         }
       ],
       "word_family": [
@@ -9537,12 +9537,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Hoffnung erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «надежда»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Hoffnung erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «надежда»."
         },
         {
-          "de": "Die Hoffnung auf Versöhnung stirbt nie in meinem Herzen.",
-          "ru": "Надежда на примирение никогда не умирает в моём сердце."
+          "de": "Am Hof von König Lear erzählt man: Die Hoffnung auf Versöhnung stirbt nie in meinem Herzen.",
+          "ru": "При дворе короля Лира рассказывают: Надежда на примирение никогда не умирает в моём сердце."
         }
       ],
       "word_family": [
@@ -9576,8 +9576,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Hoffnungslosigkeit erdrückt mich.",
-          "ru": "Безнадёжность давит меня."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Die Hoffnungslosigkeit erdrückt mich.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Безнадёжность давит меня."
         }
       ],
       "word_family": [
@@ -9612,12 +9612,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Mit eiserner Härte stoße ich ihn fort.",
-          "ru": "С железной жёсткостью я отталкиваю его."
+          "de": "Am Hof von König Lear erzählt man: Mit eiserner Härte stoße ich ihn fort.",
+          "ru": "При дворе короля Лира рассказывают: С железной жёсткостью я отталкиваю его."
         },
         {
-          "de": "Mit eiserner Härte regieren wir zusammen.",
-          "ru": "С железной суровостью мы правим вместе."
+          "de": "Am Hof von König Lear erzählt man: Mit eiserner Härte regieren wir zusammen.",
+          "ru": "При дворе короля Лира рассказывают: С железной суровостью мы правим вместе."
         }
       ],
       "word_family": [
@@ -9649,12 +9649,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Hölle verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «ад»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Hölle verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «ад»."
         },
         {
-          "de": "Die Hölle wartet auf meine schwarze Seele.",
-          "ru": "Ад ждёт мою чёрную душу."
+          "de": "Am Hof von König Lear erzählt man: Die Hölle wartet auf meine schwarze Seele.",
+          "ru": "При дворе короля Лира рассказывают: Ад ждёт мою чёрную душу."
         }
       ],
       "word_family": [
@@ -9691,12 +9691,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Diese Hütte ist ein Palast für die Verlassenen.",
-          "ru": "Эта хижина - дворец для покинутых."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Diese Hütte ist ein Palast für die Verlassenen.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Эта хижина - дворец для покинутых."
         },
         {
-          "de": "In dieser armseligen Hütte finden wir Zuflucht.",
-          "ru": "В этой жалкой хижине мы находим убежище."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: In dieser armseligen Hütte finden wir Zuflucht.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: В этой жалкой хижине мы находим убежище."
         }
       ],
       "word_family": [
@@ -9727,20 +9727,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Intrige noch bedrückender.",
-          "ru": "Во время бури само «интрига» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Intrige noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «интрига» звучит ещё тяжелее."
         },
         {
-          "de": "Jede Intrige spinne ich mit Freude.",
-          "ru": "Каждую интригу я плету с радостью."
+          "de": "Am Hof von König Lear erzählt man: Jede Intrige spinne ich mit Freude.",
+          "ru": "При дворе короля Лира рассказывают: Каждую интригу я плету с радостью."
         },
         {
-          "de": "Edmunds Intrige hat mich zum Geächteten gemacht.",
-          "ru": "Интрига Эдмунда сделала меня изгоем."
+          "de": "Am Hof von König Lear erzählt man: Edmunds Intrige hat mich zum Geächteten gemacht.",
+          "ru": "При дворе короля Лира рассказывают: Интрига Эдмунда сделала меня изгоем."
         },
         {
-          "de": "Meine Intrige wird sie vernichten.",
-          "ru": "Моя интрига уничтожит её."
+          "de": "Am Hof von König Lear erzählt man: Meine Intrige wird sie vernichten.",
+          "ru": "При дворе короля Лира рассказывают: Моя интрига уничтожит её."
         }
       ],
       "word_family": [
@@ -9777,8 +9777,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Ironie ist meine letzte Waffe.",
-          "ru": "Ирония - моё последнее оружие."
+          "de": "Am Hof von König Lear erzählt man: Die Ironie ist meine letzte Waffe.",
+          "ru": "При дворе короля Лира рассказывают: Ирония - моё последнее оружие."
         }
       ],
       "word_family": [
@@ -9810,8 +9810,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Jagd auf Gloucester macht mir Spaß.",
-          "ru": "Охота на Глостера доставляет мне удовольствие."
+          "de": "Am Hof von König Lear erzählt man: Die Jagd auf Gloucester macht mir Spaß.",
+          "ru": "При дворе короля Лира рассказывают: Охота на Глостера доставляет мне удовольствие."
         }
       ],
       "word_family": [
@@ -9843,8 +9843,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Er glaubt, wir stehen am Rand der Klippe.",
-          "ru": "Он думает, мы стоим на краю утёса."
+          "de": "An den Klippen von Dover, wo Edgar seinen Vater führt, erinnert man sich: Er glaubt, wir stehen am Rand der Klippe.",
+          "ru": "У утёсов Дувра, где Эдгар ведёт отца, вспоминают: Он думает, мы стоим на краю утёса."
         }
       ],
       "word_family": [
@@ -9874,8 +9874,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Kraft zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «сила» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Kraft zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «сила» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -9906,12 +9906,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Krone nie.",
-          "ru": "В тронном зале постоянно звучит слово «корона»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Krone nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «корона»."
         },
         {
-          "de": "Diese Krone ist schwer geworden für mein altes Haupt.",
-          "ru": "Эта корона стала тяжела для моей старой головы."
+          "de": "Am Hof von König Lear erzählt man: Diese Krone ist schwer geworden für mein altes Haupt.",
+          "ru": "При дворе короля Лира рассказывают: Эта корона стала тяжела для моей старой головы."
         }
       ],
       "word_family": [
@@ -9945,8 +9945,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Diese Kränkung werde ich nicht vergessen!",
-          "ru": "Эту обиду я не забуду!"
+          "de": "Am Hof von König Lear erzählt man: Diese Kränkung werde ich nicht vergessen!",
+          "ru": "При дворе короля Лира рассказывают: Эту обиду я не забуду!"
         }
       ],
       "word_family": [
@@ -9980,12 +9980,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Kälte dringt in unsere Knochen.",
-          "ru": "Холод проникает в наши кости."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Die Kälte dringt in unsere Knochen.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Холод проникает в наши кости."
         },
         {
-          "de": "Die Kälte meines Herzens übertrifft den Winter.",
-          "ru": "Холод моего сердца превосходит зиму."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Die Kälte meines Herzens übertrifft den Winter.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Холод моего сердца превосходит зиму."
         }
       ],
       "word_family": [
@@ -10016,8 +10016,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Königin ein ständiges Thema.",
-          "ru": "Для придворных «королева» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Königin ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «королева» — постоянная тема."
         }
       ],
       "word_family": [
@@ -10050,8 +10050,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich hinterlasse nur Leere und Erinnerung.",
-          "ru": "Я оставляю только пустоту и воспоминание."
+          "de": "Am Hof von König Lear erzählt man: Ich hinterlasse nur Leere und Erinnerung.",
+          "ru": "При дворе короля Лира рассказывают: Я оставляю только пустоту и воспоминание."
         }
       ],
       "word_family": [
@@ -10081,12 +10081,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Leidenschaft erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «страсть»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Leidenschaft erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «страсть»."
         },
         {
-          "de": "Meine Leidenschaft gilt nur Edmund.",
-          "ru": "Моя страсть принадлежит только Эдмунду."
+          "de": "Am Hof von König Lear erzählt man: Meine Leidenschaft gilt nur Edmund.",
+          "ru": "При дворе короля Лира рассказывают: Моя страсть принадлежит только Эдмунду."
         }
       ],
       "word_family": [
@@ -10118,8 +10118,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Liebe verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «любовь»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Liebe verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «любовь»."
         }
       ],
       "word_family": [
@@ -10152,8 +10152,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Liebschaft mit beiden Schwestern ist gefährlich.",
-          "ru": "Моя любовная связь с обеими сёстрами опасна."
+          "de": "Im Streitlager der Schwestern um Edmund zischt man: Meine Liebschaft mit beiden Schwestern ist gefährlich.",
+          "ru": "В спорщем лагере сестёр из-за Эдмунда шипят: Моя любовная связь с обеими сёстрами опасна."
         }
       ],
       "word_family": [
@@ -10192,16 +10192,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine List bewahrt ihn vor dem Selbstmord.",
-          "ru": "Моя хитрость спасает его от самоубийства."
+          "de": "An den Klippen von Dover, wo Edgar seinen Vater führt, erinnert man sich: Meine List bewahrt ihn vor dem Selbstmord.",
+          "ru": "У утёсов Дувра, где Эдгар ведёт отца, вспоминают: Моя хитрость спасает его от самоубийства."
         },
         {
-          "de": "Mit List gewinne ich sein Vertrauen.",
-          "ru": "Хитростью я завоёвываю его доверие."
+          "de": "An den Klippen von Dover, wo Edgar seinen Vater führt, erinnert man sich: Mit List gewinne ich sein Vertrauen.",
+          "ru": "У утёсов Дувра, где Эдгар ведёт отца, вспоминают: Хитростью я завоёвываю его доверие."
         },
         {
-          "de": "Mit List kehre ich an den Hof zurück.",
-          "ru": "Хитростью я возвращаюсь ко двору."
+          "de": "An den Klippen von Dover, wo Edgar seinen Vater führt, erinnert man sich: Mit List kehre ich an den Hof zurück.",
+          "ru": "У утёсов Дувра, где Эдгар ведёт отца, вспоминают: Хитростью я возвращаюсь ко двору."
         }
       ],
       "word_family": [
@@ -10238,12 +10238,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ihre Lust macht sie blind.",
-          "ru": "Их похоть делает их слепыми."
+          "de": "Im Streitlager der Schwestern um Edmund zischt man: Ihre Lust macht sie blind.",
+          "ru": "В спорщем лагере сестёр из-за Эдмунда шипят: Их похоть делает их слепыми."
         },
         {
-          "de": "Die Lust macht mich blind für Gefahr.",
-          "ru": "Похоть делает меня слепой к опасности."
+          "de": "Im Streitlager der Schwestern um Edmund zischt man: Die Lust macht mich blind für Gefahr.",
+          "ru": "В спорщем лагере сестёр из-за Эдмунда шипят: Похоть делает меня слепой к опасности."
         }
       ],
       "word_family": [
@@ -10274,12 +10274,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Lüge noch bedrückender.",
-          "ru": "Во время бури само «ложь» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Lüge noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «ложь» звучит ещё тяжелее."
         },
         {
-          "de": "Die Lüge klingt süßer als die Wahrheit.",
-          "ru": "Ложь звучит слаще правды."
+          "de": "Am Hof von König Lear erzählt man: Die Lüge klingt süßer als die Wahrheit.",
+          "ru": "При дворе короля Лира рассказывают: Ложь звучит слаще правды."
         }
       ],
       "word_family": [
@@ -10311,24 +10311,24 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Macht ein ständiges Thema.",
-          "ru": "Для придворных «власть» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Macht ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «власть» — постоянная тема."
         },
         {
-          "de": "Die Macht gebe ich an jene, die mich am meisten liebt.",
-          "ru": "Власть я отдаю той, кто любит меня больше всех."
+          "de": "Am Hof von König Lear erzählt man: Die Macht gebe ich an jene, die mich am meisten liebt.",
+          "ru": "При дворе короля Лира рассказывают: Власть я отдаю той, кто любит меня больше всех."
         },
         {
-          "de": "Die Macht über das Königreich ist nah.",
-          "ru": "Власть над королевством близка."
+          "de": "Am Hof von König Lear erzählt man: Die Macht über das Königreich ist nah.",
+          "ru": "При дворе короля Лира рассказывают: Власть над королевством близка."
         },
         {
-          "de": "Die Macht bedeutet nichts ohne wahre Liebe.",
-          "ru": "Власть ничего не значит без истинной любви."
+          "de": "Am Hof von König Lear erzählt man: Die Macht bedeutet nichts ohne wahre Liebe.",
+          "ru": "При дворе короля Лира рассказывают: Власть ничего не значит без истинной любви."
         },
         {
-          "de": "Die Macht über das halbe Königreich ist mein.",
-          "ru": "Власть над половиной королевства моя."
+          "de": "Am Hof von König Lear erzählt man: Die Macht über das halbe Königreich ist mein.",
+          "ru": "При дворе короля Лира рассказывают: Власть над половиной королевства моя."
         }
       ],
       "word_family": [
@@ -10365,8 +10365,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Melodie erinnert an bessere Zeiten.",
-          "ru": "Мелодия напоминает о лучших временах."
+          "de": "Am Hof von König Lear erzählt man: Die Melodie erinnert an bessere Zeiten.",
+          "ru": "При дворе короля Лира рассказывают: Мелодия напоминает о лучших временах."
         }
       ],
       "word_family": [
@@ -10398,8 +10398,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ohne Mitgift bin ich reicher an Ehre.",
-          "ru": "Без приданого я богаче честью."
+          "de": "Im Lager der französischen Cordelia berichtet man: Ohne Mitgift bin ich reicher an Ehre.",
+          "ru": "Во французском лагере Корделии рассказывают: Без приданого я богаче честью."
         }
       ],
       "word_family": [
@@ -10431,8 +10431,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Moral leitet nun meine Entscheidungen.",
-          "ru": "Мораль теперь руководит моими решениями."
+          "de": "Am Hof von König Lear erzählt man: Die Moral leitet nun meine Entscheidungen.",
+          "ru": "При дворе короля Лира рассказывают: Мораль теперь руководит моими решениями."
         }
       ],
       "word_family": [
@@ -10464,8 +10464,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Schreckliche Nachrichten erreichen mich aus England.",
-          "ru": "Ужасные известия доходят до меня из Англии."
+          "de": "Am Hof von König Lear erzählt man: Schreckliche Nachrichten erreichen mich aus England.",
+          "ru": "При дворе короля Лира рассказывают: Ужасные известия доходят до меня из Англии."
         }
       ],
       "word_family": [
@@ -10495,8 +10495,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Nacht zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «ночь» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Nacht zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «ночь» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -10527,12 +10527,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Natur nie.",
-          "ru": "В тронном зале постоянно звучит слово «природа»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Natur nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «природа»."
         },
         {
-          "de": "Die Natur ist meine Göttin, nicht das Gesetz.",
-          "ru": "Природа - моя богиня, не закон."
+          "de": "Am Hof von König Lear erzählt man: Die Natur ist meine Göttin, nicht das Gesetz.",
+          "ru": "При дворе короля Лира рассказывают: Природа - моя богиня, не закон."
         }
       ],
       "word_family": [
@@ -10570,12 +10570,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Niederlage ist mein letztes Schicksal.",
-          "ru": "Поражение - моя последняя судьба."
+          "de": "Vor dem Duell zwischen Edgar und Edmund erinnert man sich: Die Niederlage ist mein letztes Schicksal.",
+          "ru": "Перед дуэлью Эдгара и Эдмунда вспоминают: Поражение - моя последняя судьба."
         },
         {
-          "de": "Die Niederlage ist vollkommen.",
-          "ru": "Поражение полное."
+          "de": "Vor dem Duell zwischen Edgar und Edmund erinnert man sich: Die Niederlage ist vollkommen.",
+          "ru": "Перед дуэлью Эдгара и Эдмунда вспоминают: Поражение полное."
         }
       ],
       "word_family": [
@@ -10606,12 +10606,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Not erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «нужда»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Not erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «нужда»."
         },
         {
-          "de": "In meiner Not erkennen sie mich nicht als Vater.",
-          "ru": "В моей нужде они не признают меня отцом."
+          "de": "Am Hof von König Lear erzählt man: In meiner Not erkennen sie mich nicht als Vater.",
+          "ru": "При дворе короля Лира рассказывают: В моей нужде они не признают меня отцом."
         }
       ],
       "word_family": [
@@ -10645,8 +10645,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Neue Ordnung muss aus dem Chaos entstehen.",
-          "ru": "Новый порядок должен возникнуть из хаоса."
+          "de": "Am Hof von König Lear erzählt man: Neue Ordnung muss aus dem Chaos entstehen.",
+          "ru": "При дворе короля Лира рассказывают: Новый порядок должен возникнуть из хаоса."
         }
       ],
       "word_family": [
@@ -10676,16 +10676,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Pflicht verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «долг»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Pflicht verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «долг»."
         },
         {
-          "de": "Meine Pflicht ist es, ehrlich zu sein.",
-          "ru": "Мой долг - быть честной."
+          "de": "Am Hof von König Lear erzählt man: Meine Pflicht ist es, ehrlich zu sein.",
+          "ru": "При дворе короля Лира рассказывают: Мой долг - быть честной."
         },
         {
-          "de": "Meine Pflicht ruft mich zum König.",
-          "ru": "Мой долг зовёт меня к королю."
+          "de": "Am Hof von König Lear erzählt man: Meine Pflicht ruft mich zum König.",
+          "ru": "При дворе короля Лира рассказывают: Мой долг зовёт меня к королю."
         }
       ],
       "word_family": [
@@ -10720,8 +10720,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Philosophie ist einfach: Alles ist Narretei.",
-          "ru": "Моя философия проста: всё - глупость."
+          "de": "Am Hof von König Lear erzählt man: Meine Philosophie ist einfach: Alles ist Narretei.",
+          "ru": "При дворе короля Лира рассказывают: Моя философия проста: всё - глупость."
         }
       ],
       "word_family": [
@@ -10753,8 +10753,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Prophezeiung wird wahr werden.",
-          "ru": "Моё пророчество сбудется."
+          "de": "Am Hof von König Lear erzählt man: Meine Prophezeiung wird wahr werden.",
+          "ru": "При дворе короля Лира рассказывают: Моё пророчество сбудется."
         }
       ],
       "word_family": [
@@ -10784,8 +10784,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Prüfung noch bedrückender.",
-          "ru": "Во время бури само «испытание» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Prüfung noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «испытание» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -10821,12 +10821,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Qual des Giftes zerreißt mich.",
-          "ru": "Мучение от яда разрывает меня."
+          "de": "Am Hof von König Lear erzählt man: Die Qual des Giftes zerreißt mich.",
+          "ru": "При дворе короля Лира рассказывают: Мучение от яда разрывает меня."
         },
         {
-          "de": "Seine Qual bereitet mir Vergnügen.",
-          "ru": "Его мука доставляет мне удовольствие."
+          "de": "Am Hof von König Lear erzählt man: Seine Qual bereitet mir Vergnügen.",
+          "ru": "При дворе короля Лира рассказывают: Его мука доставляет мне удовольствие."
         }
       ],
       "word_family": [
@@ -10858,24 +10858,24 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Rache ein ständiges Thema.",
-          "ru": "Для придворных «месть» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Rache ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «месть» — постоянная тема."
         },
         {
-          "de": "Die Rache an der Gesellschaft ist mein Ziel.",
-          "ru": "Месть обществу - моя цель."
+          "de": "Am Hof von König Lear erzählt man: Die Rache an der Gesellschaft ist mein Ziel.",
+          "ru": "При дворе короля Лира рассказывают: Месть обществу - моя цель."
         },
         {
-          "de": "Nicht Rache, sondern Gerechtigkeit leitet meine Klinge.",
-          "ru": "Не месть, а справедливость ведёт мой клинок."
+          "de": "Am Hof von König Lear erzählt man: Nicht Rache, sondern Gerechtigkeit leitet meine Klinge.",
+          "ru": "При дворе короля Лира рассказывают: Не месть, а справедливость ведёт мой клинок."
         },
         {
-          "de": "Dies ist ihre Rache für meine Treue.",
-          "ru": "Это их месть за мою верность."
+          "de": "Am Hof von König Lear erzählt man: Dies ist ihre Rache für meine Treue.",
+          "ru": "При дворе короля Лира рассказывают: Это их месть за мою верность."
         },
         {
-          "de": "Die Rache für Jahre der Unterwerfung.",
-          "ru": "Месть за годы подчинения."
+          "de": "Am Hof von König Lear erzählt man: Die Rache für Jahre der Unterwerfung.",
+          "ru": "При дворе короля Лира рассказывают: Месть за годы подчинения."
         }
       ],
       "word_family": [
@@ -10912,8 +10912,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Respektlosigkeit kennt keine Grenzen.",
-          "ru": "Моё неуважение не знает границ."
+          "de": "Am Hof von König Lear erzählt man: Meine Respektlosigkeit kennt keine Grenzen.",
+          "ru": "При дворе короля Лира рассказывают: Моё неуважение не знает границ."
         }
       ],
       "word_family": [
@@ -10943,20 +10943,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Reue zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «раскаяние» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Reue zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «раскаяние» звучит слишком близко."
         },
         {
-          "de": "Die Reue brennt heißer als alle Feuer der Hölle.",
-          "ru": "Раскаяние жжёт горячее всех адских огней."
+          "de": "Am Hof von König Lear erzählt man: Die Reue brennt heißer als alle Feuer der Hölle.",
+          "ru": "При дворе короля Лира рассказывают: Раскаяние жжёт горячее всех адских огней."
         },
         {
-          "de": "Deine Reue ist nicht nötig, nur deine Liebe.",
-          "ru": "Твоё раскаяние не нужно, только твоя любовь."
+          "de": "Am Hof von König Lear erzählt man: Deine Reue ist nicht nötig, nur deine Liebe.",
+          "ru": "При дворе короля Лира рассказывают: Твоё раскаяние не нужно, только твоя любовь."
         },
         {
-          "de": "Die Reue überwältigt meine Seele.",
-          "ru": "Раскаяние переполняет мою душу."
+          "de": "Am Hof von König Lear erzählt man: Die Reue überwältigt meine Seele.",
+          "ru": "При дворе короля Лира рассказывают: Раскаяние переполняет мою душу."
         }
       ],
       "word_family": [
@@ -10995,12 +10995,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ihre Rivalität spielt mir in die Hände.",
-          "ru": "Их соперничество играет мне на руку."
+          "de": "Im Streitlager der Schwestern um Edmund zischt man: Ihre Rivalität spielt mir in die Hände.",
+          "ru": "В спорщем лагере сестёр из-за Эдмунда шипят: Их соперничество играет мне на руку."
         },
         {
-          "de": "Unsere Rivalität wird tödlich enden.",
-          "ru": "Наше соперничество закончится смертью."
+          "de": "Im Streitlager der Schwestern um Edmund zischt man: Unsere Rivalität wird tödlich enden.",
+          "ru": "В спорщем лагере сестёр из-за Эдмунда шипят: Наше соперничество закончится смертью."
         }
       ],
       "word_family": [
@@ -11031,8 +11031,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Ruhe nie.",
-          "ru": "В тронном зале постоянно звучит слово «покой»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Ruhe nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «покой»."
         }
       ],
       "word_family": [
@@ -11063,12 +11063,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Schande erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «позор»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Schande erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «позор»."
         },
         {
-          "de": "Diese Schande ist Cornwall's, nicht meine.",
-          "ru": "Этот позор Корнуолла, не мой."
+          "de": "Am Hof von König Lear erzählt man: Diese Schande ist Cornwall's, nicht meine.",
+          "ru": "При дворе короля Лира рассказывают: Этот позор Корнуолла, не мой."
         }
       ],
       "word_family": [
@@ -11100,12 +11100,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Schlacht verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «битва»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Schlacht verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «битва»."
         },
         {
-          "de": "Diese Schlacht entscheidet über das Schicksal des Königreichs.",
-          "ru": "Эта битва решает судьбу королевства."
+          "de": "Am Hof von König Lear erzählt man: Diese Schlacht entscheidet über das Schicksal des Königreichs.",
+          "ru": "При дворе короля Лира рассказывают: Эта битва решает судьбу королевства."
         }
       ],
       "word_family": [
@@ -11137,12 +11137,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Schuld noch bedrückender.",
-          "ru": "Во время бури само «вина» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Schuld noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «вина» звучит ещё тяжелее."
         },
         {
-          "de": "Die Schuld erdrückt mich am Ende.",
-          "ru": "Вина давит меня в конце."
+          "de": "Am Hof von König Lear erzählt man: Die Schuld erdrückt mich am Ende.",
+          "ru": "При дворе короля Лира рассказывают: Вина давит меня в конце."
         }
       ],
       "word_family": [
@@ -11174,8 +11174,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Schwester ein ständiges Thema.",
-          "ru": "Для придворных «сестра» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Schwester ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «сестра» — постоянная тема."
         }
       ],
       "word_family": [
@@ -11208,8 +11208,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Schwäche erlaubt das Böse zu wachsen.",
-          "ru": "Моя слабость позволяет злу расти."
+          "de": "Am Hof von König Lear erzählt man: Meine Schwäche erlaubt das Böse zu wachsen.",
+          "ru": "При дворе короля Лира рассказывают: Моя слабость позволяет злу расти."
         }
       ],
       "word_family": [
@@ -11239,12 +11239,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Seele zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «душа» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Seele zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «душа» звучит слишком близко."
         },
         {
-          "de": "Meine Seele ist rein vor Gott.",
-          "ru": "Моя душа чиста перед Богом."
+          "de": "Am Hof von König Lear erzählt man: Meine Seele ist rein vor Gott.",
+          "ru": "При дворе короля Лира рассказывают: Моя душа чиста перед Богом."
         }
       ],
       "word_family": [
@@ -11278,8 +11278,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Sehnsucht nach Versöhnung erfüllt mein Herz.",
-          "ru": "Тоска по примирению наполняет моё сердце."
+          "de": "Am Hof von König Lear erzählt man: Die Sehnsucht nach Versöhnung erfüllt mein Herz.",
+          "ru": "При дворе короля Лира рассказывают: Тоска по примирению наполняет моё сердце."
         }
       ],
       "word_family": [
@@ -11309,8 +11309,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Sonne nie.",
-          "ru": "В тронном зале постоянно звучит слово «солнце»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Sonne nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «солнце»."
         }
       ],
       "word_family": [
@@ -11341,12 +11341,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Sorge erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «забота»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Sorge erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «забота»."
         },
         {
-          "de": "Die Sorge um meinen Vater lässt mich nicht schlafen.",
-          "ru": "Забота об отце не даёт мне спать."
+          "de": "Am Hof von König Lear erzählt man: Die Sorge um meinen Vater lässt mich nicht schlafen.",
+          "ru": "При дворе короля Лира рассказывают: Забота об отце не даёт мне спать."
         }
       ],
       "word_family": [
@@ -11380,8 +11380,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mit Standhaftigkeit ertrage ich die Schmach.",
-          "ru": "Со стойкостью я переношу позор."
+          "de": "Am Hof von König Lear erzählt man: Mit Standhaftigkeit ertrage ich die Schmach.",
+          "ru": "При дворе короля Лира рассказывают: Со стойкостью я переношу позор."
         }
       ],
       "word_family": [
@@ -11411,28 +11411,28 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Strafe verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «наказание»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Strafe verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «наказание»."
         },
         {
-          "de": "Diese Strafe ist der Preis für meine Ehrlichkeit.",
-          "ru": "Это наказание - цена моей честности."
+          "de": "Am Hof von König Lear erzählt man: Diese Strafe ist der Preis für meine Ehrlichkeit.",
+          "ru": "При дворе короля Лира рассказывают: Это наказание - цена моей честности."
         },
         {
-          "de": "Diese Strafe nehme ich mit Würde an.",
-          "ru": "Это наказание я принимаю с достоинством."
+          "de": "Am Hof von König Lear erzählt man: Diese Strafe nehme ich mit Würde an.",
+          "ru": "При дворе короля Лира рассказывают: Это наказание я принимаю с достоинством."
         },
         {
-          "de": "Diese Strafe erdulde ich für meinen König.",
-          "ru": "Это наказание я терплю ради короля."
+          "de": "Am Hof von König Lear erzählt man: Diese Strafe erdulde ich für meinen König.",
+          "ru": "При дворе короля Лира рассказывают: Это наказание я терплю ради короля."
         },
         {
-          "de": "Die Strafe für Widerspruch ist hart.",
-          "ru": "Наказание за возражение сурово."
+          "de": "Am Hof von König Lear erzählt man: Die Strafe für Widerspruch ist hart.",
+          "ru": "При дворе короля Лира рассказывают: Наказание за возражение сурово."
         },
         {
-          "de": "Dies ist die gerechte Strafe für meine Grausamkeit.",
-          "ru": "Это справедливая кара за мою жестокость."
+          "de": "Am Hof von König Lear erzählt man: Dies ist die gerechte Strafe für meine Grausamkeit.",
+          "ru": "При дворе короля Лира рассказывают: Это справедливая кара за мою жестокость."
         }
       ],
       "word_family": [
@@ -11471,8 +11471,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Unsere Strategie wird ihn brechen.",
-          "ru": "Наша стратегия сломает его."
+          "de": "Am Hof von König Lear erzählt man: Unsere Strategie wird ihn brechen.",
+          "ru": "При дворе короля Лира рассказывают: Наша стратегия сломает его."
         }
       ],
       "word_family": [
@@ -11502,8 +11502,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Tat noch bedrückender.",
-          "ru": "Во время бури само «поступок» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Tat noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «поступок» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -11534,8 +11534,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Tochter ein ständiges Thema.",
-          "ru": "Для придворных «дочь» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Tochter ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «дочь» — постоянная тема."
         }
       ],
       "word_family": [
@@ -11566,20 +11566,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Trauer nie.",
-          "ru": "В тронном зале постоянно звучит слово «печаль»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Trauer nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «печаль»."
         },
         {
-          "de": "Die Trauer überwältigt meine Seele.",
-          "ru": "Скорбь переполняет мою душу."
+          "de": "Am Hof von König Lear erzählt man: Die Trauer überwältigt meine Seele.",
+          "ru": "При дворе короля Лира рассказывают: Скорбь переполняет мою душу."
         },
         {
-          "de": "Die Trauer ist zu schwer zu ertragen.",
-          "ru": "Скорбь слишком тяжела, чтобы вынести."
+          "de": "Am Hof von König Lear erzählt man: Die Trauer ist zu schwer zu ertragen.",
+          "ru": "При дворе короля Лира рассказывают: Скорбь слишком тяжела, чтобы вынести."
         },
         {
-          "de": "Die Trauer um Корделия macht mich stumm.",
-          "ru": "Печаль о Корделии делает меня немым."
+          "de": "Am Hof von König Lear erzählt man: Die Trauer um Корделия macht mich stumm.",
+          "ru": "При дворе короля Лира рассказывают: Печаль о Корделии делает меня немым."
         }
       ],
       "word_family": [
@@ -11614,16 +11614,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Treue erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «верность»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Treue erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «верность»."
         },
         {
-          "de": "Meine Treue gilt der Wahrheit und der echten Liebe.",
-          "ru": "Моя верность принадлежит правде и истинной любви."
+          "de": "Am Hof von König Lear erzählt man: Meine Treue gilt der Wahrheit und der echten Liebe.",
+          "ru": "При дворе короля Лира рассказывают: Моя верность принадлежит правде и истинной любви."
         },
         {
-          "de": "Die Treue zu meinem König ist unerschütterlich.",
-          "ru": "Верность моему королю непоколебима."
+          "de": "Am Hof von König Lear erzählt man: Die Treue zu meinem König ist unerschütterlich.",
+          "ru": "При дворе короля Лира рассказывают: Верность моему королю непоколебима."
         }
       ],
       "word_family": [
@@ -11656,12 +11656,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Träne zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «слеза» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Träne zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «слеза» звучит слишком близко."
         },
         {
-          "de": "Keine Träne will ich für diese Undankbaren vergießen!",
-          "ru": "Ни одной слезы я не пролью за этих неблагодарных!"
+          "de": "Am Hof von König Lear erzählt man: Keine Träne will ich für diese Undankbaren vergießen!",
+          "ru": "При дворе короля Лира рассказывают: Ни одной слезы я не пролью за этих неблагодарных!"
         }
       ],
       "word_family": [
@@ -11695,8 +11695,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Unsere Tränen waschen den Schmerz fort.",
-          "ru": "Наши слёзы смывают боль."
+          "de": "Am Hof von König Lear erzählt man: Unsere Tränen waschen den Schmerz fort.",
+          "ru": "При дворе короля Лира рассказывают: Наши слёзы смывают боль."
         }
       ],
       "word_family": [
@@ -11728,8 +11728,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Tugend wird mein Leitstern sein.",
-          "ru": "Добродетель будет моей путеводной звездой."
+          "de": "Am Hof von König Lear erzählt man: Die Tugend wird mein Leitstern sein.",
+          "ru": "При дворе короля Лира рассказывают: Добродетель будет моей путеводной звездой."
         }
       ],
       "word_family": [
@@ -11761,8 +11761,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Tyrannei erstickt jeden Widerstand.",
-          "ru": "Моя тирания душит любое сопротивление."
+          "de": "Am Hof von König Lear erzählt man: Meine Tyrannei erstickt jeden Widerstand.",
+          "ru": "При дворе короля Лира рассказывают: Моя тирания душит любое сопротивление."
         }
       ],
       "word_family": [
@@ -11797,12 +11797,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Täuschung ist vollkommen.",
-          "ru": "Обман совершенен."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Die Täuschung ist vollkommen.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Обман совершенен."
         },
         {
-          "de": "Edgars liebevolle Täuschung rettet mich.",
-          "ru": "Любящий обман Эдгара спасает меня."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Edgars liebevolle Täuschung rettet mich.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Любящий обман Эдгара спасает меня."
         }
       ],
       "word_family": [
@@ -11834,8 +11834,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Tür verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «дверь»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Tür verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «дверь»."
         }
       ],
       "word_family": [
@@ -11868,8 +11868,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Undankbarkeit ist schärfer als der Zahn einer Schlange!",
-          "ru": "Неблагодарность острее змеиного зуба!"
+          "de": "Am Hof von König Lear erzählt man: Die Undankbarkeit ist schärfer als der Zahn einer Schlange!",
+          "ru": "При дворе короля Лира рассказывают: Неблагодарность острее змеиного зуба!"
         }
       ],
       "word_family": [
@@ -11904,12 +11904,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Diese Ungerechtigkeit werde ich nicht akzeptieren.",
-          "ru": "Эту несправедливость я не приму."
+          "de": "Am Hof von König Lear erzählt man: Diese Ungerechtigkeit werde ich nicht akzeptieren.",
+          "ru": "При дворе короля Лира рассказывают: Эту несправедливость я не приму."
         },
         {
-          "de": "Ich begehe große Ungerechtigkeit.",
-          "ru": "Я совершаю большую несправедливость."
+          "de": "Am Hof von König Lear erzählt man: Ich begehe große Ungerechtigkeit.",
+          "ru": "При дворе короля Лира рассказывают: Я совершаю большую несправедливость."
         }
       ],
       "word_family": [
@@ -11942,8 +11942,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Unterdrückung ist mein Herrschaftsmittel.",
-          "ru": "Угнетение - моё средство правления."
+          "de": "Am Hof von König Lear erzählt man: Die Unterdrückung ist mein Herrschaftsmittel.",
+          "ru": "При дворе короля Лира рассказывают: Угнетение - моё средство правления."
         }
       ],
       "word_family": [
@@ -11975,8 +11975,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Verachtung für ihn wächst täglich.",
-          "ru": "Моё презрение к нему растёт ежедневно."
+          "de": "Am Hof von König Lear erzählt man: Meine Verachtung für ihn wächst täglich.",
+          "ru": "При дворе короля Лира рассказывают: Моё презрение к нему растёт ежедневно."
         }
       ],
       "word_family": [
@@ -12008,8 +12008,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Verantwortung für alle wiegt schwer.",
-          "ru": "Ответственность за всех тяжела."
+          "de": "Am Hof von König Lear erzählt man: Die Verantwortung für alle wiegt schwer.",
+          "ru": "При дворе короля Лира рассказывают: Ответственность за всех тяжела."
         }
       ],
       "word_family": [
@@ -12041,8 +12041,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Verbannung ist der Preis für meine Ehrlichkeit.",
-          "ru": "Изгнание - цена моей честности."
+          "de": "Am Hof von König Lear erzählt man: Die Verbannung ist der Preis für meine Ehrlichkeit.",
+          "ru": "При дворе короля Лира рассказывают: Изгнание - цена моей честности."
         }
       ],
       "word_family": [
@@ -12075,8 +12075,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Verfolgung des blinden Grafen beginnt.",
-          "ru": "Преследование слепого графа начинается."
+          "de": "Am Hof von König Lear erzählt man: Die Verfolgung des blinden Grafen beginnt.",
+          "ru": "При дворе короля Лира рассказывают: Преследование слепого графа начинается."
         }
       ],
       "word_family": [
@@ -12108,8 +12108,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Vergebung ist der Schlüssel zum Frieden.",
-          "ru": "Прощение - ключ к покою."
+          "de": "Am Hof von König Lear erzählt man: Die Vergebung ist der Schlüssel zum Frieden.",
+          "ru": "При дворе короля Лира рассказывают: Прощение - ключ к покою."
         }
       ],
       "word_family": [
@@ -12141,8 +12141,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Vergeltung ereilt mich unerwartet.",
-          "ru": "Возмездие настигает меня неожиданно."
+          "de": "Am Hof von König Lear erzählt man: Die Vergeltung ereilt mich unerwartet.",
+          "ru": "При дворе короля Лира рассказывают: Возмездие настигает меня неожиданно."
         }
       ],
       "word_family": [
@@ -12174,8 +12174,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Vergänglichkeit der Macht ist offenbar.",
-          "ru": "Бренность власти очевидна."
+          "de": "Am Hof von König Lear erzählt man: Die Vergänglichkeit der Macht ist offenbar.",
+          "ru": "При дворе короля Лира рассказывают: Бренность власти очевидна."
         }
       ],
       "word_family": [
@@ -12210,12 +12210,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Diese Verkleidung ist meine einzige Rettung.",
-          "ru": "Эта маскировка - моё единственное спасение."
+          "de": "Während Kent seine Verkleidung trägt, flüstert man: Diese Verkleidung ist meine einzige Rettung.",
+          "ru": "Пока Кент носит маскировку, шепчутся: Эта маскировка - моё единственное спасение."
         },
         {
-          "de": "In Verkleidung diene ich meinem König weiter.",
-          "ru": "В переодевании я продолжаю служить королю."
+          "de": "Während Kent seine Verkleidung trägt, flüstert man: In Verkleidung diene ich meinem König weiter.",
+          "ru": "Пока Кент носит маскировку, шепчутся: В переодевании я продолжаю служить королю."
         }
       ],
       "word_family": [
@@ -12247,8 +12247,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Vernunft noch bedrückender.",
-          "ru": "Во время бури само «разум» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Vernunft noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «разум» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -12279,8 +12279,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Versuchung zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «искушение» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Versuchung zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «искушение» звучит слишком близко."
         }
       ],
       "word_family": [
@@ -12311,12 +12311,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Versöhnung ein ständiges Thema.",
-          "ru": "Для придворных «примирение» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Versöhnung ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «примирение» — постоянная тема."
         },
         {
-          "de": "Die Versöhnung kommt zu spät.",
-          "ru": "Примирение приходит слишком поздно."
+          "de": "Am Hof von König Lear erzählt man: Die Versöhnung kommt zu spät.",
+          "ru": "При дворе короля Лира рассказывают: Примирение приходит слишком поздно."
         }
       ],
       "word_family": [
@@ -12348,12 +12348,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Verwandlung nie.",
-          "ru": "В тронном зале постоянно звучит слово «превращение»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Verwandlung nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «превращение»."
         },
         {
-          "de": "Eine Verwandlung beginnt in meiner Seele.",
-          "ru": "Превращение начинается в моей душе."
+          "de": "Am Hof von König Lear erzählt man: Eine Verwandlung beginnt in meiner Seele.",
+          "ru": "При дворе короля Лира рассказывают: Превращение начинается в моей душе."
         }
       ],
       "word_family": [
@@ -12385,24 +12385,24 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Verzweiflung erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «отчаяние»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Verzweiflung erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «отчаяние»."
         },
         {
-          "de": "Die Verzweiflung packt mein altes Herz!",
-          "ru": "Отчаяние охватывает моё старое сердце!"
+          "de": "Am Hof von König Lear erzählt man: Die Verzweiflung packt mein altes Herz!",
+          "ru": "При дворе короля Лира рассказывают: Отчаяние охватывает моё старое сердце!"
         },
         {
-          "de": "Seine Verzweiflung bricht mir das Herz.",
-          "ru": "Его отчаяние разбивает мне сердце."
+          "de": "Am Hof von König Lear erzählt man: Seine Verzweiflung bricht mir das Herz.",
+          "ru": "При дворе короля Лира рассказывают: Его отчаяние разбивает мне сердце."
         },
         {
-          "de": "Die Verzweiflung treibt mich zum Abgrund.",
-          "ru": "Отчаяние гонит меня к пропасти."
+          "de": "Am Hof von König Lear erzählt man: Die Verzweiflung treibt mich zum Abgrund.",
+          "ru": "При дворе короля Лира рассказывают: Отчаяние гонит меня к пропасти."
         },
         {
-          "de": "Die Verzweiflung führt mich zum Tod.",
-          "ru": "Отчаяние ведёт меня к смерти."
+          "de": "Am Hof von König Lear erzählt man: Die Verzweiflung führt mich zum Tod.",
+          "ru": "При дворе короля Лира рассказывают: Отчаяние ведёт меня к смерти."
         }
       ],
       "word_family": [
@@ -12439,8 +12439,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Eine dunkle Vorahnung erfüllt mein Herz.",
-          "ru": "Тёмное предчувствие наполняет моё сердце."
+          "de": "Am Hof von König Lear erzählt man: Eine dunkle Vorahnung erfüllt mein Herz.",
+          "ru": "При дворе короля Лира рассказывают: Тёмное предчувствие наполняет моё сердце."
         }
       ],
       "word_family": [
@@ -12472,8 +12472,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich halte Wache über seinen Schlaf.",
-          "ru": "Я держу стражу над его сном."
+          "de": "Am Hof von König Lear erzählt man: Ich halte Wache über seinen Schlaf.",
+          "ru": "При дворе короля Лира рассказывают: Я держу стражу над его сном."
         }
       ],
       "word_family": [
@@ -12503,20 +12503,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Wahrheit verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «правда»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Wahrheit verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «правда»."
         },
         {
-          "de": "Die Wahrheit war immer in deinen Worten, Kind.",
-          "ru": "Правда всегда была в твоих словах, дитя."
+          "de": "Am Hof von König Lear erzählt man: Die Wahrheit war immer in deinen Worten, Kind.",
+          "ru": "При дворе короля Лира рассказывают: Правда всегда была в твоих словах, дитя."
         },
         {
-          "de": "Die Wahrheit war vor meinen Augen verborgen.",
-          "ru": "Правда была скрыта от моих глаз."
+          "de": "Am Hof von König Lear erzählt man: Die Wahrheit war vor meinen Augen verborgen.",
+          "ru": "При дворе короля Лира рассказывают: Правда была скрыта от моих глаз."
         },
         {
-          "de": "Die Wahrheit verpacke ich in lustige Lieder.",
-          "ru": "Правду я заворачиваю в весёлые песни."
+          "de": "Am Hof von König Lear erzählt man: Die Wahrheit verpacke ich in lustige Lieder.",
+          "ru": "При дворе короля Лира рассказывают: Правду я заворачиваю в весёлые песни."
         }
       ],
       "word_family": [
@@ -12552,8 +12552,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Warnung kommt als Rätsel verkleidet.",
-          "ru": "Моё предупреждение приходит замаскированным под загадку."
+          "de": "Am Hof von König Lear erzählt man: Meine Warnung kommt als Rätsel verkleidet.",
+          "ru": "При дворе короля Лира рассказывают: Моё предупреждение приходит замаскированным под загадку."
         }
       ],
       "word_family": [
@@ -12592,20 +12592,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Mit Weisheit will ich das Land führen.",
-          "ru": "С мудростью я хочу вести страну."
+          "de": "Neben dem Narren, der Lear begleitet, singen wir: Mit Weisheit will ich das Land führen.",
+          "ru": "Рядом с шутом, что сопровождает Лира, мы поём: С мудростью я хочу вести страну."
         },
         {
-          "de": "Die Weisheit kommt zu spät zu mir.",
-          "ru": "Мудрость приходит ко мне слишком поздно."
+          "de": "Neben dem Narren, der Lear begleitet, singen wir: Die Weisheit kommt zu spät zu mir.",
+          "ru": "Рядом с шутом, что сопровождает Лира, мы поём: Мудрость приходит ко мне слишком поздно."
         },
         {
-          "de": "Durch Leiden habe ich Weisheit erlangt.",
-          "ru": "Через страдания я обрёл мудрость."
+          "de": "Neben dem Narren, der Lear begleitet, singen wir: Durch Leiden habe ich Weisheit erlangt.",
+          "ru": "Рядом с шутом, что сопровождает Лира, мы поём: Через страдания я обрёл мудрость."
         },
         {
-          "de": "Hinter meinen Späßen verbirgt sich Weisheit.",
-          "ru": "За моими шутками скрывается мудрость."
+          "de": "Neben dem Narren, der Lear begleitet, singen wir: Hinter meinen Späßen verbirgt sich Weisheit.",
+          "ru": "Рядом с шутом, что сопровождает Лира, мы поём: За моими шутками скрывается мудрость."
         }
       ],
       "word_family": [
@@ -12638,8 +12638,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Welt noch bedrückender.",
-          "ru": "Во время бури само «мир» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Welt noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «мир» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -12671,8 +12671,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Für die Höflinge bleibt die Wildnis ein ständiges Thema.",
-          "ru": "Для придворных «дикая природа» — постоянная тема."
+          "de": "Am Hof von König Lear erzählt man: Für die Höflinge bleibt die Wildnis ein ständiges Thema.",
+          "ru": "При дворе короля Лира рассказывают: Для придворных «дикая природа» — постоянная тема."
         }
       ],
       "word_family": [
@@ -12707,8 +12707,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Willkür ist das einzige Gesetz.",
-          "ru": "Мой произвол - единственный закон."
+          "de": "Am Hof von König Lear erzählt man: Meine Willkür ist das einzige Gesetz.",
+          "ru": "При дворе короля Лира рассказывают: Мой произвол - единственный закон."
         }
       ],
       "word_family": [
@@ -12740,8 +12740,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Als Witwe bin ich endlich frei.",
-          "ru": "Как вдова я наконец свободна."
+          "de": "Am Hof von König Lear erzählt man: Als Witwe bin ich endlich frei.",
+          "ru": "При дворе короля Лира рассказывают: Как вдова я наконец свободна."
         }
       ],
       "word_family": [
@@ -12773,8 +12773,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Wunde brennt wie Feuer in meinem Leib.",
-          "ru": "Рана горит как огонь в моём теле."
+          "de": "Am Hof von König Lear erzählt man: Die Wunde brennt wie Feuer in meinem Leib.",
+          "ru": "При дворе короля Лира рассказывают: Рана горит как огонь в моём теле."
         }
       ],
       "word_family": [
@@ -12804,8 +12804,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Thronsaal verstummen die Gespräche über die Wut nie.",
-          "ru": "В тронном зале постоянно звучит слово «ярость»."
+          "de": "Am Hof von König Lear erzählt man: Im Thronsaal verstummen die Gespräche über die Wut nie.",
+          "ru": "При дворе короля Лира рассказывают: В тронном зале постоянно звучит слово «ярость»."
         }
       ],
       "word_family": [
@@ -12836,12 +12836,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Lears Herz wird schwer, wenn die Würde zur Sprache kommt.",
-          "ru": "Сердце Лира тяжелеет: «достоинство» звучит слишком близко."
+          "de": "Am Hof von König Lear erzählt man: Lears Herz wird schwer, wenn die Würde zur Sprache kommt.",
+          "ru": "При дворе короля Лира рассказывают: Сердце Лира тяжелеет: «достоинство» звучит слишком близко."
         },
         {
-          "de": "Mit Würde trage ich mein Schicksal.",
-          "ru": "С достоинством я несу свою судьбу."
+          "de": "Am Hof von König Lear erzählt man: Mit Würde trage ich mein Schicksal.",
+          "ru": "При дворе короля Лира рассказывают: С достоинством я несу свою судьбу."
         }
       ],
       "word_family": [
@@ -12873,8 +12873,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spottet, sobald die Zeit erwähnt wird.",
-          "ru": "Шут насмехается, едва кто-то произносит «время»."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spottet, sobald die Zeit erwähnt wird.",
+          "ru": "При дворе короля Лира рассказывают: Шут насмехается, едва кто-то произносит «время»."
         }
       ],
       "word_family": [
@@ -12910,12 +12910,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Zeremonie der Teilung beginnt jetzt.",
-          "ru": "Церемония раздела начинается сейчас."
+          "de": "Am Hof von König Lear erzählt man: Die Zeremonie der Teilung beginnt jetzt.",
+          "ru": "При дворе короля Лира рассказывают: Церемония раздела начинается сейчас."
         },
         {
-          "de": "Die Zeremonie beginnt im prächtigen Thronsaal.",
-          "ru": "Церемония начинается в великолепном тронном зале."
+          "de": "Am Hof von König Lear erzählt man: Die Zeremonie beginnt im prächtigen Thronsaal.",
+          "ru": "При дворе короля Лира рассказывают: Церемония начинается в великолепном тронном зале."
         }
       ],
       "word_family": [
@@ -12948,8 +12948,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich suche Zuflucht für uns beide.",
-          "ru": "Я ищу убежище для нас обоих."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Ich suche Zuflucht für uns beide.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Я ищу убежище для нас обоих."
         }
       ],
       "word_family": [
@@ -12980,12 +12980,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia merkt sich genau, wie die Zukunft verteilt wird.",
-          "ru": "Корделия внимательно следит, кому достанется «будущее»."
+          "de": "Am Hof von König Lear erzählt man: Cordelia merkt sich genau, wie die Zukunft verteilt wird.",
+          "ru": "При дворе короля Лира рассказывают: Корделия внимательно следит, кому достанется «будущее»."
         },
         {
-          "de": "Die Zukunft des Königreichs liegt in unseren Händen.",
-          "ru": "Будущее королевства в наших руках."
+          "de": "Am Hof von König Lear erzählt man: Die Zukunft des Königreichs liegt in unseren Händen.",
+          "ru": "При дворе короля Лира рассказывают: Будущее королевства в наших руках."
         }
       ],
       "word_family": [
@@ -13017,8 +13017,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Während des Sturms wirkt die Zunge noch bedrückender.",
-          "ru": "Во время бури само «язык» звучит ещё тяжелее."
+          "de": "Am Hof von König Lear erzählt man: Während des Sturms wirkt die Zunge noch bedrückender.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури само «язык» звучит ещё тяжелее."
         }
       ],
       "word_family": [
@@ -13051,8 +13051,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Zwietracht zerstört unsere Ehe.",
-          "ru": "Раздор разрушает наш брак."
+          "de": "Am Hof von König Lear erzählt man: Die Zwietracht zerstört unsere Ehe.",
+          "ru": "При дворе короля Лира рассказывают: Раздор разрушает наш брак."
         }
       ],
       "word_family": [
@@ -13084,8 +13084,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Überraschung des Angriffs schockiert mich.",
-          "ru": "Неожиданность нападения шокирует меня."
+          "de": "Am Hof von König Lear erzählt man: Die Überraschung des Angriffs schockiert mich.",
+          "ru": "При дворе короля Лира рассказывают: Неожиданность нападения шокирует меня."
         }
       ],
       "word_family": [
@@ -13115,16 +13115,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Dienen ist.",
-          "ru": "Во время бури становится понятно, насколько важно служить."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Dienen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно служить."
         },
         {
-          "de": "Ich diene ohne Gewissen oder Ehre.",
-          "ru": "Я служу без совести и чести."
+          "de": "Am Hof von König Lear erzählt man: Ich diene ohne Gewissen oder Ehre.",
+          "ru": "При дворе короля Лира рассказывают: Я служу без совести и чести."
         },
         {
-          "de": "Ich diene dem König seit vielen Jahren.",
-          "ru": "Я служу королю много лет."
+          "de": "Am Hof von König Lear erzählt man: Ich diene dem König seit vielen Jahren.",
+          "ru": "При дворе короля Лира рассказывают: Я служу королю много лет."
         }
       ],
       "word_family": [
@@ -13156,8 +13156,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Drohen alle verändert.",
-          "ru": "Шут чувствует, как умение угрожать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Drohen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение угрожать меняет всех."
         }
       ],
       "word_family": [
@@ -13190,8 +13190,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich dulde ihre Grausamkeit zu lange.",
-          "ru": "Я слишком долго терплю её жестокость."
+          "de": "Am Hof von König Lear erzählt man: Ich dulde ihre Grausamkeit zu lange.",
+          "ru": "При дворе короля Лира рассказывают: Я слишком долго терплю её жестокость."
         }
       ],
       "word_family": [
@@ -13223,12 +13223,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Durchhalten fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело выдерживать."
+          "de": "Am Hof von König Lear erzählt man: Das Durchhalten fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело выдерживать."
         },
         {
-          "de": "Gemeinsam werden wir durchhalten.",
-          "ru": "Вместе мы выдержим."
+          "de": "Am Hof von König Lear erzählt man: Gemeinsam werden wir durchhalten.",
+          "ru": "При дворе короля Лира рассказывают: Вместе мы выдержим."
         }
       ],
       "word_family": [
@@ -13263,8 +13263,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich strebe nach edlen Taten.",
-          "ru": "Я стремлюсь к благородным поступкам."
+          "de": "Am Hof von König Lear erzählt man: Ich strebe nach edlen Taten.",
+          "ru": "При дворе короля Лира рассказывают: Я стремлюсь к благородным поступкам."
         }
       ],
       "word_family": [
@@ -13294,8 +13294,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Ehren auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что чтить можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Ehren auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что чтить можно и без гордыни."
         }
       ],
       "word_family": [
@@ -13327,8 +13327,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich eile, um ihre Wünsche zu erfüllen.",
-          "ru": "Я тороплюсь исполнить её желания."
+          "de": "Am Hof von König Lear erzählt man: Ich eile, um ihre Wünsche zu erfüllen.",
+          "ru": "При дворе короля Лира рассказывают: Я тороплюсь исполнить её желания."
         }
       ],
       "word_family": [
@@ -13360,8 +13360,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich greife ein, um das Schlimmste zu verhindern.",
-          "ru": "Я вмешиваюсь, чтобы предотвратить худшее."
+          "de": "Am Hof von König Lear erzählt man: Ich greife ein, um das Schlimmste zu verhindern.",
+          "ru": "При дворе короля Лира рассказывают: Я вмешиваюсь, чтобы предотвратить худшее."
         }
       ],
       "word_family": [
@@ -13391,8 +13391,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Einsperren ist.",
-          "ru": "Во время бури становится понятно, насколько важно запирать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Einsperren ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно запирать."
         }
       ],
       "word_family": [
@@ -13423,8 +13423,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Entdecken alle verändert.",
-          "ru": "Шут чувствует, как умение обнаруживать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Entdecken alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение обнаруживать меняет всех."
         }
       ],
       "word_family": [
@@ -13454,8 +13454,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Enteignen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело лишать собственности."
+          "de": "Am Hof von König Lear erzählt man: Das Enteignen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело лишать собственности."
         }
       ],
       "word_family": [
@@ -13486,8 +13486,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Entfliehen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что убегать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Entfliehen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что убегать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -13521,12 +13521,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich enthülle meine wahre Identität.",
-          "ru": "Я разоблачаю свою истинную личность."
+          "de": "Am Hof von König Lear erzählt man: Ich enthülle meine wahre Identität.",
+          "ru": "При дворе короля Лира рассказывают: Я разоблачаю свою истинную личность."
         },
         {
-          "de": "Spielerisch enthülle ich seine Fehler.",
-          "ru": "Играючи я раскрываю его ошибки."
+          "de": "Am Hof von König Lear erzählt man: Spielerisch enthülle ich seine Fehler.",
+          "ru": "При дворе короля Лира рассказывают: Играючи я раскрываю его ошибки."
         }
       ],
       "word_family": [
@@ -13558,8 +13558,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Entscheiden ist.",
-          "ru": "Во время бури становится понятно, насколько важно решать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Entscheiden ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно решать."
         }
       ],
       "word_family": [
@@ -13589,8 +13589,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Entschuldigen alle verändert.",
-          "ru": "Шут чувствует, как умение извинять меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Entschuldigen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение извинять меняет всех."
         }
       ],
       "word_family": [
@@ -13620,8 +13620,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Entstehen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело возникать."
+          "de": "Am Hof von König Lear erzählt man: Das Entstehen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело возникать."
         }
       ],
       "word_family": [
@@ -13651,8 +13651,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Entthronen ist.",
-          "ru": "Во время бури становится понятно, насколько важно свергать с трона."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Entthronen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно свергать с трона."
         }
       ],
       "word_family": [
@@ -13684,8 +13684,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Enttäuschen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что разочаровывать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Enttäuschen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что разочаровывать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -13722,16 +13722,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Erbarmungslos verfolge ich mein Ziel.",
-          "ru": "Беспощадно я преследую свою цель."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Erbarmungslos verfolge ich mein Ziel.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Беспощадно я преследую свою цель."
         },
         {
-          "de": "Ich bin erbarmungslos in meiner Rache.",
-          "ru": "Я беспощадна в своей мести."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Ich bin erbarmungslos in meiner Rache.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Я беспощадна в своей мести."
         },
         {
-          "de": "Erbarmungslos werfe ich ihn hinaus.",
-          "ru": "Беспощадно я выбрасываю его."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Erbarmungslos werfe ich ihn hinaus.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Беспощадно я выбрасываю его."
         }
       ],
       "word_family": [
@@ -13763,16 +13763,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Erben alle verändert.",
-          "ru": "Шут чувствует, как умение наследовать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Erben alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение наследовать меняет всех."
         },
         {
-          "de": "Nun erbe ich alles, was Edgar zustand.",
-          "ru": "Теперь я наследую всё, что полагалось Эдгару."
+          "de": "Am Hof von König Lear erzählt man: Nun erbe ich alles, was Edgar zustand.",
+          "ru": "При дворе короля Лира рассказывают: Теперь я наследую всё, что полагалось Эдгару."
         },
         {
-          "de": "Nun erbe ich Titel und Verantwortung.",
-          "ru": "Теперь я наследую титул и ответственность."
+          "de": "Am Hof von König Lear erzählt man: Nun erbe ich Titel und Verantwortung.",
+          "ru": "При дворе короля Лира рассказывают: Теперь я наследую титул и ответственность."
         }
       ],
       "word_family": [
@@ -13804,12 +13804,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Erblinden fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело слепнуть."
+          "de": "Am Hof von König Lear erzählt man: Das Erblinden fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело слепнуть."
         },
         {
-          "de": "Ich erblinde durch ihre Grausamkeit.",
-          "ru": "Я слепну от их жестокости."
+          "de": "Am Hof von König Lear erzählt man: Ich erblinde durch ihre Grausamkeit.",
+          "ru": "При дворе короля Лира рассказывают: Я слепну от их жестокости."
         }
       ],
       "word_family": [
@@ -13842,8 +13842,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Erbärmlich ende ich wie ich gelebt habe.",
-          "ru": "Жалко я заканчиваю, как и жил."
+          "de": "Am Hof von König Lear erzählt man: Erbärmlich ende ich wie ich gelebt habe.",
+          "ru": "При дворе короля Лира рассказывают: Жалко я заканчиваю, как и жил."
         }
       ],
       "word_family": [
@@ -13875,8 +13875,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich erdulde die Schande ohne Klage.",
-          "ru": "Я терплю позор без жалоб."
+          "de": "Am Hof von König Lear erzählt man: Ich erdulde die Schande ohne Klage.",
+          "ru": "При дворе короля Лира рассказывают: Я терплю позор без жалоб."
         }
       ],
       "word_family": [
@@ -13908,8 +13908,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Ereignen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что происходить можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Ereignen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что происходить можно и без гордыни."
         }
       ],
       "word_family": [
@@ -13940,8 +13940,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Erfahren ist.",
-          "ru": "Во время бури становится понятно, насколько важно узнавать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Erfahren ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно узнавать."
         }
       ],
       "word_family": [
@@ -13973,8 +13973,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Erfüllen alle verändert.",
-          "ru": "Шут чувствует, как умение исполнять меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Erfüllen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение исполнять меняет всех."
         }
       ],
       "word_family": [
@@ -14007,8 +14007,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ergeben folge ich jedem Befehl.",
-          "ru": "Покорно я следую каждому приказу."
+          "de": "Am Hof von König Lear erzählt man: Ergeben folge ich jedem Befehl.",
+          "ru": "При дворе короля Лира рассказывают: Покорно я следую каждому приказу."
         }
       ],
       "word_family": [
@@ -14040,8 +14040,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich ergreife jede Gelegenheit zur Macht.",
-          "ru": "Я захватываю каждую возможность власти."
+          "de": "Am Hof von König Lear erzählt man: Ich ergreife jede Gelegenheit zur Macht.",
+          "ru": "При дворе короля Лира рассказывают: Я захватываю каждую возможность власти."
         }
       ],
       "word_family": [
@@ -14071,8 +14071,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Erhalten fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело получать."
+          "de": "Am Hof von König Lear erzählt man: Das Erhalten fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело получать."
         }
       ],
       "word_family": [
@@ -14102,8 +14102,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Erinnern auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что вспоминать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Erinnern auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что вспоминать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -14133,24 +14133,24 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Erkennen ist.",
-          "ru": "Во время бури становится понятно, насколько важно узнавать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Erkennen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно узнавать."
         },
         {
-          "de": "Ich erkenne dich, meine treue Cordelia!",
-          "ru": "Я узнаю тебя, моя верная Корделия!"
+          "de": "Am Hof von König Lear erzählt man: Ich erkenne dich, meine treue Cordelia!",
+          "ru": "При дворе короля Лира рассказывают: Я узнаю тебя, моя верная Корделия!"
         },
         {
-          "de": "Erkennst du mich, dein Kind Cordelia?",
-          "ru": "Узнаёшь ли ты меня, твоё дитя Корделия?"
+          "de": "Am Hof von König Lear erzählt man: Erkennst du mich, dein Kind Cordelia?",
+          "ru": "При дворе короля Лира рассказывают: Узнаёшь ли ты меня, твоё дитя Корделия?"
         },
         {
-          "de": "Endlich erkenne ich meinen treuen Edgar.",
-          "ru": "Наконец я узнаю моего верного Эдгара."
+          "de": "Am Hof von König Lear erzählt man: Endlich erkenne ich meinen treuen Edgar.",
+          "ru": "При дворе короля Лира рассказывают: Наконец я узнаю моего верного Эдгара."
         },
         {
-          "de": "Ich erkenne die Wahrheit hinter dem Schein.",
-          "ru": "Я познаю правду за видимостью."
+          "de": "Am Hof von König Lear erzählt man: Ich erkenne die Wahrheit hinter dem Schein.",
+          "ru": "При дворе короля Лира рассказывают: Я познаю правду за видимостью."
         }
       ],
       "word_family": [
@@ -14189,8 +14189,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Tod soll mich von der Schuld erlösen.",
-          "ru": "Смерть должна избавить меня от вины."
+          "de": "An den Klippen bei Gloucesters Verzweiflung flüstert man: Der Tod soll mich von der Schuld erlösen.",
+          "ru": "У утёсов, где отчаялся Глостер, шепчутся: Смерть должна избавить меня от вины."
         }
       ],
       "word_family": [
@@ -14222,8 +14222,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich ermutige ihre dunkelsten Impulse.",
-          "ru": "Я поощряю её самые тёмные импульсы."
+          "de": "Am Hof von König Lear erzählt man: Ich ermutige ihre dunkelsten Impulse.",
+          "ru": "При дворе короля Лира рассказывают: Я поощряю её самые тёмные импульсы."
         }
       ],
       "word_family": [
@@ -14255,8 +14255,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Reich will ich erneuern und heilen.",
-          "ru": "Королевство я хочу обновить и исцелить."
+          "de": "Am Hof von König Lear erzählt man: Das Reich will ich erneuern und heilen.",
+          "ru": "При дворе короля Лира рассказывают: Королевство я хочу обновить и исцелить."
         }
       ],
       "word_family": [
@@ -14291,12 +14291,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich erniedrige den einst mächtigen König.",
-          "ru": "Я унижаю некогда могущественного короля."
+          "de": "Am Hof von König Lear erzählt man: Ich erniedrige den einst mächtigen König.",
+          "ru": "При дворе короля Лира рассказывают: Я унижаю некогда могущественного короля."
         },
         {
-          "de": "Ich erniedrige den treuen Diener.",
-          "ru": "Я унижаю верного слугу."
+          "de": "Am Hof von König Lear erzählt man: Ich erniedrige den treuen Diener.",
+          "ru": "При дворе короля Лира рассказывают: Я унижаю верного слугу."
         }
       ],
       "word_family": [
@@ -14328,16 +14328,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Erobern alle verändert.",
-          "ru": "Шут чувствует, как умение завоевывать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Erobern alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение завоевывать меняет всех."
         },
         {
-          "de": "Wir erobern das Reich gemeinsam.",
-          "ru": "Мы завоёвываем королевство вместе."
+          "de": "Am Hof von König Lear erzählt man: Wir erobern das Reich gemeinsam.",
+          "ru": "При дворе короля Лира рассказывают: Мы завоёвываем королевство вместе."
         },
         {
-          "de": "Ich erobere, was mir zusteht.",
-          "ru": "Я завоёвываю то, что мне положено."
+          "de": "Am Hof von König Lear erzählt man: Ich erobere, was mir zusteht.",
+          "ru": "При дворе короля Лира рассказывают: Я завоёвываю то, что мне положено."
         }
       ],
       "word_family": [
@@ -14370,8 +14370,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Erreichen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело достигать."
+          "de": "Am Hof von König Lear erzählt man: Das Erreichen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело достигать."
         }
       ],
       "word_family": [
@@ -14401,8 +14401,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Erscheinen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что появляться можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Erscheinen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что появляться можно и без гордыни."
         }
       ],
       "word_family": [
@@ -14434,8 +14434,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich erschleiche mir sein Königreich.",
-          "ru": "Я выманиваю его королевство."
+          "de": "Am Hof von König Lear erzählt man: Ich erschleiche mir sein Königreich.",
+          "ru": "При дворе короля Лира рассказывают: Я выманиваю его королевство."
         }
       ],
       "word_family": [
@@ -14465,12 +14465,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Erschrecken ist.",
-          "ru": "Во время бури становится понятно, насколько важно пугать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Erschrecken ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно пугать."
         },
         {
-          "de": "Ihre Taten erschrecken mein gutes Herz.",
-          "ru": "Её поступки пугают моё доброе сердце."
+          "de": "Am Hof von König Lear erzählt man: Ihre Taten erschrecken mein gutes Herz.",
+          "ru": "При дворе короля Лира рассказывают: Её поступки пугают моё доброе сердце."
         }
       ],
       "word_family": [
@@ -14502,8 +14502,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Ertragen alle verändert.",
-          "ru": "Шут чувствует, как умение терпеть меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Ertragen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение терпеть меняет всех."
         }
       ],
       "word_family": [
@@ -14535,12 +14535,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Erwachen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело просыпаться."
+          "de": "Am Hof von König Lear erzählt man: Das Erwachen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело просыпаться."
         },
         {
-          "de": "Endlich erwache ich aus meiner Blindheit.",
-          "ru": "Наконец я пробуждаюсь от своей слепоты."
+          "de": "Am Hof von König Lear erzählt man: Endlich erwache ich aus meiner Blindheit.",
+          "ru": "При дворе короля Лира рассказывают: Наконец я пробуждаюсь от своей слепоты."
         }
       ],
       "word_family": [
@@ -14573,8 +14573,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Erwarten auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что ожидать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Erwarten auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что ожидать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -14604,8 +14604,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Erzählen ist.",
-          "ru": "Во время бури становится понятно, насколько важно рассказывать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Erzählen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно рассказывать."
         }
       ],
       "word_family": [
@@ -14642,16 +14642,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Unsere Liebe wird ewig dauern, mein Kind.",
-          "ru": "Наша любовь будет вечной, дитя моё."
+          "de": "Am Hof von König Lear erzählt man: Unsere Liebe wird ewig dauern, mein Kind.",
+          "ru": "При дворе короля Лира рассказывают: Наша любовь будет вечной, дитя моё."
         },
         {
-          "de": "Unsere Liebe ist ewig, Vater.",
-          "ru": "Наша любовь вечна, отец."
+          "de": "Am Hof von König Lear erzählt man: Unsere Liebe ist ewig, Vater.",
+          "ru": "При дворе короля Лира рассказывают: Наша любовь вечна, отец."
         },
         {
-          "de": "Meine Treue ist ewig, über den Tod hinaus.",
-          "ru": "Моя верность вечна, за пределами смерти."
+          "de": "Am Hof von König Lear erzählt man: Meine Treue ist ewig, über den Tod hinaus.",
+          "ru": "При дворе короля Лира рассказывают: Моя верность вечна, за пределами смерти."
         }
       ],
       "word_family": [
@@ -14683,16 +14683,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Fallen alle verändert.",
-          "ru": "Шут чувствует, как умение падать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Fallen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение падать меняет всех."
         },
         {
-          "de": "Ich falle wie der Feigling, der ich bin.",
-          "ru": "Я падаю как трус, которым являюсь."
+          "de": "Am Hof von König Lear erzählt man: Ich falle wie der Feigling, der ich bin.",
+          "ru": "При дворе короля Лира рассказывают: Я падаю как трус, которым являюсь."
         },
         {
-          "de": "Ich falle von seinem gerechten Schwert.",
-          "ru": "Я падаю от его справедливого меча."
+          "de": "Am Hof von König Lear erzählt man: Ich falle von seinem gerechten Schwert.",
+          "ru": "При дворе короля Лира рассказывают: Я падаю от его справедливого меча."
         }
       ],
       "word_family": [
@@ -14725,8 +14725,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Fangen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело ловить."
+          "de": "Am Hof von König Lear erzählt man: Das Fangen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело ловить."
         }
       ],
       "word_family": [
@@ -14756,8 +14756,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Fehlen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что отсутствовать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Fehlen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что отсутствовать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -14789,8 +14789,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Dieser feierliche Moment wird zur Tragödie.",
-          "ru": "Этот торжественный момент становится трагедией."
+          "de": "Am Hof von König Lear erzählt man: Dieser feierliche Moment wird zur Tragödie.",
+          "ru": "При дворе короля Лира рассказывают: Этот торжественный момент становится трагедией."
         }
       ],
       "word_family": [
@@ -14822,8 +14822,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Feige verstecke ich mich hinter meiner Herrin.",
-          "ru": "Трусливо я прячусь за своей госпожой."
+          "de": "Am Hof von König Lear erzählt man: Feige verstecke ich mich hinter meiner Herrin.",
+          "ru": "При дворе короля Лира рассказывают: Трусливо я прячусь за своей госпожой."
         }
       ],
       "word_family": [
@@ -14855,8 +14855,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Sie fesseln mich wie einen gemeinen Dieb.",
-          "ru": "Они сковывают меня как обычного вора."
+          "de": "Am Hof von König Lear erzählt man: Sie fesseln mich wie einen gemeinen Dieb.",
+          "ru": "При дворе короля Лира рассказывают: Они сковывают меня как обычного вора."
         }
       ],
       "word_family": [
@@ -14886,8 +14886,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Finden ist.",
-          "ru": "Во время бури становится понятно, насколько важно находить."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Finden ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно находить."
         }
       ],
       "word_family": [
@@ -14917,12 +14917,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Fliehen alle verändert.",
-          "ru": "Шут чувствует, как умение бежать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Fliehen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение бежать меняет всех."
         },
         {
-          "de": "Ich muss vor falschen Anschuldigungen fliehen.",
-          "ru": "Я должен бежать от ложных обвинений."
+          "de": "Am Hof von König Lear erzählt man: Ich muss vor falschen Anschuldigungen fliehen.",
+          "ru": "При дворе короля Лира рассказывают: Я должен бежать от ложных обвинений."
         }
       ],
       "word_family": [
@@ -14954,8 +14954,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Fluchen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело проклинать."
+          "de": "Am Hof von König Lear erzählt man: Das Fluchen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело проклинать."
         }
       ],
       "word_family": [
@@ -14987,12 +14987,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Folgen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что следовать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Folgen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что следовать можно и без гордыни."
         },
         {
-          "de": "Bald folge ich meinem König ins Jenseits.",
-          "ru": "Скоро я последую за королём в иной мир."
+          "de": "Am Hof von König Lear erzählt man: Bald folge ich meinem König ins Jenseits.",
+          "ru": "При дворе короля Лира рассказывают: Скоро я последую за королём в иной мир."
         }
       ],
       "word_family": [
@@ -15028,12 +15028,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich foltere ihn mit kalten Worten.",
-          "ru": "Я пытаю его холодными словами."
+          "de": "Am Hof von König Lear erzählt man: Ich foltere ihn mit kalten Worten.",
+          "ru": "При дворе короля Лира рассказывают: Я пытаю его холодными словами."
         },
         {
-          "de": "Mit Lust foltere ich den alten Mann.",
-          "ru": "С наслаждением я пытаю старика."
+          "de": "Am Hof von König Lear erzählt man: Mit Lust foltere ich den alten Mann.",
+          "ru": "При дворе короля Лира рассказывают: С наслаждением я пытаю старика."
         }
       ],
       "word_family": [
@@ -15066,8 +15066,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich gehe fort, wenn keiner es bemerkt.",
-          "ru": "Я ухожу, когда никто не замечает."
+          "de": "Am Hof von König Lear erzählt man: Ich gehe fort, wenn keiner es bemerkt.",
+          "ru": "При дворе короля Лира рассказывают: Я ухожу, когда никто не замечает."
         }
       ],
       "word_family": [
@@ -15097,8 +15097,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Fragen ist.",
-          "ru": "Во время бури становится понятно, насколько важно спрашивать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Fragen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно спрашивать."
         }
       ],
       "word_family": [
@@ -15130,8 +15130,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Frech widerspreche ich dem alten Mann.",
-          "ru": "Дерзко я возражаю старику."
+          "de": "Am Hof von König Lear erzählt man: Frech widerspreche ich dem alten Mann.",
+          "ru": "При дворе короля Лира рассказывают: Дерзко я возражаю старику."
         }
       ],
       "word_family": [
@@ -15163,8 +15163,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bin jetzt fremd in meinem eigenen Land.",
-          "ru": "Я теперь чужая в своей собственной стране."
+          "de": "Im Lager der französischen Cordelia berichtet man: Ich bin jetzt fremd in meinem eigenen Land.",
+          "ru": "Во французском лагере Корделии рассказывают: Я теперь чужая в своей собственной стране."
         }
       ],
       "word_family": [
@@ -15201,16 +15201,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Wir alle frieren in dieser kalten Welt.",
-          "ru": "Мы все мёрзнем в этом холодном мире."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Wir alle frieren in dieser kalten Welt.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Мы все мёрзнем в этом холодном мире."
         },
         {
-          "de": "Wir frieren gemeinsam in dieser kalten Nacht.",
-          "ru": "Мы мёрзнем вместе в эту холодную ночь."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Wir frieren gemeinsam in dieser kalten Nacht.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Мы мёрзнем вместе в эту холодную ночь."
         },
         {
-          "de": "Wir frieren gemeinsam in der kalten Nacht.",
-          "ru": "Мы мёрзнем вместе в холодную ночь."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Wir frieren gemeinsam in der kalten Nacht.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Мы мёрзнем вместе в холодную ночь."
         }
       ],
       "word_family": [
@@ -15244,8 +15244,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich fälsche Edgars Brief perfekt.",
-          "ru": "Я идеально подделываю письмо Эдгара."
+          "de": "Am Hof von König Lear erzählt man: Ich fälsche Edgars Brief perfekt.",
+          "ru": "При дворе короля Лира рассказывают: Я идеально подделываю письмо Эдгара."
         }
       ],
       "word_family": [
@@ -15275,8 +15275,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Fühlen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело чувствовать."
+          "de": "Am Hof von König Lear erzählt man: Das Fühlen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело чувствовать."
         }
       ],
       "word_family": [
@@ -15306,12 +15306,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Führen alle verändert.",
-          "ru": "Шут чувствует, как умение вести меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Führen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение вести меняет всех."
         },
         {
-          "de": "Ich führe ihn sicher durch die Dunkelheit.",
-          "ru": "Я веду его безопасно сквозь тьму."
+          "de": "Am Hof von König Lear erzählt man: Ich führe ihn sicher durch die Dunkelheit.",
+          "ru": "При дворе короля Лира рассказывают: Я веду его безопасно сквозь тьму."
         }
       ],
       "word_family": [
@@ -15343,8 +15343,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Fürchten auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что бояться можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Fürchten auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что бояться можно и без гордыни."
         }
       ],
       "word_family": [
@@ -15374,8 +15374,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Geben ist.",
-          "ru": "Во время бури становится понятно, насколько важно давать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Geben ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно давать."
         }
       ],
       "word_family": [
@@ -15407,8 +15407,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Obwohl gefangen, bin ich frei in meinem Herzen.",
-          "ru": "Хотя я в плену, в сердце я свободна."
+          "de": "Am Hof von König Lear erzählt man: Obwohl gefangen, bin ich frei in meinem Herzen.",
+          "ru": "При дворе короля Лира рассказывают: Хотя я в плену, в сердце я свободна."
         }
       ],
       "word_family": [
@@ -15438,12 +15438,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Gehorchen alle verändert.",
-          "ru": "Шут чувствует, как умение подчиняться меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Gehorchen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение подчиняться меняет всех."
         },
         {
-          "de": "Ich kann der Lüge nicht gehorchen.",
-          "ru": "Я не могу повиноваться лжи."
+          "de": "Am Hof von König Lear erzählt man: Ich kann der Lüge nicht gehorchen.",
+          "ru": "При дворе короля Лира рассказывают: Я не могу повиноваться лжи."
         }
       ],
       "word_family": [
@@ -15475,8 +15475,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Gehören fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело принадлежать."
+          "de": "Am Hof von König Lear erzählt man: Das Gehören fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело принадлежать."
         }
       ],
       "word_family": [
@@ -15508,8 +15508,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich genieße jeden Schrei des Schmerzes.",
-          "ru": "Я наслаждаюсь каждым криком боли."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Ich genieße jeden Schrei des Schmerzes.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Я наслаждаюсь каждым криком боли."
         }
       ],
       "word_family": [
@@ -15541,8 +15541,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich kämpfe für das, was gerecht ist.",
-          "ru": "Я борюсь за то, что справедливо."
+          "de": "Bei Cordelias treuer Umarmung sagt man: Ich kämpfe für das, was gerecht ist.",
+          "ru": "У верных объятий Корделии говорят: Я борюсь за то, что справедливо."
         }
       ],
       "word_family": [
@@ -15572,8 +15572,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Geschehen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что происходить можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Geschehen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что происходить можно и без гордыни."
         }
       ],
       "word_family": [
@@ -15604,12 +15604,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Gestehen ist.",
-          "ru": "Во время бури становится понятно, насколько важно признаваться."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Gestehen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно признаваться."
         },
         {
-          "de": "Ich gestehe alle meine Verbrechen.",
-          "ru": "Я признаюсь во всех преступлениях."
+          "de": "Am Hof von König Lear erzählt man: Ich gestehe alle meine Verbrechen.",
+          "ru": "При дворе короля Лира рассказывают: Я признаюсь во всех преступлениях."
         }
       ],
       "word_family": [
@@ -15640,12 +15640,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Gewinnen alle verändert.",
-          "ru": "Шут чувствует, как умение выигрывать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Gewinnen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение выигрывать меняет всех."
         },
         {
-          "de": "Ich gewinne alles durch List.",
-          "ru": "Я выигрываю всё хитростью."
+          "de": "Am Hof von König Lear erzählt man: Ich gewinne alles durch List.",
+          "ru": "При дворе короля Лира рассказывают: Я выигрываю всё хитростью."
         }
       ],
       "word_family": [
@@ -15678,8 +15678,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Gierig greife ich nach jedem Stück Macht.",
-          "ru": "Жадно я хватаюсь за каждый кусок власти."
+          "de": "Am Hof von König Lear erzählt man: Gierig greife ich nach jedem Stück Macht.",
+          "ru": "При дворе короля Лира рассказывают: Жадно я хватаюсь за каждый кусок власти."
         }
       ],
       "word_family": [
@@ -15709,12 +15709,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Glauben fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело верить."
+          "de": "Am Hof von König Lear erzählt man: Das Glauben fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело верить."
         },
         {
-          "de": "Ich glaube Edmunds Lügen sofort.",
-          "ru": "Я сразу верю лжи Эдмунда."
+          "de": "Am Hof von König Lear erzählt man: Ich glaube Edmunds Lügen sofort.",
+          "ru": "При дворе короля Лира рассказывают: Я сразу верю лжи Эдмунда."
         }
       ],
       "word_family": [
@@ -15747,8 +15747,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bin gnadenlos wie der Winter.",
-          "ru": "Я безжалостна как зима."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Ich bin gnadenlos wie der Winter.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Я безжалостна как зима."
         }
       ],
       "word_family": [
@@ -15780,8 +15780,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bin grausam zu dem, der mir alles gab.",
-          "ru": "Я жестока к тому, кто дал мне всё."
+          "de": "Am Hof von König Lear erzählt man: Ich bin grausam zu dem, der mir alles gab.",
+          "ru": "При дворе короля Лира рассказывают: Я жестока к тому, кто дал мне всё."
         }
       ],
       "word_family": [
@@ -15813,8 +15813,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Nachts grüble ich über richtig und falsch.",
-          "ru": "Ночами я размышляю о правильном и неправильном."
+          "de": "Am Hof von König Lear erzählt man: Nachts grüble ich über richtig und falsch.",
+          "ru": "При дворе короля Лира рассказывают: Ночами я размышляю о правильном и неправильном."
         }
       ],
       "word_family": [
@@ -15846,8 +15846,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Haben auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что иметь можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Haben auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что иметь можно и без гордыни."
         }
       ],
       "word_family": [
@@ -15877,8 +15877,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Halten ist.",
-          "ru": "Во время бури становится понятно, насколько важно держать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Halten ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно держать."
         }
       ],
       "word_family": [
@@ -15908,8 +15908,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Handeln alle verändert.",
-          "ru": "Шут чувствует, как умение действовать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Handeln alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение действовать меняет всех."
         }
       ],
       "word_family": [
@@ -15939,16 +15939,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Hassen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело ненавидеть."
+          "de": "Am Hof von König Lear erzählt man: Das Hassen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело ненавидеть."
         },
         {
-          "de": "Ich hasse meine Schwester mehr als je zuvor.",
-          "ru": "Я ненавижу сестру больше, чем когда-либо."
+          "de": "Am Hof von König Lear erzählt man: Ich hasse meine Schwester mehr als je zuvor.",
+          "ru": "При дворе короля Лира рассказывают: Я ненавижу сестру больше, чем когда-либо."
         },
         {
-          "de": "Ich hasse seine Schwäche und Güte.",
-          "ru": "Я ненавижу его слабость и доброту."
+          "de": "Am Hof von König Lear erzählt man: Ich hasse seine Schwäche und Güte.",
+          "ru": "При дворе короля Лира рассказывают: Я ненавижу его слабость и доброту."
         }
       ],
       "word_family": [
@@ -15982,8 +15982,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich haste von einem Ort zum anderen.",
-          "ru": "Я спешу с места на место."
+          "de": "Am Hof von König Lear erzählt man: Ich haste von einem Ort zum anderen.",
+          "ru": "При дворе короля Лира рассказывают: Я спешу с места на место."
         }
       ],
       "word_family": [
@@ -16015,8 +16015,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Liebe wird deine Wunden heilen.",
-          "ru": "Моя любовь исцелит твои раны."
+          "de": "Am Hof von König Lear erzählt man: Meine Liebe wird deine Wunden heilen.",
+          "ru": "При дворе короля Лира рассказывают: Моя любовь исцелит твои раны."
         }
       ],
       "word_family": [
@@ -16048,8 +16048,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich handle heimlich gegen die neuen Herrscher.",
-          "ru": "Я действую тайно против новых правителей."
+          "de": "Am Hof von König Lear erzählt man: Ich handle heimlich gegen die neuen Herrscher.",
+          "ru": "При дворе короля Лира рассказывают: Я действую тайно против новых правителей."
         }
       ],
       "word_family": [
@@ -16079,8 +16079,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Heiraten auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что жениться можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Heiraten auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что жениться можно и без гордыни."
         }
       ],
       "word_family": [
@@ -16110,12 +16110,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Helfen ist.",
-          "ru": "Во время бури становится понятно, насколько важно помогать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Helfen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно помогать."
         },
         {
-          "de": "Heimlich helfe ich dem verstoßenen König.",
-          "ru": "Тайно я помогаю изгнанному королю."
+          "de": "Am Hof von König Lear erzählt man: Heimlich helfe ich dem verstoßenen König.",
+          "ru": "При дворе короля Лира рассказывают: Тайно я помогаю изгнанному королю."
         }
       ],
       "word_family": [
@@ -16146,16 +16146,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Herrschen alle verändert.",
-          "ru": "Шут чувствует, как умение править меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Herrschen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение править меняет всех."
         },
         {
-          "de": "Ich habe lange genug geherrscht.",
-          "ru": "Я правил достаточно долго."
+          "de": "Am Hof von König Lear erzählt man: Ich habe lange genug geherrscht.",
+          "ru": "При дворе короля Лира рассказывают: Я правил достаточно долго."
         },
         {
-          "de": "Jetzt herrsche ich über meine Länder.",
-          "ru": "Теперь я правлю своими землями."
+          "de": "Am Hof von König Lear erzählt man: Jetzt herrsche ich über meine Länder.",
+          "ru": "При дворе короля Лира рассказывают: Теперь я правлю своими землями."
         }
       ],
       "word_family": [
@@ -16190,8 +16190,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich hetze ihn bis zum Ende.",
-          "ru": "Я травлю его до конца."
+          "de": "Am Hof von König Lear erzählt man: Ich hetze ihn bis zum Ende.",
+          "ru": "При дворе короля Лира рассказывают: Я травлю его до конца."
         }
       ],
       "word_family": [
@@ -16223,8 +16223,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich muss vor meinem Vater heucheln.",
-          "ru": "Я должна лицемерить перед отцом."
+          "de": "Am Hof von König Lear erzählt man: Ich muss vor meinem Vater heucheln.",
+          "ru": "При дворе короля Лира рассказывают: Я должна лицемерить перед отцом."
         }
       ],
       "word_family": [
@@ -16256,8 +16256,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich beginne ihre Taten zu hinterfragen.",
-          "ru": "Я начинаю подвергать сомнению её поступки."
+          "de": "Am Hof von König Lear erzählt man: Ich beginne ihre Taten zu hinterfragen.",
+          "ru": "При дворе короля Лира рассказывают: Я начинаю подвергать сомнению её поступки."
         }
       ],
       "word_family": [
@@ -16290,8 +16290,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich hintergehe jeden, der mir traut.",
-          "ru": "Я обманываю каждого, кто мне доверяет."
+          "de": "In Edmunds Intrigenzelt tuscheln die Verbündeten: Ich hintergehe jeden, der mir traut.",
+          "ru": "В заговорщицком шатре Эдмунда перешёптываются союзники: Я обманываю каждого, кто мне доверяет."
         }
       ],
       "word_family": [
@@ -16323,8 +16323,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Hoffen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело надеяться."
+          "de": "Am Hof von König Lear erzählt man: Das Hoffen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело надеяться."
         }
       ],
       "word_family": [
@@ -16354,8 +16354,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Hören auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что слышать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Hören auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что слышать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -16387,8 +16387,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich intrigiere gegen meinen Bruder.",
-          "ru": "Я интригую против брата."
+          "de": "Am Hof von König Lear erzählt man: Ich intrigiere gegen meinen Bruder.",
+          "ru": "При дворе короля Лира рассказывают: Я интригую против брата."
         }
       ],
       "word_family": [
@@ -16418,8 +16418,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Irren ist.",
-          "ru": "Во время бури становится понятно, насколько важно ошибаться."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Irren ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно ошибаться."
         }
       ],
       "word_family": [
@@ -16454,12 +16454,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Wie ein Hund jage ich meine Beute.",
-          "ru": "Как собака я гонюсь за добычей."
+          "de": "Am Hof von König Lear erzählt man: Wie ein Hund jage ich meine Beute.",
+          "ru": "При дворе короля Лира рассказывают: Как собака я гонюсь за добычей."
         },
         {
-          "de": "Ich jage meinen Sohn fort wie einen Verbrecher.",
-          "ru": "Я гоню сына прочь как преступника."
+          "de": "Am Hof von König Lear erzählt man: Ich jage meinen Sohn fort wie einen Verbrecher.",
+          "ru": "При дворе короля Лира рассказывают: Я гоню сына прочь как преступника."
         }
       ],
       "word_family": [
@@ -16493,8 +16493,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich jongliere mit zwei gefährlichen Frauen.",
-          "ru": "Я жонглирую двумя опасными женщинами."
+          "de": "Im Streitlager der Schwestern um Edmund zischt man: Ich jongliere mit zwei gefährlichen Frauen.",
+          "ru": "В спорщем лагере сестёр из-за Эдмунда шипят: Я жонглирую двумя опасными женщинами."
         }
       ],
       "word_family": [
@@ -16524,8 +16524,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Kennen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело знать."
+          "de": "Am Hof von König Lear erzählt man: Das Kennen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело знать."
         }
       ],
       "word_family": [
@@ -16557,8 +16557,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Klagen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что жаловаться можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Klagen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что жаловаться можно и без гордыни."
         }
       ],
       "word_family": [
@@ -16590,8 +16590,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Zum ersten Mal sehe ich klar.",
-          "ru": "Впервые я вижу ясно."
+          "de": "Am Hof von König Lear erzählt man: Zum ersten Mal sehe ich klar.",
+          "ru": "При дворе короля Лира рассказывают: Впервые я вижу ясно."
         }
       ],
       "word_family": [
@@ -16625,8 +16625,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Worte klingen lustig, doch sind traurig.",
-          "ru": "Мои слова звучат весело, но печальны."
+          "de": "Am Hof von König Lear erzählt man: Meine Worte klingen lustig, doch sind traurig.",
+          "ru": "При дворе короля Лира рассказывают: Мои слова звучат весело, но печальны."
         }
       ],
       "word_family": [
@@ -16658,8 +16658,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bin klüger als alle bei Hofe.",
-          "ru": "Я умнее всех при дворе."
+          "de": "Neben dem Narren, der Lear begleitet, singen wir: Ich bin klüger als alle bei Hofe.",
+          "ru": "Рядом с шутом, что сопровождает Лира, мы поём: Я умнее всех при дворе."
         }
       ],
       "word_family": [
@@ -16691,8 +16691,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich knechte alle, die mir unterstehen.",
-          "ru": "Я порабощаю всех, кто мне подчинён."
+          "de": "Am Hof von König Lear erzählt man: Ich knechte alle, die mir unterstehen.",
+          "ru": "При дворе короля Лира рассказывают: Я порабощаю всех, кто мне подчинён."
         }
       ],
       "word_family": [
@@ -16722,8 +16722,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Kommen ist.",
-          "ru": "Во время бури становится понятно, насколько важно приходить."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Kommen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно приходить."
         }
       ],
       "word_family": [
@@ -16755,8 +16755,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich konfrontiere sie mit ihrer Grausamkeit.",
-          "ru": "Я противостою ей с её жестокостью."
+          "de": "Am Hof von König Lear erzählt man: Ich konfrontiere sie mit ihrer Grausamkeit.",
+          "ru": "При дворе короля Лира рассказывают: Я противостою ей с её жестокостью."
         }
       ],
       "word_family": [
@@ -16786,8 +16786,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Krönen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело короновать."
+          "de": "Am Hof von König Lear erzählt man: Das Krönen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело короновать."
         }
       ],
       "word_family": [
@@ -16817,16 +16817,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Kämpfen alle verändert.",
-          "ru": "Шут чувствует, как умение бороться меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Kämpfen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение бороться меняет всех."
         },
         {
-          "de": "Ich kämpfe gegen alle seine Feinde.",
-          "ru": "Я сражаюсь против всех его врагов."
+          "de": "Am Hof von König Lear erzählt man: Ich kämpfe gegen alle seine Feinde.",
+          "ru": "При дворе короля Лира рассказывают: Я сражаюсь против всех его врагов."
         },
         {
-          "de": "Ich kämpfe um das, was ich begehre.",
-          "ru": "Я борюсь за то, чего желаю."
+          "de": "Am Hof von König Lear erzählt man: Ich kämpfe um das, was ich begehre.",
+          "ru": "При дворе короля Лира рассказывают: Я борюсь за то, чего желаю."
         }
       ],
       "word_family": [
@@ -16860,8 +16860,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Können alle verändert.",
-          "ru": "Шут чувствует, как умение мочь меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Können alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение мочь меняет всех."
         }
       ],
       "word_family": [
@@ -16891,8 +16891,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Lachen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что смеяться можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Lachen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что смеяться можно и без гордыни."
         }
       ],
       "word_family": [
@@ -16922,8 +16922,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Lassen ist.",
-          "ru": "Во время бури становится понятно, насколько важно позволять."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Lassen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно позволять."
         }
       ],
       "word_family": [
@@ -16955,8 +16955,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Heimlich lausche ich allen Gesprächen.",
-          "ru": "Тайно я подслушиваю все разговоры."
+          "de": "Am Hof von König Lear erzählt man: Heimlich lausche ich allen Gesprächen.",
+          "ru": "При дворе короля Лира рассказывают: Тайно я подслушиваю все разговоры."
         }
       ],
       "word_family": [
@@ -16986,8 +16986,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Leben alle verändert.",
-          "ru": "Шут чувствует, как умение жить меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Leben alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение жить меняет всех."
         }
       ],
       "word_family": [
@@ -17020,8 +17020,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bin der legitime Sohn des Grafen.",
-          "ru": "Я законный сын графа."
+          "de": "Am Hof von König Lear erzählt man: Ich bin der legitime Sohn des Grafen.",
+          "ru": "При дворе короля Лира рассказывают: Я законный сын графа."
         }
       ],
       "word_family": [
@@ -17053,8 +17053,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bin zu leichtgläubig für diese Welt.",
-          "ru": "Я слишком легковерен для этого мира."
+          "de": "Seit Edmund den falschen Brief schrieb, raunen die Diener: Ich bin zu leichtgläubig für diese Welt.",
+          "ru": "С тех пор как Эдмунд написал фальшивое письмо, слуги шепчутся: Я слишком легковерен для этого мира."
         }
       ],
       "word_family": [
@@ -17084,28 +17084,28 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Leiden fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело страдать."
+          "de": "Am Hof von König Lear erzählt man: Das Leiden fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело страдать."
         },
         {
-          "de": "Wer nicht gelitten hat, kennt das Leben nicht.",
-          "ru": "Кто не страдал, не знает жизни."
+          "de": "Am Hof von König Lear erzählt man: Wer nicht gelitten hat, kennt das Leben nicht.",
+          "ru": "При дворе короля Лира рассказывают: Кто не страдал, не знает жизни."
         },
         {
-          "de": "Der König leidet mehr als ich jemals gelitten habe.",
-          "ru": "Король страдает больше, чем я когда-либо страдал."
+          "de": "Am Hof von König Lear erzählt man: Der König leidet mehr als ich jemals gelitten habe.",
+          "ru": "При дворе короля Лира рассказывают: Король страдает больше, чем я когда-либо страдал."
         },
         {
-          "de": "Er muss furchtbar leiden ohne mich.",
-          "ru": "Он должно быть ужасно страдает без меня."
+          "de": "Am Hof von König Lear erzählt man: Er muss furchtbar leiden ohne mich.",
+          "ru": "При дворе короля Лира рассказывают: Он должно быть ужасно страдает без меня."
         },
         {
-          "de": "Ich leide furchtbare Qualen.",
-          "ru": "Я страдаю от ужасных мук."
+          "de": "Am Hof von König Lear erzählt man: Ich leide furchtbare Qualen.",
+          "ru": "При дворе короля Лира рассказывают: Я страдаю от ужасных мук."
         },
         {
-          "de": "Zum ersten Mal leide ich selbst.",
-          "ru": "Впервые я сам страдаю."
+          "de": "Am Hof von König Lear erzählt man: Zum ersten Mal leide ich selbst.",
+          "ru": "При дворе короля Лира рассказывают: Впервые я сам страдаю."
         }
       ],
       "word_family": [
@@ -17142,8 +17142,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich lenke das Land in eine bessere Zukunft.",
-          "ru": "Я направляю страну в лучшее будущее."
+          "de": "Am Hof von König Lear erzählt man: Ich lenke das Land in eine bessere Zukunft.",
+          "ru": "При дворе короля Лира рассказывают: Я направляю страну в лучшее будущее."
         }
       ],
       "word_family": [
@@ -17173,8 +17173,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Leugnen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что отрицать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Leugnen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что отрицать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -17204,8 +17204,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Lieben ist.",
-          "ru": "Во время бури становится понятно, насколько важно любить."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Lieben ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно любить."
         }
       ],
       "word_family": [
@@ -17237,8 +17237,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich locke ihn mit Versprechungen.",
-          "ru": "Я заманиваю его обещаниями."
+          "de": "Am Hof von König Lear erzählt man: Ich locke ihn mit Versprechungen.",
+          "ru": "При дворе короля Лира рассказывают: Я заманиваю его обещаниями."
         }
       ],
       "word_family": [
@@ -17268,12 +17268,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Lügen alle verändert.",
-          "ru": "Шут чувствует, как умение лгать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Lügen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение лгать меняет всех."
         },
         {
-          "de": "Ich lüge ohne mit der Wimper zu zucken.",
-          "ru": "Я лгу не моргнув глазом."
+          "de": "Am Hof von König Lear erzählt man: Ich lüge ohne mit der Wimper zu zucken.",
+          "ru": "При дворе короля Лира рассказывают: Я лгу не моргнув глазом."
         }
       ],
       "word_family": [
@@ -17305,8 +17305,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Machen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело делать."
+          "de": "Am Hof von König Lear erzählt man: Das Machen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело делать."
         }
       ],
       "word_family": [
@@ -17339,8 +17339,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich manipuliere meinen Vater geschickt.",
-          "ru": "Я ловко манипулирую отцом."
+          "de": "Am Hof von König Lear erzählt man: Ich manipuliere meinen Vater geschickt.",
+          "ru": "При дворе короля Лира рассказывают: Я ловко манипулирую отцом."
         }
       ],
       "word_family": [
@@ -17372,8 +17372,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine milde Art wird als Schwäche gesehen.",
-          "ru": "Моя мягкость воспринимается как слабость."
+          "de": "Am Hof von König Lear erzählt man: Meine milde Art wird als Schwäche gesehen.",
+          "ru": "При дворе короля Лира рассказывают: Моя мягкость воспринимается как слабость."
         }
       ],
       "word_family": [
@@ -17405,8 +17405,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich missachte seinen früheren Rang.",
-          "ru": "Я пренебрегаю его прежним рангом."
+          "de": "Am Hof von König Lear erzählt man: Ich missachte seinen früheren Rang.",
+          "ru": "При дворе короля Лира рассказывают: Я пренебрегаю его прежним рангом."
         }
       ],
       "word_family": [
@@ -17436,8 +17436,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Missbrauchen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что злоупотреблять можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Missbrauchen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что злоупотреблять можно и без гордыни."
         }
       ],
       "word_family": [
@@ -17469,8 +17469,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich misshandle den alten Mann.",
-          "ru": "Я жестоко обращаюсь со стариком."
+          "de": "Am Hof von König Lear erzählt man: Ich misshandle den alten Mann.",
+          "ru": "При дворе короля Лира рассказывают: Я жестоко обращаюсь со стариком."
         }
       ],
       "word_family": [
@@ -17501,12 +17501,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Misstrauen ist.",
-          "ru": "Во время бури становится понятно, насколько важно не доверять."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Misstrauen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно не доверять."
         },
         {
-          "de": "Ich misstraue jedem ihrer Worte.",
-          "ru": "Я не доверяю ни одному её слову."
+          "de": "Am Hof von König Lear erzählt man: Ich misstraue jedem ihrer Worte.",
+          "ru": "При дворе короля Лира рассказывают: Я не доверяю ни одному её слову."
         }
       ],
       "word_family": [
@@ -17541,12 +17541,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Morden alle verändert.",
-          "ru": "Шут чувствует, как умение убивать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Morden alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение убивать меняет всех."
         },
         {
-          "de": "Ich bin bereit zu morden für meine Lust.",
-          "ru": "Я готова убивать ради своей страсти."
+          "de": "Am Hof von König Lear erzählt man: Ich bin bereit zu morden für meine Lust.",
+          "ru": "При дворе короля Лира рассказывают: Я готова убивать ради своей страсти."
         }
       ],
       "word_family": [
@@ -17580,8 +17580,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich murmle Unsinn, um verrückt zu wirken.",
-          "ru": "Я бормочу чепуху, чтобы казаться сумасшедшим."
+          "de": "Am Hof von König Lear erzählt man: Ich murmle Unsinn, um verrückt zu wirken.",
+          "ru": "При дворе короля Лира рассказывают: Я бормочу чепуху, чтобы казаться сумасшедшим."
         }
       ],
       "word_family": [
@@ -17613,8 +17613,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Sei mutig, mein Herz, für die gerechte Sache.",
-          "ru": "Будь храбрым, моё сердце, ради правого дела."
+          "de": "Am Hof von König Lear erzählt man: Sei mutig, mein Herz, für die gerechte Sache.",
+          "ru": "При дворе короля Лира рассказывают: Будь храбрым, моё сердце, ради правого дела."
         }
       ],
       "word_family": [
@@ -17644,8 +17644,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Müssen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело должен."
+          "de": "Am Hof von König Lear erzählt man: Das Müssen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело должен."
         }
       ],
       "word_family": [
@@ -17678,8 +17678,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich denke nach über des Lebens Sinn.",
-          "ru": "Я размышляю о смысле жизни."
+          "de": "Am Hof von König Lear erzählt man: Ich denke nach über des Lebens Sinn.",
+          "ru": "При дворе короля Лира рассказывают: Я размышляю о смысле жизни."
         }
       ],
       "word_family": [
@@ -17713,8 +17713,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Zu oft gebe ich ihrem Willen nach.",
-          "ru": "Слишком часто я уступаю её воле."
+          "de": "Am Hof von König Lear erzählt man: Zu oft gebe ich ihrem Willen nach.",
+          "ru": "При дворе короля Лира рассказывают: Слишком часто я уступаю её воле."
         }
       ],
       "word_family": [
@@ -17749,12 +17749,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Nackt kam ich auf die Welt, nackt gehe ich!",
-          "ru": "Голым я пришёл в мир, голым и уйду!"
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Nackt kam ich auf die Welt, nackt gehe ich!",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Голым я пришёл в мир, голым и уйду!"
         },
         {
-          "de": "Fast nackt wandere ich durch die Wildnis.",
-          "ru": "Почти голый, я брожу по дикой местности."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Fast nackt wandere ich durch die Wildnis.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Почти голый, я брожу по дикой местности."
         }
       ],
       "word_family": [
@@ -17787,8 +17787,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich necke den König mit der Wahrheit.",
-          "ru": "Я дразню короля правдой."
+          "de": "Am Hof von König Lear erzählt man: Ich necke den König mit der Wahrheit.",
+          "ru": "При дворе короля Лира рассказывают: Я дразню короля правдой."
         }
       ],
       "word_family": [
@@ -17818,8 +17818,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Nehmen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что брать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Nehmen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что брать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -17851,8 +17851,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Eine neue Ära beginnt für unser Land.",
-          "ru": "Новая эра начинается для нашей страны."
+          "de": "Am Hof von König Lear erzählt man: Eine neue Ära beginnt für unser Land.",
+          "ru": "При дворе короля Лира рассказывают: Новая эра начинается для нашей страны."
         }
       ],
       "word_family": [
@@ -17884,8 +17884,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich opfere ihn für meine Ambitionen.",
-          "ru": "Я жертвую им ради своих амбиций."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Ich opfere ihn für meine Ambitionen.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Я жертвую им ради своих амбиций."
         }
       ],
       "word_family": [
@@ -17917,8 +17917,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Passiv schaue ich dem Unrecht zu.",
-          "ru": "Пассивно я наблюдаю за несправедливостью."
+          "de": "Am Hof von König Lear erzählt man: Passiv schaue ich dem Unrecht zu.",
+          "ru": "При дворе короля Лира рассказывают: Пассивно я наблюдаю за несправедливостью."
         }
       ],
       "word_family": [
@@ -17950,8 +17950,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich pfeife gegen die Dunkelheit an.",
-          "ru": "Я свищу против темноты."
+          "de": "Am Hof von König Lear erzählt man: Ich pfeife gegen die Dunkelheit an.",
+          "ru": "При дворе короля Лира рассказывают: Я свищу против темноты."
         }
       ],
       "word_family": [
@@ -17983,8 +17983,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Wir planen den Untergang des alten Königs.",
-          "ru": "Мы планируем падение старого короля."
+          "de": "Am Hof von König Lear erzählt man: Wir planen den Untergang des alten Königs.",
+          "ru": "При дворе короля Лира рассказывают: Мы планируем падение старого короля."
         }
       ],
       "word_family": [
@@ -18016,8 +18016,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ein prächtiger Tag für eine verhängnisvolle Entscheidung.",
-          "ru": "Великолепный день для рокового решения."
+          "de": "Am Hof von König Lear erzählt man: Ein prächtiger Tag für eine verhängnisvolle Entscheidung.",
+          "ru": "При дворе короля Лира рассказывают: Великолепный день для рокового решения."
         }
       ],
       "word_family": [
@@ -18047,8 +18047,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Prüfen ist.",
-          "ru": "Во время бури становится понятно, насколько важно проверять."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Prüfen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно проверять."
         }
       ],
       "word_family": [
@@ -18078,16 +18078,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Quälen alle verändert.",
-          "ru": "Шут чувствует, как умение мучить меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Quälen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение мучить меняет всех."
         },
         {
-          "de": "Es bereitet mir Freude, ihn zu quälen.",
-          "ru": "Мне доставляет радость мучить его."
+          "de": "Am Hof von König Lear erzählt man: Es bereitet mir Freude, ihn zu quälen.",
+          "ru": "При дворе короля Лира рассказывают: Мне доставляет радость мучить его."
         },
         {
-          "de": "Es macht mir Freude, ihn zu quälen.",
-          "ru": "Мне доставляет радость мучить его."
+          "de": "Am Hof von König Lear erzählt man: Es macht mir Freude, ihn zu quälen.",
+          "ru": "При дворе короля Лира рассказывают: Мне доставляет радость мучить его."
         }
       ],
       "word_family": [
@@ -18121,8 +18121,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Als Кай rate ich ihm zur Vorsicht.",
-          "ru": "Как Кай я советую ему осторожность."
+          "de": "Am Hof von König Lear erzählt man: Als Кай rate ich ihm zur Vorsicht.",
+          "ru": "При дворе короля Лира рассказывают: Как Кай я советую ему осторожность."
         }
       ],
       "word_family": [
@@ -18152,8 +18152,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Rauben auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что грабить можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Rauben auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что грабить можно и без гордыни."
         }
       ],
       "word_family": [
@@ -18188,12 +18188,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich will rechtschaffen leben und handeln.",
-          "ru": "Я хочу жить и действовать праведно."
+          "de": "Am Hof von König Lear erzählt man: Ich will rechtschaffen leben und handeln.",
+          "ru": "При дворе короля Лира рассказывают: Я хочу жить и действовать праведно."
         },
         {
-          "de": "Ich bin ein rechtschaffener Mann.",
-          "ru": "Я праведный человек."
+          "de": "Am Hof von König Lear erzählt man: Ich bin ein rechtschaffener Mann.",
+          "ru": "При дворе короля Лира рассказывают: Я праведный человек."
         }
       ],
       "word_family": [
@@ -18224,8 +18224,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Reden ist.",
-          "ru": "Во время бури становится понятно, насколько важно говорить."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Reden ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно говорить."
         }
       ],
       "word_family": [
@@ -18257,16 +18257,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Regieren alle verändert.",
-          "ru": "Шут чувствует, как умение управлять меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Regieren alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение управлять меняет всех."
         },
         {
-          "de": "Mit Weisheit werde ich regieren.",
-          "ru": "С мудростью я буду править."
+          "de": "Am Hof von König Lear erzählt man: Mit Weisheit werde ich regieren.",
+          "ru": "При дворе короля Лира рассказывают: С мудростью я буду править."
         },
         {
-          "de": "Ich werde mit eiserner Hand regieren.",
-          "ru": "Я буду управлять железной рукой."
+          "de": "Am Hof von König Lear erzählt man: Ich werde mit eiserner Hand regieren.",
+          "ru": "При дворе короля Лира рассказывают: Я буду управлять железной рукой."
         }
       ],
       "word_family": [
@@ -18300,8 +18300,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Reisen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело путешествовать."
+          "de": "Am Hof von König Lear erzählt man: Das Reisen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело путешествовать."
         }
       ],
       "word_family": [
@@ -18331,8 +18331,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Reißen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что рвать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Reißen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что рвать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -18362,8 +18362,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Rennen ist.",
-          "ru": "Во время бури становится понятно, насколько важно бежать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Rennen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно бежать."
         }
       ],
       "word_family": [
@@ -18394,16 +18394,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Retten alle verändert.",
-          "ru": "Шут чувствует, как умение спасать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Retten alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение спасать меняет всех."
         },
         {
-          "de": "Mit List will ich meinen Vater retten.",
-          "ru": "Хитростью я хочу спасти отца."
+          "de": "Am Hof von König Lear erzählt man: Mit List will ich meinen Vater retten.",
+          "ru": "При дворе короля Лира рассказывают: Хитростью я хочу спасти отца."
         },
         {
-          "de": "Ich muss meinen Vater vor seinen grausamen Töchtern retten.",
-          "ru": "Я должна спасти отца от его жестоких дочерей."
+          "de": "Am Hof von König Lear erzählt man: Ich muss meinen Vater vor seinen grausamen Töchtern retten.",
+          "ru": "При дворе короля Лира рассказывают: Я должна спасти отца от его жестоких дочерей."
         }
       ],
       "word_family": [
@@ -18435,12 +18435,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Richten fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело судить."
+          "de": "Am Hof von König Lear erzählt man: Das Richten fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело судить."
         },
         {
-          "de": "Gerecht will ich über die Verbrecher richten.",
-          "ru": "Справедливо я хочу судить преступников."
+          "de": "Am Hof von König Lear erzählt man: Gerecht will ich über die Verbrecher richten.",
+          "ru": "При дворе короля Лира рассказывают: Справедливо я хочу судить преступников."
         }
       ],
       "word_family": [
@@ -18474,8 +18474,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich riskiere alles für den alten König.",
-          "ru": "Я рискую всем ради старого короля."
+          "de": "Am Hof von König Lear erzählt man: Ich riskiere alles für den alten König.",
+          "ru": "При дворе короля Лира рассказывают: Я рискую всем ради старого короля."
         }
       ],
       "word_family": [
@@ -18507,8 +18507,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich rivalisiere mit meiner Schwester um Edmund.",
-          "ru": "Я соперничаю с сестрой за Эдмунда."
+          "de": "Am Hof von König Lear erzählt man: Ich rivalisiere mit meiner Schwester um Edmund.",
+          "ru": "При дворе короля Лира рассказывают: Я соперничаю с сестрой за Эдмунда."
         }
       ],
       "word_family": [
@@ -18538,8 +18538,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Rufen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что звать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Rufen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что звать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -18569,8 +18569,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Rächen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело мстить."
+          "de": "Am Hof von König Lear erzählt man: Das Rächen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело мстить."
         }
       ],
       "word_family": [
@@ -18605,12 +18605,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine Worte bleiben rätselhaft und wahr.",
-          "ru": "Мои слова остаются загадочными и правдивыми."
+          "de": "Am Hof von König Lear erzählt man: Meine Worte bleiben rätselhaft und wahr.",
+          "ru": "При дворе короля Лира рассказывают: Мои слова остаются загадочными и правдивыми."
         },
         {
-          "de": "Mein Ende bleibt rätselhaft und stumm.",
-          "ru": "Мой конец остаётся загадочным и немым."
+          "de": "Am Hof von König Lear erzählt man: Mein Ende bleibt rätselhaft und stumm.",
+          "ru": "При дворе короля Лира рассказывают: Мой конец остаётся загадочным и немым."
         }
       ],
       "word_family": [
@@ -18643,8 +18643,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Röchelnd hauche ich mein Leben aus.",
-          "ru": "Хрипя, я испускаю дух."
+          "de": "Am Hof von König Lear erzählt man: Röchelnd hauche ich mein Leben aus.",
+          "ru": "При дворе короля Лира рассказывают: Хрипя, я испускаю дух."
         }
       ],
       "word_family": [
@@ -18674,8 +18674,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Sagen ist.",
-          "ru": "Во время бури становится понятно, насколько важно говорить."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Sagen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно говорить."
         }
       ],
       "word_family": [
@@ -18709,8 +18709,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Sei sanft zu dir selbst, lieber Vater.",
-          "ru": "Будь нежен к себе, дорогой отец."
+          "de": "Am Hof von König Lear erzählt man: Sei sanft zu dir selbst, lieber Vater.",
+          "ru": "При дворе короля Лира рассказывают: Будь нежен к себе, дорогой отец."
         }
       ],
       "word_family": [
@@ -18740,8 +18740,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Schaffen alle verändert.",
-          "ru": "Шут чувствует, как умение создавать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Schaffen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение создавать меняет всех."
         }
       ],
       "word_family": [
@@ -18771,8 +18771,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Scheitern fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело терпеть неудачу."
+          "de": "Am Hof von König Lear erzählt man: Das Scheitern fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело терпеть неудачу."
         }
       ],
       "word_family": [
@@ -18805,8 +18805,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Schenken auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что дарить можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Schenken auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что дарить можно и без гордыни."
         }
       ],
       "word_family": [
@@ -18838,8 +18838,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich scherze, um den Schmerz zu verbergen.",
-          "ru": "Я шучу, чтобы скрыть боль."
+          "de": "Neben dem Narren, der Lear begleitet, singen wir: Ich scherze, um den Schmerz zu verbergen.",
+          "ru": "Рядом с шутом, что сопровождает Лира, мы поём: Я шучу, чтобы скрыть боль."
         }
       ],
       "word_family": [
@@ -18869,8 +18869,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Schicken ist.",
-          "ru": "Во время бури становится понятно, насколько важно посылать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Schicken ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно посылать."
         }
       ],
       "word_family": [
@@ -18900,8 +18900,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Schlafen alle verändert.",
-          "ru": "Шут чувствует, как умение спать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Schlafen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение спать меняет всех."
         }
       ],
       "word_family": [
@@ -18931,8 +18931,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Schlagen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело бить."
+          "de": "Am Hof von König Lear erzählt man: Das Schlagen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело бить."
         }
       ],
       "word_family": [
@@ -18962,12 +18962,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Schmeicheln auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что льстить можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Schmeicheln auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что льстить можно и без гордыни."
         },
         {
-          "de": "Mit süßen Worten schmeichle ich ihm.",
-          "ru": "Сладкими словами я льщу ему."
+          "de": "Am Hof von König Lear erzählt man: Mit süßen Worten schmeichle ich ihm.",
+          "ru": "При дворе короля Лира рассказывают: Сладкими словами я льщу ему."
         }
       ],
       "word_family": [
@@ -19000,8 +19000,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich schmiede Pläne gegen alle Feinde.",
-          "ru": "Я кую планы против всех врагов."
+          "de": "In Edmunds Intrigenzelt tuscheln die Verbündeten: Ich schmiede Pläne gegen alle Feinde.",
+          "ru": "В заговорщицком шатре Эдмунда перешёптываются союзники: Я кую планы против всех врагов."
         }
       ],
       "word_family": [
@@ -19033,8 +19033,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Überall schnüffle ich nach Geheimnissen.",
-          "ru": "Везде я вынюхиваю секреты."
+          "de": "Am Hof von König Lear erzählt man: Überall schnüffle ich nach Geheimnissen.",
+          "ru": "При дворе короля Лира рассказывают: Везде я вынюхиваю секреты."
         }
       ],
       "word_family": [
@@ -19064,8 +19064,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Schreiben ist.",
-          "ru": "Во время бури становится понятно, насколько важно писать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Schreiben ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно писать."
         }
       ],
       "word_family": [
@@ -19100,12 +19100,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich schreie in den Wind meine Wut hinaus!",
-          "ru": "Я кричу в ветер свою ярость!"
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Ich schreie in den Wind meine Wut hinaus!",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Я кричу в ветер свою ярость!"
         },
         {
-          "de": "Ich schreie vor unerträglichem Schmerz.",
-          "ru": "Я кричу от невыносимой боли."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Ich schreie vor unerträglichem Schmerz.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Я кричу от невыносимой боли."
         }
       ],
       "word_family": [
@@ -19138,8 +19138,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bin schuldig vor meiner Tochter.",
-          "ru": "Я виновен перед своей дочерью."
+          "de": "Am Hof von König Lear erzählt man: Ich bin schuldig vor meiner Tochter.",
+          "ru": "При дворе короля Лира рассказывают: Я виновен перед своей дочерью."
         }
       ],
       "word_family": [
@@ -19169,8 +19169,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Schweigen alle verändert.",
-          "ru": "Шут чувствует, как умение молчать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Schweigen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение молчать меняет всех."
         }
       ],
       "word_family": [
@@ -19202,8 +19202,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Die Verletzung schwächt meinen starken Körper.",
-          "ru": "Ранение ослабляет моё сильное тело."
+          "de": "Am Hof von König Lear erzählt man: Die Verletzung schwächt meinen starken Körper.",
+          "ru": "При дворе короля Лира рассказывают: Ранение ослабляет моё сильное тело."
         }
       ],
       "word_family": [
@@ -19233,12 +19233,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Schwören fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело клясться."
+          "de": "Am Hof von König Lear erzählt man: Das Schwören fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело клясться."
         },
         {
-          "de": "Ich schwöre, dass ich Euch mehr liebe als mein Leben.",
-          "ru": "Я клянусь, что люблю вас больше жизни."
+          "de": "Am Hof von König Lear erzählt man: Ich schwöre, dass ich Euch mehr liebe als mein Leben.",
+          "ru": "При дворе короля Лира рассказывают: Я клянусь, что люблю вас больше жизни."
         }
       ],
       "word_family": [
@@ -19271,8 +19271,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich will den wahnsinnigen König schützen.",
-          "ru": "Я хочу защитить безумного короля."
+          "de": "Am Hof von König Lear erzählt man: Ich will den wahnsinnigen König schützen.",
+          "ru": "При дворе короля Лира рассказывают: Я хочу защитить безумного короля."
         }
       ],
       "word_family": [
@@ -19304,8 +19304,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Sehen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что видеть можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Sehen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что видеть можно и без гордыни."
         }
       ],
       "word_family": [
@@ -19336,8 +19336,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Sein ist.",
-          "ru": "Во время бури становится понятно, насколько важно быть."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Sein ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно быть."
         }
       ],
       "word_family": [
@@ -19369,8 +19369,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich löse mich auf wie Nebel im Wind.",
-          "ru": "Я растворяюсь как туман на ветру."
+          "de": "Am Hof von König Lear erzählt man: Ich löse mich auf wie Nebel im Wind.",
+          "ru": "При дворе короля Лира рассказывают: Я растворяюсь как туман на ветру."
         }
       ],
       "word_family": [
@@ -19402,8 +19402,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich wehre mich gegen ihre Tyrannei.",
-          "ru": "Я защищаюсь от её тирании."
+          "de": "Am Hof von König Lear erzählt man: Ich wehre mich gegen ihre Tyrannei.",
+          "ru": "При дворе короля Лира рассказывают: Я защищаюсь от её тирании."
         }
       ],
       "word_family": [
@@ -19434,16 +19434,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Siegen alle verändert.",
-          "ru": "Шут чувствует, как умение побеждать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Siegen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение побеждать меняет всех."
         },
         {
-          "de": "Die Wahrheit wird über die Lüge siegen.",
-          "ru": "Правда победит ложь."
+          "de": "Am Hof von König Lear erzählt man: Die Wahrheit wird über die Lüge siegen.",
+          "ru": "При дворе короля Лира рассказывают: Правда победит ложь."
         },
         {
-          "de": "Die Liebe wird über den Hass siegen.",
-          "ru": "Любовь победит ненависть."
+          "de": "Am Hof von König Lear erzählt man: Die Liebe wird über den Hass siegen.",
+          "ru": "При дворе короля Лира рассказывают: Любовь победит ненависть."
         }
       ],
       "word_family": [
@@ -19475,12 +19475,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Singen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело петь."
+          "de": "Am Hof von König Lear erzählt man: Das Singen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело петь."
         },
         {
-          "de": "Ich singe, um seine Angst zu lindern.",
-          "ru": "Я пою, чтобы облегчить его страх."
+          "de": "Am Hof von König Lear erzählt man: Ich singe, um seine Angst zu lindern.",
+          "ru": "При дворе короля Лира рассказывают: Я пою, чтобы облегчить его страх."
         }
       ],
       "word_family": [
@@ -19511,8 +19511,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Sinnen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что размышлять можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Sinnen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что размышлять можно и без гордыни."
         }
       ],
       "word_family": [
@@ -19544,8 +19544,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Sitzen ist.",
-          "ru": "Во время бури становится понятно, насколько важно сидеть."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Sitzen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно сидеть."
         }
       ],
       "word_family": [
@@ -19575,8 +19575,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Sollen alle verändert.",
-          "ru": "Шут чувствует, как умение должен меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Sollen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение должен меняет всех."
         }
       ],
       "word_family": [
@@ -19607,8 +19607,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Sorgen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело заботиться."
+          "de": "Am Hof von König Lear erzählt man: Das Sorgen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело заботиться."
         }
       ],
       "word_family": [
@@ -19638,8 +19638,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Sparen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что экономить можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Sparen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что экономить можно и без гордыни."
         }
       ],
       "word_family": [
@@ -19669,12 +19669,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Spielen ist.",
-          "ru": "Во время бури становится понятно, насколько важно играть."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Spielen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно играть."
         },
         {
-          "de": "Ich spiele mit ihren Gefühlen.",
-          "ru": "Я играю с их чувствами."
+          "de": "Am Hof von König Lear erzählt man: Ich spiele mit ihren Gefühlen.",
+          "ru": "При дворе короля Лира рассказывают: Я играю с их чувствами."
         }
       ],
       "word_family": [
@@ -19707,8 +19707,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich spioniere für meine böse Herrin.",
-          "ru": "Я шпионю для моей злой госпожи."
+          "de": "Am Hof von König Lear erzählt man: Ich spioniere für meine böse Herrin.",
+          "ru": "При дворе короля Лира рассказывают: Я шпионю для моей злой госпожи."
         }
       ],
       "word_family": [
@@ -19740,8 +19740,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich spotte über die Torheit der Mächtigen.",
-          "ru": "Я насмехаюсь над глупостью сильных."
+          "de": "Am Hof von König Lear erzählt man: Ich spotte über die Torheit der Mächtigen.",
+          "ru": "При дворе короля Лира рассказывают: Я насмехаюсь над глупостью сильных."
         }
       ],
       "word_family": [
@@ -19772,8 +19772,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Sprechen alle verändert.",
-          "ru": "Шут чувствует, как умение говорить меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Sprechen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение говорить меняет всех."
         }
       ],
       "word_family": [
@@ -19805,12 +19805,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Springen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело прыгать."
+          "de": "Am Hof von König Lear erzählt man: Das Springen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело прыгать."
         },
         {
-          "de": "Ich will von den Klippen springen.",
-          "ru": "Я хочу прыгнуть со скал."
+          "de": "Am Hof von König Lear erzählt man: Ich will von den Klippen springen.",
+          "ru": "При дворе короля Лира рассказывают: Я хочу прыгнуть со скал."
         }
       ],
       "word_family": [
@@ -19843,8 +19843,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Spurlos gehe ich aus dieser Welt.",
-          "ru": "Бесследно я ухожу из этого мира."
+          "de": "Am Hof von König Lear erzählt man: Spurlos gehe ich aus dieser Welt.",
+          "ru": "При дворе короля Лира рассказывают: Бесследно я ухожу из этого мира."
         }
       ],
       "word_family": [
@@ -19874,8 +19874,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Stehen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что стоять можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Stehen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что стоять можно и без гордыни."
         }
       ],
       "word_family": [
@@ -19905,8 +19905,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Stehlen ist.",
-          "ru": "Во время бури становится понятно, насколько важно красть."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Stehlen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно красть."
         }
       ],
       "word_family": [
@@ -19936,28 +19936,28 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Sterben alle verändert.",
-          "ru": "Шут чувствует, как умение умирать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Sterben alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение умирать меняет всех."
         },
         {
-          "de": "Lass mich an deiner Seite sterben, Cordelia.",
-          "ru": "Позволь мне умереть рядом с тобой, Корделия."
+          "de": "Am Hof von König Lear erzählt man: Lass mich an deiner Seite sterben, Cordelia.",
+          "ru": "При дворе короля Лира рассказывают: Позволь мне умереть рядом с тобой, Корделия."
         },
         {
-          "de": "Wenn ich sterben muss, sterbe ich mit reinem Herzen.",
-          "ru": "Если я должна умереть, я умру с чистым сердцем."
+          "de": "Am Hof von König Lear erzählt man: Wenn ich sterben muss, sterbe ich mit reinem Herzen.",
+          "ru": "При дворе короля Лира рассказывают: Если я должна умереть, я умру с чистым сердцем."
         },
         {
-          "de": "Ich sterbe ohne Reue für meine Taten.",
-          "ru": "Я умираю без раскаяния за свои дела."
+          "de": "Am Hof von König Lear erzählt man: Ich sterbe ohne Reue für meine Taten.",
+          "ru": "При дворе короля Лира рассказывают: Я умираю без раскаяния за свои дела."
         },
         {
-          "de": "Ich sterbe vor Freude und Kummer.",
-          "ru": "Я умираю от радости и горя."
+          "de": "Am Hof von König Lear erzählt man: Ich sterbe vor Freude und Kummer.",
+          "ru": "При дворе короля Лира рассказывают: Я умираю от радости и горя."
         },
         {
-          "de": "Ich sterbe durch meine eigene Hand.",
-          "ru": "Я умираю от своей собственной руки."
+          "de": "Am Hof von König Lear erzählt man: Ich sterbe durch meine eigene Hand.",
+          "ru": "При дворе короля Лира рассказывают: Я умираю от своей собственной руки."
         }
       ],
       "word_family": [
@@ -19992,12 +19992,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Strafen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что наказывать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Strafen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что наказывать можно и без гордыни."
         },
         {
-          "de": "Die Schuldigen müssen bestraft werden.",
-          "ru": "Виновные должны быть наказаны."
+          "de": "Am Hof von König Lear erzählt man: Die Schuldigen müssen bestraft werden.",
+          "ru": "При дворе короля Лира рассказывают: Виновные должны быть наказаны."
         }
       ],
       "word_family": [
@@ -20032,8 +20032,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich strebe nach absoluter Kontrolle.",
-          "ru": "Я стремлюсь к абсолютному контролю."
+          "de": "Am Hof von König Lear erzählt man: Ich strebe nach absoluter Kontrolle.",
+          "ru": "При дворе короля Лира рассказывают: Я стремлюсь к абсолютному контролю."
         }
       ],
       "word_family": [
@@ -20063,12 +20063,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Streiten ist.",
-          "ru": "Во время бури становится понятно, насколько важно спорить."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Streiten ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно спорить."
         },
         {
-          "de": "Ich streite mit meinem schwachen Mann.",
-          "ru": "Я ссорюсь со своим слабым мужем."
+          "de": "Am Hof von König Lear erzählt man: Ich streite mit meinem schwachen Mann.",
+          "ru": "При дворе короля Лира рассказывают: Я ссорюсь со своим слабым мужем."
         }
       ],
       "word_family": [
@@ -20100,8 +20100,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Stören fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело мешать."
+          "de": "Am Hof von König Lear erzählt man: Das Stören fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело мешать."
         }
       ],
       "word_family": [
@@ -20131,12 +20131,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Stürzen alle verändert.",
-          "ru": "Шут чувствует, как умение падать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Stürzen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение падать меняет всех."
         },
         {
-          "de": "Ich glaube, von hohen Klippen zu stürzen.",
-          "ru": "Я верю, что падаю с высоких скал."
+          "de": "Am Hof von König Lear erzählt man: Ich glaube, von hohen Klippen zu stürzen.",
+          "ru": "При дворе короля Лира рассказывают: Я верю, что падаю с высоких скал."
         }
       ],
       "word_family": [
@@ -20168,8 +20168,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Suchen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело искать."
+          "de": "Am Hof von König Lear erzählt man: Das Suchen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело искать."
         }
       ],
       "word_family": [
@@ -20201,8 +20201,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Leise summe ich alte Melodien.",
-          "ru": "Тихо я напеваю старые мелодии."
+          "de": "Am Hof von König Lear erzählt man: Leise summe ich alte Melodien.",
+          "ru": "При дворе короля Лира рассказывают: Тихо я напеваю старые мелодии."
         }
       ],
       "word_family": [
@@ -20232,8 +20232,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Tanzen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что танцевать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Tanzen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что танцевать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -20265,8 +20265,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bleibe tapfer für dich, Vater.",
-          "ru": "Я остаюсь отважной ради тебя, отец."
+          "de": "Am Hof von König Lear erzählt man: Ich bleibe tapfer für dich, Vater.",
+          "ru": "При дворе короля Лира рассказывают: Я остаюсь отважной ради тебя, отец."
         }
       ],
       "word_family": [
@@ -20296,12 +20296,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Teilen alle verändert.",
-          "ru": "Шут чувствует, как умение делить меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Teilen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение делить меняет всех."
         },
         {
-          "de": "Wir teilen das Reich zwischen uns.",
-          "ru": "Мы делим королевство между собой."
+          "de": "Am Hof von König Lear erzählt man: Wir teilen das Reich zwischen uns.",
+          "ru": "При дворе короля Лира рассказывают: Мы делим королевство между собой."
         }
       ],
       "word_family": [
@@ -20332,12 +20332,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Toben fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело бушевать."
+          "de": "Am Hof von König Lear erzählt man: Das Toben fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело бушевать."
         },
         {
-          "de": "Lasst die Winde toben und die Blitze fallen!",
-          "ru": "Пусть ветры бушуют и молнии падают!"
+          "de": "Am Hof von König Lear erzählt man: Lasst die Winde toben und die Blitze fallen!",
+          "ru": "При дворе короля Лира рассказывают: Пусть ветры бушуют и молнии падают!"
         }
       ],
       "word_family": [
@@ -20368,8 +20368,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Tragen ist.",
-          "ru": "Во время бури становится понятно, насколько важно нести."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Tragen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно нести."
         }
       ],
       "word_family": [
@@ -20399,8 +20399,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Trauen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело доверять."
+          "de": "Am Hof von König Lear erzählt man: Das Trauen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело доверять."
         }
       ],
       "word_family": [
@@ -20432,8 +20432,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Trauern auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что горевать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Trauern auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что горевать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -20463,8 +20463,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Trennen ist.",
-          "ru": "Во время бури становится понятно, насколько важно разделять."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Trennen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно разделять."
         }
       ],
       "word_family": [
@@ -20499,12 +20499,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Treu bleibe ich trotz der Verkleidung.",
-          "ru": "Верным остаюсь несмотря на переодевание."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Treu bleibe ich trotz der Verkleidung.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Верным остаюсь несмотря на переодевание."
         },
         {
-          "de": "Ich bleibe treu, wenn alle anderen fliehen.",
-          "ru": "Я остаюсь верным, когда все остальные бегут."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Ich bleibe treu, wenn alle anderen fliehen.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Я остаюсь верным, когда все остальные бегут."
         }
       ],
       "word_family": [
@@ -20537,8 +20537,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich triumphiere über meinen Bruder.",
-          "ru": "Я торжествую над братом."
+          "de": "Am Hof von König Lear erzählt man: Ich triumphiere über meinen Bruder.",
+          "ru": "При дворе короля Лира рассказывают: Я торжествую над братом."
         }
       ],
       "word_family": [
@@ -20568,8 +20568,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Träumen alle verändert.",
-          "ru": "Шут чувствует, как умение мечтать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Träumen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение мечтать меняет всех."
         }
       ],
       "word_family": [
@@ -20599,20 +20599,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Trösten alle verändert.",
-          "ru": "Шут чувствует, как умение утешать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Trösten alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение утешать меняет всех."
         },
         {
-          "de": "Als Fremder tröste ich meinen eigenen Vater.",
-          "ru": "Как чужой, я утешаю собственного отца."
+          "de": "Am Hof von König Lear erzählt man: Als Fremder tröste ich meinen eigenen Vater.",
+          "ru": "При дворе короля Лира рассказывают: Как чужой, я утешаю собственного отца."
         },
         {
-          "de": "Lass mich dich trösten in dieser dunklen Stunde.",
-          "ru": "Позволь мне утешить тебя в этот тёмный час."
+          "de": "Am Hof von König Lear erzählt man: Lass mich dich trösten in dieser dunklen Stunde.",
+          "ru": "При дворе короля Лира рассказывают: Позволь мне утешить тебя в этот тёмный час."
         },
         {
-          "de": "Mit Worten tröste ich den wahnsinnigen König.",
-          "ru": "Словами я утешаю безумного короля."
+          "de": "Am Hof von König Lear erzählt man: Mit Worten tröste ich den wahnsinnigen König.",
+          "ru": "При дворе короля Лира рассказывают: Словами я утешаю безумного короля."
         }
       ],
       "word_family": [
@@ -20645,8 +20645,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Tun fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело делать."
+          "de": "Am Hof von König Lear erzählt man: Das Tun fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело делать."
         }
       ],
       "word_family": [
@@ -20677,20 +20677,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Täuschen ist.",
-          "ru": "Во время бури становится понятно, насколько важно обманывать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Täuschen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно обманывать."
         },
         {
-          "de": "Ich täusche ihn, um sein Leben zu retten.",
-          "ru": "Я обманываю его, чтобы спасти его жизнь."
+          "de": "Am Hof von König Lear erzählt man: Ich täusche ihn, um sein Leben zu retten.",
+          "ru": "При дворе короля Лира рассказывают: Я обманываю его, чтобы спасти его жизнь."
         },
         {
-          "de": "Edmund täuscht mich mit falschen Beweisen.",
-          "ru": "Эдмунд обманывает меня ложными доказательствами."
+          "de": "Am Hof von König Lear erzählt man: Edmund täuscht mich mit falschen Beweisen.",
+          "ru": "При дворе короля Лира рассказывают: Эдмунд обманывает меня ложными доказательствами."
         },
         {
-          "de": "Ich täusche meinen alten Vater leicht.",
-          "ru": "Я легко обманываю старого отца."
+          "de": "Am Hof von König Lear erzählt man: Ich täusche meinen alten Vater leicht.",
+          "ru": "При дворе короля Лира рассказывают: Я легко обманываю старого отца."
         }
       ],
       "word_family": [
@@ -20725,8 +20725,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Töten auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что убивать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Töten auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что убивать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -20759,8 +20759,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Tückisch plane ich meinen nächsten Schritt.",
-          "ru": "Коварно я планирую свой следующий шаг."
+          "de": "In Edmunds Intrigenzelt tuscheln die Verbündeten: Tückisch plane ich meinen nächsten Schritt.",
+          "ru": "В заговорщицком шатре Эдмунда перешёптываются союзники: Коварно я планирую свой следующий шаг."
         }
       ],
       "word_family": [
@@ -20795,12 +20795,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Lass mich dich umarmen und deine Tränen trocknen.",
-          "ru": "Позволь мне обнять тебя и вытереть твои слёзы."
+          "de": "Am Hof von König Lear erzählt man: Lass mich dich umarmen und deine Tränen trocknen.",
+          "ru": "При дворе короля Лира рассказывают: Позволь мне обнять тебя и вытереть твои слёзы."
         },
         {
-          "de": "Ein letztes Mal umarme ich meinen Sohn.",
-          "ru": "В последний раз я обнимаю сына."
+          "de": "Am Hof von König Lear erzählt man: Ein letztes Mal umarme ich meinen Sohn.",
+          "ru": "При дворе короля Лира рассказывают: В последний раз я обнимаю сына."
         }
       ],
       "word_family": [
@@ -20831,8 +20831,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Umkehren alle verändert.",
-          "ru": "Шут чувствует, как умение возвращаться меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Umkehren alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение возвращаться меняет всех."
         }
       ],
       "word_family": [
@@ -20864,8 +20864,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Umringen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело окружать."
+          "de": "Am Hof von König Lear erzählt man: Das Umringen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело окружать."
         }
       ],
       "word_family": [
@@ -20897,8 +20897,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Meine uneheliche Geburt ist mein Fluch.",
-          "ru": "Моё внебрачное рождение - мой проклятие."
+          "de": "Im Schatten von Gloucester spricht man über den Bastard: Meine uneheliche Geburt ist mein Fluch.",
+          "ru": "В тени Глостера говорят о бастарде: Моё внебрачное рождение - мой проклятие."
         }
       ],
       "word_family": [
@@ -20930,8 +20930,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Unerkannt bleibe ich an seiner Seite.",
-          "ru": "Неузнанным я остаюсь рядом с ним."
+          "de": "Während Kent seine Verkleidung trägt, flüstert man: Unerkannt bleibe ich an seiner Seite.",
+          "ru": "Пока Кент носит маскировку, шепчутся: Неузнанным я остаюсь рядом с ним."
         }
       ],
       "word_family": [
@@ -20963,8 +20963,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich werde unsicher in meinem Schweigen.",
-          "ru": "Я становлюсь неуверенным в своём молчании."
+          "de": "Am Hof von König Lear erzählt man: Ich werde unsicher in meinem Schweigen.",
+          "ru": "При дворе короля Лира рассказывают: Я становлюсь неуверенным в своём молчании."
         }
       ],
       "word_family": [
@@ -20994,8 +20994,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Unterbrechen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что прерывать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Unterbrechen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что прерывать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -21025,12 +21025,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Unterdrücken ist.",
-          "ru": "Во время бури становится понятно, насколько важно подавлять."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Unterdrücken ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно подавлять."
         },
         {
-          "de": "Ich unterdrücke jeden freien Gedanken.",
-          "ru": "Я подавляю любую свободную мысль."
+          "de": "Am Hof von König Lear erzählt man: Ich unterdrücke jeden freien Gedanken.",
+          "ru": "При дворе короля Лира рассказывают: Я подавляю любую свободную мысль."
         }
       ],
       "word_family": [
@@ -21061,8 +21061,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Untergehen alle verändert.",
-          "ru": "Шут чувствует, как умение погибать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Untergehen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение погибать меняет всех."
         }
       ],
       "word_family": [
@@ -21094,8 +21094,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich unterliege dem edlen Edgar.",
-          "ru": "Я проигрываю благородному Эдгару."
+          "de": "Am Hof von König Lear erzählt man: Ich unterliege dem edlen Edgar.",
+          "ru": "При дворе короля Лира рассказывают: Я проигрываю благородному Эдгару."
         }
       ],
       "word_family": [
@@ -21126,8 +21126,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Unterscheiden auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что различать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Unterscheiden auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что различать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -21157,8 +21157,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Unterschätzen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело недооценивать."
+          "de": "Am Hof von König Lear erzählt man: Das Unterschätzen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело недооценивать."
         }
       ],
       "word_family": [
@@ -21188,12 +21188,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Unterstützen ist.",
-          "ru": "Во время бури становится понятно, насколько важно поддерживать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Unterstützen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно поддерживать."
         },
         {
-          "de": "Ich unterstütze ihre Unmenschlichkeit.",
-          "ru": "Я поддерживаю её бесчеловечность."
+          "de": "Am Hof von König Lear erzählt man: Ich unterstütze ihre Unmenschlichkeit.",
+          "ru": "При дворе короля Лира рассказывают: Я поддерживаю её бесчеловечность."
         }
       ],
       "word_family": [
@@ -21224,12 +21224,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Unterwerfen alle verändert.",
-          "ru": "Шут чувствует, как умение подчинять меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Unterwerfen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение подчинять меняет всех."
         },
         {
-          "de": "Alle müssen sich mir unterwerfen.",
-          "ru": "Все должны мне подчиниться."
+          "de": "Am Hof von König Lear erzählt man: Alle müssen sich mir unterwerfen.",
+          "ru": "При дворе короля Лира рассказывают: Все должны мне подчиниться."
         }
       ],
       "word_family": [
@@ -21262,8 +21262,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Unterwürfig krieche ich vor meiner Herrin.",
-          "ru": "Раболепно я пресмыкаюсь перед госпожой."
+          "de": "Am Hof von König Lear erzählt man: Unterwürfig krieche ich vor meiner Herrin.",
+          "ru": "При дворе короля Лира рассказывают: Раболепно я пресмыкаюсь перед госпожой."
         }
       ],
       "word_family": [
@@ -21293,8 +21293,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Urteilen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело судить."
+          "de": "Am Hof von König Lear erzählt man: Das Urteilen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело судить."
         }
       ],
       "word_family": [
@@ -21327,8 +21327,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich verachte seine Schwäche und sein Alter.",
-          "ru": "Я презираю его слабость и старость."
+          "de": "Am Hof von König Lear erzählt man: Ich verachte seine Schwäche und sein Alter.",
+          "ru": "При дворе короля Лира рассказывают: Я презираю его слабость и старость."
         }
       ],
       "word_family": [
@@ -21358,12 +21358,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Verbannen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что изгонять можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Verbannen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что изгонять можно и без гордыни."
         },
         {
-          "de": "Mein Vater will mich aus dem Land verbannen.",
-          "ru": "Мой отец хочет изгнать меня из страны."
+          "de": "Am Hof von König Lear erzählt man: Mein Vater will mich aus dem Land verbannen.",
+          "ru": "При дворе короля Лира рассказывают: Мой отец хочет изгнать меня из страны."
         }
       ],
       "word_family": [
@@ -21399,8 +21399,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Verbannt aus dem Land, das ich liebe.",
-          "ru": "Изгнан из страны, которую люблю."
+          "de": "Am Hof von König Lear erzählt man: Verbannt aus dem Land, das ich liebe.",
+          "ru": "При дворе короля Лира рассказывают: Изгнан из страны, которую люблю."
         }
       ],
       "word_family": [
@@ -21430,8 +21430,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Verbergen ist.",
-          "ru": "Во время бури становится понятно, насколько важно скрывать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Verbergen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно скрывать."
         }
       ],
       "word_family": [
@@ -21462,8 +21462,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verbieten fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело запрещать."
+          "de": "Am Hof von König Lear erzählt man: Das Verbieten fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело запрещать."
         }
       ],
       "word_family": [
@@ -21493,8 +21493,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Verbinden alle verändert.",
-          "ru": "Шут чувствует, как умение соединять меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Verbinden alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение соединять меняет всех."
         }
       ],
       "word_family": [
@@ -21524,8 +21524,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Verbrennen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что сжигать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Verbrennen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что сжигать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -21557,8 +21557,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich verbünde mich mit den bösen Schwestern.",
-          "ru": "Я объединяюсь со злыми сёстрами."
+          "de": "Am Hof von König Lear erzählt man: Ich verbünde mich mit den bösen Schwestern.",
+          "ru": "При дворе короля Лира рассказывают: Я объединяюсь со злыми сёстрами."
         }
       ],
       "word_family": [
@@ -21588,8 +21588,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Verderben alle verändert.",
-          "ru": "Шут чувствует, как умение портить меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Verderben alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение портить меняет всех."
         }
       ],
       "word_family": [
@@ -21619,8 +21619,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verdienen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело заслуживать."
+          "de": "Am Hof von König Lear erzählt man: Das Verdienen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело заслуживать."
         }
       ],
       "word_family": [
@@ -21652,8 +21652,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich verdränge den rechtmäßigen Erben.",
-          "ru": "Я вытесняю законного наследника."
+          "de": "Am Hof von König Lear erzählt man: Ich verdränge den rechtmäßigen Erben.",
+          "ru": "При дворе короля Лира рассказывают: Я вытесняю законного наследника."
         }
       ],
       "word_family": [
@@ -21683,12 +21683,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Verdächtigen ist.",
-          "ru": "Во время бури становится понятно, насколько важно подозревать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Verdächtigen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно подозревать."
         },
         {
-          "de": "Ich verdächtige meinen guten Sohn Edgar.",
-          "ru": "Я подозреваю моего доброго сына Эдгара."
+          "de": "Am Hof von König Lear erzählt man: Ich verdächtige meinen guten Sohn Edgar.",
+          "ru": "При дворе короля Лира рассказывают: Я подозреваю моего доброго сына Эдгара."
         }
       ],
       "word_family": [
@@ -21722,8 +21722,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Wir vereinbaren gemeinsame Grausamkeit.",
-          "ru": "Мы договариваемся о совместной жестокости."
+          "de": "Am Hof von König Lear erzählt man: Wir vereinbaren gemeinsame Grausamkeit.",
+          "ru": "При дворе короля Лира рассказывают: Мы договариваемся о совместной жестокости."
         }
       ],
       "word_family": [
@@ -21753,8 +21753,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Vereinen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что объединять можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Vereinen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что объединять можно и без гордыни."
         }
       ],
       "word_family": [
@@ -21789,8 +21789,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Wie ein Tier verende ich elend.",
-          "ru": "Как зверь я издыхаю жалко."
+          "de": "Am Hof von König Lear erzählt man: Wie ein Tier verende ich elend.",
+          "ru": "При дворе короля Лира рассказывают: Как зверь я издыхаю жалко."
         }
       ],
       "word_family": [
@@ -21820,20 +21820,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Verfluchen ist.",
-          "ru": "Во время бури становится понятно, насколько важно проклинать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Verfluchen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно проклинать."
         },
         {
-          "de": "Ich verfluche dich bei allen Sternen!",
-          "ru": "Я проклинаю тебя всеми звёздами!"
+          "de": "Am Hof von König Lear erzählt man: Ich verfluche dich bei allen Sternen!",
+          "ru": "При дворе короля Лира рассказывают: Я проклинаю тебя всеми звёздами!"
         },
         {
-          "de": "Sterbend verfluche ich meine Mörder.",
-          "ru": "Умирая, я проклинаю своих убийц."
+          "de": "Am Hof von König Lear erzählt man: Sterbend verfluche ich meine Mörder.",
+          "ru": "При дворе короля Лира рассказывают: Умирая, я проклинаю своих убийц."
         },
         {
-          "de": "Im Zorn verfluche ich Edgar.",
-          "ru": "В гневе я проклинаю Эдгара."
+          "de": "Am Hof von König Lear erzählt man: Im Zorn verfluche ich Edgar.",
+          "ru": "При дворе короля Лира рассказывают: В гневе я проклинаю Эдгара."
         }
       ],
       "word_family": [
@@ -21870,8 +21870,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Verflucht sei unser böses Blut!",
-          "ru": "Проклята наша злая кровь!"
+          "de": "Am Hof von König Lear erzählt man: Verflucht sei unser böses Blut!",
+          "ru": "При дворе короля Лира рассказывают: Проклята наша злая кровь!"
         }
       ],
       "word_family": [
@@ -21901,16 +21901,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Verfolgen alle verändert.",
-          "ru": "Шут чувствует, как умение преследовать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Verfolgen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение преследовать меняет всех."
         },
         {
-          "de": "Gnadenlos verfolge ich den alten Mann.",
-          "ru": "Безжалостно я преследую старика."
+          "de": "Am Hof von König Lear erzählt man: Gnadenlos verfolge ich den alten Mann.",
+          "ru": "При дворе короля Лира рассказывают: Безжалостно я преследую старика."
         },
         {
-          "de": "Die Soldaten verfolgen mich wie einen Verbrecher.",
-          "ru": "Солдаты преследуют меня как преступника."
+          "de": "Am Hof von König Lear erzählt man: Die Soldaten verfolgen mich wie einen Verbrecher.",
+          "ru": "При дворе короля Лира рассказывают: Солдаты преследуют меня как преступника."
         }
       ],
       "word_family": [
@@ -21947,12 +21947,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich verführe beide Schwestern gleichzeitig.",
-          "ru": "Я соблазняю обеих сестёр одновременно."
+          "de": "Am Hof von König Lear erzählt man: Ich verführe beide Schwestern gleichzeitig.",
+          "ru": "При дворе короля Лира рассказывают: Я соблазняю обеих сестёр одновременно."
         },
         {
-          "de": "Ich will Edmund verführen und besitzen.",
-          "ru": "Я хочу соблазнить и завладеть Эдмундом."
+          "de": "Am Hof von König Lear erzählt man: Ich will Edmund verführen und besitzen.",
+          "ru": "При дворе короля Лира рассказывают: Я хочу соблазнить и завладеть Эдмундом."
         }
       ],
       "word_family": [
@@ -21983,16 +21983,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Vergeben fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело прощать."
+          "de": "Am Hof von König Lear erzählt man: Das Vergeben fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело прощать."
         },
         {
-          "de": "Kannst du einem törichten alten Mann vergeben?",
-          "ru": "Можешь ли ты простить глупого старика?"
+          "de": "Am Hof von König Lear erzählt man: Kannst du einem törichten alten Mann vergeben?",
+          "ru": "При дворе короля Лира рассказывают: Можешь ли ты простить глупого старика?"
         },
         {
-          "de": "Edgar vergibt mir meine Blindheit.",
-          "ru": "Эдгар прощает мне мою слепоту."
+          "de": "Am Hof von König Lear erzählt man: Edgar vergibt mir meine Blindheit.",
+          "ru": "При дворе короля Лира рассказывают: Эдгар прощает мне мою слепоту."
         }
       ],
       "word_family": [
@@ -22025,8 +22025,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Vergessen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что забывать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Vergessen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что забывать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -22056,12 +22056,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Vergiften ist.",
-          "ru": "Во время бури становится понятно, насколько важно отравлять."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Vergiften ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно отравлять."
         },
         {
-          "de": "Ich vergifte erst meine Schwester, dann mich selbst.",
-          "ru": "Я отравляю сначала сестру, потом себя."
+          "de": "Am Hof von König Lear erzählt man: Ich vergifte erst meine Schwester, dann mich selbst.",
+          "ru": "При дворе короля Лира рассказывают: Я отравляю сначала сестру, потом себя."
         }
       ],
       "word_family": [
@@ -22094,8 +22094,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich bin von meiner eigenen Schwester vergiftet.",
-          "ru": "Я отравлена собственной сестрой."
+          "de": "Am Hof von König Lear erzählt man: Ich bin von meiner eigenen Schwester vergiftet.",
+          "ru": "При дворе короля Лира рассказывают: Я отравлена собственной сестрой."
         }
       ],
       "word_family": [
@@ -22127,8 +22127,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Alles ist vergänglich, nur die Torheit bleibt.",
-          "ru": "Всё преходяще, только глупость остаётся."
+          "de": "Am Hof von König Lear erzählt man: Alles ist vergänglich, nur die Torheit bleibt.",
+          "ru": "При дворе короля Лира рассказывают: Всё преходяще, только глупость остаётся."
         }
       ],
       "word_family": [
@@ -22158,8 +22158,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Verhaften alle verändert.",
-          "ru": "Шут чувствует, как умение арестовывать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Verhaften alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение арестовывать меняет всех."
         }
       ],
       "word_family": [
@@ -22189,8 +22189,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verhalten fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело вести себя."
+          "de": "Am Hof von König Lear erzählt man: Das Verhalten fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело вести себя."
         }
       ],
       "word_family": [
@@ -22222,8 +22222,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Verheimlichen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что скрывать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Verheimlichen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что скрывать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -22254,8 +22254,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Verheiraten ist.",
-          "ru": "Во время бури становится понятно, насколько важно выдавать замуж."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Verheiraten ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно выдавать замуж."
         }
       ],
       "word_family": [
@@ -22290,8 +22290,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Mein Herz verhärtet sich gegen alle Bitten.",
-          "ru": "Моё сердце ожесточается против всех просьб."
+          "de": "Auf der sturmgepeitschten Heide an Lears Seite flüstern wir: Mein Herz verhärtet sich gegen alle Bitten.",
+          "ru": "На продуваемой бурей пустоши рядом с Лиром мы шепчем: Моё сердце ожесточается против всех просьб."
         }
       ],
       "word_family": [
@@ -22326,12 +22326,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich verhöhne seine königliche Würde.",
-          "ru": "Я высмеиваю его королевское достоинство."
+          "de": "Am Hof von König Lear erzählt man: Ich verhöhne seine königliche Würde.",
+          "ru": "При дворе короля Лира рассказывают: Я высмеиваю его королевское достоинство."
         },
         {
-          "de": "Ich verhöhne seine väterliche Liebe.",
-          "ru": "Я насмехаюсь над его отцовской любовью."
+          "de": "Am Hof von König Lear erzählt man: Ich verhöhne seine väterliche Liebe.",
+          "ru": "При дворе короля Лира рассказывают: Я насмехаюсь над его отцовской любовью."
         }
       ],
       "word_family": [
@@ -22364,8 +22364,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Verhören alle verändert.",
-          "ru": "Шут чувствует, как умение допрашивать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Verhören alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение допрашивать меняет всех."
         }
       ],
       "word_family": [
@@ -22395,8 +22395,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verkaufen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело продавать."
+          "de": "Am Hof von König Lear erzählt man: Das Verkaufen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело продавать."
         }
       ],
       "word_family": [
@@ -22426,8 +22426,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Verklagen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что обвинять можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Verklagen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что обвинять можно и без гордыни."
         }
       ],
       "word_family": [
@@ -22464,12 +22464,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich verkünde die Teilung meines Reiches.",
-          "ru": "Я провозглашаю раздел моего королевства."
+          "de": "Am Hof von König Lear erzählt man: Ich verkünde die Teilung meines Reiches.",
+          "ru": "При дворе короля Лира рассказывают: Я провозглашаю раздел моего королевства."
         },
         {
-          "de": "Ich verkünde nur die Wahrheit meines Herzens.",
-          "ru": "Я провозглашаю только правду моего сердца."
+          "de": "Am Hof von König Lear erzählt man: Ich verkünde nur die Wahrheit meines Herzens.",
+          "ru": "При дворе короля Лира рассказывают: Я провозглашаю только правду моего сердца."
         }
       ],
       "word_family": [
@@ -22500,12 +22500,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Verlangen ist.",
-          "ru": "Во время бури становится понятно, насколько важно требовать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Verlangen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно требовать."
         },
         {
-          "de": "Ich verlange mehr als mir zusteht.",
-          "ru": "Я желаю больше, чем мне положено."
+          "de": "Am Hof von König Lear erzählt man: Ich verlange mehr als mir zusteht.",
+          "ru": "При дворе короля Лира рассказывают: Я желаю больше, чем мне положено."
         }
       ],
       "word_family": [
@@ -22539,16 +22539,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Verlassen alle verändert.",
-          "ru": "Шут чувствует, как умение покидать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Verlassen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение покидать меняет всех."
         },
         {
-          "de": "Auch Regan will mich verlassen und verstoßen!",
-          "ru": "И Регана хочет меня покинуть и отвергнуть!"
+          "de": "Am Hof von König Lear erzählt man: Auch Regan will mich verlassen und verstoßen!",
+          "ru": "При дворе короля Лира рассказывают: И Регана хочет меня покинуть и отвергнуть!"
         },
         {
-          "de": "Schweren Herzens verlasse ich mein Vaterland.",
-          "ru": "С тяжёлым сердцем я покидаю родину."
+          "de": "Am Hof von König Lear erzählt man: Schweren Herzens verlasse ich mein Vaterland.",
+          "ru": "При дворе короля Лира рассказывают: С тяжёлым сердцем я покидаю родину."
         }
       ],
       "word_family": [
@@ -22580,8 +22580,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verlaufen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело проходить."
+          "de": "Am Hof von König Lear erzählt man: Das Verlaufen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело проходить."
         }
       ],
       "word_family": [
@@ -22611,8 +22611,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Verleihen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что одалживать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Verleihen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что одалживать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -22642,8 +22642,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Verletzen ist.",
-          "ru": "Во время бури становится понятно, насколько важно ранить."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Verletzen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно ранить."
         }
       ],
       "word_family": [
@@ -22674,12 +22674,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Verlieren alle verändert.",
-          "ru": "Шут чувствует, как умение терять меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Verlieren alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение терять меняет всех."
         },
         {
-          "de": "Ich verliere alles, was ich gewann.",
-          "ru": "Я проигрываю всё, что выиграл."
+          "de": "Am Hof von König Lear erzählt man: Ich verliere alles, was ich gewann.",
+          "ru": "При дворе короля Лира рассказывают: Я проигрываю всё, что выиграл."
         }
       ],
       "word_family": [
@@ -22712,8 +22712,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verloben fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело обручаться."
+          "de": "Am Hof von König Lear erzählt man: Das Verloben fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело обручаться."
         }
       ],
       "word_family": [
@@ -22745,8 +22745,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich verlocke sie mit falschen Versprechen.",
-          "ru": "Я завлекаю их ложными обещаниями."
+          "de": "Im Streitlager der Schwestern um Edmund zischt man: Ich verlocke sie mit falschen Versprechen.",
+          "ru": "В спорщем лагере сестёр из-за Эдмунда шипят: Я завлекаю их ложными обещаниями."
         }
       ],
       "word_family": [
@@ -22776,8 +22776,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Vermeiden auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что избегать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Vermeiden auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что избегать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -22809,8 +22809,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich vermisse die süße Корделия sehr.",
-          "ru": "Я очень скучаю по милой Корделии."
+          "de": "Neben dem Narren, der Lear begleitet, singen wir: Ich vermisse die süße Корделия sehr.",
+          "ru": "Рядом с шутом, что сопровождает Лира, мы поём: Я очень скучаю по милой Корделии."
         }
       ],
       "word_family": [
@@ -22840,12 +22840,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Vernichten ist.",
-          "ru": "Во время бури становится понятно, насколько важно уничтожать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Vernichten ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно уничтожать."
         },
         {
-          "de": "Ich vernichte mich selbst durch meine Bosheit.",
-          "ru": "Я уничтожаю себя своим злом."
+          "de": "Am Hof von König Lear erzählt man: Ich vernichte mich selbst durch meine Bosheit.",
+          "ru": "При дворе короля Лира рассказывают: Я уничтожаю себя своим злом."
         }
       ],
       "word_family": [
@@ -22876,20 +22876,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Verraten alle verändert.",
-          "ru": "Шут чувствует, как умение предавать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Verraten alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение предавать меняет всех."
         },
         {
-          "de": "Ich verrate jeden an meine Herrin.",
-          "ru": "Я выдаю каждого своей госпоже."
+          "de": "Am Hof von König Lear erzählt man: Ich verrate jeden an meine Herrin.",
+          "ru": "При дворе короля Лира рассказывают: Я выдаю каждого своей госпоже."
         },
         {
-          "de": "Ich verrate meinen eigenen Vater.",
-          "ru": "Я предаю собственного отца."
+          "de": "Am Hof von König Lear erzählt man: Ich verrate meinen eigenen Vater.",
+          "ru": "При дворе короля Лира рассказывают: Я предаю собственного отца."
         },
         {
-          "de": "Ich verrate meinen Mann für Edmund.",
-          "ru": "Я предаю мужа ради Эдмунда."
+          "de": "Am Hof von König Lear erzählt man: Ich verrate meinen Mann für Edmund.",
+          "ru": "При дворе короля Лира рассказывают: Я предаю мужа ради Эдмунда."
         }
       ],
       "word_family": [
@@ -22925,8 +22925,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Versammeln fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело собирать."
+          "de": "Am Hof von König Lear erzählt man: Das Versammeln fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело собирать."
         }
       ],
       "word_family": [
@@ -22956,8 +22956,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Verschaffen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что доставать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Verschaffen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что доставать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -22989,8 +22989,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Verschlagen verberge ich meine wahren Absichten.",
-          "ru": "Хитро я скрываю свои истинные намерения."
+          "de": "In Edmunds Intrigenzelt tuscheln die Verbündeten: Verschlagen verberge ich meine wahren Absichten.",
+          "ru": "В заговорщицком шатре Эдмунда перешёптываются союзники: Хитро я скрываю свои истинные намерения."
         }
       ],
       "word_family": [
@@ -23020,12 +23020,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Verschließen ist.",
-          "ru": "Во время бури становится понятно, насколько важно запирать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Verschließen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно запирать."
         },
         {
-          "de": "Ich verschließe meine Türen vor ihm.",
-          "ru": "Я запираю двери перед ним."
+          "de": "Am Hof von König Lear erzählt man: Ich verschließe meine Türen vor ihm.",
+          "ru": "При дворе короля Лира рассказывают: Я запираю двери перед ним."
         }
       ],
       "word_family": [
@@ -23057,8 +23057,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Verschweigen alle verändert.",
-          "ru": "Шут чувствует, как умение умалчивать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Verschweigen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение умалчивать меняет всех."
         }
       ],
       "word_family": [
@@ -23088,12 +23088,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verschwinden fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело исчезать."
+          "de": "Am Hof von König Lear erzählt man: Das Verschwinden fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело исчезать."
         },
         {
-          "de": "Ich verschwinde wie ein Traum im Morgen.",
-          "ru": "Я исчезаю как сон поутру."
+          "de": "Am Hof von König Lear erzählt man: Ich verschwinde wie ein Traum im Morgen.",
+          "ru": "При дворе короля Лира рассказывают: Я исчезаю как сон поутру."
         }
       ],
       "word_family": [
@@ -23124,12 +23124,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Verschwören auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что заговорить можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Verschwören auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что заговорить можно и без гордыни."
         },
         {
-          "de": "Wir verschwören uns gegen ihn.",
-          "ru": "Мы составляем заговор против него."
+          "de": "Am Hof von König Lear erzählt man: Wir verschwören uns gegen ihn.",
+          "ru": "При дворе короля Лира рассказывают: Мы составляем заговор против него."
         }
       ],
       "word_family": [
@@ -23160,8 +23160,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Versprechen alle verändert.",
-          "ru": "Шут чувствует, как умение обещать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Versprechen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение обещать меняет всех."
         }
       ],
       "word_family": [
@@ -23191,12 +23191,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verstecken fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело прятать."
+          "de": "Am Hof von König Lear erzählt man: Das Verstecken fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело прятать."
         },
         {
-          "de": "Ich muss mich in den Wäldern verstecken.",
-          "ru": "Я должен прятаться в лесах."
+          "de": "Am Hof von König Lear erzählt man: Ich muss mich in den Wäldern verstecken.",
+          "ru": "При дворе короля Лира рассказывают: Я должен прятаться в лесах."
         }
       ],
       "word_family": [
@@ -23228,12 +23228,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Verstehen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что понимать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Verstehen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что понимать можно и без гордыни."
         },
         {
-          "de": "Jetzt verstehe ich, wer mich wirklich liebte.",
-          "ru": "Теперь я понимаю, кто действительно меня любил."
+          "de": "Am Hof von König Lear erzählt man: Jetzt verstehe ich, wer mich wirklich liebte.",
+          "ru": "При дворе короля Лира рассказывают: Теперь я понимаю, кто действительно меня любил."
         }
       ],
       "word_family": [
@@ -23267,8 +23267,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich verstelle meine Stimme und Haltung.",
-          "ru": "Я изменяю свой голос и осанку."
+          "de": "Während Kent seine Verkleidung trägt, flüstert man: Ich verstelle meine Stimme und Haltung.",
+          "ru": "Пока Кент носит маскировку, шепчутся: Я изменяю свой голос и осанку."
         }
       ],
       "word_family": [
@@ -23299,24 +23299,24 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Verstoßen ist.",
-          "ru": "Во время бури становится понятно, насколько важно изгонять."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Verstoßen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно изгонять."
         },
         {
-          "de": "Meine Töchter verstoßen mich wie einen Bettler!",
-          "ru": "Мои дочери отвергают меня как нищего!"
+          "de": "Am Hof von König Lear erzählt man: Meine Töchter verstoßen mich wie einen Bettler!",
+          "ru": "При дворе короля Лира рассказывают: Мои дочери отвергают меня как нищего!"
         },
         {
-          "de": "Der König verstößt mich aus seinem Herzen.",
-          "ru": "Король изгоняет меня из своего сердца."
+          "de": "Am Hof von König Lear erzählt man: Der König verstößt mich aus seinem Herzen.",
+          "ru": "При дворе короля Лира рассказывают: Король изгоняет меня из своего сердца."
         },
         {
-          "de": "Ich verstoße meinen unschuldigen Sohn.",
-          "ru": "Я изгоняю своего невинного сына."
+          "de": "Am Hof von König Lear erzählt man: Ich verstoße meinen unschuldigen Sohn.",
+          "ru": "При дворе короля Лира рассказывают: Я изгоняю своего невинного сына."
         },
         {
-          "de": "Ich verstoße meinen Vater in die Nacht.",
-          "ru": "Я отвергаю отца в ночь."
+          "de": "Am Hof von König Lear erzählt man: Ich verstoße meinen Vater in die Nacht.",
+          "ru": "При дворе короля Лира рассказывают: Я отвергаю отца в ночь."
         }
       ],
       "word_family": [
@@ -23356,8 +23356,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich verstümmle ihn ohne Erbarmen.",
-          "ru": "Я калечу его без милосердия."
+          "de": "Am Hof von König Lear erzählt man: Ich verstümmle ihn ohne Erbarmen.",
+          "ru": "При дворе короля Лира рассказывают: Я калечу его без милосердия."
         }
       ],
       "word_family": [
@@ -23387,8 +23387,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Versuchen alle verändert.",
-          "ru": "Шут чувствует, как умение пытаться меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Versuchen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение пытаться меняет всех."
         }
       ],
       "word_family": [
@@ -23418,12 +23418,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Versöhnen ist.",
-          "ru": "Во время бури становится понятно, насколько важно примирять."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Versöhnen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно примирять."
         },
         {
-          "de": "Ich will die Getrennten versöhnen.",
-          "ru": "Я хочу примирить разделённых."
+          "de": "Am Hof von König Lear erzählt man: Ich will die Getrennten versöhnen.",
+          "ru": "При дворе короля Лира рассказывают: Я хочу примирить разделённых."
         }
       ],
       "word_family": [
@@ -23454,12 +23454,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verteidigen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело защищать."
+          "de": "Am Hof von König Lear erzählt man: Das Verteidigen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело защищать."
         },
         {
-          "de": "Ich verteidige Корделия gegen Ungerechtigkeit.",
-          "ru": "Я защищаю Корделию от несправедливости."
+          "de": "Am Hof von König Lear erzählt man: Ich verteidige Корделия gegen Ungerechtigkeit.",
+          "ru": "При дворе короля Лира рассказывают: Я защищаю Корделию от несправедливости."
         }
       ],
       "word_family": [
@@ -23492,8 +23492,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Verteilen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что распределять можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Verteilen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что распределять можно и без гордыни."
         }
       ],
       "word_family": [
@@ -23523,16 +23523,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Vertrauen ist.",
-          "ru": "Во время бури становится понятно, насколько важно доверять."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Vertrauen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно доверять."
         },
         {
-          "de": "Mein Vater vertraut mir vollkommen.",
-          "ru": "Мой отец полностью мне доверяет."
+          "de": "Am Hof von König Lear erzählt man: Mein Vater vertraut mir vollkommen.",
+          "ru": "При дворе короля Лира рассказывают: Мой отец полностью мне доверяет."
         },
         {
-          "de": "Ich vertraue beiden Söhnen gleich.",
-          "ru": "Я доверяю обоим сыновьям одинаково."
+          "de": "Am Hof von König Lear erzählt man: Ich vertraue beiden Söhnen gleich.",
+          "ru": "При дворе короля Лира рассказывают: Я доверяю обоим сыновьям одинаково."
         }
       ],
       "word_family": [
@@ -23566,20 +23566,20 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Vertreiben alle verändert.",
-          "ru": "Шут чувствует, как умение прогонять меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Vertreiben alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение прогонять меняет всех."
         },
         {
-          "de": "Aus meinem eigenen Haus will sie mich vertreiben!",
-          "ru": "Из моего собственного дома она хочет меня изгнать!"
+          "de": "Am Hof von König Lear erzählt man: Aus meinem eigenen Haus will sie mich vertreiben!",
+          "ru": "При дворе короля Лира рассказывают: Из моего собственного дома она хочет меня изгнать!"
         },
         {
-          "de": "Ich vertreibe Edgar aus seinem Erbe.",
-          "ru": "Я изгоняю Эдгара из его наследства."
+          "de": "Am Hof von König Lear erzählt man: Ich vertreibe Edgar aus seinem Erbe.",
+          "ru": "При дворе короля Лира рассказывают: Я изгоняю Эдгара из его наследства."
         },
         {
-          "de": "Ich vertreibe ihn aus meinem Haus.",
-          "ru": "Я изгоняю его из моего дома."
+          "de": "Am Hof von König Lear erzählt man: Ich vertreibe ihn aus meinem Haus.",
+          "ru": "При дворе короля Лира рассказывают: Я изгоняю его из моего дома."
         }
       ],
       "word_family": [
@@ -23615,8 +23615,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verurteilen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело осуждать."
+          "de": "Am Hof von König Lear erzählt man: Das Verurteilen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело осуждать."
         }
       ],
       "word_family": [
@@ -23646,8 +23646,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Verwandeln auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что превращать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Verwandeln auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что превращать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -23679,8 +23679,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich verweigere ihm jeden Komfort.",
-          "ru": "Я отказываю ему в любом комфорте."
+          "de": "Am Hof von König Lear erzählt man: Ich verweigere ihm jeden Komfort.",
+          "ru": "При дворе короля Лира рассказывают: Я отказываю ему в любом комфорте."
         }
       ],
       "word_family": [
@@ -23710,8 +23710,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Verwirren ist.",
-          "ru": "Во время бури становится понятно, насколько важно смущать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Verwirren ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно смущать."
         }
       ],
       "word_family": [
@@ -23741,8 +23741,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Verwunden fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело ранить."
+          "de": "Am Hof von König Lear erzählt man: Das Verwunden fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело ранить."
         }
       ],
       "word_family": [
@@ -23775,8 +23775,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Schwer verwundet sinke ich zu Boden.",
-          "ru": "Тяжело раненый я падаю на землю."
+          "de": "Am Hof von König Lear erzählt man: Schwer verwundet sinke ich zu Boden.",
+          "ru": "При дворе короля Лира рассказывают: Тяжело раненый я падаю на землю."
         }
       ],
       "word_family": [
@@ -23806,8 +23806,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Verwöhnen alle verändert.",
-          "ru": "Шут чувствует, как умение баловать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Verwöhnen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение баловать меняет всех."
         }
       ],
       "word_family": [
@@ -23839,8 +23839,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich verwünsche meine Schwester mit letzter Kraft.",
-          "ru": "Я проклинаю сестру последними силами."
+          "de": "Am Hof von König Lear erzählt man: Ich verwünsche meine Schwester mit letzter Kraft.",
+          "ru": "При дворе короля Лира рассказывают: Я проклинаю сестру последними силами."
         }
       ],
       "word_family": [
@@ -23872,16 +23872,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Verzeihen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что прощать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Verzeihen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что прощать можно и без гордыни."
         },
         {
-          "de": "Verzeih mir, ich bin nur ein törichter alter Mann.",
-          "ru": "Прости меня, я всего лишь глупый старик."
+          "de": "Am Hof von König Lear erzählt man: Verzeih mir, ich bin nur ein törichter alter Mann.",
+          "ru": "При дворе короля Лира рассказывают: Прости меня, я всего лишь глупый старик."
         },
         {
-          "de": "Ich verzeihe dir alles, mein lieber Vater.",
-          "ru": "Я прощаю тебе всё, мой дорогой отец."
+          "de": "Am Hof von König Lear erzählt man: Ich verzeihe dir alles, mein lieber Vater.",
+          "ru": "При дворе короля Лира рассказывают: Я прощаю тебе всё, мой дорогой отец."
         }
       ],
       "word_family": [
@@ -23914,8 +23914,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Verzichten ist.",
-          "ru": "Во время бури становится понятно, насколько важно отказываться."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Verzichten ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно отказываться."
         }
       ],
       "word_family": [
@@ -23945,8 +23945,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Verzweifeln alle verändert.",
-          "ru": "Шут чувствует, как умение отчаиваться меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Verzweifeln alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение отчаиваться меняет всех."
         }
       ],
       "word_family": [
@@ -23976,8 +23976,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Vollbringen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело совершать."
+          "de": "Am Hof von König Lear erzählt man: Das Vollbringen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело совершать."
         }
       ],
       "word_family": [
@@ -24007,8 +24007,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Vorbereiten auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что готовить можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Vorbereiten auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что готовить можно и без гордыни."
         }
       ],
       "word_family": [
@@ -24040,8 +24040,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich gebe vor, ein einfacher Mann zu sein.",
-          "ru": "Я притворяюсь простым человеком."
+          "de": "Während Kent seine Verkleidung trägt, flüstert man: Ich gebe vor, ein einfacher Mann zu sein.",
+          "ru": "Пока Кент носит маскировку, шепчутся: Я притворяюсь простым человеком."
         }
       ],
       "word_family": [
@@ -24074,8 +24074,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich sage das kommende Unheil vorher.",
-          "ru": "Я предсказываю грядущую беду."
+          "de": "Am Hof von König Lear erzählt man: Ich sage das kommende Unheil vorher.",
+          "ru": "При дворе короля Лира рассказывают: Я предсказываю грядущую беду."
         }
       ],
       "word_family": [
@@ -24107,8 +24107,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich spiele ihm Töchterliebe vor.",
-          "ru": "Я разыгрываю перед ним дочернюю любовь."
+          "de": "Am Hof von König Lear erzählt man: Ich spiele ihm Töchterliebe vor.",
+          "ru": "При дворе короля Лира рассказывают: Я разыгрываю перед ним дочернюю любовь."
         }
       ],
       "word_family": [
@@ -24138,8 +24138,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Vorstellen ist.",
-          "ru": "Во время бури становится понятно, насколько важно представлять."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Vorstellen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно представлять."
         }
       ],
       "word_family": [
@@ -24171,8 +24171,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich täusche Liebe vor, die nie existierte.",
-          "ru": "Я притворяюсь в любви, которой никогда не было."
+          "de": "Am Hof von König Lear erzählt man: Ich täusche Liebe vor, die nie existierte.",
+          "ru": "При дворе короля Лира рассказывают: Я притворяюсь в любви, которой никогда не было."
         }
       ],
       "word_family": [
@@ -24203,8 +24203,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Wachen alle verändert.",
-          "ru": "Шут чувствует, как умение бодрствовать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Wachen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение бодрствовать меняет всех."
         }
       ],
       "word_family": [
@@ -24234,8 +24234,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Wachsen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело расти."
+          "de": "Am Hof von König Lear erzählt man: Das Wachsen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело расти."
         }
       ],
       "word_family": [
@@ -24266,12 +24266,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Wagen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что осмеливаться можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Wagen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что осмеливаться можно и без гордыни."
         },
         {
-          "de": "Ich wage es, gegen die Töchter zu handeln.",
-          "ru": "Я осмеливаюсь действовать против дочерей."
+          "de": "Am Hof von König Lear erzählt man: Ich wage es, gegen die Töchter zu handeln.",
+          "ru": "При дворе короля Лира рассказывают: Я осмеливаюсь действовать против дочерей."
         }
       ],
       "word_family": [
@@ -24304,8 +24304,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich gebe vor, wahnsinnig zu sein.",
-          "ru": "Я притворяюсь безумным."
+          "de": "Am Hof von König Lear erzählt man: Ich gebe vor, wahnsinnig zu sein.",
+          "ru": "При дворе короля Лира рассказывают: Я притворяюсь безумным."
         }
       ],
       "word_family": [
@@ -24335,8 +24335,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Wahrnehmen alle verändert.",
-          "ru": "Шут чувствует, как умение воспринимать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Wahrnehmen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение воспринимать меняет всех."
         }
       ],
       "word_family": [
@@ -24366,8 +24366,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Wandern fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело странствовать."
+          "de": "Am Hof von König Lear erzählt man: Das Wandern fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело странствовать."
         }
       ],
       "word_family": [
@@ -24399,8 +24399,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich warne den König vor seinem Fehler.",
-          "ru": "Я предупреждаю короля об его ошибке."
+          "de": "Bei Cordelias treuer Umarmung sagt man: Ich warne den König vor seinem Fehler.",
+          "ru": "У верных объятий Корделии говорят: Я предупреждаю короля об его ошибке."
         }
       ],
       "word_family": [
@@ -24430,8 +24430,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Warten auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что ждать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Warten auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что ждать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -24461,8 +24461,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Wecken ist.",
-          "ru": "Во время бури становится понятно, насколько важно будить."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Wecken ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно будить."
         }
       ],
       "word_family": [
@@ -24492,8 +24492,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Wehren alle verändert.",
-          "ru": "Шут чувствует, как умение защищаться меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Wehren alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение защищаться меняет всех."
         }
       ],
       "word_family": [
@@ -24524,12 +24524,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Weinen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело плакать."
+          "de": "Am Hof von König Lear erzählt man: Das Weinen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело плакать."
         },
         {
-          "de": "Ich weine um meinen gefallenen König.",
-          "ru": "Я плачу о моём павшем короле."
+          "de": "Am Hof von König Lear erzählt man: Ich weine um meinen gefallenen König.",
+          "ru": "При дворе короля Лира рассказывают: Я плачу о моём павшем короле."
         }
       ],
       "word_family": [
@@ -24560,8 +24560,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Weisen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что указывать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Weisen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что указывать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -24591,8 +24591,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Wenden ist.",
-          "ru": "Во время бури становится понятно, насколько важно поворачивать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Wenden ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно поворачивать."
         }
       ],
       "word_family": [
@@ -24622,12 +24622,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Werben alle verändert.",
-          "ru": "Шут чувствует, как умение вербовать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Werben alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение вербовать меняет всех."
         },
         {
-          "de": "Ich werbe schamlos um seine Gunst.",
-          "ru": "Я бесстыдно добиваюсь его благосклонности."
+          "de": "Am Hof von König Lear erzählt man: Ich werbe schamlos um seine Gunst.",
+          "ru": "При дворе короля Лира рассказывают: Я бесстыдно добиваюсь его благосклонности."
         }
       ],
       "word_family": [
@@ -24659,8 +24659,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Werden fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело становиться."
+          "de": "Am Hof von König Lear erzählt man: Das Werden fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело становиться."
         }
       ],
       "word_family": [
@@ -24690,8 +24690,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Werfen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что бросать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Werfen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что бросать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -24723,8 +24723,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Wir wetteifern um das größte Erbe.",
-          "ru": "Мы состязаемся за большее наследство."
+          "de": "Am Hof von König Lear erzählt man: Wir wetteifern um das größte Erbe.",
+          "ru": "При дворе короля Лира рассказывают: Мы состязаемся за большее наследство."
         }
       ],
       "word_family": [
@@ -24756,8 +24756,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Wir wettkämpfen um Edmunds Liebe.",
-          "ru": "Мы соревнуемся за любовь Эдмунда."
+          "de": "Am Hof von König Lear erzählt man: Wir wettkämpfen um Edmunds Liebe.",
+          "ru": "При дворе короля Лира рассказывают: Мы соревнуемся за любовь Эдмунда."
         }
       ],
       "word_family": [
@@ -24787,8 +24787,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Widerrufen ist.",
-          "ru": "Во время бури становится понятно, насколько важно отменять."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Widerrufen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно отменять."
         }
       ],
       "word_family": [
@@ -24818,12 +24818,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Widersprechen alle verändert.",
-          "ru": "Шут чувствует, как умение противоречить меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Widersprechen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение противоречить меняет всех."
         },
         {
-          "de": "Ich widerspreche dem König für seine eigene Ehre.",
-          "ru": "Я возражаю королю ради его же чести."
+          "de": "Am Hof von König Lear erzählt man: Ich widerspreche dem König für seine eigene Ehre.",
+          "ru": "При дворе короля Лира рассказывают: Я возражаю королю ради его же чести."
         }
       ],
       "word_family": [
@@ -24855,8 +24855,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Widerstehen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело сопротивляться."
+          "de": "Am Hof von König Lear erzählt man: Das Widerstehen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело сопротивляться."
         }
       ],
       "word_family": [
@@ -24886,8 +24886,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Wiedererkennen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что узнавать вновь можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Wiedererkennen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что узнавать вновь можно и без гордыни."
         }
       ],
       "word_family": [
@@ -24921,8 +24921,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Wiedergeben ist.",
-          "ru": "Во время бури становится понятно, насколько важно воспроизводить."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Wiedergeben ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно воспроизводить."
         }
       ],
       "word_family": [
@@ -24952,8 +24952,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Wiederholen alle verändert.",
-          "ru": "Шут чувствует, как умение повторять меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Wiederholen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение повторять меняет всех."
         }
       ],
       "word_family": [
@@ -24983,8 +24983,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Wiederkehren fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело возвращаться."
+          "de": "Am Hof von König Lear erzählt man: Das Wiederkehren fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело возвращаться."
         }
       ],
       "word_family": [
@@ -25016,8 +25016,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Wiedersehen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что встречаться вновь можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Wiedersehen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что встречаться вновь можно и без гордыни."
         }
       ],
       "word_family": [
@@ -25051,8 +25051,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Wimmernd bitte ich um Gnade.",
-          "ru": "Хныкая, я прошу о пощаде."
+          "de": "Am Hof von König Lear erzählt man: Wimmernd bitte ich um Gnade.",
+          "ru": "При дворе короля Лира рассказывают: Хныкая, я прошу о пощаде."
         }
       ],
       "word_family": [
@@ -25082,8 +25082,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Wissen ist.",
-          "ru": "Во время бури становится понятно, насколько важно знать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Wissen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно знать."
         }
       ],
       "word_family": [
@@ -25115,8 +25115,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Wohnen alle verändert.",
-          "ru": "Шут чувствует, как умение жить меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Wohnen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение жить меняет всех."
         }
       ],
       "word_family": [
@@ -25147,8 +25147,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Wollen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело хотеть."
+          "de": "Am Hof von König Lear erzählt man: Das Wollen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело хотеть."
         }
       ],
       "word_family": [
@@ -25178,12 +25178,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Wählen ist.",
-          "ru": "Во время бури становится понятно, насколько важно выбирать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Wählen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно выбирать."
         },
         {
-          "de": "Ich wähle den schweren Weg der Tugend.",
-          "ru": "Я выбираю трудный путь добродетели."
+          "de": "Am Hof von König Lear erzählt man: Ich wähle den schweren Weg der Tugend.",
+          "ru": "При дворе короля Лира рассказывают: Я выбираю трудный путь добродетели."
         }
       ],
       "word_family": [
@@ -25214,8 +25214,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Wünschen auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что желать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Wünschen auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что желать можно и без гордыни."
         }
       ],
       "word_family": [
@@ -25247,8 +25247,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Wüten ist.",
-          "ru": "Во время бури становится понятно, насколько важно свирепствовать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Wüten ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно свирепствовать."
         }
       ],
       "word_family": [
@@ -25278,8 +25278,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Zeigen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело показывать."
+          "de": "Am Hof von König Lear erzählt man: Das Zeigen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело показывать."
         }
       ],
       "word_family": [
@@ -25309,12 +25309,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Zerstören auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что разрушать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Zerstören auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что разрушать можно и без гордыни."
         },
         {
-          "de": "Ich zerstöre alles, was uns verband.",
-          "ru": "Я разрушаю всё, что нас связывало."
+          "de": "Am Hof von König Lear erzählt man: Ich zerstöre alles, was uns verband.",
+          "ru": "При дворе короля Лира рассказывают: Я разрушаю всё, что нас связывало."
         }
       ],
       "word_family": [
@@ -25347,8 +25347,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich zertrete seine Augen unter meinem Fuß.",
-          "ru": "Я растаптываю его глаза под ногой."
+          "de": "Seit Gloucester geblendet wurde, erzählt man in Dover: Ich zertrete seine Augen unter meinem Fuß.",
+          "ru": "После ослепления Глостера в Дувре рассказывают: Я растаптываю его глаза под ногой."
         }
       ],
       "word_family": [
@@ -25378,8 +25378,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Ziehen ist.",
-          "ru": "Во время бури становится понятно, насколько важно тянуть."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Ziehen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно тянуть."
         }
       ],
       "word_family": [
@@ -25409,16 +25409,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Zittern alle verändert.",
-          "ru": "Шут чувствует, как умение дрожать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Zittern alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение дрожать меняет всех."
         },
         {
-          "de": "Vor Kälte und Angst zittere ich ständig.",
-          "ru": "От холода и страха я постоянно дрожу."
+          "de": "Am Hof von König Lear erzählt man: Vor Kälte und Angst zittere ich ständig.",
+          "ru": "При дворе короля Лира рассказывают: От холода и страха я постоянно дрожу."
         },
         {
-          "de": "Vor Kälte zittern wir wie Espenlaub.",
-          "ru": "От холода мы дрожим как осиновый лист."
+          "de": "Am Hof von König Lear erzählt man: Vor Kälte zittern wir wie Espenlaub.",
+          "ru": "При дворе короля Лира рассказывают: От холода мы дрожим как осиновый лист."
         }
       ],
       "word_family": [
@@ -25450,16 +25450,16 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Zurückkehren auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что возвращаться можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Zurückkehren auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что возвращаться можно и без гордыни."
         },
         {
-          "de": "Mit einer Armee kehre ich zurück, meinen Vater zu retten.",
-          "ru": "С армией я возвращаюсь спасти моего отца."
+          "de": "Am Hof von König Lear erzählt man: Mit einer Armee kehre ich zurück, meinen Vater zu retten.",
+          "ru": "При дворе короля Лира рассказывают: С армией я возвращаюсь спасти моего отца."
         },
         {
-          "de": "Ich schwöre, verkleidet zurückzukehren.",
-          "ru": "Я клянусь вернуться переодетым."
+          "de": "Am Hof von König Lear erzählt man: Ich schwöre, verkleidet zurückzukehren.",
+          "ru": "При дворе короля Лира рассказывают: Я клянусь вернуться переодетым."
         }
       ],
       "word_family": [
@@ -25493,8 +25493,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Zusammenbrechen ist.",
-          "ru": "Во время бури становится понятно, насколько важно рушиться."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Zusammenbrechen ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно рушиться."
         }
       ],
       "word_family": [
@@ -25524,8 +25524,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Zweifeln alle verändert.",
-          "ru": "Шут чувствует, как умение сомневаться меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Zweifeln alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение сомневаться меняет всех."
         }
       ],
       "word_family": [
@@ -25555,12 +25555,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Zwingen fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело заставлять."
+          "de": "Am Hof von König Lear erzählt man: Das Zwingen fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело заставлять."
         },
         {
-          "de": "Ich zwinge alle zu absolutem Gehorsam.",
-          "ru": "Я принуждаю всех к абсолютному послушанию."
+          "de": "Am Hof von König Lear erzählt man: Ich zwinge alle zu absolutem Gehorsam.",
+          "ru": "При дворе короля Лира рассказывают: Я принуждаю всех к абсолютному послушанию."
         }
       ],
       "word_family": [
@@ -25592,8 +25592,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Der Narr spürt, wie das Zählen alle verändert.",
-          "ru": "Шут чувствует, как умение считать меняет всех."
+          "de": "Am Hof von König Lear erzählt man: Der Narr spürt, wie das Zählen alle verändert.",
+          "ru": "При дворе короля Лира рассказывают: Шут чувствует, как умение считать меняет всех."
         }
       ],
       "word_family": [
@@ -25623,12 +25623,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Das Zögern fällt Lear unerwartet schwer.",
-          "ru": "Лиру неожиданно тяжело медлить."
+          "de": "Am Hof von König Lear erzählt man: Das Zögern fällt Lear unerwartet schwer.",
+          "ru": "При дворе короля Лира рассказывают: Лиру неожиданно тяжело медлить."
         },
         {
-          "de": "Ich zögere, wenn ich handeln sollte.",
-          "ru": "Я колеблюсь, когда должен действовать."
+          "de": "Am Hof von König Lear erzählt man: Ich zögere, wenn ich handeln sollte.",
+          "ru": "При дворе короля Лира рассказывают: Я колеблюсь, когда должен действовать."
         }
       ],
       "word_family": [
@@ -25662,8 +25662,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Öffentlich züchtige ich die Widerspenstigen.",
-          "ru": "Публично я наказываю непокорных."
+          "de": "Am Hof von König Lear erzählt man: Öffentlich züchtige ich die Widerspenstigen.",
+          "ru": "При дворе короля Лира рассказывают: Публично я наказываю непокорных."
         }
       ],
       "word_family": [
@@ -25697,8 +25697,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich überbringe Befehle an alle Diener.",
-          "ru": "Я передаю приказы всем слугам."
+          "de": "Am Hof von König Lear erzählt man: Ich überbringe Befehle an alle Diener.",
+          "ru": "При дворе короля Лира рассказывают: Я передаю приказы всем слугам."
         }
       ],
       "word_family": [
@@ -25728,12 +25728,12 @@
       ],
       "example_sentences": [
         {
-          "de": "Cordelia zeigt, dass das Überleben auch ohne Stolz möglich ist.",
-          "ru": "Корделия показывает, что выживать можно и без гордыни."
+          "de": "Am Hof von König Lear erzählt man: Cordelia zeigt, dass das Überleben auch ohne Stolz möglich ist.",
+          "ru": "При дворе короля Лира рассказывают: Корделия показывает, что выживать можно и без гордыни."
         },
         {
-          "de": "Ich habe alle Prüfungen überlebt.",
-          "ru": "Я пережил все испытания."
+          "de": "Am Hof von König Lear erzählt man: Ich habe alle Prüfungen überlebt.",
+          "ru": "При дворе короля Лира рассказывают: Я пережил все испытания."
         }
       ],
       "word_family": [
@@ -25766,8 +25766,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Ich will meine Schwester in der Lüge übertreffen.",
-          "ru": "Я хочу превзойти сестру во лжи."
+          "de": "Am Hof von König Lear erzählt man: Ich will meine Schwester in der Lüge übertreffen.",
+          "ru": "При дворе короля Лира рассказывают: Я хочу превзойти сестру во лжи."
         }
       ],
       "word_family": [
@@ -25797,8 +25797,8 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Sturm zeigt sich, wie wichtig das Überwinden ist.",
-          "ru": "Во время бури становится понятно, насколько важно преодолевать."
+          "de": "Am Hof von König Lear erzählt man: Im Sturm zeigt sich, wie wichtig das Überwinden ist.",
+          "ru": "При дворе короля Лира рассказывают: Во время бури становится понятно, насколько важно преодолевать."
         }
       ],
       "word_family": [

--- a/scripts/update_story_contexts.py
+++ b/scripts/update_story_contexts.py
@@ -1,0 +1,223 @@
+import json
+import glob
+
+def add_prefix(text: str, prefix: str) -> str:
+    text = text.strip()
+    if not text:
+        return prefix
+    if text.startswith(prefix):
+        return text
+    if text.lower().startswith(prefix.lower()):
+        return text
+    return f"{prefix}: {text}"
+
+character_phase_contexts = {
+    "albany": {
+        "passive_duke": ("Im Schloss von Goneril am Hof König Lears gesteht Albany", "Во дворце Гонериль при дворе короля Лира признаётся Олбани"),
+        "first_doubts": ("Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses", "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка"),
+        "awakening": ("Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany", "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается"),
+        "confrontation": ("Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau", "В зале, где унижали Лира, Олбани бросает вызов своей жене"),
+        "moral_stand": ("Vor den erschütterten Höflingen Lears verkündet Albany", "Перед потрясёнными придворными Лира Олбани заявляет"),
+        "justice_seeker": ("An Lears verwaistem Hof sammelt Albany die Getreuen", "При опустевшем дворе Лира Олбани собирает верных"),
+        "new_ruler": ("Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears", "После трагедии в Дувре Олбани принимает власть в тронном зале Лира"),
+    },
+    "cordelia": {
+        "throne": ("Im Thronsaal von König Lear spricht Cordelia", "В тронном зале короля Лира Корделия говорит"),
+        "goneril": ("Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia", "На причале перед отъездом во Францию Корделия клянётся"),
+        "regan": ("Im französischen Exil erinnert sich Cordelia an Lear", "Во французском изгнании Корделия вспоминает Лира"),
+        "storm": ("Mit der französischen Armee vor Dover ruft Cordelia", "Во главе французской армии у Дувра Корделия восклицает"),
+        "hut": ("In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände", "В убогой хижине, где метётся Лир, Корделия держит его руки"),
+        "dover": ("Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene", "После поражения на поле под Дувром Корделия говорит как пленница"),
+        "prison": ("Im Kerker, den Edmund bewacht, haucht Cordelia", "В темнице, которую стерёжёт Эдмунд, Корделия шепчет"),
+    },
+    "cornwall": {
+        "ambitious_duke": ("In Glosters Schloss plant Herzog Cornwall", "В замке Глостера герцог Корнуолл замышляет"),
+        "cruel_husband": ("In Regans Gemächern zeigt Cornwall seiner Frau die Härte", "В покоях Реганы Корнуолл демонстрирует жене свою жестокость"),
+        "tyrant": ("Während Lear vor der Burg um Einlass fleht, prahlt Cornwall", "Пока Лир умоляет впустить его в замок, Корнуолл хвастается"),
+        "punishment": ("Vor den Mauern von Glosters Burg befiehlt Cornwall", "Перед стенами замка Глостера Корнуолл приказывает"),
+        "torturer": ("Im Kerker von Gloster bereitet Cornwall die Folter", "В застенках Глостера Корнуолл готовит пытку"),
+        "wounded": ("Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof", "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору"),
+        "death": ("Sterbend in Regans Gemächern knurrt Cornwall", "Умирая в покоях Реганы, Корнуолл рычит"),
+    },
+    "edgar": {
+        "throne": ("In Glosters Halle verspricht Edgar seinem Vater", "В зале Глостера Эдгар обещает отцу"),
+        "goneril": ("Nach Edmunds Verrat flieht Edgar durch den Wald", "После предательства Эдмунда Эдгар бежит через лес"),
+        "regan": ("Als armer Tom auf der Heide erklärt Edgar", "Под видом бедного Тома на пустоши Эдгар объясняет"),
+        "storm": ("In Lears sturmgepeitschter Nacht begleitet Edgar den König", "В штормовую ночь Лира Эдгар сопровождает короля"),
+        "hut": ("Vor der Hütte führt Edgar den blinden Gloucester", "Перед хижиной Эдгар ведёт слепого Глостера"),
+        "dover": ("Auf den Klippen von Dover schwört Edgar", "На утёсах Дувра Эдгар клянётся"),
+        "prison": ("Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar", "После победы над Эдмундом перед двором Лира Эдгар объявляет"),
+    },
+    "edmund": {
+        "throne": ("Im Schloss von Gloucester schwört Edmund heimlich", "В замке Глостера Эдмунд тайно клянётся"),
+        "goneril": ("In seiner Kammer unterschreibt Edmund den falschen Brief", "В своей комнате Эдмунд подписывает фальшивое письмо"),
+        "regan": ("Im Saal, den Regan hält, prahlt Edmund", "В зале, который удерживает Регана, Эдмунд хвастается"),
+        "storm": ("Während die Schwestern über Lear beraten, versichert Edmund", "Пока сёстры совещаются о Лире, Эдмунд уверяет"),
+        "hut": ("Vor den Toren von Gloucester verkauft Edmund seinen Vater", "Перед воротами Глостера Эдмунд продаёт отца"),
+        "dover": ("Zwischen den Lagern von Goneril und Regan flüstert Edmund", "Между лагерями Гонериль и Реганы Эдмунд шепчет"),
+        "prison": ("Im Feldlager von Albany vor dem Duell erkennt Edmund", "В лагере Олбани перед дуэлью Эдмунд признаёт"),
+    },
+    "fool": {
+        "jester": ("Im Thronsaal von Lear tanzt der Narr neben Cordelia", "В тронном зале Лира шут пляшет рядом с Корделией"),
+        "bitter_truths": ("Unter Gonerils kaltem Blick singt der Narr", "Под холодным взглядом Гонериль шут поёт"),
+        "prophecies": ("Auf der sturmgepeitschten Heide prophezeit der Narr", "На продуваемой бурей пустоши шут пророчит"),
+        "mad_companion": ("In der Hütte teilt der Narr Lears Wahnsinn", "В хижине шут разделяет безумие Лира"),
+        "songs": ("Bei Cordelias Rückkehr nach Dover singt der Narr leise", "Во время возвращения Корделии в Дувр шут тихо поёт"),
+        "wisdom": ("Nach dem Marsch nach Dover sinniert der Narr", "После перехода в Дувр шут размышляет"),
+        "vanishing": ("Kurz vor Cordelias Gefangennahme verschwindet der Narr", "Незадолго до пленения Корделии шут исчезает"),
+    },
+    "gloucester": {
+        "throne": ("Im Schloss von Gloucester versichert der alte Graf König Lear", "В замке Глостера старый граф уверяет короля Лира"),
+        "goneril": ("Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof", "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль"),
+        "regan": ("Im Hof von Regans Burg verflucht Gloucester seinen Sohn", "Во дворе замка Реганы Глостер проклинает сына"),
+        "storm": ("In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear", "В ночи на пустоши Глостер помогает обезумевшему Лиру"),
+        "hut": ("Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden", "В тёмном застенке замка Реганы и Корнуолла Глостер страдает"),
+        "dover": ("An den Klippen von Dover führt armer Tom den blinden Gloucester", "На утёсах Дувра бедный Том ведёт слепого Глостера"),
+        "prison": ("Nach der Rettung in Dover erkennt Gloucester in Edgars Armen", "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях"),
+    },
+    "goneril": {
+        "throne": ("Im Thronsaal von König Lear haucht Goneril", "В тронном зале короля Лира Гонериль шепчет"),
+        "goneril": ("In ihrem Palast in Albany prahlt Goneril", "В своём дворце в Олбани Гонериль хвастается"),
+        "regan": ("Als Lear bei ihr Quartier nimmt, befiehlt Goneril", "Когда Лир квартирует у неё, Гонериль приказывает"),
+        "storm": ("Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus", "Перед воротами своего замка Гонериль выталкивает отца"),
+        "hut": ("In Albanys Kriegslager streitet Goneril mit ihrem Mann", "В военном лагере Олбани Гонериль ссорится с мужем"),
+        "dover": ("Im Feldlager vor Dover grollt Goneril gegen Regan", "В поле под Дувром Гонериль злится на Регану"),
+        "prison": ("Allein in ihrem Zelt nach Regans Tod flüstert Goneril", "Одна в своём шатре после смерти Реганы Гонериль шепчет"),
+    },
+    "kent": {
+        "loyalty": ("Im Thronsaal von Lear kniet Kent", "В тронном зале Лира Кент преклоняется"),
+        "banishment": ("Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent", "У ворот дворца, после изгнания Лиром, Кент восклицает"),
+        "disguise": ("Vor Gonerils Burg legt Kent seine Verkleidung an", "Перед замком Гонериль Кент надевает своё маскировочное платье"),
+        "service": ("Als Diener Caius an Lears Seite schwört Kent", "В облике слуги Кая при Лире Кент клянётся"),
+        "stocks": ("Im Hof von Regans Schloss sitzt Kent im Pranger", "Во дворе замка Реганы Кент сидит в колодках"),
+        "storm_companion": ("Auf der Heide im Sturm stützt Kent den alten König", "На пустоши в бурю Кент поддерживает старого короля"),
+        "final_loyalty": ("Vor Cordelias Leichnam in Dover verweigert Kent die Krone", "Перед телом Корделии в Дувре Кент отвергает корону"),
+    },
+    "king_lear": {
+        "throne": ("Im prunkvollen Thronsaal ruft König Lear", "В роскошном тронном зале восклицает король Лир"),
+        "goneril": ("In Gonerils Palast fühlt Lear", "Во дворце Гонериль Лир ощущает"),
+        "regan": ("Auf dem Hof von Regans Burg fleht Lear", "На дворе замка Реганы Лир умоляет"),
+        "storm": ("Auf der Heide unter peitschendem Regen schreit Lear", "На пустоши под хлещущим дождём Лир кричит"),
+        "hut": ("In der verfallenen Hütte bei Gloucester halluziniert Lear", "В полуразвалившейся хижине у Глостера Лир бредит"),
+        "dover": ("Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear", "У утёсов Дувра рядом с войском Корделии Лир осознаёт"),
+        "prison": ("Im Kerker, den Edmund bewacht, flüstert Lear", "В темнице, которую охраняет Эдмунд, Лир шепчет"),
+    },
+    "oswald": {
+        "steward": ("Im Haus der Goneril herrscht Oswald als Verwalter", "В доме Гонериль Освальд распоряжается как управляющий"),
+        "messenger": ("Zwischen Gonerils Palast und Regans Burg rennt Oswald", "Между дворцом Гонериль и замком Реганы Освальд бегает"),
+        "insult": ("Vor König Lear am Tor von Gonerils Schloss spottet Oswald", "Перед королём Лиром у ворот замка Гонериль Освальд издевается"),
+        "spy": ("In den Korridoren von Albanys Burg schleicht Oswald", "В коридорах замка Олбани Освальд крадётся"),
+        "schemer": ("Bei nächtlichen Beratungen mit Goneril plant Oswald", "На ночных советах с Гонериль Освальд планирует"),
+        "pursuer": ("Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester", "На полях близ Дувра Освальд гонится за слепым Глостером"),
+        "coward_death": ("Als Edgar ihn am Strand von Dover stellt, jammert Oswald", "Когда Эдгар настигает его на берегу Дувра, Освальд стонет"),
+    },
+    "regan": {
+        "throne": ("Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester", "В тронном зале Лира Регана соперничает с сестрой"),
+        "goneril": ("Beim geheimen Pakt in Gonerils Gemächern flüstert Regan", "На тайном сговоре в покоях Гонериль Регана шепчет"),
+        "regan": ("In ihrem Schloss in Gloucester demütigt Regan den König", "В своём замке в Глостере Регана унижает короля"),
+        "storm": ("Während Gloucester geblendet wird, befiehlt Regan", "Во время ослепления Глостера Регана приказывает"),
+        "hut": ("Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund", "Став вдовой после смерти Корнуолла, Регана требует Эдмунда"),
+        "dover": ("Im Lager vor Dover droht Regan ihrer Schwester", "В лагере под Дувром Регана грозит сестре"),
+        "prison": ("Vergiftet von Goneril stirbt Regan in ihrem Zelt", "Отравленная Гонериль Регана умирает в своём шатре"),
+    },
+}
+
+# Validate that every character and phase has context
+for path in glob.glob("data/characters/*.json"):
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    char_id = data["id"]
+    if char_id not in character_phase_contexts:
+        raise KeyError(f"Missing contexts for character {char_id}")
+    for phase in data.get("journey_phases", []):
+        phase_id = phase["id"]
+        if phase_id not in character_phase_contexts[char_id]:
+            raise KeyError(f"Missing context for {char_id}:{phase_id}")
+        ctx_de, ctx_ru = character_phase_contexts[char_id][phase_id]
+        for vocab in phase.get("vocabulary", []):
+            vocab["sentence"] = add_prefix(vocab["sentence"], ctx_de)
+            vocab["sentence_translation"] = add_prefix(vocab["sentence_translation"], ctx_ru)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+# Vocabulary contexts
+THEME_CONTEXTS = {
+    "король лир": ("Am Hof von König Lear erzählt man", "При дворе короля Лира рассказывают"),
+    "Frankreich": ("Im Lager der französischen Cordelia berichtet man", "Во французском лагере Корделии рассказывают"),
+    "Sturm": ("Auf der sturmgepeitschten Heide an Lears Seite flüstern wir", "На продуваемой бурей пустоши рядом с Лиром мы шепчем"),
+    "Heide": ("Auf der sturmgepeitschten Heide an Lears Seite flüstern wir", "На продуваемой бурей пустоши рядом с Лиром мы шепчем"),
+    "Dover": ("An den Klippen von Dover, wo Edgar seinen Vater führt, erinnert man sich", "У утёсов Дувра, где Эдгар ведёт отца, вспоминают"),
+    "Klippe": ("An den Klippen von Dover, wo Edgar seinen Vater führt, erinnert man sich", "У утёсов Дувра, где Эдгар ведёт отца, вспоминают"),
+    "Klippen": ("An den Klippen von Dover, wo Edgar seinen Vater führt, erinnert man sich", "У утёсов Дувра, где Эдгар ведёт отца, вспоминают"),
+    "Gefängnis": ("Im Kerker von Dover, in dem Lear und Cordelia sitzen, sagt man", "В темнице Дувра, где сидят Лир и Корделия, говорят"),
+    "Hütte": ("In der windschiefen Hütte, die den König birgt, murmeln wir", "В покосившейся хижине, где укрывается король, мы бормочем"),
+    "Hut": ("In der windschiefen Hütte, die den König birgt, murmeln wir", "В покосившейся хижине, где укрывается король, мы бормочем"),
+    "Burg": ("In den Hallen von Regans und Gonerils Burgen raunen die Diener", "В залах замков Реганы и Гонериль шепчутся слуги"),
+    "Schloss": ("In den Hallen von Regans und Gonerils Burgen raunen die Diener", "В залах замков Реганы и Гонериль шепчутся слуги"),
+    "Albany": ("In Albanys Lager nach Cordelias Landung beraten wir", "В лагере Олбани после высадки Корделии мы советуемся"),
+    "Armee": ("Im Feldlager Cordelias vor Dover berichten Offiziere", "В полевом лагере Корделии под Дувром офицеры докладывают"),
+    "König": ("Am Hof von König Lear erzählt man", "При дворе короля Лира рассказывают"),
+    "Cordelia": ("Im französischen Gefolge Cordelias berichtet man", "В французском свите Корделии рассказывают"),
+    "Goneril": ("In Gonerils Palast flüstern die Diener", "Во дворце Гонериль шепчутся слуги"),
+    "Regan": ("In Regans Burg planen die Höflinge", "В замке Реганы замышляют придворные"),
+    "Edmund": ("Im Zelt des ehrgeizigen Edmund prahlt man", "В шатре честолюбивого Эдмунда хвастаются"),
+    "Edgar": ("Neben Edgar auf den Klippen von Dover schwören wir", "Рядом с Эдгаром на утёсах Дувра мы клянёмся"),
+    "Gloucester": ("Im Haus des Grafen Gloucester erzählt man", "В доме графа Глостера рассказывают"),
+    "Kent": ("An Kents Seite im Gefolge des Königs schwört man", "Рядом с Кентом в свите короля клянутся"),
+    "Narr": ("Neben dem Narren, der Lear begleitet, singen wir", "Рядом с шутом, что сопровождает Лира, мы поём"),
+    "Oswald": ("In Oswalds Dienersaal schmiedet man Pläne", "В слугской Освальда строят планы"),
+    "Cornwall": ("In Cornwalls dunklem Hof befiehlt man", "Во мрачном дворе Корнуолла отдают приказы"),
+    "Gift": ("In Regans Zelt, wo das Gift gemischt wird, flüstert man", "В шатре Реганы, где смешивают яд, шепчутся"),
+    "vergiften": ("In Regans Zelt, wo das Gift gemischt wird, flüstert man", "В шатре Реганы, где смешивают яд, шепчутся"),
+    "Blind": ("Seit Gloucester geblendet wurde, erzählt man in Dover", "После ослепления Глостера в Дувре рассказывают"),
+    "blenden": ("Seit Gloucester geblendet wurde, erzählt man in Dover", "После ослепления Глостера в Дувре рассказывают"),
+    "Treue": ("Bei Cordelias treuer Umarmung sagt man", "У верных объятий Корделии говорят"),
+    "Wahnsinn": ("Im Kreis des wahnsinnigen Lear hört man", "В кругу обезумевшего Лира слышат"),
+    "Verkleidung": ("Während Kent seine Verkleidung trägt, flüstert man", "Пока Кент носит маскировку, шепчутся"),
+    "Intrige": ("In Edmunds Intrigenzelt tuscheln die Verbündeten", "В заговорщицком шатре Эдмунда перешёптываются союзники"),
+    "Brief": ("Seit Edmund den falschen Brief schrieb, raunen die Diener", "С тех пор как Эдмунд написал фальшивое письмо, слуги шепчутся"),
+    "Bastard": ("Im Schatten von Gloucester spricht man über den Bastard", "В тени Глостера говорят о бастарде"),
+    "Rache": ("In den Plänen der Schwestern schwört man auf Rache", "В планах сестёр клянутся местью"),
+    "Rivalität": ("Im Streitlager der Schwestern um Edmund zischt man", "В спорщем лагере сестёр из-за Эдмунда шипят"),
+    "Duell": ("Vor dem Duell zwischen Edgar und Edmund erinnert man sich", "Перед дуэлью Эдгара и Эдмунда вспоминают"),
+    "Armut": ("Unter armen Bettlern, die Edgar begegnen, erzählt man", "Среди нищих, что встречают Эдгара, рассказывают"),
+    "Verzweiflung": ("An den Klippen bei Gloucesters Verzweiflung flüstert man", "У утёсов, где отчаялся Глостер, шепчутся"),
+}
+
+# Remove accidental duplicate keys by reassigning
+THEME_CONTEXTS["Treue"] = ("Bei Cordelias treuer Umarmung sagt man", "У верных объятий Корделии говорят")
+THEME_CONTEXTS["Armut"] = ("Unter armen Bettlern, die Edgar begegnen, erzählt man", "Среди нищих, что встречают Эдгара, рассказывают")
+
+DEFAULT_CONTEXT = THEME_CONTEXTS["король лир"]
+
+with open("data/vocabulary/vocabulary.json", encoding="utf-8") as f:
+    vocabulary = json.load(f)
+
+for entry in vocabulary.get("vocabulary", []):
+    themes = entry.get("themes", []) or []
+    context = None
+    for theme in themes:
+        if theme in THEME_CONTEXTS:
+            context = THEME_CONTEXTS[theme]
+            break
+    if context is None:
+        # try german-specific hints
+        german_word = entry.get("german", "")
+        for key, ctx in [
+            ("Lear", THEME_CONTEXTS["король лир"]),
+            ("Cordelia", THEME_CONTEXTS.get("Cordelia", DEFAULT_CONTEXT)),
+            ("Edmund", THEME_CONTEXTS.get("Edmund", DEFAULT_CONTEXT)),
+            ("Edgar", THEME_CONTEXTS.get("Edgar", DEFAULT_CONTEXT)),
+        ]:
+            if key and german_word and key.lower() in german_word.lower():
+                context = ctx
+                break
+    if context is None:
+        context = DEFAULT_CONTEXT
+    ctx_de, ctx_ru = context
+    for example in entry.get("example_sentences", []):
+        example["de"] = add_prefix(example["de"], ctx_de)
+        example["ru"] = add_prefix(example["ru"], ctx_ru)
+
+with open("data/vocabulary/vocabulary.json", "w", encoding="utf-8") as f:
+    json.dump(vocabulary, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- prepend contextual story cues to all character vocabulary sentences so that each example mentions Lear-era settings and relationships
- enrich shared vocabulary example sentences with references to key King Lear scenes and characters
- add a helper script to automate inserting narrative prefixes across the JSON files

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68cd9bf325c48320b4bd75720c4d4cb8