### PR TITLE
Improve word wrapping for journey vocabulary and memory cards

### DIFF
--- a/output/journeys/albany.html
+++ b/output/journeys/albany.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["молчание", "брак", "слабость", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["слабость", "брак", "молчание", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["молчание", "брак", "уступать", "слабость"], "correct_index": 1}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["слабость", "мягкий", "молчание", "терпеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["пассивный", "слабость", "колебаться", "мягкий"], "correct_index": 0}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["уступать", "мягкий", "колебаться", "молчание"], "correct_index": 0}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["мягкий", "колебаться", "слабость", "пассивный"], "correct_index": 1}, {"question": "Что означает немецкое слово «mild»?", "choices": ["молчание", "мягкий", "терпеть", "слабость"], "correct_index": 1}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["сомнение", "беспокойство", "совесть", "подвергать сомнению"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["сомнение", "подвергать сомнению", "беспокойство", "совесть"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["размышлять", "сомнение", "неуверенный", "беспокойство"], "correct_index": 3}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["подвергать сомнению", "тревожить", "беспокойство", "неуверенный"], "correct_index": 0}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["сомнение", "тревожить", "беспокойство", "неуверенный"], "correct_index": 1}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["совесть", "беспокойство", "неуверенный", "сомнение"], "correct_index": 2}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["совесть", "неуверенный", "размышлять", "сомнение"], "correct_index": 2}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["осознание", "понимать", "ужас", "пробуждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["ужас", "осознание", "пробуждаться", "понимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["понимать", "превращение", "пугаться", "пробуждаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["просыпаться", "превращение", "пробуждаться", "понимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["пугаться", "просыпаться", "понимать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["пробуждаться", "ясно видеть", "осознание", "просыпаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["понимать", "просыпаться", "ясно видеть", "превращение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["пробуждаться", "ясно видеть", "осознание", "превращение"], "correct_index": 3}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["противостоять", "спор", "сопротивление", "мужество"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "сопротивление", "противостоять", "спор"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["мужество", "спор", "сопротивление", "защищаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["обвинять", "противостоять", "защищаться", "восставать"], "correct_index": 1}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["защищаться", "обвинять", "спор", "противостоять"], "correct_index": 1}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["обвинять", "восставать", "защищаться", "спор"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["защищаться", "обвинять", "восставать", "мужество"], "correct_index": 2}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["выбирать", "справедливость", "мораль", "решение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["выбирать", "справедливость", "мораль", "решение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["благородный", "решение", "принцип", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["принцип", "выбирать", "решение", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["благородный", "справедливость", "праведный", "выбирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["принцип", "добродетель", "благородный", "мораль"], "correct_index": 0}, {"question": "Что означает немецкое слово «edel»?", "choices": ["выбирать", "благородный", "справедливость", "мораль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["решение", "благородный", "добродетель", "праведный"], "correct_index": 2}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["борьба", "право", "доброта", "наказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["борьба", "доброта", "наказывать", "право"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["защищать", "доброта", "судить", "наказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["наказывать", "борьба", "судить", "право"], "correct_index": 0}, {"question": "Что означает немецкое слово «richten»?", "choices": ["защищать", "судить", "доброта", "вмешиваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["вмешиваться", "судить", "доброта", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["защищать", "право", "доброта", "вмешиваться"], "correct_index": 3}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["мудрость", "правление", "направлять", "новое начало"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "направлять", "правление", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["правление", "направлять", "мир", "новое начало"], "correct_index": 3}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["направлять", "обновлять", "мудрость", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["примирять", "новое начало", "мир", "строить"], "correct_index": 3}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["правление", "обновлять", "мир", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["примирять", "мир", "правление", "строить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["мир", "новое начало", "мудрость", "направлять"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["слабость", "терпеть", "молчание", "брак"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["терпеть", "брак", "молчание", "слабость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["слабость", "мягкий", "брак", "терпеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["терпеть", "пассивный", "слабость", "колебаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["колебаться", "брак", "пассивный", "слабость"], "correct_index": 2}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["колебаться", "брак", "терпеть", "уступать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["слабость", "брак", "мягкий", "колебаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «mild»?", "choices": ["молчание", "слабость", "мягкий", "терпеть"], "correct_index": 2}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["подвергать сомнению", "беспокойство", "совесть", "сомнение"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["сомнение", "подвергать сомнению", "совесть", "беспокойство"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["тревожить", "неуверенный", "сомнение", "беспокойство"], "correct_index": 3}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["сомнение", "совесть", "беспокойство", "подвергать сомнению"], "correct_index": 3}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["тревожить", "совесть", "сомнение", "подвергать сомнению"], "correct_index": 0}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["неуверенный", "размышлять", "беспокойство", "совесть"], "correct_index": 0}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["тревожить", "размышлять", "подвергать сомнению", "беспокойство"], "correct_index": 1}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["понимать", "ужас", "пробуждаться", "осознание"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["ужас", "пробуждаться", "понимать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["просыпаться", "пугаться", "пробуждаться", "понимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["просыпаться", "пробуждаться", "понимать", "ясно видеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["просыпаться", "ужас", "пугаться", "понимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["просыпаться", "пробуждаться", "осознание", "ужас"], "correct_index": 0}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["ужас", "ясно видеть", "понимать", "превращение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["превращение", "просыпаться", "осознание", "пугаться"], "correct_index": 0}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["сопротивление", "мужество", "спор", "противостоять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["противостоять", "спор", "сопротивление", "мужество"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["сопротивление", "обвинять", "противостоять", "восставать"], "correct_index": 0}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["обвинять", "спор", "сопротивление", "противостоять"], "correct_index": 3}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["обвинять", "спор", "восставать", "защищаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["спор", "мужество", "защищаться", "обвинять"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["восставать", "мужество", "спор", "противостоять"], "correct_index": 0}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["справедливость", "мораль", "решение", "выбирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["мораль", "решение", "выбирать", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["решение", "праведный", "благородный", "выбирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["добродетель", "выбирать", "благородный", "решение"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["выбирать", "мораль", "благородный", "праведный"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["добродетель", "справедливость", "выбирать", "принцип"], "correct_index": 3}, {"question": "Что означает немецкое слово «edel»?", "choices": ["выбирать", "праведный", "принцип", "благородный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["благородный", "решение", "справедливость", "добродетель"], "correct_index": 3}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["право", "наказывать", "борьба", "доброта"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["наказывать", "право", "доброта", "борьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["вмешиваться", "доброта", "наказывать", "борьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["право", "наказывать", "борьба", "вмешиваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «richten»?", "choices": ["вмешиваться", "наказывать", "судить", "право"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["судить", "вмешиваться", "защищать", "борьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["право", "борьба", "вмешиваться", "судить"], "correct_index": 2}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["направлять", "правление", "новое начало", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "правление", "направлять", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["направлять", "строить", "мудрость", "новое начало"], "correct_index": 3}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["направлять", "примирять", "новое начало", "обновлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["строить", "направлять", "обновлять", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["примирять", "обновлять", "новое начало", "строить"], "correct_index": 1}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["обновлять", "мудрость", "примирять", "мир"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["строить", "примирять", "правление", "мир"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Пассивный герцог</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,47 +465,31 @@
             <div class="quiz-phase-container active" data-phase="passive_duke">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Schweigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehe»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
                             
@@ -513,15 +497,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Ehe»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                             
@@ -529,65 +513,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «passiv»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «nachgeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">уступать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «zögern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пассивный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пассивный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">колебаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «passiv»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">колебаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «nachgeben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">колебаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">уступать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «zögern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">колебаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «mild»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,23 +600,23 @@
             <div class="quiz-phase-container" data-phase="first_doubts">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Zweifel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Gewissen»?</div>
                         <div class="quiz-choices">
                             
@@ -624,9 +624,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -636,11 +636,11 @@
                         <div class="quiz-question">Что означает немецкое слово «das Unbehagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуверенный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
                             
@@ -648,65 +648,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «hinterfragen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тревожить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тревожить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неуверенный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуверенный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «grübeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -719,17 +719,17 @@
             <div class="quiz-phase-container" data-phase="awakening">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -741,55 +741,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">превращение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пугаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">превращение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
@@ -799,31 +751,79 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ясно видеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пугаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ужас</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «klar sehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
                             
@@ -831,17 +831,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Verwandlung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">превращение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пугаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,8 +854,24 @@
             <div class="quiz-phase-container" data-phase="confrontation">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Streit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
@@ -870,47 +886,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Widerstand»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «konfrontieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">восставать</button>
                             
@@ -918,17 +902,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «konfrontieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «anklagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -938,29 +938,29 @@
                         <div class="quiz-question">Что означает немецкое слово «sich wehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">защищаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «aufbegehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,49 +973,49 @@
             <div class="quiz-phase-container" data-phase="moral_stand">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Moral»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Entscheidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1025,77 +1025,77 @@
                         <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">принцип</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «edel»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Tugend»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">добродетель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,33 +1108,33 @@
             <div class="quiz-phase-container" data-phase="justice_seeker">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Recht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1144,25 +1144,41 @@
                         <div class="quiz-question">Что означает немецкое слово «die Güte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вмешиваться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «richten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
                             
@@ -1172,49 +1188,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «richten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">судить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вмешиваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">судить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «eingreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вмешиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вмешиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1231,6 +1231,22 @@
                         <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
                         <div class="quiz-choices">
                             
+                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">правление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                        <div class="quiz-choices">
+                            
                             <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">правление</button>
@@ -1243,31 +1259,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">строить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
                             
@@ -1281,27 +1281,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">примирять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обновлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «aufbauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">примирять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">строить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1311,27 +1311,11 @@
                         <div class="quiz-question">Что означает немецкое слово «erneuern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">примирять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «versöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">примирять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">строить</button>
                             
@@ -1339,17 +1323,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «versöhnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обновлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">примирять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мир</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Friede»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">примирять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мир</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1571,82 +1571,82 @@
             {
                 "question": "Что означает немецкое слово «das Schweigen»?",
                 "choices": [
-                    "молчание",
-                    "брак",
                     "слабость",
-                    "терпеть"
+                    "терпеть",
+                    "молчание",
+                    "брак"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Schwäche»?",
                 "choices": [
-                    "слабость",
+                    "терпеть",
                     "брак",
                     "молчание",
-                    "терпеть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Ehe»?",
-                "choices": [
-                    "молчание",
-                    "брак",
-                    "уступать",
                     "слабость"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «dulden»?",
-                "choices": [
-                    "слабость",
-                    "мягкий",
-                    "молчание",
-                    "терпеть"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «passiv»?",
+                "question": "Что означает немецкое слово «die Ehe»?",
                 "choices": [
+                    "слабость",
+                    "мягкий",
+                    "брак",
+                    "терпеть"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «dulden»?",
+                "choices": [
+                    "терпеть",
                     "пассивный",
                     "слабость",
-                    "колебаться",
-                    "мягкий"
+                    "колебаться"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «passiv»?",
+                "choices": [
+                    "колебаться",
+                    "брак",
+                    "пассивный",
+                    "слабость"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «nachgeben»?",
                 "choices": [
-                    "уступать",
-                    "мягкий",
                     "колебаться",
-                    "молчание"
+                    "брак",
+                    "терпеть",
+                    "уступать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «zögern»?",
                 "choices": [
-                    "мягкий",
-                    "колебаться",
                     "слабость",
-                    "пассивный"
+                    "брак",
+                    "мягкий",
+                    "колебаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «mild»?",
                 "choices": [
                     "молчание",
+                    "слабость",
                     "мягкий",
-                    "терпеть",
-                    "слабость"
+                    "терпеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -1830,29 +1830,29 @@
             {
                 "question": "Что означает немецкое слово «der Zweifel»?",
                 "choices": [
-                    "сомнение",
+                    "подвергать сомнению",
                     "беспокойство",
                     "совесть",
-                    "подвергать сомнению"
+                    "сомнение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Gewissen»?",
                 "choices": [
                     "сомнение",
                     "подвергать сомнению",
-                    "беспокойство",
-                    "совесть"
+                    "совесть",
+                    "беспокойство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Unbehagen»?",
                 "choices": [
-                    "размышлять",
-                    "сомнение",
+                    "тревожить",
                     "неуверенный",
+                    "сомнение",
                     "беспокойство"
                 ],
                 "correctIndex": 3
@@ -1860,42 +1860,42 @@
             {
                 "question": "Что означает немецкое слово «hinterfragen»?",
                 "choices": [
-                    "подвергать сомнению",
-                    "тревожить",
+                    "сомнение",
+                    "совесть",
                     "беспокойство",
-                    "неуверенный"
+                    "подвергать сомнению"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «beunruhigen»?",
                 "choices": [
-                    "сомнение",
                     "тревожить",
-                    "беспокойство",
-                    "неуверенный"
+                    "совесть",
+                    "сомнение",
+                    "подвергать сомнению"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «unsicher»?",
                 "choices": [
-                    "совесть",
-                    "беспокойство",
                     "неуверенный",
-                    "сомнение"
+                    "размышлять",
+                    "беспокойство",
+                    "совесть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «grübeln»?",
                 "choices": [
-                    "совесть",
-                    "неуверенный",
+                    "тревожить",
                     "размышлять",
-                    "сомнение"
+                    "подвергать сомнению",
+                    "беспокойство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2107,82 +2107,82 @@
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "осознание",
                     "понимать",
                     "ужас",
-                    "пробуждаться"
+                    "пробуждаться",
+                    "осознание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Entsetzen»?",
                 "choices": [
                     "ужас",
-                    "осознание",
                     "пробуждаться",
-                    "понимать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «erwachen»?",
-                "choices": [
-                    "понимать",
-                    "превращение",
-                    "пугаться",
-                    "пробуждаться"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «begreifen»?",
-                "choices": [
-                    "просыпаться",
-                    "превращение",
-                    "пробуждаться",
-                    "понимать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «erschrecken»?",
-                "choices": [
-                    "пугаться",
-                    "просыпаться",
                     "понимать",
                     "осознание"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «aufwachen»?",
+                "question": "Что означает немецкое слово «erwachen»?",
                 "choices": [
-                    "пробуждаться",
-                    "ясно видеть",
-                    "осознание",
-                    "просыпаться"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «klar sehen»?",
-                "choices": [
-                    "понимать",
                     "просыпаться",
-                    "ясно видеть",
-                    "превращение"
+                    "пугаться",
+                    "пробуждаться",
+                    "понимать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Verwandlung»?",
+                "question": "Что означает немецкое слово «begreifen»?",
                 "choices": [
+                    "просыпаться",
                     "пробуждаться",
-                    "ясно видеть",
+                    "понимать",
+                    "ясно видеть"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «erschrecken»?",
+                "choices": [
+                    "просыпаться",
+                    "ужас",
+                    "пугаться",
+                    "понимать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «aufwachen»?",
+                "choices": [
+                    "просыпаться",
+                    "пробуждаться",
                     "осознание",
+                    "ужас"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «klar sehen»?",
+                "choices": [
+                    "ужас",
+                    "ясно видеть",
+                    "понимать",
                     "превращение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Verwandlung»?",
+                "choices": [
+                    "превращение",
+                    "просыпаться",
+                    "осознание",
+                    "пугаться"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2367,72 +2367,72 @@
             {
                 "question": "Что означает немецкое слово «der Streit»?",
                 "choices": [
+                    "сопротивление",
+                    "мужество",
+                    "спор",
+                    "противостоять"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Mut»?",
+                "choices": [
                     "противостоять",
                     "спор",
                     "сопротивление",
                     "мужество"
                 ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Mut»?",
-                "choices": [
-                    "мужество",
-                    "сопротивление",
-                    "противостоять",
-                    "спор"
-                ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Widerstand»?",
                 "choices": [
-                    "мужество",
-                    "спор",
                     "сопротивление",
-                    "защищаться"
+                    "обвинять",
+                    "противостоять",
+                    "восставать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «konfrontieren»?",
                 "choices": [
                     "обвинять",
-                    "противостоять",
-                    "защищаться",
-                    "восставать"
+                    "спор",
+                    "сопротивление",
+                    "противостоять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «anklagen»?",
                 "choices": [
-                    "защищаться",
                     "обвинять",
                     "спор",
-                    "противостоять"
+                    "восставать",
+                    "защищаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «sich wehren»?",
                 "choices": [
-                    "обвинять",
-                    "восставать",
+                    "спор",
+                    "мужество",
                     "защищаться",
-                    "спор"
+                    "обвинять"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufbegehren»?",
                 "choices": [
-                    "защищаться",
-                    "обвинять",
                     "восставать",
-                    "мужество"
+                    "мужество",
+                    "спор",
+                    "противостоять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2641,82 +2641,82 @@
             {
                 "question": "Что означает немецкое слово «die Moral»?",
                 "choices": [
-                    "выбирать",
                     "справедливость",
                     "мораль",
-                    "решение"
+                    "решение",
+                    "выбирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "выбирать",
-                    "справедливость",
                     "мораль",
-                    "решение"
+                    "решение",
+                    "выбирать",
+                    "справедливость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Entscheidung»?",
                 "choices": [
-                    "благородный",
                     "решение",
-                    "принцип",
-                    "справедливость"
+                    "праведный",
+                    "благородный",
+                    "выбирать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «wählen»?",
                 "choices": [
-                    "принцип",
+                    "добродетель",
                     "выбирать",
-                    "решение",
-                    "справедливость"
+                    "благородный",
+                    "решение"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
+                    "выбирать",
+                    "мораль",
                     "благородный",
-                    "справедливость",
-                    "праведный",
-                    "выбирать"
+                    "праведный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Prinzip»?",
                 "choices": [
-                    "принцип",
                     "добродетель",
-                    "благородный",
-                    "мораль"
+                    "справедливость",
+                    "выбирать",
+                    "принцип"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «edel»?",
                 "choices": [
                     "выбирать",
-                    "благородный",
-                    "справедливость",
-                    "мораль"
+                    "праведный",
+                    "принцип",
+                    "благородный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Tugend»?",
                 "choices": [
-                    "решение",
                     "благородный",
-                    "добродетель",
-                    "праведный"
+                    "решение",
+                    "справедливость",
+                    "добродетель"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2903,72 +2903,72 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "борьба",
                     "право",
-                    "доброта",
-                    "наказывать"
+                    "наказывать",
+                    "борьба",
+                    "доброта"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Recht»?",
                 "choices": [
-                    "борьба",
-                    "доброта",
                     "наказывать",
-                    "право"
+                    "право",
+                    "доброта",
+                    "борьба"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Güte»?",
                 "choices": [
-                    "защищать",
+                    "вмешиваться",
                     "доброта",
-                    "судить",
-                    "наказывать"
+                    "наказывать",
+                    "борьба"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «strafen»?",
                 "choices": [
+                    "право",
                     "наказывать",
                     "борьба",
-                    "судить",
-                    "право"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «richten»?",
-                "choices": [
-                    "защищать",
-                    "судить",
-                    "доброта",
                     "вмешиваться"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «beschützen»?",
+                "question": "Что означает немецкое слово «richten»?",
                 "choices": [
                     "вмешиваться",
+                    "наказывать",
                     "судить",
-                    "доброта",
-                    "защищать"
+                    "право"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «beschützen»?",
+                "choices": [
+                    "судить",
+                    "вмешиваться",
+                    "защищать",
+                    "борьба"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «eingreifen»?",
                 "choices": [
-                    "защищать",
                     "право",
-                    "доброта",
-                    "вмешиваться"
+                    "борьба",
+                    "вмешиваться",
+                    "судить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -3190,10 +3190,10 @@
             {
                 "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
-                    "мудрость",
-                    "правление",
                     "направлять",
-                    "новое начало"
+                    "правление",
+                    "новое начало",
+                    "мудрость"
                 ],
                 "correctIndex": 1
             },
@@ -3201,8 +3201,8 @@
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
                     "мудрость",
-                    "направлять",
                     "правление",
+                    "направлять",
                     "новое начало"
                 ],
                 "correctIndex": 0
@@ -3210,9 +3210,9 @@
             {
                 "question": "Что означает немецкое слово «der Neuanfang»?",
                 "choices": [
-                    "правление",
                     "направлять",
-                    "мир",
+                    "строить",
+                    "мудрость",
                     "новое начало"
                 ],
                 "correctIndex": 3
@@ -3221,51 +3221,51 @@
                 "question": "Что означает немецкое слово «lenken»?",
                 "choices": [
                     "направлять",
-                    "обновлять",
-                    "мудрость",
-                    "новое начало"
+                    "примирять",
+                    "новое начало",
+                    "обновлять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «aufbauen»?",
                 "choices": [
-                    "примирять",
-                    "новое начало",
-                    "мир",
-                    "строить"
+                    "строить",
+                    "направлять",
+                    "обновлять",
+                    "новое начало"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erneuern»?",
                 "choices": [
-                    "правление",
+                    "примирять",
                     "обновлять",
-                    "мир",
-                    "мудрость"
+                    "новое начало",
+                    "строить"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «versöhnen»?",
                 "choices": [
+                    "обновлять",
+                    "мудрость",
                     "примирять",
-                    "мир",
-                    "правление",
-                    "строить"
+                    "мир"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Friede»?",
                 "choices": [
-                    "мир",
-                    "новое начало",
-                    "мудрость",
-                    "направлять"
+                    "строить",
+                    "примирять",
+                    "правление",
+                    "мир"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}

--- a/output/journeys/cordelia.html
+++ b/output/journeys/cordelia.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["церемония", "власть", "провозглашать", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["правда", "церемония", "провозглашать", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["провозглашать", "церемония", "долг", "верность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "повиноваться", "торжественный", "церемония"], "correct_index": 0}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["церемония", "верность", "провозглашать", "повиноваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["долг", "правда", "провозглашать", "торжественный"], "correct_index": 0}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["верность", "провозглашать", "торжественный", "церемония"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["долг", "повиноваться", "верность", "церемония"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["гнев", "наказание", "покидать", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["наказание", "покидать", "изгонять", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["приданое", "покидать", "гнев", "надежда"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["принимать", "покидать", "наказание", "приданое"], "correct_index": 2}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["изгонять", "чужой", "приданое", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["приданое", "покидать", "принимать", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["чужой", "наказание", "приданое", "принимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["надежда", "изгонять", "принимать", "покидать"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["известие", "страх", "забота", "одиночество"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["известие", "одиночество", "страх", "забота"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["страх", "тоска", "защищать", "известие"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["тоска", "страх", "защищать", "молиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "забота", "одиночество", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["одиночество", "защищать", "забота", "известие"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["тоска", "страдать", "одиночество", "забота"], "correct_index": 0}, {"question": "Что означает немецкое слово «beten»?", "choices": ["тоска", "забота", "молиться", "страдать"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["борьба", "битва", "возвращаться", "спасать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["спасать", "возвращаться", "битва", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["храбрый", "борьба", "побеждать", "спасать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["армия", "битва", "справедливость", "спасать"], "correct_index": 1}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["битва", "храбрый", "спасать", "возвращаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["спасать", "храбрый", "справедливость", "армия"], "correct_index": 2}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["побеждать", "армия", "храбрый", "возвращаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["побеждать", "армия", "храбрый", "битва"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["узнавать", "обнимать", "прощать", "слёзы"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["узнавать", "слёзы", "прощать", "обнимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["узнавать", "прощать", "обнимать", "прощение"], "correct_index": 2}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "слёзы", "раскаяние", "нежный"], "correct_index": 0}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["прощение", "исцелять", "раскаяние", "нежный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["нежный", "слёзы", "раскаяние", "прощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["прощение", "слёзы", "прощать", "нежный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["прощение", "раскаяние", "прощать", "узнавать"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["пленный", "утешать", "достоинство", "тюрьма"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["утешать", "тюрьма", "пленный", "достоинство"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["судьба", "достоинство", "тюрьма", "отважный"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["тюрьма", "утешать", "пленный", "достоинство"], "correct_index": 1}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["отважный", "утешать", "судьба", "пленный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["достоинство", "судьба", "смирение", "отважный"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["достоинство", "смирение", "честь", "судьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["судьба", "достоинство", "честь", "тюрьма"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "жертва", "душа", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "смерть", "душа", "жертва"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["прощание", "спасение", "вечный", "жертва"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["смерть", "конец", "душа", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["жертва", "душа", "конец", "спасение"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "конец", "спасение", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "жертва", "умирать", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["вечный", "спасение", "смерть", "конец"], "correct_index": 1}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["церемония", "власть", "провозглашать", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["правда", "провозглашать", "власть", "церемония"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["повиноваться", "торжественный", "провозглашать", "церемония"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["церемония", "верность", "власть", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["повиноваться", "церемония", "торжественный", "долг"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["власть", "торжественный", "долг", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["церемония", "торжественный", "провозглашать", "повиноваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["церемония", "власть", "провозглашать", "верность"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["изгонять", "наказание", "покидать", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["гнев", "покидать", "изгонять", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["наказание", "приданое", "изгонять", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["чужой", "надежда", "наказание", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["приданое", "надежда", "чужой", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["изгонять", "покидать", "надежда", "приданое"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["приданое", "чужой", "надежда", "принимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["принимать", "гнев", "приданое", "надежда"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["страх", "забота", "известие", "одиночество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["забота", "страх", "известие", "одиночество"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["страдать", "известие", "одиночество", "забота"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["страдать", "одиночество", "молиться", "страх"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["тоска", "страдать", "известие", "забота"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["одиночество", "тоска", "защищать", "страх"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["одиночество", "тоска", "известие", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «beten»?", "choices": ["известие", "защищать", "молиться", "забота"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["возвращаться", "борьба", "битва", "спасать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["возвращаться", "спасать", "битва", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["армия", "побеждать", "возвращаться", "спасать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["битва", "справедливость", "борьба", "возвращаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["храбрый", "возвращаться", "побеждать", "борьба"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["побеждать", "армия", "справедливость", "битва"], "correct_index": 2}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["спасать", "побеждать", "возвращаться", "армия"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["армия", "борьба", "спасать", "справедливость"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["слёзы", "прощать", "обнимать", "узнавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["прощать", "слёзы", "узнавать", "обнимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["обнимать", "узнавать", "слёзы", "нежный"], "correct_index": 0}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["прощение", "слёзы", "прощать", "узнавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["прощать", "обнимать", "нежный", "исцелять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["нежный", "прощение", "слёзы", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["обнимать", "прощать", "слёзы", "нежный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["обнимать", "нежный", "прощение", "прощать"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["утешать", "достоинство", "пленный", "тюрьма"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["достоинство", "утешать", "пленный", "тюрьма"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["честь", "судьба", "достоинство", "утешать"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["тюрьма", "утешать", "судьба", "смирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["отважный", "честь", "смирение", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["честь", "достоинство", "смирение", "тюрьма"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["пленный", "судьба", "отважный", "честь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["пленный", "честь", "судьба", "достоинство"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["душа", "умирать", "жертва", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "душа", "жертва", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["прощание", "жертва", "умирать", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["жертва", "душа", "вечный", "спасение"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["спасение", "вечный", "конец", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["прощание", "вечный", "смерть", "жертва"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["конец", "смерть", "прощание", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["спасение", "смерть", "конец", "душа"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -481,47 +481,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">повиноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжественный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                             
@@ -529,13 +497,77 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">торжественный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
                             
@@ -545,49 +577,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">торжественный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжественный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">повиноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,17 +600,17 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -620,9 +620,25 @@
                         <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">приданое</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
@@ -632,65 +648,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">приданое</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">надежда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">принимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">приданое</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «fremd»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Mitgift»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">приданое</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">чужой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Mitgift»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">приданое</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -700,11 +700,11 @@
                         <div class="quiz-question">Что означает немецкое слово «aufnehmen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">приданое</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
                             
@@ -712,17 +712,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Hoffnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">принимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">надежда</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,15 +735,15 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Sorge»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
                             
@@ -751,15 +751,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Nachricht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">известие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
                             
@@ -767,81 +783,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Nachricht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">известие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Angst»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Sehnsucht»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Sehnsucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -851,13 +851,13 @@
                         <div class="quiz-question">Что означает немецкое слово «beten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -870,15 +870,15 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                             
@@ -890,9 +890,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
                             
@@ -906,27 +906,11 @@
                         <div class="quiz-question">Что означает немецкое слово «retten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">армия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                             
@@ -934,17 +918,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «mutig»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «mutig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -954,11 +954,27 @@
                         <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">армия</button>
                             
@@ -966,33 +982,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Armee»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">армия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1005,17 +1005,17 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1025,11 +1025,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
                             
@@ -1037,31 +1037,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
                             
@@ -1069,33 +1053,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">исцелять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1105,11 +1105,11 @@
                         <div class="quiz-question">Что означает немецкое слово «sanft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
                             
@@ -1117,17 +1117,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Vergebung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нежный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1140,15 +1140,15 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «gefangen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
                             
@@ -1156,33 +1156,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Würde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отважный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1196,9 +1196,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1210,11 +1210,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">отважный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1224,45 +1224,45 @@
                         <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отважный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">отважный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1279,11 +1279,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1297,43 +1297,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Opfer»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Seele»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1343,61 +1343,61 @@
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Erlösung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1639,71 +1639,71 @@
                 "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
                     "правда",
-                    "церемония",
                     "провозглашать",
-                    "власть"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verkünden»?",
-                "choices": [
-                    "провозглашать",
-                    "церемония",
-                    "долг",
-                    "верность"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Macht»?",
-                "choices": [
                     "власть",
-                    "повиноваться",
-                    "торжественный",
                     "церемония"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «gehorchen»?",
-                "choices": [
-                    "церемония",
-                    "верность",
-                    "провозглашать",
-                    "повиноваться"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Pflicht»?",
+                "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
-                    "долг",
-                    "правда",
+                    "повиноваться",
+                    "торжественный",
                     "провозглашать",
-                    "торжественный"
+                    "церемония"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Macht»?",
+                "choices": [
+                    "церемония",
+                    "верность",
+                    "власть",
+                    "провозглашать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «gehorchen»?",
+                "choices": [
+                    "повиноваться",
+                    "церемония",
+                    "торжественный",
+                    "долг"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «feierlich»?",
+                "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
-                    "верность",
-                    "провозглашать",
+                    "власть",
                     "торжественный",
-                    "церемония"
+                    "долг",
+                    "провозглашать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «feierlich»?",
+                "choices": [
+                    "церемония",
+                    "торжественный",
+                    "провозглашать",
+                    "повиноваться"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
-                    "долг",
-                    "повиноваться",
-                    "верность",
-                    "церемония"
+                    "церемония",
+                    "власть",
+                    "провозглашать",
+                    "верность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -1920,69 +1920,69 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "гнев",
+                    "изгонять",
                     "наказание",
                     "покидать",
-                    "изгонять"
+                    "гнев"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
-                    "наказание",
+                    "гнев",
                     "покидать",
                     "изгонять",
-                    "гнев"
+                    "наказание"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
+                    "наказание",
                     "приданое",
-                    "покидать",
-                    "гнев",
-                    "надежда"
+                    "изгонять",
+                    "гнев"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "принимать",
-                    "покидать",
+                    "чужой",
+                    "надежда",
                     "наказание",
-                    "приданое"
+                    "изгонять"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «fremd»?",
                 "choices": [
-                    "изгонять",
-                    "чужой",
                     "приданое",
-                    "покидать"
+                    "надежда",
+                    "чужой",
+                    "изгонять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Mitgift»?",
                 "choices": [
-                    "приданое",
+                    "изгонять",
                     "покидать",
-                    "принимать",
-                    "изгонять"
+                    "надежда",
+                    "приданое"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «aufnehmen»?",
                 "choices": [
-                    "чужой",
-                    "наказание",
                     "приданое",
+                    "чужой",
+                    "надежда",
                     "принимать"
                 ],
                 "correctIndex": 3
@@ -1990,12 +1990,12 @@
             {
                 "question": "Что означает немецкое слово «die Hoffnung»?",
                 "choices": [
-                    "надежда",
-                    "изгонять",
                     "принимать",
-                    "покидать"
+                    "гнев",
+                    "приданое",
+                    "надежда"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2206,80 +2206,80 @@
             {
                 "question": "Что означает немецкое слово «die Sorge»?",
                 "choices": [
-                    "известие",
                     "страх",
                     "забота",
+                    "известие",
                     "одиночество"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
+                    "забота",
+                    "страх",
+                    "известие",
+                    "одиночество"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Nachricht»?",
+                "choices": [
+                    "страдать",
                     "известие",
                     "одиночество",
-                    "страх",
                     "забота"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Nachricht»?",
+                "question": "Что означает немецкое слово «die Angst»?",
                 "choices": [
-                    "страх",
-                    "тоска",
-                    "защищать",
-                    "известие"
+                    "страдать",
+                    "одиночество",
+                    "молиться",
+                    "страх"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Angst»?",
-                "choices": [
-                    "тоска",
-                    "страх",
-                    "защищать",
-                    "молиться"
-                ],
-                "correctIndex": 1
-            },
-            {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
+                    "тоска",
                     "страдать",
-                    "забота",
-                    "одиночество",
-                    "защищать"
+                    "известие",
+                    "забота"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
                     "одиночество",
+                    "тоска",
                     "защищать",
-                    "забота",
-                    "известие"
+                    "страх"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Sehnsucht»?",
                 "choices": [
-                    "тоска",
-                    "страдать",
                     "одиночество",
-                    "забота"
+                    "тоска",
+                    "известие",
+                    "защищать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beten»?",
                 "choices": [
-                    "тоска",
-                    "забота",
+                    "известие",
+                    "защищать",
                     "молиться",
-                    "страдать"
+                    "забота"
                 ],
                 "correctIndex": 2
             }
@@ -2491,18 +2491,18 @@
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
+                    "возвращаться",
                     "борьба",
                     "битва",
-                    "возвращаться",
                     "спасать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "спасать",
                     "возвращаться",
+                    "спасать",
                     "битва",
                     "борьба"
                 ],
@@ -2511,9 +2511,9 @@
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
-                    "храбрый",
-                    "борьба",
+                    "армия",
                     "побеждать",
+                    "возвращаться",
                     "спасать"
                 ],
                 "correctIndex": 3
@@ -2521,52 +2521,52 @@
             {
                 "question": "Что означает немецкое слово «die Schlacht»?",
                 "choices": [
-                    "армия",
                     "битва",
                     "справедливость",
-                    "спасать"
+                    "борьба",
+                    "возвращаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «mutig»?",
                 "choices": [
-                    "битва",
                     "храбрый",
-                    "спасать",
-                    "возвращаться"
+                    "возвращаться",
+                    "побеждать",
+                    "борьба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "спасать",
-                    "храбрый",
+                    "побеждать",
+                    "армия",
                     "справедливость",
-                    "армия"
+                    "битва"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
+                    "спасать",
                     "побеждать",
-                    "армия",
-                    "храбрый",
-                    "возвращаться"
+                    "возвращаться",
+                    "армия"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Armee»?",
                 "choices": [
-                    "побеждать",
                     "армия",
-                    "храбрый",
-                    "битва"
+                    "борьба",
+                    "спасать",
+                    "справедливость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2783,19 +2783,19 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "узнавать",
-                    "обнимать",
+                    "слёзы",
                     "прощать",
-                    "слёзы"
+                    "обнимать",
+                    "узнавать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Tränen»?",
                 "choices": [
-                    "узнавать",
-                    "слёзы",
                     "прощать",
+                    "слёзы",
+                    "узнавать",
                     "обнимать"
                 ],
                 "correctIndex": 1
@@ -2803,49 +2803,49 @@
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
-                    "узнавать",
-                    "прощать",
                     "обнимать",
-                    "прощение"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «erkennen»?",
-                "choices": [
                     "узнавать",
                     "слёзы",
-                    "раскаяние",
                     "нежный"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «heilen»?",
+                "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
                     "прощение",
-                    "исцелять",
-                    "раскаяние",
-                    "нежный"
+                    "слёзы",
+                    "прощать",
+                    "узнавать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «heilen»?",
+                "choices": [
+                    "прощать",
+                    "обнимать",
+                    "нежный",
+                    "исцелять"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
                     "нежный",
+                    "прощение",
                     "слёзы",
-                    "раскаяние",
-                    "прощать"
+                    "раскаяние"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sanft»?",
                 "choices": [
-                    "прощение",
-                    "слёзы",
+                    "обнимать",
                     "прощать",
+                    "слёзы",
                     "нежный"
                 ],
                 "correctIndex": 3
@@ -2853,12 +2853,12 @@
             {
                 "question": "Что означает немецкое слово «die Vergebung»?",
                 "choices": [
+                    "обнимать",
+                    "нежный",
                     "прощение",
-                    "раскаяние",
-                    "прощать",
-                    "узнавать"
+                    "прощать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -3064,40 +3064,40 @@
             {
                 "question": "Что означает немецкое слово «gefangen»?",
                 "choices": [
-                    "пленный",
                     "утешать",
                     "достоинство",
+                    "пленный",
                     "тюрьма"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Gefängnis»?",
                 "choices": [
+                    "достоинство",
                     "утешать",
-                    "тюрьма",
                     "пленный",
-                    "достоинство"
+                    "тюрьма"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Würde»?",
                 "choices": [
+                    "честь",
                     "судьба",
                     "достоинство",
-                    "тюрьма",
-                    "отважный"
+                    "утешать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
                     "тюрьма",
                     "утешать",
-                    "пленный",
-                    "достоинство"
+                    "судьба",
+                    "смирение"
                 ],
                 "correctIndex": 1
             },
@@ -3105,41 +3105,41 @@
                 "question": "Что означает немецкое слово «tapfer»?",
                 "choices": [
                     "отважный",
-                    "утешать",
-                    "судьба",
-                    "пленный"
+                    "честь",
+                    "смирение",
+                    "утешать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Demut»?",
                 "choices": [
+                    "честь",
                     "достоинство",
-                    "судьба",
                     "смирение",
-                    "отважный"
+                    "тюрьма"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
-                    "достоинство",
-                    "смирение",
-                    "честь",
-                    "судьба"
+                    "пленный",
+                    "судьба",
+                    "отважный",
+                    "честь"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "судьба",
-                    "достоинство",
+                    "пленный",
                     "честь",
-                    "тюрьма"
+                    "судьба",
+                    "достоинство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -3368,9 +3368,9 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
+                    "душа",
                     "умирать",
                     "жертва",
-                    "душа",
                     "смерть"
                 ],
                 "correctIndex": 3
@@ -3379,9 +3379,9 @@
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
                     "умирать",
-                    "смерть",
                     "душа",
-                    "жертва"
+                    "жертва",
+                    "смерть"
                 ],
                 "correctIndex": 0
             },
@@ -3389,61 +3389,61 @@
                 "question": "Что означает немецкое слово «das Opfer»?",
                 "choices": [
                     "прощание",
-                    "спасение",
-                    "вечный",
-                    "жертва"
+                    "жертва",
+                    "умирать",
+                    "конец"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Seele»?",
                 "choices": [
-                    "смерть",
-                    "конец",
+                    "жертва",
                     "душа",
-                    "вечный"
+                    "вечный",
+                    "спасение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "жертва",
-                    "душа",
+                    "спасение",
+                    "вечный",
                     "конец",
-                    "спасение"
+                    "прощание"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
+                    "прощание",
                     "вечный",
-                    "конец",
-                    "спасение",
-                    "умирать"
+                    "смерть",
+                    "жертва"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
+                    "конец",
+                    "смерть",
                     "прощание",
-                    "жертва",
-                    "умирать",
-                    "смерть"
+                    "вечный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Erlösung»?",
                 "choices": [
-                    "вечный",
                     "спасение",
                     "смерть",
-                    "конец"
+                    "конец",
+                    "душа"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}

--- a/output/journeys/cornwall.html
+++ b/output/journeys/cornwall.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["стремиться", "желать", "жадность", "честолюбие"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["честолюбие", "стремиться", "желать", "жадность"], "correct_index": 3}, {"question": "Что означает немецкое слово «streben»?", "choices": ["жадность", "стремиться", "захватывать", "желать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["захватывать", "жадность", "желать", "властолюбие"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["жадность", "вожделеть", "захватывать", "стремиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["честолюбие", "желать", "жадный", "жадность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["вожделеть", "властолюбие", "жадность", "стремиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["честолюбие", "вожделеть", "захватывать", "властолюбие"], "correct_index": 2}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "одобрять", "поддерживать", "злоба"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["одобрять", "поддерживать", "жестокость", "злоба"], "correct_index": 3}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["поддерживать", "поощрять", "жестокость", "одобрять"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["жестокость", "поддерживать", "суровость", "подстрекать"], "correct_index": 1}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["злоба", "жестокость", "подстрекать", "одобрять"], "correct_index": 2}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["жестокость", "поощрять", "суровость", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жестокость", "поощрять", "одобрять", "суровость"], "correct_index": 3}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["тирания", "угнетение", "страх", "подавлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["страх", "угнетение", "подавлять", "тирания"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["страх", "порабощать", "принуждать", "подавлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["угнетение", "тирания", "подавлять", "порабощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["угнетение", "порабощать", "брутальный", "произвол"], "correct_index": 1}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["произвол", "подавлять", "брутальный", "принуждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["брутальный", "угнетение", "порабощать", "произвол"], "correct_index": 3}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["тирания", "подавлять", "брутальный", "страх"], "correct_index": 2}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказывать", "гнев", "наказание", "карать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["наказывать", "наказание", "гнев", "карать"], "correct_index": 2}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["наказание", "гнев", "унижать", "карать"], "correct_index": 3}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["мучить", "наказывать", "гнев", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "наказывать", "наказание", "карать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["гнев", "унижать", "карать", "мучить"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["мучить", "наказывать", "карать", "унижать"], "correct_index": 0}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытать", "кровь", "садизм", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытка", "пытать", "садизм", "кровь"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["садизм", "ослеплять", "кровь", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["ослеплять", "кровь", "садизм", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["пытка", "кровь", "ослеплять", "калечить"], "correct_index": 3}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["кровь", "калечить", "садизм", "ослеплять"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["пытка", "кровь", "выкалывать", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["пытать", "садизм", "пытка", "мука"], "correct_index": 3}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["удивление", "боль", "кровоточить", "рана"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["рана", "боль", "удивление", "кровоточить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["рана", "ослаблять", "удивление", "кровоточить"], "correct_index": 2}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["боль", "раненый", "ослаблять", "кровоточить"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["рана", "боль", "кровоточить", "раненый"], "correct_index": 3}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["кровоточить", "страдать", "удивление", "ослаблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["боль", "ослаблять", "удивление", "страдать"], "correct_index": 3}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["конец", "смерть", "умирать", "возмездие"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["смерть", "умирать", "конец", "возмездие"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["хрипеть", "конец", "проклинать", "кара"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["проклинать", "кара", "умирать", "хрипеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["смерть", "конец", "издыхать", "хрипеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "издыхать", "хрипеть", "конец"], "correct_index": 0}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["хрипеть", "возмездие", "конец", "издыхать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["проклинать", "хрипеть", "смерть", "кара"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["честолюбие", "жадность", "стремиться", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["жадность", "честолюбие", "стремиться", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «streben»?", "choices": ["честолюбие", "жадный", "захватывать", "стремиться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["желать", "честолюбие", "жадный", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вожделеть", "жадность", "жадный", "честолюбие"], "correct_index": 0}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["стремиться", "честолюбие", "жадность", "жадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["властолюбие", "стремиться", "вожделеть", "захватывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["желать", "захватывать", "властолюбие", "жадность"], "correct_index": 1}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "одобрять", "злоба", "поддерживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["поддерживать", "злоба", "жестокость", "одобрять"], "correct_index": 1}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["злоба", "жестокость", "поддерживать", "одобрять"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["поддерживать", "одобрять", "злоба", "поощрять"], "correct_index": 0}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["одобрять", "поддерживать", "подстрекать", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["поощрять", "жестокость", "злоба", "подстрекать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["подстрекать", "суровость", "поощрять", "злоба"], "correct_index": 1}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["подавлять", "угнетение", "страх", "тирания"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["тирания", "подавлять", "страх", "угнетение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["брутальный", "порабощать", "страх", "тирания"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["подавлять", "порабощать", "произвол", "брутальный"], "correct_index": 0}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["порабощать", "произвол", "угнетение", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["принуждать", "порабощать", "угнетение", "подавлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["принуждать", "произвол", "страх", "порабощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["произвол", "принуждать", "подавлять", "брутальный"], "correct_index": 3}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["карать", "наказание", "гнев", "наказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["карать", "наказание", "наказывать", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["наказывать", "гнев", "карать", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["унижать", "гнев", "наказывать", "карать"], "correct_index": 2}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "гнев", "карать", "наказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["мучить", "гнев", "карать", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["унижать", "наказание", "мучить", "наказывать"], "correct_index": 2}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["кровь", "пытка", "пытать", "садизм"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["кровь", "пытка", "пытать", "садизм"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["пытать", "пытка", "кровь", "калечить"], "correct_index": 2}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["ослеплять", "пытка", "мука", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["кровь", "садизм", "калечить", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["садизм", "ослеплять", "мука", "калечить"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["ослеплять", "выкалывать", "калечить", "мука"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["пытать", "мука", "пытка", "выкалывать"], "correct_index": 1}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["кровоточить", "удивление", "рана", "боль"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["удивление", "рана", "боль", "кровоточить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["удивление", "боль", "рана", "раненый"], "correct_index": 0}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["ослаблять", "кровоточить", "рана", "раненый"], "correct_index": 1}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["боль", "удивление", "раненый", "ослаблять"], "correct_index": 2}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["страдать", "ослаблять", "раненый", "кровоточить"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["ослаблять", "рана", "удивление", "страдать"], "correct_index": 3}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "конец", "смерть", "возмездие"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["умирать", "возмездие", "смерть", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["кара", "умирать", "конец", "возмездие"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["проклинать", "смерть", "издыхать", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["издыхать", "возмездие", "хрипеть", "конец"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "издыхать", "хрипеть", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["хрипеть", "издыхать", "смерть", "кара"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["издыхать", "проклинать", "возмездие", "кара"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Амбициозный герцог</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,47 +465,15 @@
             <div class="quiz-phase-container active" data-phase="ambitious_duke">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Ehrgeiz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «streben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
                             
@@ -513,29 +481,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verlangen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «streben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
                             
@@ -545,49 +513,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verlangen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">властолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">захватывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «ergreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">властолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -608,25 +608,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -636,11 +636,11 @@
                         <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
                             
@@ -648,17 +648,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">суровость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подстрекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -668,27 +668,11 @@
                         <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">суровость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
                             
@@ -696,17 +680,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">поощрять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подстрекать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">суровость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">суровость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -719,31 +719,15 @@
             <div class="quiz-phase-container" data-phase="tyrant">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Tyrannei»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подавлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
                             
@@ -751,15 +735,79 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Furcht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принуждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unterdrücken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">произвол</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">брутальный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">произвол</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «zwingen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">принуждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">подавлять</button>
                             
@@ -767,15 +815,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unterdrücken»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">принуждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">произвол</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
                             
@@ -783,65 +831,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «zwingen»?</div>
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «brutal»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">произвол</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">принуждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">принуждать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">порабощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «brutal»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">брутальный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,65 +854,65 @@
             <div class="quiz-phase-container" data-phase="punishment">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «bestrafen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «züchtigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -924,43 +924,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,33 +973,33 @@
             <div class="quiz-phase-container" data-phase="torturer">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1009,13 +1009,13 @@
                         <div class="quiz-question">Что означает немецкое слово «das Blut»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1027,9 +1027,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мука</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                             
@@ -1037,15 +1037,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мука</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
                             
@@ -1053,49 +1069,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мука</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,79 +1108,47 @@
             <div class="quiz-phase-container" data-phase="wounded">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Wunde»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">удивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «bluten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раненый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослаблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">раненый</button>
                             
@@ -1188,17 +1156,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «bluten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослаблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">кровоточить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раненый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">удивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">раненый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раненый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1208,9 +1208,9 @@
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослаблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
                             
@@ -1227,15 +1227,15 @@
             <div class="quiz-phase-container" data-phase="death">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
                             
@@ -1243,11 +1243,27 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Vergeltung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">кара</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
@@ -1259,49 +1275,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1317,7 +1317,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1329,11 +1329,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">хрипеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1343,11 +1343,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
                             
@@ -1575,82 +1575,82 @@
             {
                 "question": "Что означает немецкое слово «der Ehrgeiz»?",
                 "choices": [
-                    "стремиться",
-                    "желать",
+                    "честолюбие",
                     "жадность",
-                    "честолюбие"
+                    "стремиться",
+                    "желать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Gier»?",
                 "choices": [
+                    "жадность",
                     "честолюбие",
                     "стремиться",
-                    "желать",
-                    "жадность"
+                    "желать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «streben»?",
                 "choices": [
-                    "жадность",
-                    "стремиться",
+                    "честолюбие",
+                    "жадный",
                     "захватывать",
-                    "желать"
+                    "стремиться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verlangen»?",
                 "choices": [
-                    "захватывать",
-                    "жадность",
                     "желать",
-                    "властолюбие"
+                    "честолюбие",
+                    "жадный",
+                    "вожделеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "жадность",
                     "вожделеть",
-                    "захватывать",
-                    "стремиться"
+                    "жадность",
+                    "жадный",
+                    "честолюбие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «gierig»?",
                 "choices": [
+                    "стремиться",
                     "честолюбие",
-                    "желать",
-                    "жадный",
-                    "жадность"
+                    "жадность",
+                    "жадный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Herrschsucht»?",
                 "choices": [
-                    "вожделеть",
                     "властолюбие",
-                    "жадность",
-                    "стремиться"
+                    "стремиться",
+                    "вожделеть",
+                    "захватывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ergreifen»?",
                 "choices": [
-                    "честолюбие",
-                    "вожделеть",
+                    "желать",
                     "захватывать",
-                    "властолюбие"
+                    "властолюбие",
+                    "жадность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -1853,27 +1853,27 @@
                 "choices": [
                     "жестокость",
                     "одобрять",
-                    "поддерживать",
-                    "злоба"
+                    "злоба",
+                    "поддерживать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
-                    "одобрять",
                     "поддерживать",
+                    "злоба",
                     "жестокость",
-                    "злоба"
+                    "одобрять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «billigen»?",
                 "choices": [
-                    "поддерживать",
-                    "поощрять",
+                    "злоба",
                     "жестокость",
+                    "поддерживать",
                     "одобрять"
                 ],
                 "correctIndex": 3
@@ -1881,42 +1881,42 @@
             {
                 "question": "Что означает немецкое слово «unterstützen»?",
                 "choices": [
-                    "жестокость",
                     "поддерживать",
-                    "суровость",
-                    "подстрекать"
+                    "одобрять",
+                    "злоба",
+                    "поощрять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «anstacheln»?",
                 "choices": [
-                    "злоба",
-                    "жестокость",
+                    "одобрять",
+                    "поддерживать",
                     "подстрекать",
-                    "одобрять"
+                    "злоба"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ermutigen»?",
                 "choices": [
-                    "жестокость",
                     "поощрять",
-                    "суровость",
-                    "злоба"
+                    "жестокость",
+                    "злоба",
+                    "подстрекать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Härte»?",
                 "choices": [
-                    "жестокость",
+                    "подстрекать",
+                    "суровость",
                     "поощрять",
-                    "одобрять",
-                    "суровость"
+                    "злоба"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2122,82 +2122,82 @@
             {
                 "question": "Что означает немецкое слово «die Tyrannei»?",
                 "choices": [
-                    "тирания",
+                    "подавлять",
                     "угнетение",
                     "страх",
-                    "подавлять"
+                    "тирания"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Unterdrückung»?",
                 "choices": [
-                    "страх",
-                    "угнетение",
+                    "тирания",
                     "подавлять",
-                    "тирания"
+                    "страх",
+                    "угнетение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Furcht»?",
                 "choices": [
-                    "страх",
+                    "брутальный",
                     "порабощать",
+                    "страх",
+                    "тирания"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «unterdrücken»?",
+                "choices": [
+                    "подавлять",
+                    "порабощать",
+                    "произвол",
+                    "брутальный"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «knechten»?",
+                "choices": [
+                    "порабощать",
+                    "произвол",
+                    "угнетение",
+                    "страх"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «zwingen»?",
+                "choices": [
                     "принуждать",
+                    "порабощать",
+                    "угнетение",
                     "подавлять"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «unterdrücken»?",
+                "question": "Что означает немецкое слово «die Willkür»?",
                 "choices": [
-                    "угнетение",
-                    "тирания",
-                    "подавлять",
+                    "принуждать",
+                    "произвол",
+                    "страх",
                     "порабощать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «knechten»?",
-                "choices": [
-                    "угнетение",
-                    "порабощать",
-                    "брутальный",
-                    "произвол"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «zwingen»?",
-                "choices": [
-                    "произвол",
-                    "подавлять",
-                    "брутальный",
-                    "принуждать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Willkür»?",
-                "choices": [
-                    "брутальный",
-                    "угнетение",
-                    "порабощать",
-                    "произвол"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «brutal»?",
                 "choices": [
-                    "тирания",
+                    "произвол",
+                    "принуждать",
                     "подавлять",
-                    "брутальный",
-                    "страх"
+                    "брутальный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2401,72 +2401,72 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "наказывать",
-                    "гнев",
+                    "карать",
                     "наказание",
-                    "карать"
+                    "гнев",
+                    "наказывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
+                    "карать",
+                    "наказание",
                     "наказывать",
-                    "наказание",
-                    "гнев",
-                    "карать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «bestrafen»?",
-                "choices": [
-                    "наказание",
-                    "гнев",
-                    "унижать",
-                    "карать"
+                    "гнев"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «züchtigen»?",
+                "question": "Что означает немецкое слово «bestrafen»?",
                 "choices": [
-                    "мучить",
                     "наказывать",
                     "гнев",
+                    "карать",
                     "унижать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «züchtigen»?",
+                "choices": [
+                    "унижать",
+                    "гнев",
+                    "наказывать",
+                    "карать"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
                     "унижать",
-                    "наказывать",
-                    "наказание",
-                    "карать"
+                    "гнев",
+                    "карать",
+                    "наказывать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
+                    "мучить",
                     "гнев",
-                    "унижать",
                     "карать",
-                    "мучить"
+                    "унижать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
+                    "унижать",
+                    "наказание",
                     "мучить",
-                    "наказывать",
-                    "карать",
-                    "унижать"
+                    "наказывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2696,30 +2696,30 @@
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "пытать",
                     "кровь",
-                    "садизм",
-                    "пытка"
+                    "пытка",
+                    "пытать",
+                    "садизм"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
+                    "кровь",
                     "пытка",
                     "пытать",
-                    "садизм",
-                    "кровь"
+                    "садизм"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Blut»?",
                 "choices": [
-                    "садизм",
-                    "ослеплять",
+                    "пытать",
+                    "пытка",
                     "кровь",
-                    "пытать"
+                    "калечить"
                 ],
                 "correctIndex": 2
             },
@@ -2727,8 +2727,8 @@
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
                     "ослеплять",
-                    "кровь",
-                    "садизм",
+                    "пытка",
+                    "мука",
                     "пытать"
                 ],
                 "correctIndex": 3
@@ -2736,42 +2736,42 @@
             {
                 "question": "Что означает немецкое слово «verstümmeln»?",
                 "choices": [
-                    "пытка",
                     "кровь",
-                    "ослеплять",
-                    "калечить"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «blenden»?",
-                "choices": [
-                    "кровь",
-                    "калечить",
                     "садизм",
-                    "ослеплять"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «ausstechen»?",
-                "choices": [
-                    "пытка",
-                    "кровь",
-                    "выкалывать",
+                    "калечить",
                     "пытать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «blenden»?",
+                "choices": [
+                    "садизм",
+                    "ослеплять",
+                    "мука",
+                    "калечить"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «ausstechen»?",
+                "choices": [
+                    "ослеплять",
+                    "выкалывать",
+                    "калечить",
+                    "мука"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
                     "пытать",
-                    "садизм",
+                    "мука",
                     "пытка",
-                    "мука"
+                    "выкалывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2956,68 +2956,68 @@
             {
                 "question": "Что означает немецкое слово «die Wunde»?",
                 "choices": [
-                    "удивление",
-                    "боль",
                     "кровоточить",
-                    "рана"
+                    "удивление",
+                    "рана",
+                    "боль"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
+                    "удивление",
                     "рана",
                     "боль",
-                    "удивление",
-                    "кровоточить"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Überraschung»?",
-                "choices": [
-                    "рана",
-                    "ослаблять",
-                    "удивление",
                     "кровоточить"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «die Überraschung»?",
+                "choices": [
+                    "удивление",
+                    "боль",
+                    "рана",
+                    "раненый"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «bluten»?",
                 "choices": [
-                    "боль",
-                    "раненый",
                     "ослаблять",
-                    "кровоточить"
+                    "кровоточить",
+                    "рана",
+                    "раненый"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verwundet»?",
                 "choices": [
-                    "рана",
                     "боль",
-                    "кровоточить",
-                    "раненый"
+                    "удивление",
+                    "раненый",
+                    "ослаблять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «schwächen»?",
                 "choices": [
-                    "кровоточить",
                     "страдать",
-                    "удивление",
-                    "ослаблять"
+                    "ослаблять",
+                    "раненый",
+                    "кровоточить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "боль",
                     "ослаблять",
+                    "рана",
                     "удивление",
                     "страдать"
                 ],
@@ -3245,52 +3245,52 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
+                    "умирать",
                     "конец",
                     "смерть",
-                    "умирать",
                     "возмездие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Vergeltung»?",
                 "choices": [
-                    "смерть",
                     "умирать",
-                    "конец",
-                    "возмездие"
+                    "возмездие",
+                    "смерть",
+                    "конец"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "хрипеть",
+                    "кара",
+                    "умирать",
                     "конец",
-                    "проклинать",
-                    "кара"
+                    "возмездие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
                     "проклинать",
-                    "кара",
-                    "умирать",
-                    "хрипеть"
+                    "смерть",
+                    "издыхать",
+                    "умирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
-                    "смерть",
-                    "конец",
                     "издыхать",
-                    "хрипеть"
+                    "возмездие",
+                    "хрипеть",
+                    "конец"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
@@ -3298,7 +3298,7 @@
                     "проклинать",
                     "издыхать",
                     "хрипеть",
-                    "конец"
+                    "смерть"
                 ],
                 "correctIndex": 0
             },
@@ -3306,18 +3306,18 @@
                 "question": "Что означает немецкое слово «röcheln»?",
                 "choices": [
                     "хрипеть",
-                    "возмездие",
-                    "конец",
-                    "издыхать"
+                    "издыхать",
+                    "смерть",
+                    "кара"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
+                    "издыхать",
                     "проклинать",
-                    "хрипеть",
-                    "смерть",
+                    "возмездие",
                     "кара"
                 ],
                 "correctIndex": 3

--- a/output/journeys/edgar.html
+++ b/output/journeys/edgar.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["королевство", "наследник", "доверять", "знать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["доверять", "знать", "наследник", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["знать", "доверять", "честь", "королевство"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["королевство", "граф", "ничего не подозревающий", "доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["доверять", "знать", "честь", "наследник"], "correct_index": 2}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["законный", "знать", "граф", "доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["доверять", "законный", "граф", "честь"], "correct_index": 2}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["ничего не подозревающий", "знать", "наследник", "королевство"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["преследовать", "опасность", "предательство", "бежать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["преследовать", "бежать", "опасность", "предательство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["опасность", "преследовать", "обман", "прятаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["обман", "интрига", "преследовать", "бежать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["обман", "преследовать", "изгнать", "прятаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["опасность", "бежать", "изгнать", "интрига"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["прятаться", "обман", "изгнать", "бежать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["прятаться", "опасность", "обман", "изгнать"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["безумие", "нищий", "голый", "маскировка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["безумие", "нищий", "маскировка", "голый"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["безумный", "маскировка", "безумие", "голый"], "correct_index": 1}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["дрожать", "маскировка", "голый", "безумный"], "correct_index": 2}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["безумие", "голый", "дрожать", "бормотать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["нищий", "голый", "дрожать", "нищета"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["маскировка", "голый", "дрожать", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["безумие", "безумный", "дрожать", "голый"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["страдать", "мёрзнуть", "хижина", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "хижина", "страдать", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "защищать", "молния", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["буря", "хижина", "гром", "мёрзнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["страдать", "защищать", "хижина", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["молния", "защищать", "сопровождать", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["гром", "защищать", "мёрзнуть", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["хижина", "молния", "мёрзнуть", "страдать"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["слепой", "вести", "утёс", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «führen»?", "choices": ["вести", "обманывать", "утёс", "слепой"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["утёс", "утешать", "слепой", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["отчаяние", "спасать", "обманывать", "вести"], "correct_index": 2}, {"question": "Что означает немецкое слово «retten»?", "choices": ["утёс", "спасать", "отчаяние", "хитрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["спасать", "хитрость", "слепой", "вести"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["спасать", "вести", "утешать", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["вести", "хитрость", "обманывать", "отчаяние"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["бой", "разоблачать", "месть", "дуэль"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["дуэль", "бой", "разоблачать", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["справедливость", "месть", "брат", "побеждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["месть", "разоблачать", "меч", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["месть", "побеждать", "меч", "дуэль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["меч", "справедливость", "брат", "разоблачать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["меч", "справедливость", "дуэль", "разоблачать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["меч", "побеждать", "бой", "брат"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["править", "выживать", "будущее", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "править", "будущее", "выживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["порядок", "наследовать", "будущее", "новый"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["наследовать", "править", "ответственность", "выживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["будущее", "новый", "ответственность", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["мудрость", "править", "новый", "порядок"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["ответственность", "новый", "выживать", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «neu»?", "choices": ["порядок", "будущее", "мудрость", "новый"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["королевство", "наследник", "знать", "доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["знать", "наследник", "королевство", "доверять"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["королевство", "наследник", "знать", "ничего не подозревающий"], "correct_index": 0}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["доверять", "честь", "знать", "граф"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["честь", "доверять", "наследник", "ничего не подозревающий"], "correct_index": 0}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["знать", "ничего не подозревающий", "наследник", "законный"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["граф", "честь", "законный", "ничего не подозревающий"], "correct_index": 0}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["граф", "честь", "законный", "ничего не подозревающий"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["предательство", "опасность", "преследовать", "бежать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["бежать", "преследовать", "опасность", "предательство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["опасность", "изгнать", "бежать", "преследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["преследовать", "обман", "прятаться", "предательство"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["опасность", "предательство", "преследовать", "прятаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["обман", "преследовать", "интрига", "предательство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["бежать", "интрига", "обман", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["бежать", "предательство", "изгнать", "обман"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["безумие", "нищий", "маскировка", "голый"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["безумие", "нищий", "маскировка", "голый"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["маскировка", "бормотать", "голый", "нищета"], "correct_index": 0}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["безумие", "безумный", "бормотать", "голый"], "correct_index": 3}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["нищий", "бормотать", "голый", "дрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["дрожать", "безумие", "нищета", "голый"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["голый", "бормотать", "безумие", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["безумный", "нищета", "маскировка", "дрожать"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["мёрзнуть", "страдать", "буря", "хижина"], "correct_index": 2}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["буря", "страдать", "мёрзнуть", "хижина"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["буря", "страдать", "мёрзнуть", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["хижина", "буря", "страдать", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["сопровождать", "страдать", "буря", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["мёрзнуть", "гром", "сопровождать", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["гром", "мёрзнуть", "хижина", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["молния", "хижина", "сопровождать", "буря"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["слепой", "вести", "обманывать", "утёс"], "correct_index": 0}, {"question": "Что означает немецкое слово «führen»?", "choices": ["обманывать", "вести", "утёс", "слепой"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["утёс", "хитрость", "утешать", "слепой"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["вести", "слепой", "обманывать", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «retten»?", "choices": ["отчаяние", "хитрость", "спасать", "слепой"], "correct_index": 2}, {"question": "Что означает немецкое слово «die List»?", "choices": ["спасать", "вести", "утешать", "хитрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["вести", "хитрость", "обманывать", "утешать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["утёс", "слепой", "обманывать", "отчаяние"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["месть", "разоблачать", "дуэль", "бой"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["разоблачать", "дуэль", "месть", "бой"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["разоблачать", "брат", "побеждать", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["брат", "разоблачать", "дуэль", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["брат", "месть", "меч", "побеждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["бой", "справедливость", "разоблачать", "меч"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["справедливость", "месть", "разоблачать", "меч"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["справедливость", "бой", "дуэль", "брат"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["выживать", "наследовать", "править", "будущее"], "correct_index": 0}, {"question": "Что означает немецкое слово «erben»?", "choices": ["править", "наследовать", "будущее", "выживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["новый", "будущее", "выживать", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["новый", "порядок", "ответственность", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["будущее", "править", "мудрость", "наследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["порядок", "выживать", "наследовать", "ответственность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["выживать", "наследовать", "будущее", "ответственность"], "correct_index": 3}, {"question": "Что означает немецкое слово «neu»?", "choices": ["мудрость", "порядок", "новый", "выживать"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный сын</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,7 +465,7 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
                         <div class="quiz-choices">
                             
@@ -473,121 +473,121 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Erbe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ничего не подозревающий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ничего не подозревающий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ничего не подозревающий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">законный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -604,11 +604,11 @@
                         <div class="quiz-question">Что означает немецкое слово «fliehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
                             
@@ -620,9 +620,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
@@ -638,27 +638,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прятаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -668,11 +668,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verstecken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
                             
@@ -680,49 +680,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -743,9 +743,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">маскировка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -767,15 +767,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бормотать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
                             
@@ -783,49 +799,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бормотать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бормотать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -835,11 +835,11 @@
                         <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бормотать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
                             
@@ -847,17 +847,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «wahnsinnig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -870,63 +870,63 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
@@ -934,17 +934,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -954,13 +954,13 @@
                         <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -972,27 +972,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1013,21 +1013,21 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утёс</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «führen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
                             
@@ -1043,11 +1043,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1057,52 +1057,36 @@
                         <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «retten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
@@ -1111,7 +1095,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1121,9 +1121,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
@@ -1140,49 +1140,49 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1192,11 +1192,11 @@
                         <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
@@ -1204,17 +1204,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1224,29 +1224,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">меч</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Schwert»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">меч</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1256,11 +1256,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Bruder»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">брат</button>
                             
@@ -1275,109 +1275,45 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «überleben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">будущее</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Zukunft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ответственность</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Zukunft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ответственность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">новый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ответственность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
                             
@@ -1387,17 +1323,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «neu»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">порядок</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ответственность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ответственность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ответственность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «neu»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">порядок</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">новый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1627,80 +1627,80 @@
                 "choices": [
                     "королевство",
                     "наследник",
-                    "доверять",
-                    "знать"
+                    "знать",
+                    "доверять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Erbe»?",
                 "choices": [
-                    "доверять",
                     "знать",
                     "наследник",
-                    "королевство"
+                    "королевство",
+                    "доверять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
+                    "королевство",
+                    "наследник",
                     "знать",
-                    "доверять",
-                    "честь",
-                    "королевство"
+                    "ничего не подозревающий"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
-                    "королевство",
-                    "граф",
-                    "ничего не подозревающий",
-                    "доверять"
+                    "доверять",
+                    "честь",
+                    "знать",
+                    "граф"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "доверять",
-                    "знать",
                     "честь",
-                    "наследник"
+                    "доверять",
+                    "наследник",
+                    "ничего не подозревающий"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «legitim»?",
                 "choices": [
-                    "законный",
                     "знать",
-                    "граф",
-                    "доверять"
+                    "ничего не подозревающий",
+                    "наследник",
+                    "законный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
-                    "доверять",
-                    "законный",
                     "граф",
-                    "честь"
+                    "честь",
+                    "законный",
+                    "ничего не подозревающий"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ahnungslos»?",
                 "choices": [
-                    "ничего не подозревающий",
-                    "знать",
-                    "наследник",
-                    "королевство"
+                    "граф",
+                    "честь",
+                    "законный",
+                    "ничего не подозревающий"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -1914,9 +1914,9 @@
             {
                 "question": "Что означает немецкое слово «fliehen»?",
                 "choices": [
-                    "преследовать",
-                    "опасность",
                     "предательство",
+                    "опасность",
+                    "преследовать",
                     "бежать"
                 ],
                 "correctIndex": 3
@@ -1924,8 +1924,8 @@
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "преследовать",
                     "бежать",
+                    "преследовать",
                     "опасность",
                     "предательство"
                 ],
@@ -1935,28 +1935,28 @@
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
                     "опасность",
-                    "преследовать",
-                    "обман",
-                    "прятаться"
+                    "изгнать",
+                    "бежать",
+                    "преследовать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
-                    "обман",
-                    "интрига",
                     "преследовать",
-                    "бежать"
+                    "обман",
+                    "прятаться",
+                    "предательство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verstecken»?",
                 "choices": [
-                    "обман",
+                    "опасность",
+                    "предательство",
                     "преследовать",
-                    "изгнать",
                     "прятаться"
                 ],
                 "correctIndex": 3
@@ -1964,32 +1964,32 @@
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "опасность",
-                    "бежать",
-                    "изгнать",
-                    "интрига"
+                    "обман",
+                    "преследовать",
+                    "интрига",
+                    "предательство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
-                    "прятаться",
+                    "бежать",
+                    "интрига",
                     "обман",
-                    "изгнать",
-                    "бежать"
+                    "преследовать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verbannen»?",
                 "choices": [
-                    "прятаться",
-                    "опасность",
-                    "обман",
-                    "изгнать"
+                    "бежать",
+                    "предательство",
+                    "изгнать",
+                    "обман"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2210,8 +2210,8 @@
                 "choices": [
                     "безумие",
                     "нищий",
-                    "голый",
-                    "маскировка"
+                    "маскировка",
+                    "голый"
                 ],
                 "correctIndex": 0
             },
@@ -2228,49 +2228,49 @@
             {
                 "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
-                    "безумный",
                     "маскировка",
-                    "безумие",
-                    "голый"
+                    "бормотать",
+                    "голый",
+                    "нищета"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
-                    "дрожать",
-                    "маскировка",
-                    "голый",
-                    "безумный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «murmeln»?",
-                "choices": [
                     "безумие",
-                    "голый",
-                    "дрожать",
-                    "бормотать"
+                    "безумный",
+                    "бормотать",
+                    "голый"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «zittern»?",
+                "question": "Что означает немецкое слово «murmeln»?",
                 "choices": [
                     "нищий",
+                    "бормотать",
                     "голый",
-                    "дрожать",
-                    "нищета"
+                    "дрожать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «zittern»?",
+                "choices": [
+                    "дрожать",
+                    "безумие",
+                    "нищета",
+                    "голый"
+                ],
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
-                    "маскировка",
                     "голый",
-                    "дрожать",
+                    "бормотать",
+                    "безумие",
                     "нищета"
                 ],
                 "correctIndex": 3
@@ -2278,12 +2278,12 @@
             {
                 "question": "Что означает немецкое слово «wahnsinnig»?",
                 "choices": [
-                    "безумие",
                     "безумный",
-                    "дрожать",
-                    "голый"
+                    "нищета",
+                    "маскировка",
+                    "дрожать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2514,60 +2514,60 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "страдать",
                     "мёрзнуть",
-                    "хижина",
-                    "буря"
+                    "страдать",
+                    "буря",
+                    "хижина"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "мёрзнуть",
-                    "хижина",
+                    "буря",
                     "страдать",
-                    "буря"
+                    "мёрзнуть",
+                    "хижина"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
+                    "буря",
                     "страдать",
-                    "защищать",
-                    "молния",
-                    "сопровождать"
+                    "мёрзнуть",
+                    "защищать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
-                    "буря",
                     "хижина",
-                    "гром",
+                    "буря",
+                    "страдать",
                     "мёрзнуть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
+                    "сопровождать",
                     "страдать",
-                    "защищать",
-                    "хижина",
-                    "буря"
+                    "буря",
+                    "защищать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "молния",
-                    "защищать",
+                    "мёрзнуть",
+                    "гром",
                     "сопровождать",
-                    "страдать"
+                    "защищать"
                 ],
                 "correctIndex": 2
             },
@@ -2575,21 +2575,21 @@
                 "question": "Что означает немецкое слово «der Donner»?",
                 "choices": [
                     "гром",
-                    "защищать",
                     "мёрзнуть",
-                    "буря"
+                    "хижина",
+                    "защищать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Blitz»?",
                 "choices": [
-                    "хижина",
                     "молния",
-                    "мёрзнуть",
-                    "страдать"
+                    "хижина",
+                    "сопровождать",
+                    "буря"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2815,76 +2815,76 @@
                 "choices": [
                     "слепой",
                     "вести",
-                    "утёс",
-                    "обманывать"
+                    "обманывать",
+                    "утёс"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «führen»?",
                 "choices": [
-                    "вести",
                     "обманывать",
+                    "вести",
                     "утёс",
                     "слепой"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Klippe»?",
                 "choices": [
                     "утёс",
+                    "хитрость",
                     "утешать",
-                    "слепой",
-                    "отчаяние"
+                    "слепой"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
-                    "отчаяние",
-                    "спасать",
+                    "вести",
+                    "слепой",
                     "обманывать",
-                    "вести"
+                    "отчаяние"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
-                    "утёс",
-                    "спасать",
                     "отчаяние",
-                    "хитрость"
+                    "хитрость",
+                    "спасать",
+                    "слепой"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
                     "спасать",
-                    "хитрость",
-                    "слепой",
-                    "вести"
+                    "вести",
+                    "утешать",
+                    "хитрость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "спасать",
                     "вести",
-                    "утешать",
-                    "отчаяние"
+                    "хитрость",
+                    "обманывать",
+                    "утешать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "вести",
-                    "хитрость",
+                    "утёс",
+                    "слепой",
                     "обманывать",
                     "отчаяние"
                 ],
@@ -3101,39 +3101,39 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "бой",
-                    "разоблачать",
                     "месть",
-                    "дуэль"
+                    "разоблачать",
+                    "дуэль",
+                    "бой"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Duell»?",
                 "choices": [
-                    "дуэль",
-                    "бой",
                     "разоблачать",
-                    "месть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Rache»?",
-                "choices": [
-                    "справедливость",
+                    "дуэль",
                     "месть",
-                    "брат",
-                    "побеждать"
+                    "бой"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «die Rache»?",
+                "choices": [
+                    "разоблачать",
+                    "брат",
+                    "побеждать",
+                    "месть"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «enthüllen»?",
                 "choices": [
-                    "месть",
+                    "брат",
                     "разоблачать",
-                    "меч",
+                    "дуэль",
                     "справедливость"
                 ],
                 "correctIndex": 1
@@ -3141,39 +3141,39 @@
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
+                    "брат",
                     "месть",
-                    "побеждать",
                     "меч",
-                    "дуэль"
+                    "побеждать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "меч",
+                    "бой",
                     "справедливость",
-                    "брат",
-                    "разоблачать"
+                    "разоблачать",
+                    "меч"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Schwert»?",
                 "choices": [
-                    "меч",
                     "справедливость",
-                    "дуэль",
-                    "разоблачать"
+                    "месть",
+                    "разоблачать",
+                    "меч"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Bruder»?",
                 "choices": [
-                    "меч",
-                    "побеждать",
+                    "справедливость",
                     "бой",
+                    "дуэль",
                     "брат"
                 ],
                 "correctIndex": 3
@@ -3392,82 +3392,82 @@
             {
                 "question": "Что означает немецкое слово «überleben»?",
                 "choices": [
-                    "править",
                     "выживать",
+                    "наследовать",
+                    "править",
+                    "будущее"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «erben»?",
+                "choices": [
+                    "править",
+                    "наследовать",
                     "будущее",
+                    "выживать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Zukunft»?",
+                "choices": [
+                    "новый",
+                    "будущее",
+                    "выживать",
                     "наследовать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «erben»?",
-                "choices": [
-                    "наследовать",
-                    "править",
-                    "будущее",
-                    "выживать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Zukunft»?",
-                "choices": [
-                    "порядок",
-                    "наследовать",
-                    "будущее",
-                    "новый"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
-                    "наследовать",
-                    "править",
+                    "новый",
+                    "порядок",
                     "ответственность",
-                    "выживать"
+                    "править"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
                     "будущее",
-                    "новый",
-                    "ответственность",
-                    "мудрость"
+                    "править",
+                    "мудрость",
+                    "наследовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Ordnung»?",
                 "choices": [
-                    "мудрость",
-                    "править",
-                    "новый",
-                    "порядок"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Verantwortung»?",
-                "choices": [
-                    "ответственность",
-                    "новый",
+                    "порядок",
                     "выживать",
-                    "наследовать"
+                    "наследовать",
+                    "ответственность"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «neu»?",
+                "question": "Что означает немецкое слово «die Verantwortung»?",
                 "choices": [
-                    "порядок",
+                    "выживать",
+                    "наследовать",
                     "будущее",
-                    "мудрость",
-                    "новый"
+                    "ответственность"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «neu»?",
+                "choices": [
+                    "мудрость",
+                    "порядок",
+                    "новый",
+                    "выживать"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}

--- a/output/journeys/edmund.html
+++ b/output/journeys/edmund.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["амбиция", "зависть", "обделённый", "бастард"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["бастард", "обделённый", "зависть", "амбиция"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["обделённый", "амбиция", "зависть", "природа"], "correct_index": 1}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["обделённый", "бастард", "месть", "внебрачный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "внебрачный", "возвышаться", "амбиция"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["амбиция", "бастард", "природа", "возвышаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["месть", "обделённый", "внебрачный", "природа"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["амбиция", "зависть", "природа", "внебрачный"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["интриговать", "обвинять", "план", "подделывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["обвинять", "план", "подделывать", "интриговать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["интриговать", "письмо", "обвинять", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["обман", "лгать", "подделывать", "план"], "correct_index": 3}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["подделывать", "письмо", "манипулировать", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["лгать", "обвинять", "письмо", "план"], "correct_index": 2}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["лгать", "письмо", "подделывать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["обман", "обвинять", "манипулировать", "интриговать"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["торжествовать", "успех", "наследовать", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["торжествовать", "изгонять", "успех", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erben»?", "choices": ["успех", "выигрывать", "награда", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["успех", "торжествовать", "победа", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["изгонять", "награда", "выигрывать", "наследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["награда", "победа", "успех", "выигрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["выигрывать", "награда", "торжествовать", "вытеснять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["наследовать", "изгонять", "победа", "успех"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["власть", "союз", "объединяться", "завоёвывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["союз", "объединяться", "завоёвывать", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоёвывать", "соблазнять", "господствовать", "объединяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["господствовать", "власть", "объединяться", "союз"], "correct_index": 3}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["завоевание", "соблазнять", "завоёвывать", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["объединяться", "завоевание", "власть", "союз"], "correct_index": 1}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["объединяться", "господствовать", "союз", "завоевание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["завоёвывать", "господствовать", "завоевание", "альянс"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["жестокость", "предавать", "ослеплять", "доносить"], "correct_index": 1}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["жестокость", "доносить", "ослеплять", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "пытка", "выдавать", "жертвовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["жертвовать", "жестокость", "пытка", "доносить"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["ослеплять", "выдавать", "жестокость", "беспощадный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["выдавать", "доносить", "пытка", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["жертвовать", "жестокость", "выдавать", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["ослеплять", "беспощадный", "жестокость", "жертвовать"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["соперничество", "завлекать", "играть", "любовная связь"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["играть", "любовная связь", "завлекать", "соперничество"], "correct_index": 3}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["любовная связь", "соперничество", "похоть", "играть"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["завлекать", "играть", "соперничество", "жонглировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["жонглировать", "похоть", "играть", "завлекать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["использовать", "соперничество", "жонглировать", "похоть"], "correct_index": 0}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["интрига", "жонглировать", "играть", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["играть", "использовать", "интрига", "любовная связь"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["падать", "дуэль", "поражение", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["дуэль", "падать", "поражение", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["проигрывать", "признаваться", "поражение", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["поражение", "проигрывать", "конец", "падать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["конец", "падение", "сожалеть", "проигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["дуэль", "признаваться", "конец", "падение"], "correct_index": 3}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["поражение", "дуэль", "признаваться", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["сожалеть", "поражение", "конец", "падение"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["обделённый", "амбиция", "бастард", "зависть"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["амбиция", "обделённый", "зависть", "бастард"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["зависть", "обделённый", "месть", "амбиция"], "correct_index": 3}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["обделённый", "зависть", "природа", "бастард"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["внебрачный", "месть", "возвышаться", "природа"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["зависть", "возвышаться", "внебрачный", "бастард"], "correct_index": 1}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["внебрачный", "обделённый", "зависть", "бастард"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["возвышаться", "амбиция", "обделённый", "природа"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["подделывать", "обвинять", "интриговать", "план"], "correct_index": 0}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["интриговать", "план", "подделывать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["обвинять", "манипулировать", "письмо", "лгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["подделывать", "обман", "письмо", "план"], "correct_index": 3}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["манипулировать", "план", "обман", "подделывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["интриговать", "письмо", "лгать", "обвинять"], "correct_index": 1}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["план", "письмо", "подделывать", "лгать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["лгать", "манипулировать", "обман", "интриговать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["успех", "изгонять", "наследовать", "торжествовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["успех", "изгонять", "торжествовать", "наследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erben»?", "choices": ["победа", "наследовать", "успех", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["изгонять", "награда", "вытеснять", "успех"], "correct_index": 3}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["наследовать", "победа", "награда", "выигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["наследовать", "награда", "торжествовать", "успех"], "correct_index": 1}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["победа", "вытеснять", "торжествовать", "успех"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["выигрывать", "победа", "награда", "успех"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["союз", "завоёвывать", "власть", "объединяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["союз", "власть", "завоёвывать", "объединяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["господствовать", "завоёвывать", "власть", "соблазнять"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["союз", "объединяться", "завоёвывать", "альянс"], "correct_index": 0}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["объединяться", "альянс", "соблазнять", "союз"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["власть", "завоёвывать", "завоевание", "соблазнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["власть", "объединяться", "господствовать", "завоёвывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["альянс", "завоёвывать", "завоевание", "объединяться"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["предавать", "жестокость", "доносить", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "жестокость", "доносить", "предавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["пытка", "доносить", "жестокость", "беспощадный"], "correct_index": 2}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["жестокость", "доносить", "беспощадный", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["жертвовать", "жестокость", "выдавать", "доносить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["жестокость", "жертвовать", "ослеплять", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["жестокость", "выдавать", "беспощадный", "жертвовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["беспощадный", "жестокость", "пытка", "доносить"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["играть", "соперничество", "любовная связь", "завлекать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["соперничество", "любовная связь", "завлекать", "играть"], "correct_index": 0}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["играть", "использовать", "интрига", "жонглировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["завлекать", "интрига", "использовать", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["похоть", "завлекать", "использовать", "играть"], "correct_index": 0}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["использовать", "любовная связь", "похоть", "играть"], "correct_index": 0}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["интрига", "похоть", "жонглировать", "использовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["использовать", "интрига", "соперничество", "похоть"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["падать", "дуэль", "сожалеть", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["поражение", "сожалеть", "дуэль", "падать"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["поражение", "дуэль", "сожалеть", "признаваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["падать", "поражение", "падение", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["признаваться", "дуэль", "проигрывать", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["конец", "сожалеть", "поражение", "падение"], "correct_index": 3}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["признаваться", "проигрывать", "сожалеть", "дуэль"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "сожалеть", "дуэль", "падать"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Незаконнорождённый</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,17 +465,17 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Bastard»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">зависть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бастард</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">зависть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -485,29 +485,29 @@
                         <div class="quiz-question">Что означает немецкое слово «der Neid»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -519,57 +519,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">зависть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">природа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвышаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">внебрачный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">внебрачный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
                             
@@ -577,17 +545,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">возвышаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">внебрачный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">внебрачный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Natur»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвышаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">зависть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">природа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,95 +600,15 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «fälschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «intrigieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «beschuldigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">лгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                             
@@ -696,13 +616,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «lügen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «intrigieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
                             
@@ -712,15 +632,95 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «beschuldigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">манипулировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">лгать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">лгать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «lügen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">лгать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">манипулировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
                             
@@ -735,15 +735,47 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">торжествовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">победа</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
@@ -751,79 +783,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">награда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Erfolg»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вытеснять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">награда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
                             
@@ -831,31 +815,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">победа</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Sieg»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">награда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
                             
@@ -870,24 +870,56 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verbünden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">господствовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
@@ -896,69 +928,21 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">господствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">господствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Eroberung»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">альянс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
                             
@@ -966,33 +950,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Eroberung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">объединяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">господствовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Allianz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">альянс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1005,31 +1005,31 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
                             
@@ -1037,45 +1037,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертвовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
@@ -1085,24 +1053,24 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «opfern»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
@@ -1111,23 +1079,55 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жертвовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «opfern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жертвовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1140,49 +1140,49 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Liebschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1194,27 +1194,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1226,43 +1226,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «jonglieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">использовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Affäre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1283,55 +1283,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
                             
@@ -1339,17 +1307,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">падение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">падение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">признаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1359,11 +1359,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
                             
@@ -1371,33 +1371,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">признаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">признаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1618,82 +1618,82 @@
             {
                 "question": "Что означает немецкое слово «der Bastard»?",
                 "choices": [
-                    "амбиция",
-                    "зависть",
                     "обделённый",
-                    "бастард"
+                    "амбиция",
+                    "бастард",
+                    "зависть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Neid»?",
                 "choices": [
-                    "бастард",
+                    "амбиция",
                     "обделённый",
                     "зависть",
-                    "амбиция"
+                    "бастард"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Ambition»?",
                 "choices": [
-                    "обделённый",
-                    "амбиция",
                     "зависть",
-                    "природа"
+                    "обделённый",
+                    "месть",
+                    "амбиция"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «benachteiligt»?",
                 "choices": [
                     "обделённый",
-                    "бастард",
-                    "месть",
-                    "внебрачный"
+                    "зависть",
+                    "природа",
+                    "бастард"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "месть",
                     "внебрачный",
+                    "месть",
                     "возвышаться",
-                    "амбиция"
+                    "природа"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufsteigen»?",
                 "choices": [
-                    "амбиция",
-                    "бастард",
-                    "природа",
-                    "возвышаться"
+                    "зависть",
+                    "возвышаться",
+                    "внебрачный",
+                    "бастард"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unehelich»?",
                 "choices": [
-                    "месть",
-                    "обделённый",
                     "внебрачный",
-                    "природа"
+                    "обделённый",
+                    "зависть",
+                    "бастард"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Natur»?",
                 "choices": [
+                    "возвышаться",
                     "амбиция",
-                    "зависть",
-                    "природа",
-                    "внебрачный"
+                    "обделённый",
+                    "природа"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -1910,39 +1910,39 @@
             {
                 "question": "Что означает немецкое слово «fälschen»?",
                 "choices": [
-                    "интриговать",
+                    "подделывать",
                     "обвинять",
-                    "план",
-                    "подделывать"
+                    "интриговать",
+                    "план"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «intrigieren»?",
                 "choices": [
-                    "обвинять",
+                    "интриговать",
                     "план",
                     "подделывать",
-                    "интриговать"
+                    "обвинять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beschuldigen»?",
                 "choices": [
-                    "интриговать",
-                    "письмо",
                     "обвинять",
-                    "обман"
+                    "манипулировать",
+                    "письмо",
+                    "лгать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
-                    "обман",
-                    "лгать",
                     "подделывать",
+                    "обман",
+                    "письмо",
                     "план"
                 ],
                 "correctIndex": 3
@@ -1950,42 +1950,42 @@
             {
                 "question": "Что означает немецкое слово «manipulieren»?",
                 "choices": [
-                    "подделывать",
-                    "письмо",
                     "манипулировать",
-                    "обман"
+                    "план",
+                    "обман",
+                    "подделывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
-                    "лгать",
-                    "обвинять",
+                    "интриговать",
                     "письмо",
-                    "план"
+                    "лгать",
+                    "обвинять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «lügen»?",
                 "choices": [
-                    "лгать",
+                    "план",
                     "письмо",
                     "подделывать",
-                    "обвинять"
+                    "лгать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
-                    "обман",
-                    "обвинять",
+                    "лгать",
                     "манипулировать",
+                    "обман",
                     "интриговать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2194,82 +2194,82 @@
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "торжествовать",
                     "успех",
+                    "изгонять",
                     "наследовать",
-                    "изгонять"
+                    "торжествовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «triumphieren»?",
                 "choices": [
-                    "торжествовать",
-                    "изгонять",
                     "успех",
+                    "изгонять",
+                    "торжествовать",
                     "наследовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
+                    "победа",
+                    "наследовать",
                     "успех",
-                    "выигрывать",
-                    "награда",
-                    "наследовать"
+                    "изгонять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Erfolg»?",
                 "choices": [
-                    "успех",
-                    "торжествовать",
-                    "победа",
-                    "наследовать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «gewinnen»?",
-                "choices": [
                     "изгонять",
                     "награда",
-                    "выигрывать",
-                    "наследовать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Belohnung»?",
-                "choices": [
-                    "награда",
-                    "победа",
-                    "успех",
-                    "выигрывать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «verdrängen»?",
-                "choices": [
-                    "выигрывать",
-                    "награда",
-                    "торжествовать",
-                    "вытеснять"
+                    "вытеснять",
+                    "успех"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «der Sieg»?",
+                "question": "Что означает немецкое слово «gewinnen»?",
                 "choices": [
                     "наследовать",
-                    "изгонять",
                     "победа",
+                    "награда",
+                    "выигрывать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Belohnung»?",
+                "choices": [
+                    "наследовать",
+                    "награда",
+                    "торжествовать",
                     "успех"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «verdrängen»?",
+                "choices": [
+                    "победа",
+                    "вытеснять",
+                    "торжествовать",
+                    "успех"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «der Sieg»?",
+                "choices": [
+                    "выигрывать",
+                    "победа",
+                    "награда",
+                    "успех"
+                ],
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2486,82 +2486,82 @@
             {
                 "question": "Что означает немецкое слово «verbünden»?",
                 "choices": [
-                    "власть",
                     "союз",
-                    "объединяться",
-                    "завоёвывать"
+                    "завоёвывать",
+                    "власть",
+                    "объединяться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
                     "союз",
-                    "объединяться",
+                    "власть",
                     "завоёвывать",
-                    "власть"
+                    "объединяться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
-                    "завоёвывать",
-                    "соблазнять",
                     "господствовать",
-                    "объединяться"
+                    "завоёвывать",
+                    "власть",
+                    "соблазнять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
-                    "господствовать",
-                    "власть",
+                    "союз",
                     "объединяться",
-                    "союз"
+                    "завоёвывать",
+                    "альянс"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
-                    "завоевание",
+                    "объединяться",
+                    "альянс",
                     "соблазнять",
-                    "завоёвывать",
-                    "власть"
+                    "союз"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Eroberung»?",
                 "choices": [
-                    "объединяться",
-                    "завоевание",
                     "власть",
-                    "союз"
+                    "завоёвывать",
+                    "завоевание",
+                    "соблазнять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «beherrschen»?",
                 "choices": [
+                    "власть",
                     "объединяться",
                     "господствовать",
-                    "союз",
-                    "завоевание"
+                    "завоёвывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Allianz»?",
                 "choices": [
+                    "альянс",
                     "завоёвывать",
-                    "господствовать",
                     "завоевание",
-                    "альянс"
+                    "объединяться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2801,82 +2801,82 @@
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "жестокость",
                     "предавать",
-                    "ослеплять",
-                    "доносить"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «blenden»?",
-                "choices": [
                     "жестокость",
                     "доносить",
-                    "ослеплять",
-                    "предавать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Grausamkeit»?",
-                "choices": [
-                    "жестокость",
-                    "пытка",
-                    "выдавать",
-                    "жертвовать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «denunzieren»?",
-                "choices": [
-                    "жертвовать",
-                    "жестокость",
-                    "пытка",
-                    "доносить"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «ausliefern»?",
-                "choices": [
-                    "ослеплять",
-                    "выдавать",
-                    "жестокость",
-                    "беспощадный"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Folter»?",
-                "choices": [
-                    "выдавать",
-                    "доносить",
-                    "пытка",
-                    "жестокость"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «opfern»?",
-                "choices": [
-                    "жертвовать",
-                    "жестокость",
-                    "выдавать",
                     "ослеплять"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «erbarmungslos»?",
+                "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
                     "ослеплять",
-                    "беспощадный",
                     "жестокость",
-                    "жертвовать"
+                    "доносить",
+                    "предавать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Grausamkeit»?",
+                "choices": [
+                    "пытка",
+                    "доносить",
+                    "жестокость",
+                    "беспощадный"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «denunzieren»?",
+                "choices": [
+                    "жестокость",
+                    "доносить",
+                    "беспощадный",
+                    "ослеплять"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «ausliefern»?",
+                "choices": [
+                    "жертвовать",
+                    "жестокость",
+                    "выдавать",
+                    "доносить"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Folter»?",
+                "choices": [
+                    "жестокость",
+                    "жертвовать",
+                    "ослеплять",
+                    "пытка"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «opfern»?",
+                "choices": [
+                    "жестокость",
+                    "выдавать",
+                    "беспощадный",
+                    "жертвовать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «erbarmungslos»?",
+                "choices": [
+                    "беспощадный",
+                    "жестокость",
+                    "пытка",
+                    "доносить"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -3091,60 +3091,60 @@
             {
                 "question": "Что означает немецкое слово «die Liebschaft»?",
                 "choices": [
-                    "соперничество",
-                    "завлекать",
                     "играть",
-                    "любовная связь"
+                    "соперничество",
+                    "любовная связь",
+                    "завлекать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
-                    "играть",
+                    "соперничество",
                     "любовная связь",
                     "завлекать",
-                    "соперничество"
+                    "играть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «spielen»?",
                 "choices": [
-                    "любовная связь",
-                    "соперничество",
-                    "похоть",
-                    "играть"
+                    "играть",
+                    "использовать",
+                    "интрига",
+                    "жонглировать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verlocken»?",
                 "choices": [
                     "завлекать",
-                    "играть",
-                    "соперничество",
-                    "жонглировать"
+                    "интрига",
+                    "использовать",
+                    "соперничество"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
-                    "жонглировать",
                     "похоть",
-                    "играть",
-                    "завлекать"
+                    "завлекать",
+                    "использовать",
+                    "играть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ausnutzen»?",
                 "choices": [
                     "использовать",
-                    "соперничество",
-                    "жонглировать",
-                    "похоть"
+                    "любовная связь",
+                    "похоть",
+                    "играть"
                 ],
                 "correctIndex": 0
             },
@@ -3152,21 +3152,21 @@
                 "question": "Что означает немецкое слово «jonglieren»?",
                 "choices": [
                     "интрига",
+                    "похоть",
                     "жонглировать",
-                    "играть",
-                    "соперничество"
+                    "использовать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Affäre»?",
                 "choices": [
-                    "играть",
                     "использовать",
                     "интрига",
-                    "любовная связь"
+                    "соперничество",
+                    "похоть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -3383,57 +3383,57 @@
                 "choices": [
                     "падать",
                     "дуэль",
-                    "поражение",
-                    "сожалеть"
+                    "сожалеть",
+                    "поражение"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
-                    "дуэль",
-                    "падать",
                     "поражение",
-                    "сожалеть"
+                    "сожалеть",
+                    "дуэль",
+                    "падать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "проигрывать",
-                    "признаваться",
                     "поражение",
-                    "сожалеть"
+                    "дуэль",
+                    "сожалеть",
+                    "признаваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
+                    "падать",
                     "поражение",
-                    "проигрывать",
-                    "конец",
-                    "падать"
+                    "падение",
+                    "конец"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verlieren»?",
                 "choices": [
-                    "конец",
-                    "падение",
-                    "сожалеть",
-                    "проигрывать"
+                    "признаваться",
+                    "дуэль",
+                    "проигрывать",
+                    "сожалеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Untergang»?",
                 "choices": [
-                    "дуэль",
-                    "признаваться",
                     "конец",
+                    "сожалеть",
+                    "поражение",
                     "падение"
                 ],
                 "correctIndex": 3
@@ -3441,22 +3441,22 @@
             {
                 "question": "Что означает немецкое слово «gestehen»?",
                 "choices": [
-                    "поражение",
-                    "дуэль",
                     "признаваться",
-                    "конец"
+                    "проигрывать",
+                    "сожалеть",
+                    "дуэль"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "сожалеть",
-                    "поражение",
                     "конец",
-                    "падение"
+                    "сожалеть",
+                    "дуэль",
+                    "падать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}

--- a/output/journeys/fool.html
+++ b/output/journeys/fool.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "мудрость", "шутить", "печаль"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["шут", "шутить", "печаль", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["печаль", "забава", "остроумие", "умный"], "correct_index": 0}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["умный", "остроумие", "шутить", "печаль"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["мудрость", "остроумие", "печаль", "забава"], "correct_index": 3}, {"question": "Что означает немецкое слово «klug»?", "choices": ["остроумие", "шут", "скучать", "умный"], "correct_index": 3}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["шут", "скучать", "печаль", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["мудрость", "остроумие", "забава", "шутить"], "correct_index": 1}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["горький", "шутка", "предупреждение", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["правда", "предупреждение", "шутка", "горький"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["горький", "шутка", "дразнить", "предупреждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["дразнить", "насмехаться", "шутка", "горький"], "correct_index": 3}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["правда", "насмехаться", "предупреждение", "горький"], "correct_index": 1}, {"question": "Что означает немецкое слово «necken»?", "choices": ["дразнить", "шутка", "предупреждение", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["предупреждение", "раскрывать", "правда", "шутка"], "correct_index": 1}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["предчувствие", "загадка", "пророчество", "предсказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["загадка", "предчувствие", "предсказывать", "пророчество"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["предчувствие", "загадка", "предчувствовать", "знамение"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["знамение", "предсказывать", "загадка", "предчувствовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["толковать", "знамение", "предчувствовать", "загадочный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["предчувствовать", "знамение", "предсказывать", "загадка"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["предсказывать", "толковать", "знамение", "предчувствовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадка", "предчувствие", "загадочный", "предсказывать"], "correct_index": 2}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["дружба", "безумие", "сопровождать", "мёрзнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["мёрзнуть", "дружба", "сопровождать", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["петь", "безумие", "сопровождать", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["дружба", "сопровождать", "петь", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «singen»?", "choices": ["верный", "петь", "дружба", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["сопровождать", "петь", "дрожать", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["петь", "безумие", "мёрзнуть", "верный"], "correct_index": 3}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["песня", "напевать", "ирония", "утешение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["ирония", "напевать", "утешение", "песня"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["свистеть", "рифма", "ирония", "напевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «summen»?", "choices": ["напевать", "звучать", "мелодия", "ирония"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["напевать", "звучать", "мелодия", "рифма"], "correct_index": 2}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["свистеть", "песня", "рифма", "утешение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["утешение", "напевать", "рифма", "звучать"], "correct_index": 2}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["звучать", "свистеть", "ирония", "мелодия"], "correct_index": 0}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["бренность", "размышлять", "философия", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["бренность", "судьба", "размышлять", "философия"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["смысл", "размышлять", "бренность", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["философия", "преходящий", "бренность", "размышлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["преходящий", "бренность", "смысл", "познавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["познавать", "смысл", "преходящий", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["преходящий", "философия", "бренность", "познавать"], "correct_index": 0}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["исчезать", "пустота", "тайна", "растворяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["растворяться", "пустота", "тайна", "исчезать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["туман", "загадочный", "пустота", "уходить"], "correct_index": 2}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["тайна", "загадочный", "растворяться", "туман"], "correct_index": 2}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["бесследно", "туман", "исчезать", "тайна"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["уходить", "тайна", "туман", "загадочный"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["бесследно", "тайна", "пустота", "загадочный"], "correct_index": 3}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["уходить", "исчезать", "растворяться", "туман"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["печаль", "шутить", "мудрость", "шут"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["шутить", "печаль", "шут", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["печаль", "забава", "мудрость", "остроумие"], "correct_index": 0}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["шутить", "мудрость", "шут", "скучать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["скучать", "шутить", "умный", "забава"], "correct_index": 3}, {"question": "Что означает немецкое слово «klug»?", "choices": ["забава", "шут", "остроумие", "умный"], "correct_index": 3}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["мудрость", "скучать", "шут", "шутить"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["мудрость", "печаль", "забава", "остроумие"], "correct_index": 3}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "горький", "шутка", "предупреждение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["предупреждение", "горький", "шутка", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["шутка", "горький", "раскрывать", "предупреждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["горький", "предупреждение", "насмехаться", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["правда", "шутка", "предупреждение", "насмехаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «necken»?", "choices": ["предупреждение", "горький", "насмехаться", "дразнить"], "correct_index": 3}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["раскрывать", "горький", "шутка", "правда"], "correct_index": 0}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["предсказывать", "предчувствие", "пророчество", "загадка"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["загадка", "пророчество", "предсказывать", "предчувствие"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["знамение", "загадка", "предчувствовать", "предчувствие"], "correct_index": 3}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["пророчество", "предсказывать", "предчувствовать", "толковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["знамение", "пророчество", "предчувствовать", "толковать"], "correct_index": 3}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["пророчество", "предчувствовать", "загадка", "знамение"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["толковать", "предчувствовать", "знамение", "предсказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["предсказывать", "загадка", "загадочный", "толковать"], "correct_index": 2}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["сопровождать", "мёрзнуть", "безумие", "дружба"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["безумие", "дружба", "мёрзнуть", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["мёрзнуть", "безумие", "дружба", "сопровождать"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "дрожать", "сопровождать", "верный"], "correct_index": 0}, {"question": "Что означает немецкое слово «singen»?", "choices": ["дружба", "безумие", "сопровождать", "петь"], "correct_index": 3}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["верный", "дружба", "дрожать", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["петь", "верный", "дружба", "мёрзнуть"], "correct_index": 1}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["ирония", "утешение", "песня", "напевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["ирония", "напевать", "песня", "утешение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["свистеть", "ирония", "утешение", "звучать"], "correct_index": 1}, {"question": "Что означает немецкое слово «summen»?", "choices": ["утешение", "напевать", "звучать", "мелодия"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["звучать", "утешение", "мелодия", "песня"], "correct_index": 2}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["свистеть", "утешение", "напевать", "песня"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["мелодия", "ирония", "песня", "рифма"], "correct_index": 3}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["напевать", "звучать", "рифма", "ирония"], "correct_index": 1}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["бренность", "судьба", "философия", "размышлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["судьба", "бренность", "размышлять", "философия"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["философия", "бренность", "познавать", "преходящий"], "correct_index": 1}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["размышлять", "бренность", "преходящий", "познавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["преходящий", "познавать", "бренность", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["бренность", "преходящий", "смысл", "размышлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["судьба", "преходящий", "смысл", "бренность"], "correct_index": 1}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["исчезать", "тайна", "растворяться", "пустота"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["растворяться", "пустота", "исчезать", "тайна"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["уходить", "исчезать", "тайна", "пустота"], "correct_index": 3}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["пустота", "уходить", "растворяться", "бесследно"], "correct_index": 2}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["пустота", "загадочный", "бесследно", "туман"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["уходить", "туман", "пустота", "тайна"], "correct_index": 1}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["пустота", "исчезать", "загадочный", "туман"], "correct_index": 2}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["пустота", "уходить", "исчезать", "растворяться"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Королевский шут</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,17 +465,17 @@
             <div class="quiz-phase-container active" data-phase="jester">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -485,11 +485,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
@@ -505,25 +505,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «scherzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скучать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -533,11 +533,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
                             
@@ -549,11 +549,11 @@
                         <div class="quiz-question">Что означает немецкое слово «klug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">забава</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">скучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">остроумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">умный</button>
                             
@@ -565,29 +565,29 @@
                         <div class="quiz-question">Что означает немецкое слово «vermissen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">скучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Witz»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,17 +600,17 @@
             <div class="quiz-phase-container" data-phase="bitter_truths">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -620,13 +620,13 @@
                         <div class="quiz-question">Что означает немецкое слово «der Scherz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -636,11 +636,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дразнить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
                             
@@ -648,47 +648,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «necken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
                             
@@ -696,17 +664,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «necken»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дразнить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -723,13 +723,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Prophezeiung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">загадка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -741,27 +741,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Vorahnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -771,45 +771,45 @@
                         <div class="quiz-question">Что означает немецкое слово «vorhersagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «ahnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -819,13 +819,13 @@
                         <div class="quiz-question">Что означает немецкое слово «das Omen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">знамение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -835,13 +835,13 @@
                         <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,17 +854,17 @@
             <div class="quiz-phase-container" data-phase="mad_companion">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -874,61 +874,61 @@
                         <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «singen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «singen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">петь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -938,9 +938,9 @@
                         <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
                             
@@ -950,17 +950,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">петь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,47 +973,15 @@
             <div class="quiz-phase-container" data-phase="songs">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Lied»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Trost»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ironie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">песня</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">напевать</button>
                             
@@ -1021,17 +989,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Trost»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">песня</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Ironie»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «summen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">звучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1041,13 +1041,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">звучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1059,43 +1059,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мелодия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">песня</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">рифма</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «klingen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рифма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1114,23 +1114,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
                             
@@ -1140,63 +1140,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Vergänglichkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смысл</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преходящий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преходящий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">преходящий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">познавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">преходящий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">познавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">познавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смысл</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">преходящий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
@@ -1204,17 +1188,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">преходящий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vergänglich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преходящий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преходящий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">познавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1233,71 +1233,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">туман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
                             
@@ -1307,49 +1259,97 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">туман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «fortgehen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">уходить</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="3">бесследно</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бесследно</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «fortgehen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">уходить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1581,19 +1581,19 @@
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "шут",
-                    "мудрость",
+                    "печаль",
                     "шутить",
-                    "печаль"
+                    "мудрость",
+                    "шут"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "шут",
                     "шутить",
                     "печаль",
+                    "шут",
                     "мудрость"
                 ],
                 "correctIndex": 3
@@ -1603,27 +1603,27 @@
                 "choices": [
                     "печаль",
                     "забава",
-                    "остроумие",
-                    "умный"
+                    "мудрость",
+                    "остроумие"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «scherzen»?",
                 "choices": [
-                    "умный",
-                    "остроумие",
                     "шутить",
-                    "печаль"
+                    "мудрость",
+                    "шут",
+                    "скучать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Spaß»?",
                 "choices": [
-                    "мудрость",
-                    "остроумие",
-                    "печаль",
+                    "скучать",
+                    "шутить",
+                    "умный",
                     "забава"
                 ],
                 "correctIndex": 3
@@ -1631,9 +1631,9 @@
             {
                 "question": "Что означает немецкое слово «klug»?",
                 "choices": [
-                    "остроумие",
+                    "забава",
                     "шут",
-                    "скучать",
+                    "остроумие",
                     "умный"
                 ],
                 "correctIndex": 3
@@ -1641,10 +1641,10 @@
             {
                 "question": "Что означает немецкое слово «vermissen»?",
                 "choices": [
-                    "шут",
+                    "мудрость",
                     "скучать",
-                    "печаль",
-                    "мудрость"
+                    "шут",
+                    "шутить"
                 ],
                 "correctIndex": 1
             },
@@ -1652,11 +1652,11 @@
                 "question": "Что означает немецкое слово «der Witz»?",
                 "choices": [
                     "мудрость",
-                    "остроумие",
+                    "печаль",
                     "забава",
-                    "шутить"
+                    "остроумие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -1844,29 +1844,29 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
+                    "правда",
                     "горький",
                     "шутка",
-                    "предупреждение",
-                    "правда"
+                    "предупреждение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Scherz»?",
                 "choices": [
-                    "правда",
                     "предупреждение",
+                    "горький",
                     "шутка",
-                    "горький"
+                    "правда"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Warnung»?",
                 "choices": [
-                    "горький",
                     "шутка",
-                    "дразнить",
+                    "горький",
+                    "раскрывать",
                     "предупреждение"
                 ],
                 "correctIndex": 3
@@ -1874,42 +1874,42 @@
             {
                 "question": "Что означает немецкое слово «bitter»?",
                 "choices": [
-                    "дразнить",
-                    "насмехаться",
-                    "шутка",
-                    "горький"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «spotten»?",
-                "choices": [
-                    "правда",
-                    "насмехаться",
+                    "горький",
                     "предупреждение",
-                    "горький"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «necken»?",
-                "choices": [
-                    "дразнить",
-                    "шутка",
-                    "предупреждение",
+                    "насмехаться",
                     "правда"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «enthüllen»?",
+                "question": "Что означает немецкое слово «spotten»?",
+                "choices": [
+                    "правда",
+                    "шутка",
+                    "предупреждение",
+                    "насмехаться"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «necken»?",
                 "choices": [
                     "предупреждение",
-                    "раскрывать",
-                    "правда",
-                    "шутка"
+                    "горький",
+                    "насмехаться",
+                    "дразнить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «enthüllen»?",
+                "choices": [
+                    "раскрывать",
+                    "горький",
+                    "шутка",
+                    "правда"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2119,10 +2119,10 @@
             {
                 "question": "Что означает немецкое слово «die Prophezeiung»?",
                 "choices": [
+                    "предсказывать",
                     "предчувствие",
-                    "загадка",
                     "пророчество",
-                    "предсказывать"
+                    "загадка"
                 ],
                 "correctIndex": 2
             },
@@ -2130,69 +2130,69 @@
                 "question": "Что означает немецкое слово «das Rätsel»?",
                 "choices": [
                     "загадка",
-                    "предчувствие",
+                    "пророчество",
                     "предсказывать",
-                    "пророчество"
+                    "предчувствие"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Vorahnung»?",
                 "choices": [
-                    "предчувствие",
+                    "знамение",
                     "загадка",
                     "предчувствовать",
-                    "знамение"
+                    "предчувствие"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vorhersagen»?",
                 "choices": [
-                    "знамение",
+                    "пророчество",
                     "предсказывать",
-                    "загадка",
-                    "предчувствовать"
+                    "предчувствовать",
+                    "толковать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «deuten»?",
                 "choices": [
-                    "толковать",
                     "знамение",
+                    "пророчество",
                     "предчувствовать",
-                    "загадочный"
+                    "толковать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ahnen»?",
                 "choices": [
+                    "пророчество",
                     "предчувствовать",
-                    "знамение",
-                    "предсказывать",
-                    "загадка"
+                    "загадка",
+                    "знамение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Omen»?",
                 "choices": [
-                    "предсказывать",
                     "толковать",
+                    "предчувствовать",
                     "знамение",
-                    "предчувствовать"
+                    "предсказывать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
+                    "предсказывать",
                     "загадка",
-                    "предчувствие",
                     "загадочный",
-                    "предсказывать"
+                    "толковать"
                 ],
                 "correctIndex": 2
             }
@@ -2393,58 +2393,58 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "дружба",
-                    "безумие",
                     "сопровождать",
-                    "мёрзнуть"
+                    "мёрзнуть",
+                    "безумие",
+                    "дружба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Freundschaft»?",
                 "choices": [
-                    "мёрзнуть",
+                    "безумие",
                     "дружба",
-                    "сопровождать",
-                    "безумие"
+                    "мёрзнуть",
+                    "сопровождать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "петь",
+                    "мёрзнуть",
                     "безумие",
-                    "сопровождать",
-                    "мёрзнуть"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «frieren»?",
-                "choices": [
                     "дружба",
-                    "сопровождать",
-                    "петь",
-                    "мёрзнуть"
+                    "сопровождать"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «frieren»?",
+                "choices": [
+                    "мёрзнуть",
+                    "дрожать",
+                    "сопровождать",
+                    "верный"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «singen»?",
                 "choices": [
-                    "верный",
-                    "петь",
                     "дружба",
-                    "безумие"
+                    "безумие",
+                    "сопровождать",
+                    "петь"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
-                    "сопровождать",
-                    "петь",
+                    "верный",
+                    "дружба",
                     "дрожать",
                     "безумие"
                 ],
@@ -2454,11 +2454,11 @@
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
                     "петь",
-                    "безумие",
-                    "мёрзнуть",
-                    "верный"
+                    "верный",
+                    "дружба",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2664,50 +2664,50 @@
             {
                 "question": "Что означает немецкое слово «das Lied»?",
                 "choices": [
-                    "песня",
-                    "напевать",
                     "ирония",
-                    "утешение"
+                    "утешение",
+                    "песня",
+                    "напевать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Trost»?",
                 "choices": [
                     "ирония",
                     "напевать",
-                    "утешение",
-                    "песня"
+                    "песня",
+                    "утешение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ironie»?",
                 "choices": [
                     "свистеть",
-                    "рифма",
                     "ирония",
-                    "напевать"
+                    "утешение",
+                    "звучать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «summen»?",
                 "choices": [
+                    "утешение",
                     "напевать",
                     "звучать",
-                    "мелодия",
-                    "ирония"
+                    "мелодия"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Melodie»?",
                 "choices": [
-                    "напевать",
                     "звучать",
+                    "утешение",
                     "мелодия",
-                    "рифма"
+                    "песня"
                 ],
                 "correctIndex": 2
             },
@@ -2715,31 +2715,31 @@
                 "question": "Что означает немецкое слово «pfeifen»?",
                 "choices": [
                     "свистеть",
-                    "песня",
-                    "рифма",
-                    "утешение"
+                    "утешение",
+                    "напевать",
+                    "песня"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Reim»?",
                 "choices": [
-                    "утешение",
-                    "напевать",
-                    "рифма",
-                    "звучать"
+                    "мелодия",
+                    "ирония",
+                    "песня",
+                    "рифма"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «klingen»?",
                 "choices": [
+                    "напевать",
                     "звучать",
-                    "свистеть",
-                    "ирония",
-                    "мелодия"
+                    "рифма",
+                    "ирония"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2929,71 +2929,71 @@
                 "question": "Что означает немецкое слово «die Philosophie»?",
                 "choices": [
                     "бренность",
-                    "размышлять",
+                    "судьба",
                     "философия",
-                    "судьба"
+                    "размышлять"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
-                    "бренность",
                     "судьба",
+                    "бренность",
                     "размышлять",
                     "философия"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Vergänglichkeit»?",
                 "choices": [
-                    "смысл",
-                    "размышлять",
+                    "философия",
                     "бренность",
-                    "судьба"
+                    "познавать",
+                    "преходящий"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «nachdenken»?",
                 "choices": [
-                    "философия",
-                    "преходящий",
+                    "размышлять",
                     "бренность",
-                    "размышлять"
+                    "преходящий",
+                    "познавать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
                     "преходящий",
-                    "бренность",
-                    "смысл",
-                    "познавать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Sinn»?",
-                "choices": [
                     "познавать",
-                    "смысл",
-                    "преходящий",
+                    "бренность",
                     "размышлять"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «der Sinn»?",
+                "choices": [
+                    "бренность",
+                    "преходящий",
+                    "смысл",
+                    "размышлять"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «vergänglich»?",
                 "choices": [
+                    "судьба",
                     "преходящий",
-                    "философия",
-                    "бренность",
-                    "познавать"
+                    "смысл",
+                    "бренность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -3202,9 +3202,9 @@
                 "question": "Что означает немецкое слово «verschwinden»?",
                 "choices": [
                     "исчезать",
-                    "пустота",
                     "тайна",
-                    "растворяться"
+                    "растворяться",
+                    "пустота"
                 ],
                 "correctIndex": 0
             },
@@ -3213,70 +3213,70 @@
                 "choices": [
                     "растворяться",
                     "пустота",
-                    "тайна",
-                    "исчезать"
+                    "исчезать",
+                    "тайна"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Leere»?",
                 "choices": [
-                    "туман",
-                    "загадочный",
-                    "пустота",
-                    "уходить"
+                    "уходить",
+                    "исчезать",
+                    "тайна",
+                    "пустота"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sich auflösen»?",
                 "choices": [
-                    "тайна",
-                    "загадочный",
+                    "пустота",
+                    "уходить",
                     "растворяться",
-                    "туман"
+                    "бесследно"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «spurlos»?",
                 "choices": [
+                    "пустота",
+                    "загадочный",
                     "бесследно",
-                    "туман",
-                    "исчезать",
-                    "тайна"
+                    "туман"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Nebel»?",
                 "choices": [
                     "уходить",
-                    "тайна",
                     "туман",
-                    "загадочный"
+                    "пустота",
+                    "тайна"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
-                    "бесследно",
-                    "тайна",
                     "пустота",
-                    "загадочный"
+                    "исчезать",
+                    "загадочный",
+                    "туман"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «fortgehen»?",
                 "choices": [
+                    "пустота",
                     "уходить",
                     "исчезать",
-                    "растворяться",
-                    "туман"
+                    "растворяться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}

--- a/output/journeys/gloucester.html
+++ b/output/journeys/gloucester.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["доверять", "граф", "знать", "служить"], "correct_index": 2}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["граф", "доверять", "служить", "знать"], "correct_index": 2}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["доверять", "служить", "праведный", "уважать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["уважать", "праведный", "граф", "честь"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["долг", "служить", "праведный", "честь"], "correct_index": 3}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["знать", "праведный", "уважать", "доверять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["праведный", "долг", "знать", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «achten»?", "choices": ["честь", "уважать", "долг", "знать"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["письмо", "верить", "обман", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["обман", "верить", "письмо", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "простодушный", "письмо", "ловушка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["подозревать", "простодушный", "обман", "верить"], "correct_index": 2}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["ловушка", "простодушный", "верить", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["верить", "подозревать", "обман", "письмо"], "correct_index": 1}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["верить", "обманывать", "легковерный", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["верить", "ловушка", "письмо", "обман"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["заблуждение", "сожалеть", "изгонять", "проклинать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["заблуждение", "сожалеть", "изгонять", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "проклинать", "гнать", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["несправедливость", "слепой", "изгонять", "заблуждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «blind»?", "choices": ["несправедливость", "сожалеть", "слепой", "проклинать"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["несправедливость", "слепой", "гнать", "заблуждение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["сожалеть", "несправедливость", "слепой", "заблуждение"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["сострадание", "рисковать", "помогать", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["помогать", "сострадание", "рисковать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["осмеливаться", "измена", "рисковать", "сострадание"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["помогать", "тайно", "измена", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["тайно", "сострадание", "рисковать", "осмеливаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["защищать", "опасность", "сострадание", "помогать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["тайно", "осмеливаться", "измена", "рисковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["тайно", "сострадание", "осмеливаться", "опасность"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "боль", "темнота", "пытка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["боль", "пытка", "ослеплять", "темнота"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["боль", "месть", "слепнуть", "пытка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["темнота", "ослеплять", "боль", "слепнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["ослеплять", "темнота", "пытка", "кричать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["кричать", "месть", "слепнуть", "темнота"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "пытка", "слепнуть", "боль"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["прыгать", "отчаяние", "пропасть", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «springen»?", "choices": ["пропасть", "прыгать", "отчаяние", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["избавлять", "обман", "прыгать", "сдаваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["прыгать", "падать", "пропасть", "сдаваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["отчаяние", "прыгать", "сдаваться", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["падать", "безнадёжность", "обман", "пропасть"], "correct_index": 1}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["избавлять", "сдаваться", "падать", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["прыгать", "сдаваться", "отчаяние", "избавлять"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["осознание", "прощать", "умирать", "узнавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["узнавать", "осознание", "умирать", "прощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "обнимать", "сердце", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["узнавать", "примирение", "прощать", "осознание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "прощать", "сердце", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["обнимать", "осознание", "прощать", "примирение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["обнимать", "примирение", "прощать", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["примирение", "раскаяние", "обнимать", "сердце"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["доверять", "знать", "служить", "граф"], "correct_index": 1}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["доверять", "граф", "служить", "знать"], "correct_index": 2}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["уважать", "доверять", "честь", "праведный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["граф", "честь", "уважать", "доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["честь", "служить", "праведный", "знать"], "correct_index": 0}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["праведный", "долг", "уважать", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["уважать", "доверять", "долг", "граф"], "correct_index": 2}, {"question": "Что означает немецкое слово «achten»?", "choices": ["знать", "уважать", "служить", "честь"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["обман", "обманывать", "верить", "письмо"], "correct_index": 3}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["письмо", "верить", "обман", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "простодушный", "обман", "подозревать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["обман", "письмо", "верить", "простодушный"], "correct_index": 0}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["ловушка", "обман", "простодушный", "письмо"], "correct_index": 2}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["письмо", "простодушный", "подозревать", "легковерный"], "correct_index": 2}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["подозревать", "письмо", "легковерный", "ловушка"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["письмо", "обман", "ловушка", "простодушный"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["заблуждение", "изгонять", "проклинать", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "сожалеть", "заблуждение", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["заблуждение", "гнать", "сожалеть", "несправедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["сожалеть", "заблуждение", "гнать", "несправедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «blind»?", "choices": ["заблуждение", "несправедливость", "слепой", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["изгонять", "гнать", "слепой", "несправедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["несправедливость", "изгонять", "заблуждение", "гнать"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["сострадание", "помогать", "рисковать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["опасность", "рисковать", "сострадание", "помогать"], "correct_index": 2}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["измена", "сострадание", "рисковать", "осмеливаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["помогать", "тайно", "рисковать", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["тайно", "помогать", "рисковать", "осмеливаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["рисковать", "защищать", "сострадание", "измена"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["измена", "рисковать", "осмеливаться", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["опасность", "сострадание", "осмеливаться", "помогать"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["пытка", "ослеплять", "темнота", "боль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["темнота", "ослеплять", "пытка", "боль"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["кричать", "ослеплять", "месть", "боль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["боль", "темнота", "ослеплять", "кричать"], "correct_index": 1}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["кричать", "месть", "ослеплять", "темнота"], "correct_index": 0}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["ослеплять", "месть", "пытка", "слепнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["пытка", "ослеплять", "месть", "слепнуть"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["обман", "отчаяние", "пропасть", "прыгать"], "correct_index": 1}, {"question": "Что означает немецкое слово «springen»?", "choices": ["пропасть", "прыгать", "отчаяние", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["падать", "сдаваться", "безнадёжность", "обман"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["отчаяние", "обман", "пропасть", "сдаваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["пропасть", "избавлять", "прыгать", "сдаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["избавлять", "безнадёжность", "падать", "пропасть"], "correct_index": 1}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["падать", "отчаяние", "обман", "прыгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["сдаваться", "прыгать", "избавлять", "безнадёжность"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "прощать", "умирать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["узнавать", "прощать", "осознание", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["обнимать", "умирать", "примирение", "сердце"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["примирение", "осознание", "сердце", "обнимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["узнавать", "сердце", "прощать", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["примирение", "осознание", "обнимать", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["сердце", "обнимать", "примирение", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["узнавать", "сердце", "умирать", "осознание"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный граф</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,17 +465,17 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -485,9 +485,9 @@
                         <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
@@ -497,61 +497,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
                             
@@ -561,17 +529,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">уважать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -581,13 +581,13 @@
                         <div class="quiz-question">Что означает немецкое слово «achten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,17 +600,17 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -620,11 +620,11 @@
                         <div class="quiz-question">Что означает немецкое слово «glauben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
@@ -640,57 +640,57 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">простодушный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">простодушный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «arglos»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">простодушный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">простодушный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">простодушный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">легковерный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -700,29 +700,29 @@
                         <div class="quiz-question">Что означает немецкое слово «leichtgläubig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,47 +735,31 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
@@ -783,17 +767,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -803,45 +803,45 @@
                         <div class="quiz-question">Что означает немецкое слово «blind»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,15 +854,15 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «helfen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
@@ -870,17 +870,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -890,13 +890,13 @@
                         <div class="quiz-question">Что означает немецкое слово «riskieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">измена</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -910,7 +910,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">измена</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
@@ -924,7 +924,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
                             
@@ -934,33 +934,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «schützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">измена</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">измена</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">измена</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">осмеливаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -970,13 +970,13 @@
                         <div class="quiz-question">Что означает немецкое слово «wagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">осмеливаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -989,29 +989,77 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Dunkelheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
@@ -1021,31 +1069,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erblinden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Dunkelheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
                             
@@ -1053,49 +1085,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «erblinden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1112,13 +1112,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1140,17 +1140,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безнадёжность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1160,9 +1160,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Abgrund»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
                             
@@ -1172,17 +1172,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">избавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1192,11 +1192,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Hoffnungslosigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
                             
@@ -1204,33 +1204,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «erlösen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">избавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">избавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1243,129 +1243,129 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">примирение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">примирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">примирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">примирение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">примирение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">примирение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1596,17 +1596,17 @@
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
                     "доверять",
-                    "граф",
                     "знать",
-                    "служить"
+                    "служить",
+                    "граф"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
-                    "граф",
                     "доверять",
+                    "граф",
                     "служить",
                     "знать"
                 ],
@@ -1615,60 +1615,60 @@
             {
                 "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
+                    "уважать",
                     "доверять",
-                    "служить",
-                    "праведный",
-                    "уважать"
+                    "честь",
+                    "праведный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
-                    "уважать",
-                    "праведный",
                     "граф",
-                    "честь"
+                    "честь",
+                    "уважать",
+                    "доверять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "долг",
+                    "честь",
                     "служить",
                     "праведный",
-                    "честь"
+                    "знать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
-                    "знать",
                     "праведный",
+                    "долг",
                     "уважать",
-                    "доверять"
+                    "служить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
-                    "праведный",
+                    "уважать",
+                    "доверять",
                     "долг",
-                    "знать",
-                    "служить"
+                    "граф"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «achten»?",
                 "choices": [
-                    "честь",
+                    "знать",
                     "уважать",
-                    "долг",
-                    "знать"
+                    "служить",
+                    "честь"
                 ],
                 "correctIndex": 1
             }
@@ -1883,19 +1883,19 @@
             {
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
-                    "письмо",
-                    "верить",
                     "обман",
-                    "обманывать"
+                    "обманывать",
+                    "верить",
+                    "письмо"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «glauben»?",
                 "choices": [
-                    "обман",
-                    "верить",
                     "письмо",
+                    "верить",
+                    "обман",
                     "обманывать"
                 ],
                 "correctIndex": 1
@@ -1905,60 +1905,60 @@
                 "choices": [
                     "обманывать",
                     "простодушный",
-                    "письмо",
-                    "ловушка"
+                    "обман",
+                    "подозревать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
-                    "подозревать",
-                    "простодушный",
                     "обман",
-                    "верить"
+                    "письмо",
+                    "верить",
+                    "простодушный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «arglos»?",
                 "choices": [
                     "ловушка",
+                    "обман",
                     "простодушный",
-                    "верить",
-                    "обман"
+                    "письмо"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verdächtigen»?",
                 "choices": [
-                    "верить",
+                    "письмо",
+                    "простодушный",
                     "подозревать",
-                    "обман",
-                    "письмо"
+                    "легковерный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «leichtgläubig»?",
                 "choices": [
-                    "верить",
-                    "обманывать",
+                    "подозревать",
+                    "письмо",
                     "легковерный",
-                    "обман"
+                    "ловушка"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
-                    "верить",
-                    "ловушка",
                     "письмо",
-                    "обман"
+                    "обман",
+                    "ловушка",
+                    "простодушный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2165,71 +2165,71 @@
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
                     "заблуждение",
-                    "сожалеть",
                     "изгонять",
-                    "проклинать"
+                    "проклинать",
+                    "сожалеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "заблуждение",
-                    "сожалеть",
-                    "изгонять",
-                    "проклинать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «bereuen»?",
-                "choices": [
-                    "сожалеть",
                     "проклинать",
-                    "гнать",
+                    "сожалеть",
+                    "заблуждение",
                     "изгонять"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «bereuen»?",
+                "choices": [
+                    "заблуждение",
+                    "гнать",
+                    "сожалеть",
+                    "несправедливость"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «der Irrtum»?",
                 "choices": [
-                    "несправедливость",
-                    "слепой",
-                    "изгонять",
-                    "заблуждение"
+                    "сожалеть",
+                    "заблуждение",
+                    "гнать",
+                    "несправедливость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
+                    "заблуждение",
                     "несправедливость",
-                    "сожалеть",
                     "слепой",
-                    "проклинать"
+                    "изгонять"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
-                    "несправедливость",
-                    "слепой",
+                    "изгонять",
                     "гнать",
-                    "заблуждение"
+                    "слепой",
+                    "несправедливость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
-                    "сожалеть",
                     "несправедливость",
-                    "слепой",
-                    "заблуждение"
+                    "изгонять",
+                    "заблуждение",
+                    "гнать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2438,29 +2438,29 @@
                 "question": "Что означает немецкое слово «helfen»?",
                 "choices": [
                     "сострадание",
-                    "рисковать",
                     "помогать",
-                    "опасность"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «das Mitleid»?",
-                "choices": [
-                    "помогать",
-                    "сострадание",
                     "рисковать",
                     "опасность"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «das Mitleid»?",
+                "choices": [
+                    "опасность",
+                    "рисковать",
+                    "сострадание",
+                    "помогать"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «riskieren»?",
                 "choices": [
-                    "осмеливаться",
                     "измена",
+                    "сострадание",
                     "рисковать",
-                    "сострадание"
+                    "осмеливаться"
                 ],
                 "correctIndex": 2
             },
@@ -2469,7 +2469,7 @@
                 "choices": [
                     "помогать",
                     "тайно",
-                    "измена",
+                    "рисковать",
                     "опасность"
                 ],
                 "correctIndex": 3
@@ -2478,7 +2478,7 @@
                 "question": "Что означает немецкое слово «heimlich»?",
                 "choices": [
                     "тайно",
-                    "сострадание",
+                    "помогать",
                     "рисковать",
                     "осмеливаться"
                 ],
@@ -2487,30 +2487,30 @@
             {
                 "question": "Что означает немецкое слово «schützen»?",
                 "choices": [
+                    "рисковать",
                     "защищать",
-                    "опасность",
                     "сострадание",
-                    "помогать"
+                    "измена"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "тайно",
-                    "осмеливаться",
                     "измена",
-                    "рисковать"
+                    "рисковать",
+                    "осмеливаться",
+                    "опасность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «wagen»?",
                 "choices": [
-                    "тайно",
+                    "опасность",
                     "сострадание",
                     "осмеливаться",
-                    "опасность"
+                    "помогать"
                 ],
                 "correctIndex": 2
             }
@@ -2708,72 +2708,72 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "ослеплять",
-                    "боль",
-                    "темнота",
-                    "пытка"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Folter»?",
-                "choices": [
-                    "боль",
                     "пытка",
                     "ослеплять",
-                    "темнота"
+                    "темнота",
+                    "боль"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «der Schmerz»?",
-                "choices": [
-                    "боль",
-                    "месть",
-                    "слепнуть",
-                    "пытка"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Dunkelheit»?",
+                "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
                     "темнота",
                     "ослеплять",
-                    "боль",
-                    "слепнуть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «schreien»?",
-                "choices": [
-                    "ослеплять",
-                    "темнота",
                     "пытка",
-                    "кричать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «erblinden»?",
-                "choices": [
-                    "кричать",
-                    "месть",
-                    "слепнуть",
-                    "темнота"
+                    "боль"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Rache»?",
+                "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
+                    "кричать",
+                    "ослеплять",
                     "месть",
-                    "пытка",
-                    "слепнуть",
                     "боль"
                 ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Dunkelheit»?",
+                "choices": [
+                    "боль",
+                    "темнота",
+                    "ослеплять",
+                    "кричать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «schreien»?",
+                "choices": [
+                    "кричать",
+                    "месть",
+                    "ослеплять",
+                    "темнота"
+                ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «erblinden»?",
+                "choices": [
+                    "ослеплять",
+                    "месть",
+                    "пытка",
+                    "слепнуть"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Rache»?",
+                "choices": [
+                    "пытка",
+                    "ослеплять",
+                    "месть",
+                    "слепнуть"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2989,10 +2989,10 @@
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "прыгать",
+                    "обман",
                     "отчаяние",
                     "пропасть",
-                    "обман"
+                    "прыгать"
                 ],
                 "correctIndex": 1
             },
@@ -3009,18 +3009,18 @@
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
-                    "избавлять",
-                    "обман",
-                    "прыгать",
-                    "сдаваться"
+                    "падать",
+                    "сдаваться",
+                    "безнадёжность",
+                    "обман"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Abgrund»?",
                 "choices": [
-                    "прыгать",
-                    "падать",
+                    "отчаяние",
+                    "обман",
                     "пропасть",
                     "сдаваться"
                 ],
@@ -3029,19 +3029,19 @@
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
-                    "отчаяние",
+                    "пропасть",
+                    "избавлять",
                     "прыгать",
-                    "сдаваться",
-                    "обман"
+                    "сдаваться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Hoffnungslosigkeit»?",
                 "choices": [
-                    "падать",
+                    "избавлять",
                     "безнадёжность",
-                    "обман",
+                    "падать",
                     "пропасть"
                 ],
                 "correctIndex": 1
@@ -3049,22 +3049,22 @@
             {
                 "question": "Что означает немецкое слово «stürzen»?",
                 "choices": [
-                    "избавлять",
-                    "сдаваться",
                     "падать",
-                    "отчаяние"
+                    "отчаяние",
+                    "обман",
+                    "прыгать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erlösen»?",
                 "choices": [
-                    "прыгать",
                     "сдаваться",
-                    "отчаяние",
-                    "избавлять"
+                    "прыгать",
+                    "избавлять",
+                    "безнадёжность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -3285,82 +3285,82 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "осознание",
+                    "узнавать",
                     "прощать",
                     "умирать",
-                    "узнавать"
+                    "осознание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
                     "узнавать",
+                    "прощать",
                     "осознание",
-                    "умирать",
-                    "прощать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «sterben»?",
-                "choices": [
-                    "умирать",
-                    "обнимать",
-                    "сердце",
-                    "прощать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Erkenntnis»?",
-                "choices": [
-                    "узнавать",
-                    "примирение",
-                    "прощать",
-                    "осознание"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Reue»?",
-                "choices": [
-                    "раскаяние",
-                    "прощать",
-                    "сердце",
-                    "осознание"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «umarmen»?",
-                "choices": [
-                    "обнимать",
-                    "осознание",
-                    "прощать",
-                    "примирение"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Versöhnung»?",
-                "choices": [
-                    "обнимать",
-                    "примирение",
-                    "прощать",
-                    "осознание"
+                    "умирать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «das Herz»?",
+                "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "примирение",
-                    "раскаяние",
                     "обнимать",
+                    "умирать",
+                    "примирение",
                     "сердце"
                 ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Erkenntnis»?",
+                "choices": [
+                    "примирение",
+                    "осознание",
+                    "сердце",
+                    "обнимать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Reue»?",
+                "choices": [
+                    "узнавать",
+                    "сердце",
+                    "прощать",
+                    "раскаяние"
+                ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «umarmen»?",
+                "choices": [
+                    "примирение",
+                    "осознание",
+                    "обнимать",
+                    "умирать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Versöhnung»?",
+                "choices": [
+                    "сердце",
+                    "обнимать",
+                    "примирение",
+                    "раскаяние"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «das Herz»?",
+                "choices": [
+                    "узнавать",
+                    "сердце",
+                    "умирать",
+                    "осознание"
+                ],
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}

--- a/output/journeys/goneril.html
+++ b/output/journeys/goneril.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["наследство", "лицемерить", "ложь", "клясться"], "correct_index": 2}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["клясться", "ложь", "наследство", "лицемерить"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["состояние", "обманывать", "лицемерить", "наследство"], "correct_index": 3}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["состояние", "лицемерить", "наследство", "ложь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["льстить", "наследство", "лицемерить", "жадность"], "correct_index": 3}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["ложь", "обманывать", "наследство", "лицемерить"], "correct_index": 1}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["клясться", "состояние", "льстить", "наследство"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["состояние", "клясться", "наследство", "ложь"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["править", "власть", "трон", "приказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["приказывать", "править", "трон", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["господство", "править", "приказывать", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["приказывать", "завоёвывать", "трон", "подчинять"], "correct_index": 2}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["приказывать", "господство", "завоёвывать", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["завоёвывать", "подчинять", "трон", "господство"], "correct_index": 3}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["власть", "управлять", "господство", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["управлять", "власть", "подчинять", "завоёвывать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "изгонять", "месть", "жестокий"], "correct_index": 0}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["унижать", "жестокий", "месть", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["жестокий", "отказывать", "презирать", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["изгонять", "отказывать", "ограничивать", "презирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["жестокий", "презирать", "отказывать", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["месть", "презирать", "отказывать", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["мучить", "жестокий", "ограничивать", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["презирать", "ограничивать", "изгонять", "унижать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["отвергать", "запирать", "буря", "безжалостный"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["запирать", "безжалостный", "буря", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["безжалостный", "беспощадный", "холод", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["отвергать", "запирать", "беспощадный", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["безжалостный", "беспощадный", "холод", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["безжалостный", "беспощадный", "ожесточаться", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["безжалостный", "холод", "буря", "ожесточаться"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["предавать", "ненавидеть", "ссориться", "раздор"], "correct_index": 2}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["ссориться", "ненавидеть", "раздор", "предавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["изменять", "ненавидеть", "предавать", "раздор"], "correct_index": 3}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["ссориться", "ненавидеть", "предавать", "разрушать"], "correct_index": 1}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["изменять", "ненавидеть", "разрушать", "ссориться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["презрение", "предавать", "изменять", "разрушать"], "correct_index": 0}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["изменять", "ненавидеть", "раздор", "разрушать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["изменять", "страсть", "раздор", "ссориться"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["бороться", "ревность", "желать", "соперничать"], "correct_index": 1}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["ревность", "бороться", "желать", "соперничать"], "correct_index": 3}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["убивать", "ревность", "бороться", "яд"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["яд", "убивать", "интрига", "желать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["устранять", "желать", "яд", "бороться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["устранять", "ревность", "яд", "соперничать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["желать", "устранять", "интрига", "соперничать"], "correct_index": 2}, {"question": "Что означает немецкое слово «morden»?", "choices": ["ревность", "желать", "убивать", "бороться"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["отравлять", "отчаяние", "умирать", "вина"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отравлять", "отчаяние", "умирать", "вина"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "отравлять", "вина", "ад"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["умирать", "вина", "отравлять", "ад"], "correct_index": 1}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["уничтожать", "ад", "вина", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["отчаяние", "вина", "погибель", "уничтожать"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["умирать", "сожалеть", "погибель", "вина"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["ад", "отчаяние", "отравлять", "вина"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["ложь", "лицемерить", "клясться", "наследство"], "correct_index": 0}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["лицемерить", "наследство", "ложь", "клясться"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["льстить", "наследство", "обманывать", "жадность"], "correct_index": 1}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["клясться", "наследство", "обманывать", "лицемерить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["лицемерить", "жадность", "обманывать", "состояние"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["льстить", "жадность", "обманывать", "ложь"], "correct_index": 2}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["жадность", "льстить", "лицемерить", "наследство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["состояние", "ложь", "лицемерить", "обманывать"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["править", "власть", "трон", "приказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["приказывать", "править", "власть", "трон"], "correct_index": 1}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["приказывать", "управлять", "власть", "трон"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["править", "приказывать", "трон", "управлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["править", "приказывать", "управлять", "завоёвывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["власть", "завоёвывать", "господство", "подчинять"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["трон", "власть", "управлять", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["господство", "подчинять", "управлять", "власть"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["жестокий", "месть", "унижать", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["жестокий", "унижать", "изгонять", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["мучить", "месть", "изгонять", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["жестокий", "мучить", "унижать", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["мучить", "отказывать", "ограничивать", "презирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["ограничивать", "отказывать", "изгонять", "презирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["изгонять", "ограничивать", "мучить", "презирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["унижать", "ограничивать", "отказывать", "изгонять"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["запирать", "безжалостный", "отвергать", "буря"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["безжалостный", "отвергать", "буря", "запирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["безжалостный", "отвергать", "ожесточаться", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["беспощадный", "ожесточаться", "безжалостный", "запирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["холод", "буря", "беспощадный", "запирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["безжалостный", "отвергать", "буря", "беспощадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["буря", "ожесточаться", "отвергать", "безжалостный"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["раздор", "ненавидеть", "ссориться", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["раздор", "ссориться", "предавать", "ненавидеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["раздор", "предавать", "изменять", "презрение"], "correct_index": 0}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["предавать", "ненавидеть", "презрение", "разрушать"], "correct_index": 1}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["презрение", "изменять", "раздор", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["презрение", "ссориться", "изменять", "раздор"], "correct_index": 0}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["разрушать", "ненавидеть", "раздор", "предавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["страсть", "ссориться", "презрение", "ненавидеть"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["желать", "соперничать", "ревность", "бороться"], "correct_index": 2}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["бороться", "желать", "соперничать", "ревность"], "correct_index": 2}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["бороться", "интрига", "желать", "яд"], "correct_index": 0}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["устранять", "желать", "яд", "ревность"], "correct_index": 1}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["устранять", "убивать", "яд", "бороться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["соперничать", "ревность", "желать", "яд"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["бороться", "интрига", "желать", "ревность"], "correct_index": 1}, {"question": "Что означает немецкое слово «morden»?", "choices": ["желать", "устранять", "яд", "убивать"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["вина", "умирать", "отчаяние", "отравлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["вина", "отравлять", "умирать", "отчаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["погибель", "сожалеть", "ад", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["уничтожать", "вина", "отравлять", "ад"], "correct_index": 1}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["отравлять", "вина", "погибель", "уничтожать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["сожалеть", "отравлять", "уничтожать", "погибель"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "погибель", "вина", "ад"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["вина", "уничтожать", "ад", "отравлять"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Лесть и обман</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,13 +465,29 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Lüge»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «schwören»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
                             
@@ -481,63 +497,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «schwören»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Erbe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
                             
@@ -545,15 +513,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
                             
@@ -561,15 +529,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">состояние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">льстить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">льстить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
                             
@@ -583,11 +583,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -624,25 +624,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «befehlen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">господство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -652,11 +652,43 @@
                         <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">управлять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">управлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">господство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
                             
@@ -664,47 +696,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подчинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">господство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">управлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">править</button>
                             
@@ -712,17 +712,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">управлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">господство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подчинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подчинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">управлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,31 +735,15 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
@@ -767,15 +751,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
@@ -783,11 +767,43 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
                             
@@ -799,49 +815,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verweigern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ограничивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -851,13 +851,13 @@
                         <div class="quiz-question">Что означает немецкое слово «beschränken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -870,17 +870,17 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -890,13 +890,13 @@
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -908,9 +908,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ожесточаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
@@ -918,65 +918,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verschließen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verhärten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -993,27 +993,11 @@
                         <div class="quiz-question">Что означает немецкое слово «streiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
                             
@@ -1021,17 +1005,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1041,11 +1041,11 @@
                         <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
                             
@@ -1053,17 +1053,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">разрушать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1075,43 +1075,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Leidenschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страсть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страсть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1124,47 +1124,47 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Eifersucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">убивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">яд</button>
                             
@@ -1172,17 +1172,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1194,7 +1194,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
                             
@@ -1204,49 +1204,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Gift»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">яд</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «morden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">устранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «morden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">убивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1259,49 +1259,49 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vergiften»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">погибель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ад</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1311,7 +1311,7 @@
                         <div class="quiz-question">Что означает немецкое слово «die Schuld»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
                             
@@ -1323,27 +1323,11 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vernichten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
                             
@@ -1355,33 +1339,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">погибель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уничтожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">погибель</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Hölle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">уничтожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ад</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1600,80 +1600,80 @@
             {
                 "question": "Что означает немецкое слово «die Lüge»?",
                 "choices": [
-                    "наследство",
+                    "ложь",
                     "лицемерить",
-                    "ложь",
-                    "клясться"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «schwören»?",
-                "choices": [
                     "клясться",
-                    "ложь",
-                    "наследство",
-                    "лицемерить"
+                    "наследство"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «das Erbe»?",
+                "question": "Что означает немецкое слово «schwören»?",
                 "choices": [
-                    "состояние",
-                    "обманывать",
                     "лицемерить",
-                    "наследство"
+                    "наследство",
+                    "ложь",
+                    "клясться"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «das Erbe»?",
+                "choices": [
+                    "льстить",
+                    "наследство",
+                    "обманывать",
+                    "жадность"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «heucheln»?",
                 "choices": [
-                    "состояние",
-                    "лицемерить",
+                    "клясться",
                     "наследство",
-                    "ложь"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Gier»?",
-                "choices": [
-                    "льстить",
-                    "наследство",
-                    "лицемерить",
-                    "жадность"
+                    "обманывать",
+                    "лицемерить"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «täuschen»?",
+                "question": "Что означает немецкое слово «die Gier»?",
                 "choices": [
-                    "ложь",
+                    "лицемерить",
+                    "жадность",
                     "обманывать",
-                    "наследство",
-                    "лицемерить"
+                    "состояние"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «schmeicheln»?",
+                "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
-                    "клясться",
-                    "состояние",
                     "льстить",
-                    "наследство"
+                    "жадность",
+                    "обманывать",
+                    "ложь"
                 ],
                 "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «schmeicheln»?",
+                "choices": [
+                    "жадность",
+                    "льстить",
+                    "лицемерить",
+                    "наследство"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Vermögen»?",
                 "choices": [
                     "состояние",
-                    "клясться",
-                    "наследство",
-                    "ложь"
+                    "ложь",
+                    "лицемерить",
+                    "обманывать"
                 ],
                 "correctIndex": 0
             }
@@ -1902,70 +1902,70 @@
                 "choices": [
                     "приказывать",
                     "править",
-                    "трон",
-                    "власть"
+                    "власть",
+                    "трон"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «befehlen»?",
                 "choices": [
-                    "господство",
-                    "править",
                     "приказывать",
-                    "власть"
+                    "управлять",
+                    "власть",
+                    "трон"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
+                    "править",
                     "приказывать",
-                    "завоёвывать",
                     "трон",
-                    "подчинять"
+                    "управлять"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
+                    "править",
                     "приказывать",
-                    "господство",
-                    "завоёвывать",
-                    "трон"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Herrschaft»?",
-                "choices": [
-                    "завоёвывать",
-                    "подчинять",
-                    "трон",
-                    "господство"
+                    "управлять",
+                    "завоёвывать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «regieren»?",
+                "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
                     "власть",
-                    "управлять",
+                    "завоёвывать",
                     "господство",
+                    "подчинять"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «regieren»?",
+                "choices": [
+                    "трон",
+                    "власть",
+                    "управлять",
                     "править"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «unterwerfen»?",
                 "choices": [
-                    "управлять",
-                    "власть",
+                    "господство",
                     "подчинять",
-                    "завоёвывать"
+                    "управлять",
+                    "власть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2184,80 +2184,80 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "унижать",
-                    "изгонять",
-                    "месть",
-                    "жестокий"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «grausam»?",
-                "choices": [
-                    "унижать",
                     "жестокий",
                     "месть",
+                    "унижать",
                     "изгонять"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Rache»?",
-                "choices": [
-                    "жестокий",
-                    "отказывать",
-                    "презирать",
-                    "месть"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «vertreiben»?",
-                "choices": [
-                    "изгонять",
-                    "отказывать",
-                    "ограничивать",
-                    "презирать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «verachten»?",
-                "choices": [
-                    "жестокий",
-                    "презирать",
-                    "отказывать",
-                    "месть"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verweigern»?",
-                "choices": [
-                    "месть",
-                    "презирать",
-                    "отказывать",
-                    "унижать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «quälen»?",
+                "question": "Что означает немецкое слово «grausam»?",
                 "choices": [
-                    "мучить",
                     "жестокий",
-                    "ограничивать",
-                    "изгонять"
+                    "унижать",
+                    "изгонять",
+                    "месть"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «beschränken»?",
+                "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "презирать",
-                    "ограничивать",
+                    "мучить",
+                    "месть",
                     "изгонять",
                     "унижать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «vertreiben»?",
+                "choices": [
+                    "жестокий",
+                    "мучить",
+                    "унижать",
+                    "изгонять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «verachten»?",
+                "choices": [
+                    "мучить",
+                    "отказывать",
+                    "ограничивать",
+                    "презирать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «verweigern»?",
+                "choices": [
+                    "ограничивать",
+                    "отказывать",
+                    "изгонять",
+                    "презирать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «quälen»?",
+                "choices": [
+                    "изгонять",
+                    "ограничивать",
+                    "мучить",
+                    "презирать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «beschränken»?",
+                "choices": [
+                    "унижать",
+                    "ограничивать",
+                    "отказывать",
+                    "изгонять"
                 ],
                 "correctIndex": 1
             }
@@ -2459,20 +2459,20 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "отвергать",
                     "запирать",
-                    "буря",
-                    "безжалостный"
+                    "безжалостный",
+                    "отвергать",
+                    "буря"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "запирать",
                     "безжалостный",
+                    "отвергать",
                     "буря",
-                    "отвергать"
+                    "запирать"
                 ],
                 "correctIndex": 2
             },
@@ -2480,8 +2480,8 @@
                 "question": "Что означает немецкое слово «gnadenlos»?",
                 "choices": [
                     "безжалостный",
-                    "беспощадный",
-                    "холод",
+                    "отвергать",
+                    "ожесточаться",
                     "буря"
                 ],
                 "correctIndex": 0
@@ -2489,42 +2489,42 @@
             {
                 "question": "Что означает немецкое слово «verschließen»?",
                 "choices": [
-                    "отвергать",
-                    "запирать",
                     "беспощадный",
-                    "холод"
+                    "ожесточаться",
+                    "безжалостный",
+                    "запирать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "безжалостный",
-                    "беспощадный",
                     "холод",
-                    "отвергать"
+                    "буря",
+                    "беспощадный",
+                    "запирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
                     "безжалостный",
-                    "беспощадный",
-                    "ожесточаться",
-                    "холод"
+                    "отвергать",
+                    "буря",
+                    "беспощадный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verhärten»?",
                 "choices": [
-                    "безжалостный",
-                    "холод",
                     "буря",
-                    "ожесточаться"
+                    "ожесточаться",
+                    "отвергать",
+                    "безжалостный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2735,39 +2735,39 @@
             {
                 "question": "Что означает немецкое слово «streiten»?",
                 "choices": [
-                    "предавать",
+                    "раздор",
                     "ненавидеть",
                     "ссориться",
-                    "раздор"
+                    "предавать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "ссориться",
-                    "ненавидеть",
                     "раздор",
-                    "предавать"
+                    "ссориться",
+                    "предавать",
+                    "ненавидеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Zwietracht»?",
                 "choices": [
-                    "изменять",
-                    "ненавидеть",
+                    "раздор",
                     "предавать",
-                    "раздор"
+                    "изменять",
+                    "презрение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
-                    "ссориться",
-                    "ненавидеть",
                     "предавать",
+                    "ненавидеть",
+                    "презрение",
                     "разрушать"
                 ],
                 "correctIndex": 1
@@ -2775,42 +2775,42 @@
             {
                 "question": "Что означает немецкое слово «betrügen»?",
                 "choices": [
+                    "презрение",
                     "изменять",
-                    "ненавидеть",
-                    "разрушать",
-                    "ссориться"
+                    "раздор",
+                    "ненавидеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Verachtung»?",
                 "choices": [
                     "презрение",
-                    "предавать",
+                    "ссориться",
                     "изменять",
-                    "разрушать"
+                    "раздор"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «zerstören»?",
                 "choices": [
-                    "изменять",
+                    "разрушать",
                     "ненавидеть",
                     "раздор",
-                    "разрушать"
+                    "предавать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Leidenschaft»?",
                 "choices": [
-                    "изменять",
                     "страсть",
-                    "раздор",
-                    "ссориться"
+                    "ссориться",
+                    "презрение",
+                    "ненавидеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -3023,48 +3023,48 @@
             {
                 "question": "Что означает немецкое слово «die Eifersucht»?",
                 "choices": [
-                    "бороться",
-                    "ревность",
                     "желать",
-                    "соперничать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «rivalisieren»?",
-                "choices": [
+                    "соперничать",
                     "ревность",
-                    "бороться",
-                    "желать",
-                    "соперничать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «kämpfen»?",
-                "choices": [
-                    "убивать",
-                    "ревность",
-                    "бороться",
-                    "яд"
+                    "бороться"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «rivalisieren»?",
+                "choices": [
+                    "бороться",
+                    "желать",
+                    "соперничать",
+                    "ревность"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «kämpfen»?",
+                "choices": [
+                    "бороться",
+                    "интрига",
+                    "желать",
+                    "яд"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
+                    "устранять",
+                    "желать",
                     "яд",
-                    "убивать",
-                    "интрига",
-                    "желать"
+                    "ревность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beseitigen»?",
                 "choices": [
                     "устранять",
-                    "желать",
+                    "убивать",
                     "яд",
                     "бороться"
                 ],
@@ -3073,32 +3073,32 @@
             {
                 "question": "Что означает немецкое слово «das Gift»?",
                 "choices": [
-                    "устранять",
+                    "соперничать",
                     "ревность",
-                    "яд",
-                    "соперничать"
+                    "желать",
+                    "яд"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "желать",
-                    "устранять",
+                    "бороться",
                     "интрига",
-                    "соперничать"
+                    "желать",
+                    "ревность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «morden»?",
                 "choices": [
-                    "ревность",
                     "желать",
-                    "убивать",
-                    "бороться"
+                    "устранять",
+                    "яд",
+                    "убивать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -3307,37 +3307,37 @@
             {
                 "question": "Что означает немецкое слово «vergiften»?",
                 "choices": [
-                    "отравлять",
-                    "отчаяние",
+                    "вина",
                     "умирать",
-                    "вина"
+                    "отчаяние",
+                    "отравлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
+                    "вина",
                     "отравлять",
-                    "отчаяние",
                     "умирать",
-                    "вина"
+                    "отчаяние"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "умирать",
-                    "отравлять",
-                    "вина",
-                    "ад"
+                    "погибель",
+                    "сожалеть",
+                    "ад",
+                    "умирать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Schuld»?",
                 "choices": [
-                    "умирать",
+                    "уничтожать",
                     "вина",
                     "отравлять",
                     "ад"
@@ -3347,42 +3347,42 @@
             {
                 "question": "Что означает немецкое слово «vernichten»?",
                 "choices": [
-                    "уничтожать",
-                    "ад",
-                    "вина",
-                    "отчаяние"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «das Verderben»?",
-                "choices": [
-                    "отчаяние",
+                    "отравлять",
                     "вина",
                     "погибель",
                     "уничтожать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «das Verderben»?",
+                "choices": [
+                    "сожалеть",
+                    "отравлять",
+                    "уничтожать",
+                    "погибель"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "умирать",
                     "сожалеть",
                     "погибель",
-                    "вина"
+                    "вина",
+                    "ад"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Hölle»?",
                 "choices": [
+                    "вина",
+                    "уничтожать",
                     "ад",
-                    "отчаяние",
-                    "отравлять",
-                    "вина"
+                    "отравлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}

--- a/output/journeys/kent.html
+++ b/output/journeys/kent.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["мужество", "верность", "возражать", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["верность", "возражать", "защищать", "мужество"], "correct_index": 3}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["искренний", "возражать", "мужество", "предупреждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["предупреждать", "справедливый", "защищать", "искренний"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["слуга", "справедливый", "искренний", "возражать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["справедливый", "слуга", "искренний", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["предупреждать", "искренний", "верность", "мужество"], "correct_index": 0}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["справедливый", "мужество", "защищать", "предупреждать"], "correct_index": 0}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["изгнанный", "гнев", "несправедливость", "изгнание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["изгнанный", "изгнание", "гнев", "несправедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["наказание", "изгнанный", "гнев", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["изгнание", "наказание", "гнев", "изгнанный"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["изгнанный", "гнев", "возвращаться", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возвращаться", "прощание", "несправедливость", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["изгнанный", "гнев", "возвращаться", "изгнание"], "correct_index": 2}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["хитрость", "переодевание", "неузнанный", "притворяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["неузнанный", "притворяться", "переодевание", "хитрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["наниматься", "борода", "неузнанный", "изменять"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["борода", "переодевание", "неузнанный", "притворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["изменять", "хитрость", "борода", "наниматься"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["наниматься", "хитрость", "верный", "борода"], "correct_index": 3}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["верный", "хитрость", "борода", "наниматься"], "correct_index": 3}, {"question": "Что означает немецкое слово «treu»?", "choices": ["переодевание", "изменять", "верный", "хитрость"], "correct_index": 2}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["опасность", "охранять", "защита", "служба"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["охранять", "защита", "служба", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["стража", "опасность", "охранять", "защита"], "correct_index": 1}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["защита", "охранять", "советовать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["сражаться", "охранять", "стража", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «raten»?", "choices": ["служба", "стража", "охранять", "советовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["опасность", "защита", "советовать", "стража"], "correct_index": 3}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "сковывать", "стойкость", "унижение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["наказание", "стойкость", "унижение", "сковывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["унижение", "колодка", "стойкость", "выдерживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["сковывать", "унижение", "выдерживать", "колодка"], "correct_index": 0}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["терпеть", "стойкость", "выдерживать", "позор"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["выдерживать", "наказание", "сковывать", "колодка"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["унижение", "сковывать", "стойкость", "выдерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["позор", "выдерживать", "стойкость", "унижение"], "correct_index": 0}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "сопровождать", "утешать", "поддержка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["поддержка", "буря", "утешать", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["сопровождать", "выдерживать", "утешать", "холод"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["убежище", "холод", "утешать", "поддержка"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["сопровождать", "буря", "утешать", "убежище"], "correct_index": 3}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["убежище", "выдерживать", "утешать", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["утешать", "холод", "поддержка", "выдерживать"], "correct_index": 1}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "плакать", "вечный", "прощание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "плакать", "вечный", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["скорбь", "вечный", "сдаваться", "плакать"], "correct_index": 1}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["сдаваться", "плакать", "следовать", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["скорбь", "сдаваться", "следовать", "истощение"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["скорбь", "смерть", "плакать", "сдаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["истощение", "скорбь", "плакать", "сдаваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["истощение", "плакать", "сдаваться", "следовать"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["защищать", "возражать", "мужество", "верность"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["возражать", "защищать", "верность", "мужество"], "correct_index": 3}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["защищать", "справедливый", "верность", "возражать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["верность", "искренний", "защищать", "справедливый"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["справедливый", "предупреждать", "слуга", "искренний"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["искренний", "верность", "слуга", "справедливый"], "correct_index": 2}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["предупреждать", "защищать", "справедливый", "слуга"], "correct_index": 0}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["предупреждать", "возражать", "искренний", "справедливый"], "correct_index": 3}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["изгнанный", "изгнание", "несправедливость", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["изгнанный", "несправедливость", "гнев", "изгнание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["прощание", "несправедливость", "наказание", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["прощание", "несправедливость", "возвращаться", "изгнанный"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["наказание", "прощание", "несправедливость", "возвращаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "гнев", "изгнание", "изгнанный"], "correct_index": 0}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["возвращаться", "изгнанный", "несправедливость", "наказание"], "correct_index": 0}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["неузнанный", "хитрость", "переодевание", "притворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die List»?", "choices": ["неузнанный", "хитрость", "переодевание", "притворяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["неузнанный", "переодевание", "наниматься", "притворяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["хитрость", "притворяться", "борода", "неузнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["изменять", "притворяться", "верный", "наниматься"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["хитрость", "притворяться", "наниматься", "борода"], "correct_index": 3}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["притворяться", "наниматься", "верный", "хитрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «treu»?", "choices": ["неузнанный", "переодевание", "верный", "изменять"], "correct_index": 2}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["защита", "служба", "охранять", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["служба", "охранять", "защита", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["защита", "опасность", "служба", "охранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["охранять", "служба", "стража", "сражаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["защита", "служба", "советовать", "сражаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «raten»?", "choices": ["советовать", "охранять", "защита", "стража"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["опасность", "стража", "советовать", "охранять"], "correct_index": 1}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "сковывать", "стойкость", "унижение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["стойкость", "наказание", "сковывать", "унижение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["стойкость", "позор", "унижение", "колодка"], "correct_index": 0}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["сковывать", "колодка", "выдерживать", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["терпеть", "сковывать", "позор", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["унижение", "колодка", "терпеть", "сковывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["выдерживать", "колодка", "сковывать", "унижение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["сковывать", "наказание", "унижение", "позор"], "correct_index": 3}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "утешать", "сопровождать", "поддержка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["буря", "поддержка", "утешать", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["сопровождать", "буря", "убежище", "поддержка"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["утешать", "поддержка", "холод", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["утешать", "убежище", "выдерживать", "поддержка"], "correct_index": 1}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["поддержка", "холод", "выдерживать", "сопровождать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["холод", "поддержка", "выдерживать", "буря"], "correct_index": 0}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "вечный", "прощание", "плакать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["вечный", "плакать", "прощание", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["прощание", "сдаваться", "скорбь", "вечный"], "correct_index": 3}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["вечный", "плакать", "скорбь", "истощение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["вечный", "скорбь", "следовать", "истощение"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["следовать", "сдаваться", "плакать", "истощение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["следовать", "плакать", "скорбь", "истощение"], "correct_index": 2}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["истощение", "смерть", "плакать", "следовать"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Верность королю</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,17 +465,17 @@
             <div class="quiz-phase-container active" data-phase="loyalty">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -485,11 +485,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
                             
@@ -497,17 +497,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «widersprechen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -517,11 +517,27 @@
                         <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">искренний</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">справедливый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">искренний</button>
                             
@@ -529,33 +545,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">искренний</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -567,27 +567,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">предупреждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «gerecht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">искренний</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,15 +600,31 @@
             <div class="quiz-phase-container" data-phase="banishment">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Verbannung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
                             
@@ -616,33 +632,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -652,11 +652,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verbannt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
                             
@@ -664,49 +664,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -719,15 +719,15 @@
             <div class="quiz-phase-container" data-phase="disguise">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
                             
@@ -735,49 +735,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die List»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наниматься</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наниматься</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vorgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -789,9 +789,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наниматься</button>
                             
@@ -803,11 +803,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наниматься</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наниматься</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
                             
@@ -815,17 +815,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наниматься</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -835,13 +835,13 @@
                         <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,31 +854,31 @@
             <div class="quiz-phase-container" data-phase="service">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Dienst»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
@@ -890,77 +890,77 @@
                         <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «bewachen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">стража</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сражаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">советовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сражаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стража</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «raten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">советовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">советовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Wache»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">советовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -989,33 +989,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Standhaftigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">колодка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1027,11 +1027,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">колодка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1043,59 +1043,59 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">позор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">колодка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ausharren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «ausharren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">позор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1114,9 +1114,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
                             
@@ -1124,13 +1124,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Beistand»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
@@ -1146,25 +1146,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">убежище</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
                             
@@ -1172,49 +1156,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">убежище</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">убежище</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1233,25 +1233,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1259,17 +1259,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1279,13 +1279,13 @@
                         <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">истощение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1295,9 +1295,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Erschöpfung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
                             
@@ -1307,33 +1307,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">следовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">истощение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">следовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">истощение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1345,9 +1345,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">следовать</button>
                             
@@ -1570,19 +1570,19 @@
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
-                    "мужество",
-                    "верность",
+                    "защищать",
                     "возражать",
-                    "защищать"
+                    "мужество",
+                    "верность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
-                    "верность",
                     "возражать",
                     "защищать",
+                    "верность",
                     "мужество"
                 ],
                 "correctIndex": 3
@@ -1590,62 +1590,62 @@
             {
                 "question": "Что означает немецкое слово «widersprechen»?",
                 "choices": [
-                    "искренний",
-                    "возражать",
-                    "мужество",
-                    "предупреждать"
+                    "защищать",
+                    "справедливый",
+                    "верность",
+                    "возражать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verteidigen»?",
                 "choices": [
-                    "предупреждать",
-                    "справедливый",
+                    "верность",
+                    "искренний",
                     "защищать",
-                    "искренний"
+                    "справедливый"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufrichtig»?",
                 "choices": [
-                    "слуга",
                     "справедливый",
-                    "искренний",
-                    "возражать"
+                    "предупреждать",
+                    "слуга",
+                    "искренний"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
-                    "справедливый",
-                    "слуга",
                     "искренний",
-                    "защищать"
+                    "верность",
+                    "слуга",
+                    "справедливый"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «warnen»?",
                 "choices": [
                     "предупреждать",
-                    "искренний",
-                    "верность",
-                    "мужество"
+                    "защищать",
+                    "справедливый",
+                    "слуга"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «gerecht»?",
                 "choices": [
-                    "справедливый",
-                    "мужество",
-                    "защищать",
-                    "предупреждать"
+                    "предупреждать",
+                    "возражать",
+                    "искренний",
+                    "справедливый"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -1852,38 +1852,38 @@
                 "question": "Что означает немецкое слово «die Verbannung»?",
                 "choices": [
                     "изгнанный",
-                    "гнев",
+                    "изгнание",
                     "несправедливость",
-                    "изгнание"
+                    "гнев"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
                     "изгнанный",
-                    "изгнание",
+                    "несправедливость",
                     "гнев",
-                    "несправедливость"
+                    "изгнание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
+                    "прощание",
+                    "несправедливость",
                     "наказание",
-                    "изгнанный",
-                    "гнев",
-                    "прощание"
+                    "гнев"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verbannt»?",
                 "choices": [
-                    "изгнание",
-                    "наказание",
-                    "гнев",
+                    "прощание",
+                    "несправедливость",
+                    "возвращаться",
                     "изгнанный"
                 ],
                 "correctIndex": 3
@@ -1891,32 +1891,32 @@
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "изгнанный",
-                    "гнев",
-                    "возвращаться",
-                    "прощание"
+                    "наказание",
+                    "прощание",
+                    "несправедливость",
+                    "возвращаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "возвращаться",
-                    "прощание",
-                    "несправедливость",
-                    "наказание"
+                    "наказание",
+                    "гнев",
+                    "изгнание",
+                    "изгнанный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
-                    "изгнанный",
-                    "гнев",
                     "возвращаться",
-                    "изгнание"
+                    "изгнанный",
+                    "несправедливость",
+                    "наказание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2141,49 +2141,49 @@
             {
                 "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
+                    "неузнанный",
                     "хитрость",
                     "переодевание",
-                    "неузнанный",
                     "притворяться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
                     "неузнанный",
-                    "притворяться",
+                    "хитрость",
                     "переодевание",
-                    "хитрость"
+                    "притворяться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unerkannt»?",
                 "choices": [
-                    "наниматься",
-                    "борода",
                     "неузнанный",
-                    "изменять"
+                    "переодевание",
+                    "наниматься",
+                    "притворяться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vorgeben»?",
                 "choices": [
+                    "хитрость",
+                    "притворяться",
                     "борода",
-                    "переодевание",
-                    "неузнанный",
-                    "притворяться"
+                    "неузнанный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verstellen»?",
                 "choices": [
                     "изменять",
-                    "хитрость",
-                    "борода",
+                    "притворяться",
+                    "верный",
                     "наниматься"
                 ],
                 "correctIndex": 0
@@ -2191,9 +2191,9 @@
             {
                 "question": "Что означает немецкое слово «der Bart»?",
                 "choices": [
-                    "наниматься",
                     "хитрость",
-                    "верный",
+                    "притворяться",
+                    "наниматься",
                     "борода"
                 ],
                 "correctIndex": 3
@@ -2201,20 +2201,20 @@
             {
                 "question": "Что означает немецкое слово «anheuern»?",
                 "choices": [
+                    "притворяться",
+                    "наниматься",
                     "верный",
-                    "хитрость",
-                    "борода",
-                    "наниматься"
+                    "хитрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
+                    "неузнанный",
                     "переодевание",
-                    "изменять",
                     "верный",
-                    "хитрость"
+                    "изменять"
                 ],
                 "correctIndex": 2
             }
@@ -2401,72 +2401,72 @@
             {
                 "question": "Что означает немецкое слово «der Dienst»?",
                 "choices": [
-                    "опасность",
-                    "охранять",
-                    "защита",
-                    "служба"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Schutz»?",
-                "choices": [
-                    "охранять",
                     "защита",
                     "служба",
+                    "охранять",
                     "опасность"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «der Schutz»?",
+                "choices": [
+                    "служба",
+                    "охранять",
+                    "защита",
+                    "опасность"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "стража",
+                    "защита",
                     "опасность",
-                    "охранять",
-                    "защита"
+                    "служба",
+                    "охранять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bewachen»?",
                 "choices": [
-                    "защита",
                     "охранять",
-                    "советовать",
-                    "опасность"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «kämpfen»?",
-                "choices": [
-                    "сражаться",
-                    "охранять",
+                    "служба",
                     "стража",
-                    "опасность"
+                    "сражаться"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «raten»?",
+                "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
+                    "защита",
                     "служба",
-                    "стража",
-                    "охранять",
-                    "советовать"
+                    "советовать",
+                    "сражаться"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «raten»?",
+                "choices": [
+                    "советовать",
+                    "охранять",
+                    "защита",
+                    "стража"
+                ],
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Wache»?",
                 "choices": [
                     "опасность",
-                    "защита",
+                    "стража",
                     "советовать",
-                    "стража"
+                    "охранять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2689,30 +2689,30 @@
             {
                 "question": "Что означает немецкое слово «die Demütigung»?",
                 "choices": [
-                    "наказание",
                     "стойкость",
-                    "унижение",
-                    "сковывать"
+                    "наказание",
+                    "сковывать",
+                    "унижение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Standhaftigkeit»?",
                 "choices": [
-                    "унижение",
-                    "колодка",
                     "стойкость",
-                    "выдерживать"
+                    "позор",
+                    "унижение",
+                    "колодка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «fesseln»?",
                 "choices": [
                     "сковывать",
-                    "унижение",
+                    "колодка",
                     "выдерживать",
-                    "колодка"
+                    "терпеть"
                 ],
                 "correctIndex": 0
             },
@@ -2720,41 +2720,41 @@
                 "question": "Что означает немецкое слово «erdulden»?",
                 "choices": [
                     "терпеть",
-                    "стойкость",
-                    "выдерживать",
-                    "позор"
+                    "сковывать",
+                    "позор",
+                    "наказание"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Stock»?",
                 "choices": [
-                    "выдерживать",
-                    "наказание",
-                    "сковывать",
-                    "колодка"
+                    "унижение",
+                    "колодка",
+                    "терпеть",
+                    "сковывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ausharren»?",
                 "choices": [
-                    "унижение",
+                    "выдерживать",
+                    "колодка",
                     "сковывать",
-                    "стойкость",
-                    "выдерживать"
+                    "унижение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Schande»?",
                 "choices": [
-                    "позор",
-                    "выдерживать",
-                    "стойкость",
-                    "унижение"
+                    "сковывать",
+                    "наказание",
+                    "унижение",
+                    "позор"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2951,8 +2951,8 @@
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
                     "буря",
-                    "сопровождать",
                     "утешать",
+                    "сопровождать",
                     "поддержка"
                 ],
                 "correctIndex": 0
@@ -2960,62 +2960,62 @@
             {
                 "question": "Что означает немецкое слово «der Beistand»?",
                 "choices": [
-                    "поддержка",
                     "буря",
+                    "поддержка",
                     "утешать",
                     "сопровождать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
                     "сопровождать",
-                    "выдерживать",
-                    "утешать",
-                    "холод"
+                    "буря",
+                    "убежище",
+                    "поддержка"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "убежище",
-                    "холод",
                     "утешать",
-                    "поддержка"
+                    "поддержка",
+                    "холод",
+                    "сопровождать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Zuflucht»?",
                 "choices": [
-                    "сопровождать",
-                    "буря",
                     "утешать",
-                    "убежище"
+                    "убежище",
+                    "выдерживать",
+                    "поддержка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «durchhalten»?",
                 "choices": [
-                    "убежище",
+                    "поддержка",
+                    "холод",
                     "выдерживать",
-                    "утешать",
-                    "холод"
+                    "сопровождать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "утешать",
                     "холод",
                     "поддержка",
-                    "выдерживать"
+                    "выдерживать",
+                    "буря"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -3247,47 +3247,47 @@
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
                     "смерть",
-                    "плакать",
                     "вечный",
-                    "прощание"
+                    "прощание",
+                    "плакать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "прощание",
-                    "плакать",
                     "вечный",
+                    "плакать",
+                    "прощание",
                     "смерть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "скорбь",
-                    "вечный",
+                    "прощание",
                     "сдаваться",
-                    "плакать"
+                    "скорбь",
+                    "вечный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «weinen»?",
                 "choices": [
-                    "сдаваться",
+                    "вечный",
                     "плакать",
-                    "следовать",
-                    "смерть"
+                    "скорбь",
+                    "истощение"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Erschöpfung»?",
                 "choices": [
+                    "вечный",
                     "скорбь",
-                    "сдаваться",
                     "следовать",
                     "истощение"
                 ],
@@ -3296,29 +3296,29 @@
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
-                    "скорбь",
-                    "смерть",
+                    "следовать",
+                    "сдаваться",
                     "плакать",
-                    "сдаваться"
+                    "истощение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "истощение",
-                    "скорбь",
+                    "следовать",
                     "плакать",
-                    "сдаваться"
+                    "скорбь",
+                    "истощение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «folgen»?",
                 "choices": [
                     "истощение",
+                    "смерть",
                     "плакать",
-                    "сдаваться",
                     "следовать"
                 ],
                 "correctIndex": 3

--- a/output/journeys/king_lear.html
+++ b/output/journeys/king_lear.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["власть", "королевство", "трон", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["трон", "власть", "править", "королевство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["трон", "власть", "провозглашать", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["церемония", "королевство", "великолепный", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["власть", "церемония", "провозглашать", "корона"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["трон", "корона", "провозглашать", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "трон", "провозглашать", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["церемония", "власть", "править", "великолепный"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "проклинать", "неблагодарность", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["неблагодарность", "проклинать", "унижать", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["изгонять", "неблагодарность", "унижать", "обида"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["обида", "сожалеть", "проклятие", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["проклинать", "изгонять", "унижать", "неблагодарность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["проклятие", "обида", "гнев", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["изгонять", "сожалеть", "проклинать", "неблагодарность"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["проклятие", "изгонять", "проклинать", "сожалеть"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["жестокость", "покидать", "отвергать", "отчаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["жестокость", "покидать", "отчаяние", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "слеза", "просить", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["просить", "отчаяние", "слеза", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["просить", "жестокость", "отвергать", "покидать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["одиночество", "нужда", "слеза", "просить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["просить", "одиночество", "слеза", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["отвергать", "жестокость", "одиночество", "нужда"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "безумие", "гром", "бушевать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["буря", "безумие", "бушевать", "гром"], "correct_index": 1}, {"question": "Что означает немецкое слово «toben»?", "choices": ["безумие", "голый", "бушевать", "хаос"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["безумие", "буря", "гром", "молния"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["кричать", "гром", "молния", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["гром", "кричать", "молния", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["хаос", "молния", "голый", "кричать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["хаос", "гром", "голый", "буря"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["мёрзнуть", "бедный", "нищий", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["нищета", "бедный", "нищий", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «arm»?", "choices": ["шут", "бедный", "хижина", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["нищета", "страдать", "мёрзнуть", "нищий"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["хижина", "нищий", "нищета", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["мёрзнуть", "страдать", "хижина", "познание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["хижина", "шут", "мёрзнуть", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["познание", "страдать", "нищий", "хижина"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "правда", "понимать", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["правда", "раскаяние", "понимать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "виновный", "раскаяние", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["мудрость", "раскаяние", "прощать", "узнавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["узнавать", "прощать", "мудрость", "прозрение"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["раскаяние", "правда", "мудрость", "прощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["прозрение", "мудрость", "понимать", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["узнавать", "понимать", "виновный", "правда"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["конец", "смерть", "прощать", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "смерть", "конец", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["смерть", "прощание", "умирать", "скорбь"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "умирать", "скорбь", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["сердце", "прощание", "прощать", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["конец", "скорбь", "сердце", "прощание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "прощать", "умирать", "вечный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["умирать", "скорбь", "прощать", "вечный"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["править", "королевство", "трон", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["править", "власть", "трон", "королевство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["великолепный", "власть", "трон", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["великолепный", "трон", "провозглашать", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["провозглашать", "власть", "править", "церемония"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["королевство", "власть", "корона", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["великолепный", "церемония", "трон", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["великолепный", "править", "провозглашать", "трон"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["неблагодарность", "проклинать", "гнев", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["проклинать", "унижать", "гнев", "неблагодарность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["проклинать", "неблагодарность", "изгонять", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклятие", "проклинать", "неблагодарность", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["гнев", "неблагодарность", "унижать", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["проклинать", "обида", "изгонять", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["унижать", "проклятие", "неблагодарность", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["неблагодарность", "сожалеть", "проклятие", "проклинать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["жестокость", "отчаяние", "отвергать", "покидать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["отвергать", "покидать", "жестокость", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["слеза", "жестокость", "одиночество", "нужда"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["жестокость", "одиночество", "слеза", "отчаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["покидать", "просить", "одиночество", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["отвергать", "покидать", "просить", "одиночество"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["просить", "слеза", "нужда", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["просить", "слеза", "жестокость", "нужда"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["безумие", "буря", "гром", "бушевать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["безумие", "гром", "бушевать", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «toben»?", "choices": ["молния", "бушевать", "безумие", "хаос"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["голый", "хаос", "безумие", "гром"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["буря", "молния", "хаос", "кричать"], "correct_index": 1}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["хаос", "молния", "кричать", "бушевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["молния", "гром", "голый", "кричать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["гром", "буря", "безумие", "хаос"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищий", "мёрзнуть", "бедный", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["нищий", "нищета", "мёрзнуть", "бедный"], "correct_index": 0}, {"question": "Что означает немецкое слово «arm»?", "choices": ["бедный", "мёрзнуть", "нищий", "шут"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "познание", "бедный", "хижина"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["нищий", "шут", "хижина", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["хижина", "мёрзнуть", "страдать", "нищий"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "хижина", "нищета", "бедный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["бедный", "познание", "нищета", "мёрзнуть"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "правда", "понимать", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["понимать", "раскаяние", "правда", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["понимать", "прозрение", "правда", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "понимать", "правда", "прозрение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["узнавать", "правда", "мудрость", "виновный"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["узнавать", "прозрение", "прощать", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["прощать", "прозрение", "раскаяние", "виновный"], "correct_index": 1}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["прозрение", "мудрость", "раскаяние", "виновный"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["конец", "смерть", "прощать", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["конец", "прощать", "смерть", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["сердце", "умирать", "прощание", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["скорбь", "сердце", "смерть", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["смерть", "прощать", "умирать", "сердце"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["прощать", "скорбь", "конец", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "скорбь", "конец", "сердце"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["конец", "умирать", "вечный", "прощание"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -469,13 +469,13 @@
                         <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -485,11 +485,11 @@
                         <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                             
@@ -501,11 +501,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">править</button>
                             
@@ -517,55 +517,7 @@
                         <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">великолепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
                             
@@ -577,17 +529,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «prächtig»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">великолепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">корона</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «prächtig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,11 +600,59 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Undankbarkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
@@ -616,65 +664,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Undankbarkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -684,45 +684,45 @@
                         <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклятие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Fluch»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,47 +735,31 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
@@ -783,65 +767,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слеза</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">нужда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нужда</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">просить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">просить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нужда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -851,11 +851,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Not»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нужда</button>
                             
@@ -870,13 +870,13 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
                             
@@ -886,31 +886,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «toben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">хаос</button>
                             
@@ -918,49 +918,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хаос</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -970,9 +970,9 @@
                         <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
                             
@@ -982,17 +982,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Chaos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хаос</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1009,11 +1009,11 @@
                         <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
                             
@@ -1021,63 +1021,63 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «arm»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «arm»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">познание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
@@ -1085,31 +1085,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">познание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
@@ -1117,17 +1101,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">познание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">познание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1156,15 +1156,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verstehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
@@ -1172,33 +1172,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">виновный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1210,59 +1210,59 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «schuldig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прозрение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «schuldig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">виновный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1291,47 +1291,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1339,17 +1323,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1359,13 +1359,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1377,27 +1377,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1627,19 +1627,19 @@
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
-                    "власть",
+                    "править",
                     "королевство",
                     "трон",
-                    "править"
+                    "власть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
-                    "трон",
-                    "власть",
                     "править",
+                    "власть",
+                    "трон",
                     "королевство"
                 ],
                 "correctIndex": 3
@@ -1647,9 +1647,9 @@
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "трон",
+                    "великолепный",
                     "власть",
-                    "провозглашать",
+                    "трон",
                     "править"
                 ],
                 "correctIndex": 1
@@ -1657,9 +1657,9 @@
             {
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
-                    "церемония",
-                    "королевство",
                     "великолепный",
+                    "трон",
+                    "провозглашать",
                     "править"
                 ],
                 "correctIndex": 3
@@ -1667,42 +1667,42 @@
             {
                 "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
+                    "провозглашать",
                     "власть",
-                    "церемония",
-                    "провозглашать",
-                    "корона"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Krone»?",
-                "choices": [
-                    "трон",
-                    "корона",
-                    "провозглашать",
-                    "власть"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Zeremonie»?",
-                "choices": [
-                    "церемония",
-                    "трон",
-                    "провозглашать",
-                    "править"
+                    "править",
+                    "церемония"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Krone»?",
+                "choices": [
+                    "королевство",
+                    "власть",
+                    "корона",
+                    "править"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Zeremonie»?",
+                "choices": [
+                    "великолепный",
+                    "церемония",
+                    "трон",
+                    "править"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «prächtig»?",
                 "choices": [
-                    "церемония",
-                    "власть",
+                    "великолепный",
                     "править",
-                    "великолепный"
+                    "провозглашать",
+                    "трон"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -1925,82 +1925,82 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "унижать",
-                    "проклинать",
-                    "неблагодарность",
-                    "гнев"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Zorn»?",
-                "choices": [
                     "неблагодарность",
                     "проклинать",
-                    "унижать",
-                    "гнев"
+                    "гнев",
+                    "унижать"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «der Zorn»?",
+                "choices": [
+                    "проклинать",
+                    "унижать",
+                    "гнев",
+                    "неблагодарность"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Undankbarkeit»?",
                 "choices": [
-                    "изгонять",
+                    "проклинать",
                     "неблагодарность",
-                    "унижать",
-                    "обида"
+                    "изгонять",
+                    "сожалеть"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "обида",
-                    "сожалеть",
                     "проклятие",
-                    "проклинать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «vertreiben»?",
-                "choices": [
                     "проклинать",
-                    "изгонять",
-                    "унижать",
-                    "неблагодарность"
+                    "неблагодарность",
+                    "гнев"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «vertreiben»?",
+                "choices": [
+                    "гнев",
+                    "неблагодарность",
+                    "унижать",
+                    "изгонять"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Kränkung»?",
                 "choices": [
-                    "проклятие",
+                    "проклинать",
                     "обида",
-                    "гнев",
-                    "изгонять"
+                    "изгонять",
+                    "сожалеть"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "изгонять",
-                    "сожалеть",
-                    "проклинать",
-                    "неблагодарность"
+                    "унижать",
+                    "проклятие",
+                    "неблагодарность",
+                    "сожалеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Fluch»?",
                 "choices": [
+                    "неблагодарность",
+                    "сожалеть",
                     "проклятие",
-                    "изгонять",
-                    "проклинать",
-                    "сожалеть"
+                    "проклинать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2230,78 +2230,78 @@
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
                     "жестокость",
-                    "покидать",
-                    "отвергать",
-                    "отчаяние"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verstoßen»?",
-                "choices": [
-                    "жестокость",
-                    "покидать",
                     "отчаяние",
-                    "отвергать"
+                    "отвергать",
+                    "покидать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Grausamkeit»?",
+                "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
+                    "отвергать",
+                    "покидать",
                     "жестокость",
-                    "слеза",
-                    "просить",
                     "отчаяние"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Verzweiflung»?",
+                "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "просить",
-                    "отчаяние",
                     "слеза",
-                    "покидать"
+                    "жестокость",
+                    "одиночество",
+                    "нужда"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «die Verzweiflung»?",
+                "choices": [
+                    "жестокость",
+                    "одиночество",
+                    "слеза",
+                    "отчаяние"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «betteln»?",
                 "choices": [
+                    "покидать",
                     "просить",
-                    "жестокость",
-                    "отвергать",
-                    "покидать"
+                    "одиночество",
+                    "жестокость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
-                    "одиночество",
-                    "нужда",
-                    "слеза",
-                    "просить"
+                    "отвергать",
+                    "покидать",
+                    "просить",
+                    "одиночество"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Träne»?",
                 "choices": [
                     "просить",
-                    "одиночество",
                     "слеза",
-                    "покидать"
+                    "нужда",
+                    "жестокость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Not»?",
                 "choices": [
-                    "отвергать",
+                    "просить",
+                    "слеза",
                     "жестокость",
-                    "одиночество",
                     "нужда"
                 ],
                 "correctIndex": 3
@@ -2519,68 +2519,68 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "буря",
                     "безумие",
+                    "буря",
                     "гром",
                     "бушевать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "буря",
                     "безумие",
+                    "гром",
                     "бушевать",
-                    "гром"
+                    "буря"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «toben»?",
                 "choices": [
-                    "безумие",
-                    "голый",
+                    "молния",
                     "бушевать",
-                    "хаос"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Donner»?",
-                "choices": [
                     "безумие",
-                    "буря",
-                    "гром",
-                    "молния"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Blitz»?",
-                "choices": [
-                    "кричать",
-                    "гром",
-                    "молния",
-                    "безумие"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «schreien»?",
-                "choices": [
-                    "гром",
-                    "кричать",
-                    "молния",
-                    "безумие"
+                    "хаос"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «nackt»?",
+                "question": "Что означает немецкое слово «der Donner»?",
+                "choices": [
+                    "голый",
+                    "хаос",
+                    "безумие",
+                    "гром"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Blitz»?",
+                "choices": [
+                    "буря",
+                    "молния",
+                    "хаос",
+                    "кричать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
                     "хаос",
                     "молния",
+                    "кричать",
+                    "бушевать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «nackt»?",
+                "choices": [
+                    "молния",
+                    "гром",
                     "голый",
                     "кричать"
                 ],
@@ -2589,12 +2589,12 @@
             {
                 "question": "Что означает немецкое слово «das Chaos»?",
                 "choices": [
-                    "хаос",
                     "гром",
-                    "голый",
-                    "буря"
+                    "буря",
+                    "безумие",
+                    "хаос"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2819,9 +2819,9 @@
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
+                    "нищий",
                     "мёрзнуть",
                     "бедный",
-                    "нищий",
                     "нищета"
                 ],
                 "correctIndex": 3
@@ -2829,72 +2829,72 @@
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
-                    "нищета",
-                    "бедный",
                     "нищий",
-                    "мёрзнуть"
+                    "нищета",
+                    "мёрзнуть",
+                    "бедный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «arm»?",
                 "choices": [
-                    "шут",
                     "бедный",
-                    "хижина",
-                    "нищий"
+                    "мёрзнуть",
+                    "нищий",
+                    "шут"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "нищета",
-                    "страдать",
                     "мёрзнуть",
+                    "познание",
+                    "бедный",
+                    "хижина"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Hütte»?",
+                "choices": [
+                    "нищий",
+                    "шут",
+                    "хижина",
+                    "страдать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «leiden»?",
+                "choices": [
+                    "хижина",
+                    "мёрзнуть",
+                    "страдать",
                     "нищий"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Hütte»?",
-                "choices": [
-                    "хижина",
-                    "нищий",
-                    "нищета",
-                    "страдать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «leiden»?",
-                "choices": [
-                    "мёрзнуть",
-                    "страдать",
-                    "хижина",
-                    "познание"
-                ],
-                "correctIndex": 1
-            },
-            {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "хижина",
                     "шут",
-                    "мёрзнуть",
-                    "нищий"
+                    "хижина",
+                    "нищета",
+                    "бедный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
+                    "бедный",
                     "познание",
-                    "страдать",
-                    "нищий",
-                    "хижина"
+                    "нищета",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -3128,72 +3128,72 @@
             {
                 "question": "Что означает немецкое слово «verstehen»?",
                 "choices": [
-                    "правда",
-                    "раскаяние",
                     "понимать",
-                    "узнавать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Wahrheit»?",
-                "choices": [
-                    "правда",
-                    "виновный",
                     "раскаяние",
-                    "прощать"
+                    "правда",
+                    "узнавать"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Wahrheit»?",
+                "choices": [
+                    "понимать",
+                    "прозрение",
+                    "правда",
+                    "раскаяние"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "мудрость",
                     "раскаяние",
-                    "прощать",
-                    "узнавать"
+                    "понимать",
+                    "правда",
+                    "прозрение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
                     "узнавать",
-                    "прощать",
+                    "правда",
                     "мудрость",
-                    "прозрение"
+                    "виновный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
-                    "раскаяние",
-                    "правда",
-                    "мудрость",
-                    "прощать"
+                    "узнавать",
+                    "прозрение",
+                    "прощать",
+                    "правда"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Einsicht»?",
                 "choices": [
+                    "прощать",
                     "прозрение",
-                    "мудрость",
-                    "понимать",
-                    "правда"
+                    "раскаяние",
+                    "виновный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schuldig»?",
                 "choices": [
-                    "узнавать",
-                    "понимать",
-                    "виновный",
-                    "правда"
+                    "прозрение",
+                    "мудрость",
+                    "раскаяние",
+                    "виновный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -3438,50 +3438,50 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "умирать",
-                    "смерть",
                     "конец",
-                    "прощать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «sterben»?",
-                "choices": [
+                    "прощать",
                     "смерть",
-                    "прощание",
-                    "умирать",
-                    "скорбь"
+                    "умирать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «das Ende»?",
+                "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "конец",
+                    "сердце",
                     "умирать",
-                    "скорбь",
+                    "прощание",
                     "смерть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «das Ende»?",
+                "choices": [
+                    "скорбь",
+                    "сердце",
+                    "смерть",
+                    "конец"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
-                    "сердце",
-                    "прощание",
+                    "смерть",
                     "прощать",
-                    "умирать"
+                    "умирать",
+                    "сердце"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "конец",
+                    "прощать",
                     "скорбь",
-                    "сердце",
-                    "прощание"
+                    "конец",
+                    "смерть"
                 ],
                 "correctIndex": 1
             },
@@ -3489,21 +3489,21 @@
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
                     "прощание",
-                    "прощать",
-                    "умирать",
-                    "вечный"
+                    "скорбь",
+                    "конец",
+                    "сердце"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
+                    "конец",
                     "умирать",
-                    "скорбь",
-                    "прощать",
-                    "вечный"
+                    "вечный",
+                    "прощание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}

--- a/output/journeys/oswald.html
+++ b/output/journeys/oswald.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["служить", "преданность", "слуга", "послушание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["преданность", "слуга", "служить", "послушание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["раболепный", "служить", "преданность", "покорный"], "correct_index": 2}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["преданность", "покорный", "служить", "управляющий"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["слуга", "покорный", "управляющий", "исполнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["покорный", "исполнять", "служить", "слуга"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["слуга", "покорный", "раболепный", "преданность"], "correct_index": 2}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["управляющий", "раболепный", "послушание", "исполнять"], "correct_index": 3}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["спешка", "передавать", "гонец", "поручение"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["поручение", "гонец", "передавать", "спешка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["поручение", "передавать", "торопиться", "спешка"], "correct_index": 3}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["передавать", "торопиться", "поручение", "послание"], "correct_index": 0}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["спешить", "поручение", "послание", "передавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["послание", "передавать", "спешка", "поручение"], "correct_index": 0}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["торопиться", "передавать", "спешка", "гонец"], "correct_index": 0}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["оскорблять", "трусость", "неуважение", "оскорбление"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорблять", "неуважение", "трусость", "оскорбление"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["неуважение", "пренебрегать", "трусость", "высмеивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["пренебрегать", "оскорбление", "трусливый", "оскорблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["высмеивать", "оскорблять", "трусливый", "оскорбление"], "correct_index": 0}, {"question": "Что означает немецкое слово «frech»?", "choices": ["оскорбление", "трусливый", "дерзкий", "пренебрегать"], "correct_index": 2}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["пренебрегать", "дерзкий", "оскорбление", "оскорблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «feige»?", "choices": ["трусливый", "трусость", "дерзкий", "пренебрегать"], "correct_index": 0}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["скрытность", "шпион", "шпионить", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["скрытность", "предательство", "шпионить", "шпион"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["вынюхивать", "скрытность", "выдавать", "шпионить"], "correct_index": 1}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["шпионить", "подслушивать", "вынюхивать", "предательство"], "correct_index": 0}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["выдавать", "подслушивать", "скрытность", "шпион"], "correct_index": 1}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["вынюхивать", "шпион", "подслушивать", "выдавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["вынюхивать", "шпион", "предательство", "выдавать"], "correct_index": 0}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["ковать", "план", "интрига", "коварство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["ковать", "план", "коварство", "интрига"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["хитрый", "ковать", "коварство", "план"], "correct_index": 2}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["коварный", "ковать", "интрига", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["план", "интрига", "коварный", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["интрига", "коварный", "ковать", "коварство"], "correct_index": 1}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["ловушка", "хитрый", "обманывать", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["план", "ловушка", "ковать", "коварство"], "correct_index": 1}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["преследование", "преследовать", "гнаться", "охота"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["гнаться", "преследовать", "преследование", "охота"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["охота", "добыча", "преследовать", "травить"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["добыча", "выслеживать", "преследовать", "гнаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["охота", "выслеживать", "добыча", "преследование"], "correct_index": 1}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["выслеживать", "преследовать", "добыча", "травить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["преследовать", "гнаться", "преследование", "добыча"], "correct_index": 3}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["падать", "трусость", "смерть", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["падать", "трусость", "поражение", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["смерть", "проигрывать", "хныкать", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["хныкать", "трусость", "смерть", "падать"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["смерть", "проигрывать", "жалкий", "хныкать"], "correct_index": 1}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["проигрывать", "поражение", "хныкать", "умолять"], "correct_index": 2}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["трусость", "проигрывать", "умолять", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["жалкий", "смерть", "трусость", "хныкать"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["преданность", "служить", "слуга", "послушание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["послушание", "преданность", "слуга", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["служить", "управляющий", "преданность", "слуга"], "correct_index": 2}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["раболепный", "служить", "управляющий", "преданность"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["покорный", "управляющий", "слуга", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["послушание", "слуга", "управляющий", "покорный"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["послушание", "раболепный", "служить", "исполнять"], "correct_index": 1}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["покорный", "исполнять", "преданность", "раболепный"], "correct_index": 1}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["гонец", "поручение", "передавать", "спешка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["поручение", "передавать", "спешка", "гонец"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["поручение", "гонец", "спешка", "послание"], "correct_index": 2}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["передавать", "торопиться", "спешить", "гонец"], "correct_index": 0}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["торопиться", "поручение", "спешка", "спешить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["спешить", "поручение", "послание", "спешка"], "correct_index": 2}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["торопиться", "спешка", "послание", "поручение"], "correct_index": 0}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["оскорбление", "трусость", "неуважение", "оскорблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["неуважение", "трусость", "оскорблять", "оскорбление"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["трусость", "пренебрегать", "неуважение", "оскорблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["пренебрегать", "трусость", "оскорбление", "оскорблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["дерзкий", "высмеивать", "пренебрегать", "оскорбление"], "correct_index": 1}, {"question": "Что означает немецкое слово «frech»?", "choices": ["дерзкий", "оскорбление", "оскорблять", "трусливый"], "correct_index": 0}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["оскорблять", "дерзкий", "пренебрегать", "трусливый"], "correct_index": 2}, {"question": "Что означает немецкое слово «feige»?", "choices": ["дерзкий", "оскорбление", "высмеивать", "трусливый"], "correct_index": 3}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["предательство", "шпион", "шпионить", "скрытность"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["скрытность", "шпионить", "шпион", "предательство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["скрытность", "подслушивать", "шпион", "выдавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["шпионить", "подслушивать", "шпион", "выдавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["подслушивать", "выдавать", "шпион", "предательство"], "correct_index": 0}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["выдавать", "шпион", "предательство", "скрытность"], "correct_index": 0}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["вынюхивать", "предательство", "шпион", "выдавать"], "correct_index": 0}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["коварство", "план", "интрига", "ковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["план", "ковать", "интрига", "коварство"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["ловушка", "ковать", "план", "коварство"], "correct_index": 3}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["план", "интрига", "ковать", "обманывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["хитрый", "коварный", "ковать", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["коварство", "хитрый", "коварный", "ковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["интрига", "ковать", "коварство", "хитрый"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["ловушка", "хитрый", "коварство", "коварный"], "correct_index": 0}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["преследование", "гнаться", "охота", "преследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["гнаться", "преследование", "охота", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["охота", "травить", "преследовать", "выслеживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["преследовать", "добыча", "гнаться", "преследование"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["выслеживать", "травить", "добыча", "преследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["травить", "преследовать", "охота", "выслеживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["добыча", "гнаться", "охота", "травить"], "correct_index": 0}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["падать", "трусость", "смерть", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["поражение", "падать", "трусость", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["трусость", "поражение", "умолять", "жалкий"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["смерть", "жалкий", "проигрывать", "падать"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["проигрывать", "трусость", "хныкать", "умолять"], "correct_index": 0}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["проигрывать", "поражение", "хныкать", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["умолять", "жалкий", "смерть", "падать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["трусость", "жалкий", "смерть", "проигрывать"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Управляющий</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -469,9 +469,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                             
@@ -481,17 +481,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Gehorsam»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -501,59 +501,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Ergebenheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">покорный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">исполнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
                             
@@ -561,15 +513,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раболепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
                             
@@ -577,17 +529,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «befolgen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">управляющий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">покорный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">раболепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «befolgen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">исполнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">преданность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раболепный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,17 +600,17 @@
             <div class="quiz-phase-container" data-phase="messenger">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Bote»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -622,27 +622,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Eile»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">торопиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -656,16 +656,32 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «hasten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">торопиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">спешить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">спешить</button>
@@ -674,23 +690,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">послание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">послание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -702,11 +702,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">торопиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">послание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -719,49 +719,49 @@
             <div class="quiz-phase-container" data-phase="insult">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Beleidigung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Respektlosigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">неуважение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">пренебрегать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -773,55 +773,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">высмеивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «frech»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дерзкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
                             
@@ -831,17 +783,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">высмеивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пренебрегать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «frech»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусливый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дерзкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пренебрегать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусливый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «feige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусливый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -858,11 +858,27 @@
                         <div class="quiz-question">Что означает немецкое слово «der Spion»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
                             
@@ -870,33 +886,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -910,7 +910,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вынюхивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «lauschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подслушивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
                             
@@ -918,33 +934,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «lauschen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подслушивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -956,9 +956,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
                             
@@ -977,9 +977,25 @@
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
@@ -989,49 +1005,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1041,11 +1041,11 @@
                         <div class="quiz-question">Что означает немецкое слово «hintergehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">коварный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
@@ -1053,49 +1053,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «tückisch»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verschlagen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">хитрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1114,27 +1114,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Jagd»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1146,41 +1146,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выслеживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">добыча</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
                             
@@ -1188,33 +1172,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «hetzen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выслеживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">добыча</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «hetzen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">травить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выслеживать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Beute»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">добыча</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1243,15 +1243,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1259,17 +1259,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жалкий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1279,11 +1279,11 @@
                         <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
                             
@@ -1291,17 +1291,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умолять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1317,39 +1317,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умолять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erbärmlich»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erbärmlich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жалкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1570,8 +1570,8 @@
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
-                    "служить",
                     "преданность",
+                    "служить",
                     "слуга",
                     "послушание"
                 ],
@@ -1580,72 +1580,72 @@
             {
                 "question": "Что означает немецкое слово «der Gehorsam»?",
                 "choices": [
+                    "послушание",
                     "преданность",
                     "слуга",
-                    "служить",
-                    "послушание"
+                    "служить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ergebenheit»?",
                 "choices": [
-                    "раболепный",
                     "служить",
+                    "управляющий",
                     "преданность",
-                    "покорный"
+                    "слуга"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
-                    "преданность",
-                    "покорный",
+                    "раболепный",
                     "служить",
-                    "управляющий"
+                    "управляющий",
+                    "преданность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Verwalter»?",
                 "choices": [
-                    "слуга",
                     "покорный",
                     "управляющий",
-                    "исполнять"
+                    "слуга",
+                    "служить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ergeben»?",
                 "choices": [
-                    "покорный",
-                    "исполнять",
-                    "служить",
-                    "слуга"
+                    "послушание",
+                    "слуга",
+                    "управляющий",
+                    "покорный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «unterwürfig»?",
                 "choices": [
-                    "слуга",
-                    "покорный",
+                    "послушание",
                     "раболепный",
-                    "преданность"
+                    "служить",
+                    "исполнять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «befolgen»?",
                 "choices": [
-                    "управляющий",
-                    "раболепный",
-                    "послушание",
-                    "исполнять"
+                    "покорный",
+                    "исполнять",
+                    "преданность",
+                    "раболепный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -1827,20 +1827,20 @@
             {
                 "question": "Что означает немецкое слово «der Bote»?",
                 "choices": [
-                    "спешка",
-                    "передавать",
                     "гонец",
-                    "поручение"
+                    "поручение",
+                    "передавать",
+                    "спешка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Auftrag»?",
                 "choices": [
                     "поручение",
-                    "гонец",
                     "передавать",
-                    "спешка"
+                    "спешка",
+                    "гонец"
                 ],
                 "correctIndex": 0
             },
@@ -1848,49 +1848,49 @@
                 "question": "Что означает немецкое слово «die Eile»?",
                 "choices": [
                     "поручение",
-                    "передавать",
-                    "торопиться",
-                    "спешка"
+                    "гонец",
+                    "спешка",
+                    "послание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «überbringen»?",
                 "choices": [
                     "передавать",
                     "торопиться",
-                    "поручение",
-                    "послание"
+                    "спешить",
+                    "гонец"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «hasten»?",
                 "choices": [
-                    "спешить",
+                    "торопиться",
                     "поручение",
-                    "послание",
-                    "передавать"
+                    "спешка",
+                    "спешить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Botschaft»?",
                 "choices": [
+                    "спешить",
+                    "поручение",
                     "послание",
-                    "передавать",
-                    "спешка",
-                    "поручение"
+                    "спешка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «eilen»?",
                 "choices": [
                     "торопиться",
-                    "передавать",
                     "спешка",
-                    "гонец"
+                    "послание",
+                    "поручение"
                 ],
                 "correctIndex": 0
             }
@@ -2106,39 +2106,39 @@
             {
                 "question": "Что означает немецкое слово «die Beleidigung»?",
                 "choices": [
-                    "оскорблять",
+                    "оскорбление",
                     "трусость",
                     "неуважение",
-                    "оскорбление"
+                    "оскорблять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Respektlosigkeit»?",
                 "choices": [
-                    "оскорблять",
                     "неуважение",
                     "трусость",
+                    "оскорблять",
                     "оскорбление"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
-                    "неуважение",
-                    "пренебрегать",
                     "трусость",
-                    "высмеивать"
+                    "пренебрегать",
+                    "неуважение",
+                    "оскорблять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beleidigen»?",
                 "choices": [
                     "пренебрегать",
+                    "трусость",
                     "оскорбление",
-                    "трусливый",
                     "оскорблять"
                 ],
                 "correctIndex": 3
@@ -2146,42 +2146,42 @@
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
+                    "дерзкий",
                     "высмеивать",
-                    "оскорблять",
-                    "трусливый",
+                    "пренебрегать",
                     "оскорбление"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «frech»?",
                 "choices": [
-                    "оскорбление",
-                    "трусливый",
                     "дерзкий",
-                    "пренебрегать"
+                    "оскорбление",
+                    "оскорблять",
+                    "трусливый"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «missachten»?",
                 "choices": [
-                    "пренебрегать",
+                    "оскорблять",
                     "дерзкий",
-                    "оскорбление",
-                    "оскорблять"
+                    "пренебрегать",
+                    "трусливый"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «feige»?",
                 "choices": [
-                    "трусливый",
-                    "трусость",
                     "дерзкий",
-                    "пренебрегать"
+                    "оскорбление",
+                    "высмеивать",
+                    "трусливый"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2369,10 +2369,10 @@
             {
                 "question": "Что означает немецкое слово «der Spion»?",
                 "choices": [
-                    "скрытность",
+                    "предательство",
                     "шпион",
                     "шпионить",
-                    "предательство"
+                    "скрытность"
                 ],
                 "correctIndex": 1
             },
@@ -2380,58 +2380,58 @@
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
                     "скрытность",
-                    "предательство",
                     "шпионить",
-                    "шпион"
+                    "шпион",
+                    "предательство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Heimlichkeit»?",
                 "choices": [
-                    "вынюхивать",
                     "скрытность",
-                    "выдавать",
-                    "шпионить"
+                    "подслушивать",
+                    "шпион",
+                    "выдавать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «spionieren»?",
                 "choices": [
                     "шпионить",
                     "подслушивать",
-                    "вынюхивать",
-                    "предательство"
+                    "шпион",
+                    "выдавать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «lauschen»?",
                 "choices": [
-                    "выдавать",
                     "подслушивать",
-                    "скрытность",
-                    "шпион"
+                    "выдавать",
+                    "шпион",
+                    "предательство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "вынюхивать",
+                    "выдавать",
                     "шпион",
-                    "подслушивать",
-                    "выдавать"
+                    "предательство",
+                    "скрытность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «schnüffeln»?",
                 "choices": [
                     "вынюхивать",
-                    "шпион",
                     "предательство",
+                    "шпион",
                     "выдавать"
                 ],
                 "correctIndex": 0
@@ -2652,49 +2652,49 @@
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "ковать",
+                    "коварство",
                     "план",
                     "интрига",
-                    "коварство"
+                    "ковать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
-                    "ковать",
                     "план",
-                    "коварство",
-                    "интрига"
+                    "ковать",
+                    "интрига",
+                    "коварство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Hinterlist»?",
                 "choices": [
-                    "хитрый",
+                    "ловушка",
                     "ковать",
-                    "коварство",
-                    "план"
+                    "план",
+                    "коварство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «schmieden»?",
                 "choices": [
-                    "коварный",
-                    "ковать",
+                    "план",
                     "интрига",
-                    "план"
+                    "ковать",
+                    "обманывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «hintergehen»?",
                 "choices": [
-                    "план",
-                    "интрига",
+                    "хитрый",
                     "коварный",
+                    "ковать",
                     "обманывать"
                 ],
                 "correctIndex": 3
@@ -2702,32 +2702,32 @@
             {
                 "question": "Что означает немецкое слово «tückisch»?",
                 "choices": [
-                    "интрига",
+                    "коварство",
+                    "хитрый",
                     "коварный",
-                    "ковать",
-                    "коварство"
+                    "ковать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verschlagen»?",
                 "choices": [
-                    "ловушка",
-                    "хитрый",
-                    "обманывать",
-                    "план"
+                    "интрига",
+                    "ковать",
+                    "коварство",
+                    "хитрый"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
-                    "план",
                     "ловушка",
-                    "ковать",
-                    "коварство"
+                    "хитрый",
+                    "коварство",
+                    "коварный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2915,9 +2915,9 @@
                 "question": "Что означает немецкое слово «die Verfolgung»?",
                 "choices": [
                     "преследование",
-                    "преследовать",
                     "гнаться",
-                    "охота"
+                    "охота",
+                    "преследовать"
                 ],
                 "correctIndex": 0
             },
@@ -2925,61 +2925,61 @@
                 "question": "Что означает немецкое слово «die Jagd»?",
                 "choices": [
                     "гнаться",
-                    "преследовать",
                     "преследование",
-                    "охота"
+                    "охота",
+                    "преследовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
                     "охота",
-                    "добыча",
+                    "травить",
                     "преследовать",
-                    "травить"
+                    "выслеживать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
-                    "добыча",
-                    "выслеживать",
                     "преследовать",
-                    "гнаться"
+                    "добыча",
+                    "гнаться",
+                    "преследование"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufspüren»?",
                 "choices": [
-                    "охота",
                     "выслеживать",
+                    "травить",
                     "добыча",
-                    "преследование"
+                    "преследовать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «hetzen»?",
                 "choices": [
-                    "выслеживать",
+                    "травить",
                     "преследовать",
-                    "добыча",
-                    "травить"
+                    "охота",
+                    "выслеживать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Beute»?",
                 "choices": [
-                    "преследовать",
+                    "добыча",
                     "гнаться",
-                    "преследование",
-                    "добыча"
+                    "охота",
+                    "травить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -3213,29 +3213,29 @@
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
+                    "поражение",
                     "падать",
                     "трусость",
-                    "поражение",
                     "смерть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "смерть",
-                    "проигрывать",
-                    "хныкать",
-                    "поражение"
+                    "трусость",
+                    "поражение",
+                    "умолять",
+                    "жалкий"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
-                    "хныкать",
-                    "трусость",
                     "смерть",
+                    "жалкий",
+                    "проигрывать",
                     "падать"
                 ],
                 "correctIndex": 3
@@ -3243,12 +3243,12 @@
             {
                 "question": "Что означает немецкое слово «unterliegen»?",
                 "choices": [
-                    "смерть",
                     "проигрывать",
-                    "жалкий",
-                    "хныкать"
+                    "трусость",
+                    "хныкать",
+                    "умолять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «wimmern»?",
@@ -3256,29 +3256,29 @@
                     "проигрывать",
                     "поражение",
                     "хныкать",
-                    "умолять"
+                    "трусость"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «betteln»?",
                 "choices": [
-                    "трусость",
-                    "проигрывать",
                     "умолять",
-                    "поражение"
+                    "жалкий",
+                    "смерть",
+                    "падать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erbärmlich»?",
                 "choices": [
+                    "трусость",
                     "жалкий",
                     "смерть",
-                    "трусость",
-                    "хныкать"
+                    "проигрывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}

--- a/output/journeys/regan.html
+++ b/output/journeys/regan.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["притворяться", "превосходить", "фальшь", "состязаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["притворяться", "фальшь", "состязаться", "превосходить"], "correct_index": 3}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["притворяться", "фальшь", "разыгрывать", "состязаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["разыгрывать", "алчность", "фальшь", "превосходить"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["выманивать", "алчность", "разыгрывать", "превосходить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die List»?", "choices": ["состязаться", "притворяться", "хитрость", "выманивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["хитрость", "притворяться", "выманивать", "фальшь"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["алчность", "разыгрывать", "превосходить", "притворяться"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["союз", "заговорить", "планировать", "делить"], "correct_index": 0}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["союз", "планировать", "делить", "заговорить"], "correct_index": 2}, {"question": "Что означает немецкое слово «planen»?", "choices": ["делить", "сговор", "заговорить", "планировать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["заговорить", "договариваться", "союз", "планировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["договариваться", "союз", "сговор", "стратегия"], "correct_index": 2}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["договариваться", "сговор", "заговорить", "планировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["договариваться", "союз", "стратегия", "делить"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["злоба", "пытать", "насмехаться", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["злоба", "пытать", "насмехаться", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["жёсткость", "злоба", "жестоко обращаться", "насмехаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["отвергать", "насмехаться", "пытать", "злоба"], "correct_index": 3}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["унижать", "жестоко обращаться", "злоба", "отвергать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жестокость", "унижать", "жёсткость", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["пытать", "отвергать", "жёсткость", "насмехаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "унижать", "пытать", "злоба"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["садизм", "ослеплять", "выкалывать", "наслаждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["выкалывать", "садизм", "ослеплять", "наслаждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["пытка", "брутальность", "наслаждаться", "садизм"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["наслаждаться", "ослеплять", "выкалывать", "брутальность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["наслаждаться", "брутальность", "пытка", "садизм"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["растаптывать", "наслаждаться", "беспощадный", "брутальность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["садизм", "выкалывать", "брутальность", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["пытка", "растаптывать", "беспощадный", "брутальность"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вдова", "вожделение", "соблазнять", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["соблазнять", "вожделеть", "вдова", "вожделение"], "correct_index": 1}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["вожделеть", "вдова", "соблазнять", "добиваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["вдова", "соблазнять", "вожделение", "вожделеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «locken»?", "choices": ["заманивать", "вожделеть", "похоть", "вдова"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["вожделеть", "вожделение", "похоть", "добиваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «werben»?", "choices": ["соблазнять", "добиваться", "заманивать", "похоть"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["соревноваться", "соперничество", "угрожать", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["соревноваться", "ненавидеть", "соперничество", "угрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["соревноваться", "не доверять", "угрожать", "бороться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["угрожать", "ненавидеть", "соперничество", "не доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["бороться", "соревноваться", "подозревать", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["соревноваться", "соперничество", "бороться", "не доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["соперничество", "соревноваться", "подозревать", "угрожать"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["мучение", "издыхать", "страдать", "отравленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "отравленный", "мучение", "издыхать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["мучение", "издыхать", "проклятый", "проклинать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["мучение", "страдать", "расплачиваться", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["проклятый", "проклинать", "расплачиваться", "отравленный"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["мучение", "страдать", "проклинать", "рок"], "correct_index": 3}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["проклинать", "проклятый", "страдать", "расплачиваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["издыхать", "расплачиваться", "рок", "проклятый"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["фальшь", "притворяться", "превосходить", "состязаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["превосходить", "притворяться", "состязаться", "фальшь"], "correct_index": 0}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["выманивать", "превосходить", "разыгрывать", "состязаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["фальшь", "алчность", "хитрость", "разыгрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["превосходить", "хитрость", "разыгрывать", "алчность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die List»?", "choices": ["притворяться", "выманивать", "хитрость", "алчность"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["алчность", "выманивать", "разыгрывать", "притворяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["алчность", "притворяться", "выманивать", "фальшь"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["союз", "заговорить", "планировать", "делить"], "correct_index": 0}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["делить", "союз", "заговорить", "планировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «planen»?", "choices": ["планировать", "стратегия", "заговорить", "сговор"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["стратегия", "союз", "заговорить", "делить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["делить", "сговор", "союз", "планировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["планировать", "договариваться", "союз", "сговор"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["планировать", "союз", "сговор", "стратегия"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["насмехаться", "унижать", "злоба", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["насмехаться", "пытать", "злоба", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["жестокость", "насмехаться", "пытать", "жестоко обращаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["злоба", "насмехаться", "пытать", "жестоко обращаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["жестоко обращаться", "пытать", "жёсткость", "насмехаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["злоба", "жестоко обращаться", "жестокость", "жёсткость"], "correct_index": 3}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["насмехаться", "отвергать", "пытать", "жёсткость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "унижать", "пытать", "насмехаться"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["садизм", "ослеплять", "наслаждаться", "выкалывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["выкалывать", "ослеплять", "наслаждаться", "садизм"], "correct_index": 3}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["выкалывать", "наслаждаться", "беспощадный", "садизм"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["брутальность", "садизм", "беспощадный", "выкалывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["беспощадный", "пытка", "ослеплять", "брутальность"], "correct_index": 1}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["ослеплять", "беспощадный", "выкалывать", "растаптывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["брутальность", "пытка", "растаптывать", "наслаждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["беспощадный", "садизм", "пытка", "растаптывать"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["соблазнять", "вожделеть", "вдова", "вожделение"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вожделение", "соблазнять", "вожделеть", "вдова"], "correct_index": 2}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["добиваться", "вдова", "соблазнять", "вожделеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["похоть", "вожделеть", "вдова", "вожделение"], "correct_index": 3}, {"question": "Что означает немецкое слово «locken»?", "choices": ["похоть", "соблазнять", "вожделение", "заманивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["похоть", "заманивать", "добиваться", "соблазнять"], "correct_index": 0}, {"question": "Что означает немецкое слово «werben»?", "choices": ["вожделение", "добиваться", "соблазнять", "заманивать"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["соперничество", "ненавидеть", "угрожать", "соревноваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["соревноваться", "угрожать", "ненавидеть", "соперничество"], "correct_index": 2}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["соперничество", "не доверять", "угрожать", "ненавидеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["ненавидеть", "бороться", "соревноваться", "соперничество"], "correct_index": 3}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["не доверять", "угрожать", "бороться", "ненавидеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["соревноваться", "не доверять", "ненавидеть", "угрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["не доверять", "соревноваться", "ненавидеть", "подозревать"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["издыхать", "отравленный", "мучение", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["издыхать", "страдать", "мучение", "отравленный"], "correct_index": 1}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["отравленный", "проклинать", "рок", "издыхать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["мучение", "расплачиваться", "издыхать", "проклятый"], "correct_index": 0}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["проклинать", "мучение", "издыхать", "отравленный"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["рок", "мучение", "страдать", "расплачиваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["отравленный", "проклинать", "расплачиваться", "издыхать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["мучение", "проклинать", "издыхать", "проклятый"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Притворная любовь</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,15 +465,15 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vortäuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
                             
@@ -481,17 +481,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «übertreffen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">состязаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -501,9 +501,9 @@
                         <div class="quiz-question">Что означает немецкое слово «wetteifern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
                             
@@ -513,17 +513,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Falschheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">алчность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">разыгрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -533,13 +533,13 @@
                         <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">алчность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">алчность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -549,29 +549,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die List»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выманивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">алчность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erschleichen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -583,11 +583,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">разыгрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -616,29 +616,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «teilen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «planen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
                             
@@ -648,13 +632,45 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «planen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">стратегия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                             
@@ -664,49 +680,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">договариваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Strategie»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сговор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Strategie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стратегия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -719,17 +719,17 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -739,11 +739,11 @@
                         <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
@@ -751,15 +751,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестоко обращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестоко обращаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестоко обращаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
                             
@@ -767,49 +799,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестоко обращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестоко обращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -819,13 +819,13 @@
                         <div class="quiz-question">Что означает немецкое слово «abweisen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -841,7 +841,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -862,37 +862,21 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «genießen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
                             
@@ -902,31 +886,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «genießen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
                             
@@ -934,49 +902,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">брутальность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">растаптывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Brutalität»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">брутальность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">растаптывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">растаптывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">растаптывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -989,24 +989,8 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Witwe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
@@ -1021,47 +1005,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «locken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
                             
@@ -1069,17 +1021,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">добиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «locken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">заманивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1089,13 +1089,13 @@
                         <div class="quiz-question">Что означает немецкое слово «werben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">заманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">заманивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,33 +1108,33 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «wettkämpfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соревноваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1144,43 +1144,11 @@
                         <div class="quiz-question">Что означает немецкое слово «bedrohen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">не доверять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
@@ -1188,33 +1156,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">не доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">не доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «argwöhnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">не доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,15 +1227,31 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vergiftet»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
                             
@@ -1243,33 +1259,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1281,25 +1281,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклятый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
                             
@@ -1307,29 +1307,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Verhängnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
@@ -1339,15 +1323,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
                     <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verflucht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">проклятый</button>
                             
@@ -1578,28 +1578,28 @@
             {
                 "question": "Что означает немецкое слово «vortäuschen»?",
                 "choices": [
+                    "фальшь",
                     "притворяться",
                     "превосходить",
-                    "фальшь",
                     "состязаться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «übertreffen»?",
                 "choices": [
+                    "превосходить",
                     "притворяться",
-                    "фальшь",
                     "состязаться",
-                    "превосходить"
+                    "фальшь"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «wetteifern»?",
                 "choices": [
-                    "притворяться",
-                    "фальшь",
+                    "выманивать",
+                    "превосходить",
                     "разыгрывать",
                     "состязаться"
                 ],
@@ -1608,50 +1608,50 @@
             {
                 "question": "Что означает немецкое слово «die Falschheit»?",
                 "choices": [
-                    "разыгрывать",
-                    "алчность",
                     "фальшь",
-                    "превосходить"
+                    "алчность",
+                    "хитрость",
+                    "разыгрывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vorspielen»?",
                 "choices": [
-                    "выманивать",
-                    "алчность",
+                    "превосходить",
+                    "хитрость",
                     "разыгрывать",
-                    "превосходить"
+                    "алчность"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "состязаться",
                     "притворяться",
+                    "выманивать",
                     "хитрость",
-                    "выманивать"
+                    "алчность"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erschleichen»?",
                 "choices": [
-                    "хитрость",
-                    "притворяться",
+                    "алчность",
                     "выманивать",
-                    "фальшь"
+                    "разыгрывать",
+                    "притворяться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Habgier»?",
                 "choices": [
                     "алчность",
-                    "разыгрывать",
-                    "превосходить",
-                    "притворяться"
+                    "притворяться",
+                    "выманивать",
+                    "фальшь"
                 ],
                 "correctIndex": 0
             }
@@ -1847,62 +1847,62 @@
             {
                 "question": "Что означает немецкое слово «teilen»?",
                 "choices": [
-                    "союз",
-                    "планировать",
                     "делить",
-                    "заговорить"
+                    "союз",
+                    "заговорить",
+                    "планировать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «planen»?",
                 "choices": [
-                    "делить",
-                    "сговор",
+                    "планировать",
+                    "стратегия",
                     "заговорить",
-                    "планировать"
+                    "сговор"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verschwören»?",
                 "choices": [
-                    "заговорить",
-                    "договариваться",
+                    "стратегия",
                     "союз",
-                    "планировать"
+                    "заговорить",
+                    "делить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Absprache»?",
                 "choices": [
-                    "договариваться",
-                    "союз",
+                    "делить",
                     "сговор",
-                    "стратегия"
+                    "союз",
+                    "планировать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vereinbaren»?",
                 "choices": [
+                    "планировать",
                     "договариваться",
-                    "сговор",
-                    "заговорить",
-                    "планировать"
+                    "союз",
+                    "сговор"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Strategie»?",
                 "choices": [
-                    "договариваться",
+                    "планировать",
                     "союз",
-                    "стратегия",
-                    "делить"
+                    "сговор",
+                    "стратегия"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2145,19 +2145,19 @@
             {
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
-                    "злоба",
-                    "пытать",
                     "насмехаться",
-                    "унижать"
+                    "унижать",
+                    "злоба",
+                    "пытать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
-                    "злоба",
-                    "пытать",
                     "насмехаться",
+                    "пытать",
+                    "злоба",
                     "унижать"
                 ],
                 "correctIndex": 3
@@ -2165,50 +2165,50 @@
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "жёсткость",
-                    "злоба",
-                    "жестоко обращаться",
-                    "насмехаться"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Bosheit»?",
-                "choices": [
-                    "отвергать",
+                    "жестокость",
                     "насмехаться",
                     "пытать",
-                    "злоба"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «misshandeln»?",
-                "choices": [
-                    "унижать",
-                    "жестоко обращаться",
-                    "злоба",
-                    "отвергать"
+                    "жестоко обращаться"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «die Bosheit»?",
+                "choices": [
+                    "злоба",
+                    "насмехаться",
+                    "пытать",
+                    "жестоко обращаться"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «misshandeln»?",
+                "choices": [
+                    "жестоко обращаться",
+                    "пытать",
+                    "жёсткость",
+                    "насмехаться"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Härte»?",
                 "choices": [
+                    "злоба",
+                    "жестоко обращаться",
                     "жестокость",
-                    "унижать",
-                    "жёсткость",
-                    "пытать"
+                    "жёсткость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «abweisen»?",
                 "choices": [
-                    "пытать",
+                    "насмехаться",
                     "отвергать",
-                    "жёсткость",
-                    "насмехаться"
+                    "пытать",
+                    "жёсткость"
                 ],
                 "correctIndex": 1
             },
@@ -2218,7 +2218,7 @@
                     "жестокость",
                     "унижать",
                     "пытать",
-                    "злоба"
+                    "насмехаться"
                 ],
                 "correctIndex": 0
             }
@@ -2451,8 +2451,8 @@
                 "choices": [
                     "садизм",
                     "ослеплять",
-                    "выкалывать",
-                    "наслаждаться"
+                    "наслаждаться",
+                    "выкалывать"
                 ],
                 "correctIndex": 1
             },
@@ -2460,71 +2460,71 @@
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
                     "выкалывать",
-                    "садизм",
                     "ослеплять",
-                    "наслаждаться"
+                    "наслаждаться",
+                    "садизм"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «genießen»?",
                 "choices": [
-                    "пытка",
-                    "брутальность",
+                    "выкалывать",
                     "наслаждаться",
+                    "беспощадный",
                     "садизм"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
-                    "наслаждаться",
-                    "ослеплять",
-                    "выкалывать",
-                    "брутальность"
+                    "брутальность",
+                    "садизм",
+                    "беспощадный",
+                    "выкалывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "наслаждаться",
-                    "брутальность",
+                    "беспощадный",
                     "пытка",
-                    "садизм"
+                    "ослеплять",
+                    "брутальность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
-                    "растаптывать",
-                    "наслаждаться",
+                    "ослеплять",
                     "беспощадный",
-                    "брутальность"
+                    "выкалывать",
+                    "растаптывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Brutalität»?",
                 "choices": [
-                    "садизм",
-                    "выкалывать",
                     "брутальность",
-                    "ослеплять"
+                    "пытка",
+                    "растаптывать",
+                    "наслаждаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «zertreten»?",
                 "choices": [
-                    "пытка",
-                    "растаптывать",
                     "беспощадный",
-                    "брутальность"
+                    "садизм",
+                    "пытка",
+                    "растаптывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2718,70 +2718,70 @@
             {
                 "question": "Что означает немецкое слово «die Witwe»?",
                 "choices": [
-                    "вдова",
-                    "вожделение",
-                    "соблазнять",
-                    "вожделеть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «begehren»?",
-                "choices": [
                     "соблазнять",
                     "вожделеть",
                     "вдова",
                     "вожделение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «begehren»?",
+                "choices": [
+                    "вожделение",
+                    "соблазнять",
+                    "вожделеть",
+                    "вдова"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
-                    "вожделеть",
+                    "добиваться",
                     "вдова",
                     "соблазнять",
-                    "добиваться"
+                    "вожделеть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Begierde»?",
                 "choices": [
+                    "похоть",
+                    "вожделеть",
                     "вдова",
-                    "соблазнять",
-                    "вожделение",
-                    "вожделеть"
+                    "вожделение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «locken»?",
                 "choices": [
-                    "заманивать",
-                    "вожделеть",
                     "похоть",
-                    "вдова"
+                    "соблазнять",
+                    "вожделение",
+                    "заманивать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
-                    "вожделеть",
-                    "вожделение",
                     "похоть",
-                    "добиваться"
+                    "заманивать",
+                    "добиваться",
+                    "соблазнять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «werben»?",
                 "choices": [
-                    "соблазнять",
+                    "вожделение",
                     "добиваться",
-                    "заманивать",
-                    "похоть"
+                    "соблазнять",
+                    "заманивать"
                 ],
                 "correctIndex": 1
             }
@@ -2975,72 +2975,72 @@
             {
                 "question": "Что означает немецкое слово «wettkämpfen»?",
                 "choices": [
-                    "соревноваться",
                     "соперничество",
+                    "ненавидеть",
                     "угрожать",
-                    "ненавидеть"
+                    "соревноваться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
                     "соревноваться",
+                    "угрожать",
                     "ненавидеть",
-                    "соперничество",
-                    "угрожать"
+                    "соперничество"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «bedrohen»?",
                 "choices": [
-                    "соревноваться",
+                    "соперничество",
                     "не доверять",
                     "угрожать",
-                    "бороться"
+                    "ненавидеть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
-                    "угрожать",
                     "ненавидеть",
-                    "соперничество",
-                    "не доверять"
+                    "бороться",
+                    "соревноваться",
+                    "соперничество"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «bekämpfen»?",
                 "choices": [
+                    "не доверять",
+                    "угрожать",
                     "бороться",
-                    "соревноваться",
-                    "подозревать",
                     "ненавидеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «misstrauen»?",
                 "choices": [
                     "соревноваться",
-                    "соперничество",
-                    "бороться",
-                    "не доверять"
+                    "не доверять",
+                    "ненавидеть",
+                    "угрожать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «argwöhnen»?",
                 "choices": [
-                    "соперничество",
+                    "не доверять",
                     "соревноваться",
-                    "подозревать",
-                    "угрожать"
+                    "ненавидеть",
+                    "подозревать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -3259,79 +3259,79 @@
             {
                 "question": "Что означает немецкое слово «vergiftet»?",
                 "choices": [
-                    "мучение",
                     "издыхать",
-                    "страдать",
-                    "отравленный"
+                    "отравленный",
+                    "мучение",
+                    "страдать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
+                    "издыхать",
                     "страдать",
-                    "отравленный",
                     "мучение",
-                    "издыхать"
+                    "отравленный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
-                    "мучение",
-                    "издыхать",
-                    "проклятый",
-                    "проклинать"
+                    "отравленный",
+                    "проклинать",
+                    "рок",
+                    "издыхать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
                     "мучение",
-                    "страдать",
                     "расплачиваться",
-                    "проклинать"
+                    "издыхать",
+                    "проклятый"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verwünschen»?",
                 "choices": [
-                    "проклятый",
                     "проклинать",
-                    "расплачиваться",
+                    "мучение",
+                    "издыхать",
                     "отравленный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Verhängnis»?",
                 "choices": [
+                    "рок",
                     "мучение",
                     "страдать",
-                    "проклинать",
-                    "рок"
+                    "расплачиваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «büßen»?",
                 "choices": [
+                    "отравленный",
                     "проклинать",
-                    "проклятый",
-                    "страдать",
-                    "расплачиваться"
+                    "расплачиваться",
+                    "издыхать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verflucht»?",
                 "choices": [
+                    "мучение",
+                    "проклинать",
                     "издыхать",
-                    "расплачиваться",
-                    "рок",
                     "проклятый"
                 ],
                 "correctIndex": 3

--- a/output/static/css/journey.css
+++ b/output/static/css/journey.css
@@ -201,7 +201,7 @@ body {
 
 .vocabulary-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 20px;
     margin-bottom: 30px;
     min-height: 200px;
@@ -218,13 +218,13 @@ body {
     transition: all 0.3s ease;
     animation: slideIn 0.4s ease;
     position: relative;
-    overflow: hidden;
 }
 
 .word-card::after {
     content: "";
     position: absolute;
     inset: 0;
+    border-radius: inherit;
     background: linear-gradient(120deg, rgba(102, 126, 234, 0.1), rgba(118, 75, 162, 0.08));
     opacity: 0;
     transition: opacity 0.3s ease;
@@ -300,6 +300,18 @@ body {
     font-size: 0.9em;
     color: #888;
     font-style: italic;
+}
+
+.word-german,
+.word-translation,
+.word-transcription,
+.sentence-german,
+.sentence-translation,
+.memory-card-content,
+.memory-card-content * {
+    word-break: break-word;
+    hyphens: auto;
+    white-space: normal;
 }
 
 .word-sentence {
@@ -602,6 +614,19 @@ body {
     transition: color 0.3s ease;
 }
 
+.pair-card,
+.pair-status,
+.memory-status,
+.drag-target,
+.drag-source,
+.match-token,
+.synonym-item,
+.collocation-item {
+    word-break: break-word;
+    hyphens: auto;
+    white-space: normal;
+}
+
 .pair-status.success {
     color: #059669;
 }
@@ -618,7 +643,7 @@ body {
 
 .memory-card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
     gap: 14px;
 }
 
@@ -630,14 +655,14 @@ body {
     color: #312e81;
     font-weight: 600;
     min-height: 110px;
-    padding: 14px 16px;
+    padding: 16px 18px;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     text-align: center;
     transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
     cursor: pointer;
-    overflow: hidden;
 }
 
 .memory-card:hover {
@@ -650,16 +675,28 @@ body {
     font-weight: 700;
     opacity: 0.75;
     transition: opacity 0.3s ease, transform 0.3s ease;
+    position: absolute;
+    top: 16px;
+    bottom: 16px;
+    left: 18px;
+    right: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
 }
 
 .memory-card-content {
-    position: absolute;
-    left: 12px;
-    right: 12px;
+    width: 100%;
     opacity: 0;
     transform: translateY(12px);
-    transition: opacity 0.3s ease, transform 0.3s ease;
-    line-height: 1.3;
+    transition: opacity 0.3s ease, transform 0.3s ease, max-height 0.35s ease;
+    line-height: 1.4;
+    max-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .memory-card.flipped {
@@ -675,6 +712,7 @@ body {
 .memory-card.flipped .memory-card-content {
     opacity: 1;
     transform: translateY(0);
+    max-height: 1000px;
 }
 
 .memory-card.correct {

--- a/static/css/journey.css
+++ b/static/css/journey.css
@@ -201,7 +201,7 @@ body {
 
 .vocabulary-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 20px;
     margin-bottom: 30px;
     min-height: 200px;
@@ -218,13 +218,13 @@ body {
     transition: all 0.3s ease;
     animation: slideIn 0.4s ease;
     position: relative;
-    overflow: hidden;
 }
 
 .word-card::after {
     content: "";
     position: absolute;
     inset: 0;
+    border-radius: inherit;
     background: linear-gradient(120deg, rgba(102, 126, 234, 0.1), rgba(118, 75, 162, 0.08));
     opacity: 0;
     transition: opacity 0.3s ease;
@@ -300,6 +300,18 @@ body {
     font-size: 0.9em;
     color: #888;
     font-style: italic;
+}
+
+.word-german,
+.word-translation,
+.word-transcription,
+.sentence-german,
+.sentence-translation,
+.memory-card-content,
+.memory-card-content * {
+    word-break: break-word;
+    hyphens: auto;
+    white-space: normal;
 }
 
 .word-sentence {
@@ -602,6 +614,19 @@ body {
     transition: color 0.3s ease;
 }
 
+.pair-card,
+.pair-status,
+.memory-status,
+.drag-target,
+.drag-source,
+.match-token,
+.synonym-item,
+.collocation-item {
+    word-break: break-word;
+    hyphens: auto;
+    white-space: normal;
+}
+
 .pair-status.success {
     color: #059669;
 }
@@ -618,7 +643,7 @@ body {
 
 .memory-card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
     gap: 14px;
 }
 
@@ -630,14 +655,14 @@ body {
     color: #312e81;
     font-weight: 600;
     min-height: 110px;
-    padding: 14px 16px;
+    padding: 16px 18px;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     text-align: center;
     transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
     cursor: pointer;
-    overflow: hidden;
 }
 
 .memory-card:hover {
@@ -650,16 +675,28 @@ body {
     font-weight: 700;
     opacity: 0.75;
     transition: opacity 0.3s ease, transform 0.3s ease;
+    position: absolute;
+    top: 16px;
+    bottom: 16px;
+    left: 18px;
+    right: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
 }
 
 .memory-card-content {
-    position: absolute;
-    left: 12px;
-    right: 12px;
+    width: 100%;
     opacity: 0;
     transform: translateY(12px);
-    transition: opacity 0.3s ease, transform 0.3s ease;
-    line-height: 1.3;
+    transition: opacity 0.3s ease, transform 0.3s ease, max-height 0.35s ease;
+    line-height: 1.4;
+    max-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .memory-card.flipped {
@@ -675,6 +712,7 @@ body {
 .memory-card.flipped .memory-card-content {
     opacity: 1;
     transform: translateY(0);
+    max-height: 1000px;
 }
 
 .memory-card.correct {


### PR DESCRIPTION
## Summary
- add hyphenation rules and remove overflow clipping so vocabulary and exercise text blocks can expand naturally
- tweak vocabulary and memory-card grid/card layouts to keep long content readable across screen sizes
- regenerate journey outputs so the published pages include the refreshed assets

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68cdb0d972f883208f992f99058a67b3