### PR TITLE
Simplify vocabulary card layout

### DIFF
--- a/generators/js_lira.py
+++ b/generators/js_lira.py
@@ -616,27 +616,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class=\"word-theme\">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/albany.html
+++ b/output/journeys/albany.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["молчание", "брак", "слабость", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["слабость", "брак", "молчание", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["молчание", "брак", "уступать", "слабость"], "correct_index": 1}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["слабость", "мягкий", "молчание", "терпеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["пассивный", "слабость", "колебаться", "мягкий"], "correct_index": 0}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["уступать", "мягкий", "колебаться", "молчание"], "correct_index": 0}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["мягкий", "колебаться", "слабость", "пассивный"], "correct_index": 1}, {"question": "Что означает немецкое слово «mild»?", "choices": ["молчание", "мягкий", "терпеть", "слабость"], "correct_index": 1}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["сомнение", "беспокойство", "совесть", "подвергать сомнению"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["сомнение", "подвергать сомнению", "беспокойство", "совесть"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["размышлять", "сомнение", "неуверенный", "беспокойство"], "correct_index": 3}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["подвергать сомнению", "тревожить", "беспокойство", "неуверенный"], "correct_index": 0}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["сомнение", "тревожить", "беспокойство", "неуверенный"], "correct_index": 1}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["совесть", "беспокойство", "неуверенный", "сомнение"], "correct_index": 2}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["совесть", "неуверенный", "размышлять", "сомнение"], "correct_index": 2}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["осознание", "понимать", "ужас", "пробуждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["ужас", "осознание", "пробуждаться", "понимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["понимать", "превращение", "пугаться", "пробуждаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["просыпаться", "превращение", "пробуждаться", "понимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["пугаться", "просыпаться", "понимать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["пробуждаться", "ясно видеть", "осознание", "просыпаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["понимать", "просыпаться", "ясно видеть", "превращение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["пробуждаться", "ясно видеть", "осознание", "превращение"], "correct_index": 3}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["противостоять", "спор", "сопротивление", "мужество"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "сопротивление", "противостоять", "спор"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["мужество", "спор", "сопротивление", "защищаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["обвинять", "противостоять", "защищаться", "восставать"], "correct_index": 1}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["защищаться", "обвинять", "спор", "противостоять"], "correct_index": 1}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["обвинять", "восставать", "защищаться", "спор"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["защищаться", "обвинять", "восставать", "мужество"], "correct_index": 2}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["выбирать", "справедливость", "мораль", "решение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["выбирать", "справедливость", "мораль", "решение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["благородный", "решение", "принцип", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["принцип", "выбирать", "решение", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["благородный", "справедливость", "праведный", "выбирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["принцип", "добродетель", "благородный", "мораль"], "correct_index": 0}, {"question": "Что означает немецкое слово «edel»?", "choices": ["выбирать", "благородный", "справедливость", "мораль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["решение", "благородный", "добродетель", "праведный"], "correct_index": 2}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["борьба", "право", "доброта", "наказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["борьба", "доброта", "наказывать", "право"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["защищать", "доброта", "судить", "наказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["наказывать", "борьба", "судить", "право"], "correct_index": 0}, {"question": "Что означает немецкое слово «richten»?", "choices": ["защищать", "судить", "доброта", "вмешиваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["вмешиваться", "судить", "доброта", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["защищать", "право", "доброта", "вмешиваться"], "correct_index": 3}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["мудрость", "правление", "направлять", "новое начало"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "направлять", "правление", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["правление", "направлять", "мир", "новое начало"], "correct_index": 3}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["направлять", "обновлять", "мудрость", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["примирять", "новое начало", "мир", "строить"], "correct_index": 3}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["правление", "обновлять", "мир", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["примирять", "мир", "правление", "строить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["мир", "новое начало", "мудрость", "направлять"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["молчание", "терпеть", "слабость", "брак"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["брак", "слабость", "терпеть", "молчание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["брак", "колебаться", "слабость", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["терпеть", "молчание", "колебаться", "брак"], "correct_index": 0}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["мягкий", "пассивный", "терпеть", "брак"], "correct_index": 1}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["уступать", "брак", "слабость", "мягкий"], "correct_index": 0}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["терпеть", "колебаться", "слабость", "брак"], "correct_index": 1}, {"question": "Что означает немецкое слово «mild»?", "choices": ["мягкий", "молчание", "уступать", "колебаться"], "correct_index": 0}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["подвергать сомнению", "беспокойство", "сомнение", "совесть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["подвергать сомнению", "сомнение", "беспокойство", "совесть"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["тревожить", "неуверенный", "беспокойство", "сомнение"], "correct_index": 2}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["подвергать сомнению", "беспокойство", "неуверенный", "совесть"], "correct_index": 0}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["тревожить", "подвергать сомнению", "сомнение", "неуверенный"], "correct_index": 0}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["сомнение", "размышлять", "тревожить", "неуверенный"], "correct_index": 3}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["тревожить", "совесть", "размышлять", "сомнение"], "correct_index": 2}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["пробуждаться", "понимать", "ужас", "осознание"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["ужас", "пробуждаться", "понимать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["просыпаться", "осознание", "ясно видеть", "пробуждаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["ясно видеть", "осознание", "понимать", "пробуждаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["пробуждаться", "пугаться", "превращение", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["пробуждаться", "просыпаться", "ужас", "пугаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["осознание", "пугаться", "просыпаться", "ясно видеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["ясно видеть", "пугаться", "ужас", "превращение"], "correct_index": 3}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["мужество", "сопротивление", "спор", "противостоять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "противостоять", "сопротивление", "спор"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["спор", "защищаться", "противостоять", "сопротивление"], "correct_index": 3}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["мужество", "спор", "восставать", "противостоять"], "correct_index": 3}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["противостоять", "мужество", "спор", "обвинять"], "correct_index": 3}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["мужество", "противостоять", "защищаться", "спор"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["обвинять", "восставать", "мужество", "спор"], "correct_index": 1}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["выбирать", "мораль", "решение", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["выбирать", "справедливость", "решение", "мораль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["решение", "мораль", "справедливость", "принцип"], "correct_index": 0}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["выбирать", "мораль", "добродетель", "решение"], "correct_index": 0}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["решение", "добродетель", "праведный", "благородный"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["принцип", "мораль", "решение", "справедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «edel»?", "choices": ["мораль", "принцип", "благородный", "праведный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["принцип", "праведный", "справедливость", "добродетель"], "correct_index": 3}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["право", "борьба", "наказывать", "доброта"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["доброта", "борьба", "право", "наказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["доброта", "защищать", "судить", "наказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["вмешиваться", "наказывать", "борьба", "судить"], "correct_index": 1}, {"question": "Что означает немецкое слово «richten»?", "choices": ["защищать", "наказывать", "судить", "доброта"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["наказывать", "право", "защищать", "борьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["вмешиваться", "доброта", "наказывать", "право"], "correct_index": 0}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["новое начало", "мудрость", "направлять", "правление"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["новое начало", "мудрость", "направлять", "правление"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["строить", "новое начало", "направлять", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["направлять", "мир", "правление", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["строить", "мир", "направлять", "обновлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["правление", "строить", "обновлять", "новое начало"], "correct_index": 2}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["примирять", "мир", "обновлять", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["мир", "новое начало", "примирять", "направлять"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Пассивный герцог</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -471,7 +471,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Ehe»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
                             
@@ -481,65 +513,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «passiv»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пассивный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -551,11 +551,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">уступать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -565,29 +565,29 @@
                         <div class="quiz-question">Что означает немецкое слово «zögern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пассивный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «mild»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">колебаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,17 +600,17 @@
             <div class="quiz-phase-container" data-phase="first_doubts">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Zweifel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -620,9 +620,9 @@
                         <div class="quiz-question">Что означает немецкое слово «das Gewissen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
                             
@@ -632,17 +632,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Unbehagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуверенный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -654,43 +654,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тревожить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тревожить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">неуверенный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">тревожить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -700,9 +700,9 @@
                         <div class="quiz-question">Что означает немецкое слово «grübeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
                             
@@ -719,17 +719,17 @@
             <div class="quiz-phase-container" data-phase="awakening">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -741,55 +741,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">превращение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пугаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">превращение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
@@ -799,33 +751,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «klar sehen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ясно видеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пугаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «klar sehen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">просыпаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ясно видеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -835,11 +835,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Verwandlung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ясно видеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
                             
@@ -854,17 +854,17 @@
             <div class="quiz-phase-container" data-phase="confrontation">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Streit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -876,9 +876,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
                             
@@ -886,49 +886,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Widerstand»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопротивление</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «konfrontieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «konfrontieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «anklagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -938,9 +938,9 @@
                         <div class="quiz-question">Что означает немецкое слово «sich wehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">защищаться</button>
                             
@@ -950,17 +950,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «aufbegehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,17 +973,17 @@
             <div class="quiz-phase-container" data-phase="moral_stand">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Moral»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -997,41 +997,41 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Entscheidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">принцип</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">добродетель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1041,13 +1041,13 @@
                         <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1059,43 +1059,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «edel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Tugend»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">добродетель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,15 +1108,31 @@
             <div class="quiz-phase-container" data-phase="justice_seeker">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Recht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
                             
@@ -1124,97 +1140,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Recht»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Güte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «richten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «eingreifen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">право</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Güte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «richten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">судить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вмешиваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">судить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «eingreifen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вмешиваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,49 +1227,49 @@
             <div class="quiz-phase-container" data-phase="new_ruler">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">правление</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">правление</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1281,43 +1281,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «aufbauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">примирять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">строить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обновлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «erneuern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">строить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1331,9 +1331,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">строить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1347,7 +1347,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">примирять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
                             
@@ -1376,8 +1376,8 @@
                 "word": "das Schweigen",
                 "translation": "молчание",
                 "transcription": "[дас ШВАЙ-ген]",
-                "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Mein Schweigen macht mich zum Mitschuldigen.",
-                "sentenceTranslation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Моё молчание делает меня соучастником.",
+                "sentence": "Im goldenen Saal sitzt Albany schweigend neben Gonerils Thron. Mein Atem zeichnet das Wort „das Schweigen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В золотом зале Олбани молча сидит рядом с троном Гонерильи. Моё дыхание рисует слово «молчание» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehe",
@@ -1400,8 +1400,8 @@
                 "word": "die Schwäche",
                 "translation": "слабость",
                 "transcription": "[ди ШВЕ-хе]",
-                "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Meine Schwäche erlaubt das Böse zu wachsen.",
-                "sentenceTranslation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Моя слабость позволяет злу расти.",
+                "sentence": "Vor den streitenden Schwestern faltet Albany die Hände hinter dem Rücken. Ich halte das Wort „die Schwäche“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед ссорящимися сёстрами Олбани складывает руки за спиной. Я держу слово «слабость» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehe",
@@ -1424,8 +1424,8 @@
                 "word": "die Ehe",
                 "translation": "брак",
                 "transcription": "[ди Э-е]",
-                "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Die Ehe bindet mich an eine grausame Frau.",
-                "sentenceTranslation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Брак связывает меня с жестокой женой.",
+                "sentence": "Am Fenster der Audienzhalle betrachtet Albany die vorbeiziehenden Wolken. Ich zeichne das Wort „die Ehe“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "У окна зала приёмов Олбани наблюдает за плывущими облаками. Я вывожу слово «брак» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehe",
@@ -1448,8 +1448,8 @@
                 "word": "dulden",
                 "translation": "терпеть",
                 "transcription": "[ДУЛЬ-ден]",
-                "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Ich dulde ihre Grausamkeit zu lange.",
-                "sentenceTranslation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Я слишком долго терплю её жестокость.",
+                "sentence": "Zwischen zerstreuten Ratsmitgliedern nickt Albany zu allem bereitwillig. Ich zeichne das Wort „dulden“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Среди рассеянных советников Олбани покорно кивает всему. Я черчу слово «терпеть» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehe",
@@ -1474,8 +1474,8 @@
                 "word": "passiv",
                 "translation": "пассивный",
                 "transcription": "[па-СИФ]",
-                "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Passiv schaue ich dem Unrecht zu.",
-                "sentenceTranslation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Пассивно я наблюдаю за несправедливостью.",
+                "sentence": "Am Ende der Tafel legt Albany das Besteck ordentlich beiseite. Wie ein stilles Gebet legt sich das Wort „passiv“ auf meine Lippen.",
+                "sentenceTranslation": "В конце стола Олбани аккуратно откладывает приборы. Как тихая молитва слово «пассивный» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehe",
@@ -1498,8 +1498,8 @@
                 "word": "nachgeben",
                 "translation": "уступать",
                 "transcription": "[НАХ-ге-бен]",
-                "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Zu oft gebe ich ihrem Willen nach.",
-                "sentenceTranslation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Слишком часто я уступаю её воле.",
+                "sentence": "Neben Gonerils triumphierendem Lächeln bleibt Albany reglos. Ich atme tief ein und lasse nur das Wort „nachgeben“ wieder hinaus.",
+                "sentenceTranslation": "Рядом с торжествующей улыбкой Гонерильи Олбани остаётся неподвижным. Я глубоко вдыхаю и выпускаю только слово «уступать».",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehe",
@@ -1522,8 +1522,8 @@
                 "word": "zögern",
                 "translation": "колебаться",
                 "transcription": "[ЦЁ-герн]",
-                "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Ich zögere, wenn ich handeln sollte.",
-                "sentenceTranslation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Я колеблюсь, когда должен действовать.",
+                "sentence": "Auf dem Balkon lauscht Albany stumm den Beschwerden der Diener. Das kalte Licht lässt das Wort „zögern“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На балконе Олбани безмолвно слушает жалобы слуг. Холодный свет заставляет слово «колебаться» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1546,8 +1546,8 @@
                 "word": "mild",
                 "translation": "мягкий",
                 "transcription": "[МИЛЬД]",
-                "sentence": "Im Schloss von Goneril am Hof König Lears gesteht Albany: Meine milde Art wird als Schwäche gesehen.",
-                "sentenceTranslation": "Во дворце Гонериль при дворе короля Лира признаётся Олбани: Моя мягкость воспринимается как слабость.",
+                "sentence": "Im Schatten der Säulen lässt Albany den Streit an sich vorbeiziehen. Mein Atem zeichnet das Wort „mild“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тени колонн Олбани позволяет спору пройти мимо себя. Моё дыхание рисует слово «мягкий» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehe",
@@ -1572,81 +1572,81 @@
                 "question": "Что означает немецкое слово «das Schweigen»?",
                 "choices": [
                     "молчание",
-                    "брак",
+                    "терпеть",
                     "слабость",
-                    "терпеть"
+                    "брак"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Schwäche»?",
                 "choices": [
+                    "брак",
                     "слабость",
-                    "брак",
-                    "молчание",
-                    "терпеть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Ehe»?",
-                "choices": [
-                    "молчание",
-                    "брак",
-                    "уступать",
-                    "слабость"
+                    "терпеть",
+                    "молчание"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «dulden»?",
+                "question": "Что означает немецкое слово «die Ehe»?",
                 "choices": [
+                    "брак",
+                    "колебаться",
                     "слабость",
-                    "мягкий",
-                    "молчание",
                     "терпеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «dulden»?",
+                "choices": [
+                    "терпеть",
+                    "молчание",
+                    "колебаться",
+                    "брак"
+                ],
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «passiv»?",
                 "choices": [
+                    "мягкий",
                     "пассивный",
-                    "слабость",
-                    "колебаться",
-                    "мягкий"
+                    "терпеть",
+                    "брак"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «nachgeben»?",
                 "choices": [
                     "уступать",
-                    "мягкий",
-                    "колебаться",
-                    "молчание"
+                    "брак",
+                    "слабость",
+                    "мягкий"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «zögern»?",
                 "choices": [
-                    "мягкий",
+                    "терпеть",
                     "колебаться",
                     "слабость",
-                    "пассивный"
+                    "брак"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «mild»?",
                 "choices": [
-                    "молчание",
                     "мягкий",
-                    "терпеть",
-                    "слабость"
+                    "молчание",
+                    "уступать",
+                    "колебаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -1659,8 +1659,8 @@
                 "word": "der Zweifel",
                 "translation": "сомнение",
                 "transcription": "[дер ЦВАЙ-фель]",
-                "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Der Zweifel an ihrer Güte wächst in mir.",
-                "sentenceTranslation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Сомнение в её доброте растёт во мне.",
+                "sentence": "In der nächtlichen Galerie betrachtet Albany das verblassende Familienwappen. Wie ein stilles Gebet legt sich das Wort „der Zweifel“ auf meine Lippen.",
+                "sentenceTranslation": "В ночной галерее Олбани рассматривает тускнеющий семейный герб. Как тихая молитва слово «сомнение» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gewissen",
@@ -1683,8 +1683,8 @@
                 "word": "das Gewissen",
                 "translation": "совесть",
                 "transcription": "[дас ге-ВИ-сен]",
-                "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Mein Gewissen beginnt mich zu quälen.",
-                "sentenceTranslation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Моя совесть начинает мучить меня.",
+                "sentence": "Vor dem Spiegel entdeckt Albany zum ersten Mal den Schatten des Zweifels. Mit fester Stimme schwöre ich mir: Das Wort „das Gewissen“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед зеркалом Олбани впервые замечает тень сомнения. Твёрдым голосом я клянусь себе: слово «совесть» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1706,8 +1706,8 @@
                 "word": "das Unbehagen",
                 "translation": "беспокойство",
                 "transcription": "[дас УН-бе-ха-ген]",
-                "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Ein tiefes Unbehagen erfüllt meine Seele.",
-                "sentenceTranslation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Глубокое беспокойство наполняет мою душу.",
+                "sentence": "Neben gestapelten Tributschriften blättert Albany nervös. Das Echo des Wortes „das Unbehagen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Рядом с кипами податных свитков Олбани нервно перелистывает страницы. Эхо слова «беспокойство» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gewissen",
@@ -1730,8 +1730,8 @@
                 "word": "hinterfragen",
                 "translation": "подвергать сомнению",
                 "transcription": "[ХИН-тер-фра-ген]",
-                "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Ich beginne ihre Taten zu hinterfragen.",
-                "sentenceTranslation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Я начинаю подвергать сомнению её поступки.",
+                "sentence": "Am dunklen Hof beobachtet Albany heimlich die Grausamkeit der Wachen. Mit fester Stimme schwöre ich mir: Das Wort „hinterfragen“ wird heute nicht verraten.",
+                "sentenceTranslation": "Во тёмном дворе Олбани украдкой наблюдает жестокость стражи. Твёрдым голосом я клянусь себе: слово «подвергать сомнению» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gewissen",
@@ -1755,8 +1755,8 @@
                 "word": "beunruhigen",
                 "translation": "тревожить",
                 "transcription": "[бе-УН-ру-и-ген]",
-                "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Ihre Grausamkeit beunruhigt mich zunehmend.",
-                "sentenceTranslation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Её жестокость всё больше тревожит меня.",
+                "sentence": "Zwischen verlassenen Banketttischen greift Albany nach einem halb vollen Kelch. Das kalte Licht lässt das Wort „beunruhigen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Среди пустых банкетных столов Олбани тянется к наполовину полному кубку. Холодный свет заставляет слово «тревожить» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gewissen",
@@ -1779,8 +1779,8 @@
                 "word": "unsicher",
                 "translation": "неуверенный",
                 "transcription": "[УН-зи-хер]",
-                "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Ich werde unsicher in meinem Schweigen.",
-                "sentenceTranslation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Я становлюсь неуверенным в своём молчании.",
+                "sentence": "Auf dem Flur belauscht Albany ein Gespräch über Lear. Mit fester Stimme schwöre ich mir: Das Wort „unsicher“ wird heute nicht verraten.",
+                "sentenceTranslation": "В коридоре Олбани подслушивает разговор о Лире. Твёрдым голосом я клянусь себе: слово «неуверенный» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gewissen",
@@ -1803,8 +1803,8 @@
                 "word": "grübeln",
                 "translation": "размышлять",
                 "transcription": "[ГРЮ-бельн]",
-                "sentence": "Nach Cordelias Verbannung flüstert Albany in den stillen Fluren seines Schlosses: Nachts grüble ich über richtig und falsch.",
-                "sentenceTranslation": "После изгнания Корделии Олбани шепчет в тихих коридорах своего замка: Ночами я размышляю о правильном и неправильном.",
+                "sentence": "Im Schlafgemach rollt Albany die Karten des Reiches unruhig zusammen. Das Echo des Wortes „grübeln“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В опочивальне Олбани беспокойно скручивает карты королевства. Эхо слова «размышлять» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gewissen",
@@ -1830,18 +1830,18 @@
             {
                 "question": "Что означает немецкое слово «der Zweifel»?",
                 "choices": [
-                    "сомнение",
+                    "подвергать сомнению",
                     "беспокойство",
-                    "совесть",
-                    "подвергать сомнению"
+                    "сомнение",
+                    "совесть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Gewissen»?",
                 "choices": [
-                    "сомнение",
                     "подвергать сомнению",
+                    "сомнение",
                     "беспокойство",
                     "совесть"
                 ],
@@ -1850,48 +1850,48 @@
             {
                 "question": "Что означает немецкое слово «das Unbehagen»?",
                 "choices": [
-                    "размышлять",
-                    "сомнение",
+                    "тревожить",
                     "неуверенный",
-                    "беспокойство"
+                    "беспокойство",
+                    "сомнение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «hinterfragen»?",
                 "choices": [
                     "подвергать сомнению",
-                    "тревожить",
                     "беспокойство",
-                    "неуверенный"
+                    "неуверенный",
+                    "совесть"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beunruhigen»?",
                 "choices": [
-                    "сомнение",
                     "тревожить",
-                    "беспокойство",
+                    "подвергать сомнению",
+                    "сомнение",
                     "неуверенный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «unsicher»?",
                 "choices": [
-                    "совесть",
-                    "беспокойство",
-                    "неуверенный",
-                    "сомнение"
+                    "сомнение",
+                    "размышлять",
+                    "тревожить",
+                    "неуверенный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «grübeln»?",
                 "choices": [
+                    "тревожить",
                     "совесть",
-                    "неуверенный",
                     "размышлять",
                     "сомнение"
                 ],
@@ -1908,8 +1908,8 @@
                 "word": "die Erkenntnis",
                 "translation": "осознание",
                 "transcription": "[ди ер-КЕНТ-нис]",
-                "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Die Erkenntnis ihrer Bosheit erschüttert mich.",
-                "sentenceTranslation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Осознание её злобы потрясает меня.",
+                "sentence": "Vor einem zerschlagenen Spiegel erkennt Albany die eigene Ohnmacht. Mein Atem zeichnet das Wort „die Erkenntnis“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед разбитым зеркалом Олбани понимает собственное бессилие. Моё дыхание рисует слово «осознание» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1934,8 +1934,8 @@
                 "word": "das Entsetzen",
                 "translation": "ужас",
                 "transcription": "[дас энт-ЗЕ-цен]",
-                "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Mit Entsetzen sehe ich ihr wahres Gesicht.",
-                "sentenceTranslation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: С ужасом я вижу её истинное лицо.",
+                "sentence": "Auf dem staubigen Kampfplatz zieht Albany zum ersten Mal das Schwert. Ich zeichne das Wort „das Entsetzen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На пыльном плацу Олбани впервые обнажает меч. Я черчу слово «ужас» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Entsetzen",
@@ -1959,8 +1959,8 @@
                 "word": "erwachen",
                 "translation": "пробуждаться",
                 "transcription": "[ер-ВА-хен]",
-                "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Endlich erwache ich aus meiner Blindheit.",
-                "sentenceTranslation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Наконец я пробуждаюсь от своей слепоты.",
+                "sentence": "Zwischen aufgebrachten Dienern erhebt Albany die Stimme gegen Goneril. Ich presse das Wort „erwachen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди взбунтовавшихся слуг Олбани поднимает голос против Гонерильи. Я стискиваю слово «пробуждаться» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1984,8 +1984,8 @@
                 "word": "begreifen",
                 "translation": "понимать",
                 "transcription": "[бе-ГРАЙ-фен]",
-                "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Ich begreife das Ausmaß ihrer Grausamkeit.",
-                "sentenceTranslation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Я понимаю масштаб её жестокости.",
+                "sentence": "Am Fenster beobachtet Albany Lear, der in den Sturm getrieben wird. Ich halte das Wort „begreifen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У окна Олбани видит, как Лира гонят в бурю. Я держу слово «понимать» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2008,8 +2008,8 @@
                 "word": "erschrecken",
                 "translation": "пугаться",
                 "transcription": "[ер-ШРЕК-кен]",
-                "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Ihre Taten erschrecken mein gutes Herz.",
-                "sentenceTranslation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Её поступки пугают моё доброе сердце.",
+                "sentence": "Auf dem Hof stoppt Albany eine grausame Strafe mit ausgestreckter Hand. Das kalte Licht lässt das Wort „erschrecken“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На дворе Олбани протянутой рукой останавливает жестокую казнь. Холодный свет заставляет слово «пугаться» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2032,8 +2032,8 @@
                 "word": "aufwachen",
                 "translation": "просыпаться",
                 "transcription": "[АУФ-ва-хен]",
-                "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Ich wache auf aus meinem langen Schlaf.",
-                "sentenceTranslation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Я просыпаюсь от долгого сна.",
+                "sentence": "Im Kriegssaal zerreißt Albany einen falschen Befehl. Mit jeder Faser meines Körpers verspreche ich: Das Wort „aufwachen“ bleibt lebendig.",
+                "sentenceTranslation": "В военном зале Олбани разрывает ложный приказ. Каждой клеткой тела я обещаю: слово «просыпаться» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Entsetzen",
@@ -2057,8 +2057,8 @@
                 "word": "klar sehen",
                 "translation": "ясно видеть",
                 "transcription": "[КЛАР ЗЕ-ен]",
-                "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Zum ersten Mal sehe ich klar.",
-                "sentenceTranslation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Впервые я вижу ясно.",
+                "sentence": "Neben Kent tauscht Albany einen verständnisvollen Blick. Mit fester Stimme schwöre ich mir: Das Wort „klar sehen“ wird heute nicht verraten.",
+                "sentenceTranslation": "Рядом с Кентом Олбани обменивается понимающим взглядом. Твёрдым голосом я клянусь себе: слово «ясно видеть» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Entsetzen",
@@ -2083,8 +2083,8 @@
                 "word": "die Verwandlung",
                 "translation": "превращение",
                 "transcription": "[ди фер-ВАНД-лунг]",
-                "sentence": "Als Gonerils Grausamkeit vor König Lear offenbart wird, erwacht Albany: Eine Verwandlung beginnt in meiner Seele.",
-                "sentenceTranslation": "Когда жестокость Гонериль раскрывается перед королём Лиром, Олбани пробуждается: Превращение начинается в моей душе.",
+                "sentence": "An der Grenze des Herzogtums schwört Albany dem Unrecht ab. Ich zeichne das Wort „die Verwandlung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На границе герцогства Олбани отрекается от несправедливости. Я вывожу слово «превращение» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2107,29 +2107,29 @@
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "осознание",
+                    "пробуждаться",
                     "понимать",
                     "ужас",
-                    "пробуждаться"
+                    "осознание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Entsetzen»?",
                 "choices": [
                     "ужас",
-                    "осознание",
                     "пробуждаться",
-                    "понимать"
+                    "понимать",
+                    "осознание"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erwachen»?",
                 "choices": [
-                    "понимать",
-                    "превращение",
-                    "пугаться",
+                    "просыпаться",
+                    "осознание",
+                    "ясно видеть",
                     "пробуждаться"
                 ],
                 "correctIndex": 3
@@ -2137,49 +2137,49 @@
             {
                 "question": "Что означает немецкое слово «begreifen»?",
                 "choices": [
-                    "просыпаться",
-                    "превращение",
-                    "пробуждаться",
-                    "понимать"
+                    "ясно видеть",
+                    "осознание",
+                    "понимать",
+                    "пробуждаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erschrecken»?",
                 "choices": [
+                    "пробуждаться",
                     "пугаться",
-                    "просыпаться",
-                    "понимать",
+                    "превращение",
                     "осознание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufwachen»?",
                 "choices": [
                     "пробуждаться",
-                    "ясно видеть",
-                    "осознание",
-                    "просыпаться"
+                    "просыпаться",
+                    "ужас",
+                    "пугаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «klar sehen»?",
                 "choices": [
-                    "понимать",
+                    "осознание",
+                    "пугаться",
                     "просыпаться",
-                    "ясно видеть",
-                    "превращение"
+                    "ясно видеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Verwandlung»?",
                 "choices": [
-                    "пробуждаться",
                     "ясно видеть",
-                    "осознание",
+                    "пугаться",
+                    "ужас",
                     "превращение"
                 ],
                 "correctIndex": 3
@@ -2195,8 +2195,8 @@
                 "word": "der Streit",
                 "translation": "спор",
                 "transcription": "[дер ШТРАЙТ]",
-                "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Der Streit mit meiner Frau eskaliert.",
-                "sentenceTranslation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Спор с моей женой обостряется.",
+                "sentence": "Im Kriegslager stellt sich Albany Goneril mitten zwischen die Zelte. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Streit“ gehört mir.",
+                "sentenceTranslation": "В военном лагере Олбани становится перед Гонерильей среди шатров. Буря за окнами усиливает клятву: слово «спор» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mut",
@@ -2219,8 +2219,8 @@
                 "word": "der Mut",
                 "translation": "мужество",
                 "transcription": "[дер МУТ]",
-                "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Endlich finde ich den Mut zu widersprechen.",
-                "sentenceTranslation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Наконец я нахожу мужество возражать.",
+                "sentence": "Vor den versammelten Offizieren wirft Albany den Handschuh auf den Tisch. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Mut“ darf nicht vergehen.",
+                "sentenceTranslation": "Перед собравшимися офицерами Олбани бросает перчатку на стол. Я шепчу стражам судьбы: слово «мужество» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2243,8 +2243,8 @@
                 "word": "der Widerstand",
                 "translation": "сопротивление",
                 "transcription": "[дер ВИ-дер-штанд]",
-                "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Mein Widerstand gegen das Böse beginnt.",
-                "sentenceTranslation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Моё сопротивление злу начинается.",
+                "sentence": "Am Wagen voller Waffen blockiert Albany den Weg der Flüchtenden. Mein Atem zeichnet das Wort „der Widerstand“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У повозки с оружием Олбани преграждает путь беглянке. Моё дыхание рисует слово «сопротивление» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mut",
@@ -2267,8 +2267,8 @@
                 "word": "konfrontieren",
                 "translation": "противостоять",
                 "transcription": "[кон-фрон-ТИ-рен]",
-                "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Ich konfrontiere sie mit ihrer Grausamkeit.",
-                "sentenceTranslation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Я противостою ей с её жестокостью.",
+                "sentence": "Zwischen wehenden Bannern nennt Albany laut den Verrat. Ich zeichne das Wort „konfrontieren“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под развевающимися знамёнами Олбани громко называет предательство. Я черчу слово «противостоять» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mut",
@@ -2291,8 +2291,8 @@
                 "word": "anklagen",
                 "translation": "обвинять",
                 "transcription": "[АН-кла-ген]",
-                "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Ich klage sie ihrer Unmenschlichkeit an.",
-                "sentenceTranslation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Я обвиняю её в бесчеловечности.",
+                "sentence": "Auf dem Felsen bei Dover fordert Albany Edmund heraus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „anklagen“ bleibt lebendig.",
+                "sentenceTranslation": "На скале у Дувра Олбани вызывает Эдмунда. Каждой клеткой тела я обещаю: слово «обвинять» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mut",
@@ -2317,8 +2317,8 @@
                 "word": "sich wehren",
                 "translation": "защищаться",
                 "transcription": "[зих ВЕ-рен]",
-                "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Ich wehre mich gegen ihre Tyrannei.",
-                "sentenceTranslation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Я защищаюсь от её тирании.",
+                "sentence": "Vor der Armee verliest Albany Gonerils geheime Briefe. Mein Atem zeichnet das Wort „sich wehren“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед войском Олбани зачитывает тайные письма Гонерильи. Моё дыхание рисует слово «защищаться» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mut",
@@ -2342,8 +2342,8 @@
                 "word": "aufbegehren",
                 "translation": "восставать",
                 "transcription": "[АУФ-бе-ге-рен]",
-                "sentence": "Im Saal, in dem Lear gedemütigt wurde, stellt Albany seine Frau: Ich begehre auf gegen das Unrecht.",
-                "sentenceTranslation": "В зале, где унижали Лира, Олбани бросает вызов своей жене: Я восстаю против несправедливости.",
+                "sentence": "Im hellen Tageslicht zeigt Albany auf die Verräter, ohne zu zittern. Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufbegehren“ darf nicht vergehen.",
+                "sentenceTranslation": "При ярком дневном свете Олбани указывает на предателей без дрожи. Я шепчу стражам судьбы: слово «восставать» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mut",
@@ -2367,19 +2367,19 @@
             {
                 "question": "Что означает немецкое слово «der Streit»?",
                 "choices": [
-                    "противостоять",
-                    "спор",
+                    "мужество",
                     "сопротивление",
-                    "мужество"
+                    "спор",
+                    "противостоять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
                     "мужество",
-                    "сопротивление",
                     "противостоять",
+                    "сопротивление",
                     "спор"
                 ],
                 "correctIndex": 0
@@ -2387,38 +2387,38 @@
             {
                 "question": "Что означает немецкое слово «der Widerstand»?",
                 "choices": [
-                    "мужество",
                     "спор",
-                    "сопротивление",
-                    "защищаться"
+                    "защищаться",
+                    "противостоять",
+                    "сопротивление"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «konfrontieren»?",
                 "choices": [
-                    "обвинять",
-                    "противостоять",
-                    "защищаться",
-                    "восставать"
+                    "мужество",
+                    "спор",
+                    "восставать",
+                    "противостоять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «anklagen»?",
                 "choices": [
-                    "защищаться",
-                    "обвинять",
+                    "противостоять",
+                    "мужество",
                     "спор",
-                    "противостоять"
+                    "обвинять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sich wehren»?",
                 "choices": [
-                    "обвинять",
-                    "восставать",
+                    "мужество",
+                    "противостоять",
                     "защищаться",
                     "спор"
                 ],
@@ -2427,12 +2427,12 @@
             {
                 "question": "Что означает немецкое слово «aufbegehren»?",
                 "choices": [
-                    "защищаться",
                     "обвинять",
                     "восставать",
-                    "мужество"
+                    "мужество",
+                    "спор"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2445,8 +2445,8 @@
                 "word": "die Moral",
                 "translation": "мораль",
                 "transcription": "[ди мо-РАЛЬ]",
-                "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Die Moral leitet nun meine Entscheidungen.",
-                "sentenceTranslation": "Перед потрясёнными придворными Лира Олбани заявляет: Мораль теперь руководит моими решениями.",
+                "sentence": "Im Feldzelt der Verbündeten zeichnet Albany eine Linie in den Sand. Mein Atem zeichnet das Wort „die Moral“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В шатре союзников Олбани проводит линию на песке. Моё дыхание рисует слово «мораль» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Entscheidung",
@@ -2469,8 +2469,8 @@
                 "word": "die Gerechtigkeit",
                 "translation": "справедливость",
                 "transcription": "[ди ге-РЕХ-тиг-кайт]",
-                "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Für Gerechtigkeit will ich kämpfen.",
-                "sentenceTranslation": "Перед потрясёнными придворными Лира Олбани заявляет: За справедливость я хочу бороться.",
+                "sentence": "Zwischen verletzten Soldaten spricht Albany von Gnade. Mein Atem zeichnet das Wort „die Gerechtigkeit“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Среди раненых солдат Олбани говорит о милосердии. Моё дыхание рисует слово «справедливость» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2494,8 +2494,8 @@
                 "word": "die Entscheidung",
                 "translation": "решение",
                 "transcription": "[ди энт-ШАЙ-дунг]",
-                "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Meine Entscheidung steht fest: ich wähle das Gute.",
-                "sentenceTranslation": "Перед потрясёнными придворными Лира Олбани заявляет: Моё решение твёрдо: я выбираю добро.",
+                "sentence": "Am Schlachtplan stellt Albany die Figuren der Gerechten nach vorn. Ich zeichne das Wort „die Entscheidung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Над картой сражения Олбани выдвигает вперёд фигуры праведников. Я вывожу слово «решение» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2517,8 +2517,8 @@
                 "word": "wählen",
                 "translation": "выбирать",
                 "transcription": "[ВЕ-лен]",
-                "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Ich wähle den schweren Weg der Tugend.",
-                "sentenceTranslation": "Перед потрясёнными придворными Лира Олбани заявляет: Я выбираю трудный путь добродетели.",
+                "sentence": "Im Rat der Feldherren widerspricht Albany einer grausamen Idee. Ich atme tief ein und lasse nur das Wort „wählen“ wieder hinaus.",
+                "sentenceTranslation": "На совете полководцев Олбани возражает жестокой задумке. Я глубоко вдыхаю и выпускаю только слово «выбирать».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2540,8 +2540,8 @@
                 "word": "rechtschaffen",
                 "translation": "праведный",
                 "transcription": "[РЕХТ-ша-фен]",
-                "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Ich will rechtschaffen leben und handeln.",
-                "sentenceTranslation": "Перед потрясёнными придворными Лира Олбани заявляет: Я хочу жить и действовать праведно.",
+                "sentence": "Vor dem Banner der Wahrheit hebt Albany die Stimme zu einem Eid. Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Перед знаменем правды Олбани поднимает голос для клятвы. Я стискиваю слово «праведный» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Adel",
@@ -2568,8 +2568,8 @@
                 "word": "das Prinzip",
                 "translation": "принцип",
                 "transcription": "[дас прин-ЦИП]",
-                "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Meine Prinzipien sind wichtiger als meine Ehe.",
-                "sentenceTranslation": "Перед потрясёнными придворными Лира Олбани заявляет: Мои принципы важнее моего брака.",
+                "sentence": "Auf dem Hügel über dem Schlachtfeld hält Albany ein feierliches Gebet. Wie ein stilles Gebet legt sich das Wort „das Prinzip“ auf meine Lippen.",
+                "sentenceTranslation": "На холме над полем битвы Олбани произносит торжественную молитву. Как тихая молитва слово «принцип» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Entscheidung",
@@ -2592,8 +2592,8 @@
                 "word": "edel",
                 "translation": "благородный",
                 "transcription": "[Э-дель]",
-                "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Ich strebe nach edlen Taten.",
-                "sentenceTranslation": "Перед потрясёнными придворными Лира Олбани заявляет: Я стремлюсь к благородным поступкам.",
+                "sentence": "In der Morgensonne wäscht Albany das Blut vom Schwert und schwört Frieden. Selbst wenn die Welt zerfällt, bleibt das Wort „edel“ mein Nordstern.",
+                "sentenceTranslation": "В утреннем солнце Олбани смывает кровь с меча и клянётся миром. Даже если мир распадается, слово «благородный» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Entscheidung",
@@ -2616,8 +2616,8 @@
                 "word": "die Tugend",
                 "translation": "добродетель",
                 "transcription": "[ди ТУ-генд]",
-                "sentence": "Vor den erschütterten Höflingen Lears verkündet Albany: Die Tugend wird mein Leitstern sein.",
-                "sentenceTranslation": "Перед потрясёнными придворными Лира Олбани заявляет: Добродетель будет моей путеводной звездой.",
+                "sentence": "Bei den Feldärzten verspricht Albany Schutz den Verwundeten. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Tugend“ darf nicht vergehen.",
+                "sentenceTranslation": "У полевых лекарей Олбани обещает защиту раненым. Я шепчу стражам судьбы: слово «добродетель» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Entscheidung",
@@ -2642,49 +2642,49 @@
                 "question": "Что означает немецкое слово «die Moral»?",
                 "choices": [
                     "выбирать",
-                    "справедливость",
                     "мораль",
-                    "решение"
+                    "решение",
+                    "справедливость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
                     "выбирать",
                     "справедливость",
-                    "мораль",
-                    "решение"
+                    "решение",
+                    "мораль"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Entscheidung»?",
                 "choices": [
-                    "благородный",
                     "решение",
-                    "принцип",
-                    "справедливость"
+                    "мораль",
+                    "справедливость",
+                    "принцип"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «wählen»?",
                 "choices": [
-                    "принцип",
                     "выбирать",
-                    "решение",
-                    "справедливость"
+                    "мораль",
+                    "добродетель",
+                    "решение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
-                    "благородный",
-                    "справедливость",
+                    "решение",
+                    "добродетель",
                     "праведный",
-                    "выбирать"
+                    "благородный"
                 ],
                 "correctIndex": 2
             },
@@ -2692,31 +2692,31 @@
                 "question": "Что означает немецкое слово «das Prinzip»?",
                 "choices": [
                     "принцип",
-                    "добродетель",
-                    "благородный",
-                    "мораль"
+                    "мораль",
+                    "решение",
+                    "справедливость"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «edel»?",
                 "choices": [
-                    "выбирать",
+                    "мораль",
+                    "принцип",
                     "благородный",
-                    "справедливость",
-                    "мораль"
+                    "праведный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Tugend»?",
                 "choices": [
-                    "решение",
-                    "благородный",
-                    "добродетель",
-                    "праведный"
+                    "принцип",
+                    "праведный",
+                    "справедливость",
+                    "добродетель"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2729,8 +2729,8 @@
                 "word": "der Kampf",
                 "translation": "борьба",
                 "transcription": "[дер КАМПФ]",
-                "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Der Kampf für das Recht beginnt jetzt.",
-                "sentenceTranslation": "При опустевшем дворе Лира Олбани собирает верных: Борьба за право начинается сейчас.",
+                "sentence": "Auf dem Tribunal errichtet Albany einen einfachen Holzstuhl als Richterstuhl. Ich zeichne das Wort „der Kampf“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На трибунале Олбани ставит простой деревянный стул как судейский. Я вывожу слово «борьба» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2755,8 +2755,8 @@
                 "word": "das Recht",
                 "translation": "право",
                 "transcription": "[дас РЕХТ]",
-                "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Das Recht muss über das Unrecht siegen.",
-                "sentenceTranslation": "При опустевшем дворе Лира Олбани собирает верных: Право должно победить неправду.",
+                "sentence": "Vor den überlebenden Soldaten verliest Albany die Namen der Schuldigen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Recht“ gehört mir.",
+                "sentenceTranslation": "Перед уцелевшими солдатами Олбани читает имена виновных. Буря за окнами усиливает клятву: слово «право» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2778,8 +2778,8 @@
                 "word": "die Güte",
                 "translation": "доброта",
                 "transcription": "[ди ГЮ-те]",
-                "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Mit Güte will ich das Böse besiegen.",
-                "sentenceTranslation": "При опустевшем дворе Лира Олбани собирает верных: Добротой я хочу победить зло.",
+                "sentence": "In der Kapelle legt Albany die Hand auf die Bibel, bevor er urteilt. Das Echo des Wortes „die Güte“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В капелле Олбани кладёт руку на Библию, прежде чем судить. Эхо слова «доброта» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Güte",
@@ -2802,8 +2802,8 @@
                 "word": "strafen",
                 "translation": "наказывать",
                 "transcription": "[ШТРА-фен]",
-                "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Die Schuldigen müssen bestraft werden.",
-                "sentenceTranslation": "При опустевшем дворе Лира Олбани собирает верных: Виновные должны быть наказаны.",
+                "sentence": "Am Tor von Dover begrüßt Albany die Rückkehrer mit offenen Armen. Ich zeichne das Wort „strafen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У ворот Дувра Олбани встречает возвращающихся с распахнутыми руками. Я черчу слово «наказывать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2827,8 +2827,8 @@
                 "word": "richten",
                 "translation": "судить",
                 "transcription": "[РИХ-тен]",
-                "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Gerecht will ich über die Verbrecher richten.",
-                "sentenceTranslation": "При опустевшем дворе Лира Олбани собирает верных: Справедливо я хочу судить преступников.",
+                "sentence": "Auf dem Feldlager sammelt Albany Zeugnisse der Überlebenden. Ich zeichne das Wort „richten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В походном лагере Олбани собирает свидетельства выживших. Я вывожу слово «судить» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2851,8 +2851,8 @@
                 "word": "beschützen",
                 "translation": "защищать",
                 "transcription": "[бе-ШЮ-цен]",
-                "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Die Unschuldigen will ich beschützen.",
-                "sentenceTranslation": "При опустевшем дворе Лира Олбани собирает верных: Невинных я хочу защитить.",
+                "sentence": "Zwischen verstummten Trommeln verliest Albany den Befehl zur Gerechtigkeit. Ich zeichne das Wort „beschützen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Среди смолкших барабанов Олбани зачитывает приказ о справедливости. Я черчу слово «защищать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2878,8 +2878,8 @@
                 "word": "eingreifen",
                 "translation": "вмешиваться",
                 "transcription": "[АЙН-грай-фен]",
-                "sentence": "An Lears verwaistem Hof sammelt Albany die Getreuen: Ich greife ein, um das Schlimmste zu verhindern.",
-                "sentenceTranslation": "При опустевшем дворе Лира Олбани собирает верных: Я вмешиваюсь, чтобы предотвратить худшее.",
+                "sentence": "Im Schatten des zerstörten Schlosses schwört Albany das Reich zu erneuern. Ich zeichne das Wort „eingreifen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В тени разрушенного замка Олбани клянётся обновить королевство. Я черчу слово «вмешиваться» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Güte",
@@ -2903,72 +2903,72 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "борьба",
                     "право",
-                    "доброта",
-                    "наказывать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «das Recht»?",
-                "choices": [
                     "борьба",
-                    "доброта",
                     "наказывать",
-                    "право"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Güte»?",
-                "choices": [
-                    "защищать",
-                    "доброта",
-                    "судить",
-                    "наказывать"
+                    "доброта"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «strafen»?",
+                "question": "Что означает немецкое слово «das Recht»?",
                 "choices": [
-                    "наказывать",
+                    "доброта",
                     "борьба",
+                    "право",
+                    "наказывать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Güte»?",
+                "choices": [
+                    "доброта",
+                    "защищать",
                     "судить",
-                    "право"
+                    "наказывать"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «strafen»?",
+                "choices": [
+                    "вмешиваться",
+                    "наказывать",
+                    "борьба",
+                    "судить"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «richten»?",
                 "choices": [
                     "защищать",
+                    "наказывать",
                     "судить",
-                    "доброта",
-                    "вмешиваться"
+                    "доброта"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
-                    "вмешиваться",
-                    "судить",
-                    "доброта",
-                    "защищать"
+                    "наказывать",
+                    "право",
+                    "защищать",
+                    "борьба"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «eingreifen»?",
                 "choices": [
-                    "защищать",
-                    "право",
+                    "вмешиваться",
                     "доброта",
-                    "вмешиваться"
+                    "наказывать",
+                    "право"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2981,8 +2981,8 @@
                 "word": "die Herrschaft",
                 "translation": "правление",
                 "transcription": "[ди ХЕР-шафт]",
-                "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Die Herrschaft fällt nun in meine Hände.",
-                "sentenceTranslation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Правление теперь переходит в мои руки.",
+                "sentence": "Im Saal voller Verwundeter verteilt Albany sanfte Worte und Befehle zugleich. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Herrschaft“ darf nicht vergehen.",
+                "sentenceTranslation": "В зале, полном раненых, Олбани раздаёт мягкие слова и приказы одновременно. Я шепчу стражам судьбы: слово «правление» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Herrschaft",
@@ -3010,8 +3010,8 @@
                 "word": "die Weisheit",
                 "translation": "мудрость",
                 "transcription": "[ди ВАЙС-хайт]",
-                "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Mit Weisheit will ich das Land führen.",
-                "sentenceTranslation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: С мудростью я хочу вести страну.",
+                "sentence": "Auf dem behelfsmäßigen Thron richtet Albany das Reich wieder auf. Das Echo des Wortes „die Weisheit“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На временном троне Олбани вновь поднимает королевство. Эхо слова «мудрость» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Erbe",
@@ -3044,8 +3044,8 @@
                 "word": "der Neuanfang",
                 "translation": "новое начало",
                 "transcription": "[дер НОЙ-ан-фанг]",
-                "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Ein Neuanfang für das Königreich beginnt.",
-                "sentenceTranslation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Новое начало для королевства начинается.",
+                "sentence": "Zwischen vertrockneten Kränzen trägt Albany die neue Krone ohne Triumph. Ich umarme das Wort „der Neuanfang“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Среди засохших венков Олбани носит новую корону без торжества. Я обнимаю слово «новое начало», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Herrschaft",
@@ -3069,8 +3069,8 @@
                 "word": "lenken",
                 "translation": "направлять",
                 "transcription": "[ЛЕН-кен]",
-                "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Ich lenke das Land in eine bessere Zukunft.",
-                "sentenceTranslation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Я направляю страну в лучшее будущее.",
+                "sentence": "Vor dem Volk verspricht Albany Heilung für das verwundete Land. Das Echo des Wortes „lenken“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Перед народом Олбани обещает исцеление раненой земле. Эхо слова «направлять» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Herrschaft",
@@ -3093,8 +3093,8 @@
                 "word": "aufbauen",
                 "translation": "строить",
                 "transcription": "[АУФ-бау-ен]",
-                "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Ich baue auf, was zerstört wurde.",
-                "sentenceTranslation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Я строю то, что было разрушено.",
+                "sentence": "Auf den Stufen des Tempels hebt Albany die Gefallenen in Ehren hervor. Ich halte das Wort „aufbauen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На ступенях храма Олбани чтит павших. Я держу слово «строить» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Herrschaft",
@@ -3117,8 +3117,8 @@
                 "word": "erneuern",
                 "translation": "обновлять",
                 "transcription": "[ер-НОЙ-ерн]",
-                "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Das Reich will ich erneuern und heilen.",
-                "sentenceTranslation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Королевство я хочу обновить и исцелить.",
+                "sentence": "Unter wehenden Flaggen lässt Albany die Glocken der Hoffnung schlagen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erneuern“ gehört mir.",
+                "sentenceTranslation": "Под развевающимися флагами Олбани велит бить колоколам надежды. Буря за окнами усиливает клятву: слово «обновлять» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Herrschaft",
@@ -3141,8 +3141,8 @@
                 "word": "versöhnen",
                 "translation": "примирять",
                 "transcription": "[фер-ЗЁ-нен]",
-                "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Ich will die Getrennten versöhnen.",
-                "sentenceTranslation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Я хочу примирить разделённых.",
+                "sentence": "Im Rat der Überlebenden hört Albany jedem zu, bevor er entscheidet. Selbst wenn die Welt zerfällt, bleibt das Wort „versöhnen“ mein Nordstern.",
+                "sentenceTranslation": "На совете выживших Олбани выслушивает каждого, прежде чем решать. Даже если мир распадается, слово «примирять» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3164,8 +3164,8 @@
                 "word": "der Friede",
                 "translation": "мир",
                 "transcription": "[дер ФРИ-де]",
-                "sentence": "Nach der Tragödie von Dover übernimmt Albany im Thronsaal Lears: Der Friede soll wieder ins Land kommen.",
-                "sentenceTranslation": "После трагедии в Дувре Олбани принимает власть в тронном зале Лира: Мир должен вернуться в страну.",
+                "sentence": "An der Küste von Dover lässt Albany neue Schiffe zum Schutz auslaufen. Ich zeichne das Wort „der Friede“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У берега Дувра Олбани отправляет в море новые корабли для защиты. Я черчу слово «мир» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Herrschaft",
@@ -3190,70 +3190,70 @@
             {
                 "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
+                    "новое начало",
                     "мудрость",
-                    "правление",
                     "направлять",
-                    "новое начало"
+                    "правление"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
+                    "новое начало",
                     "мудрость",
                     "направлять",
-                    "правление",
-                    "новое начало"
+                    "правление"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Neuanfang»?",
                 "choices": [
-                    "правление",
+                    "строить",
+                    "новое начало",
                     "направлять",
-                    "мир",
-                    "новое начало"
+                    "мудрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «lenken»?",
                 "choices": [
                     "направлять",
-                    "обновлять",
-                    "мудрость",
-                    "новое начало"
+                    "мир",
+                    "правление",
+                    "мудрость"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «aufbauen»?",
                 "choices": [
-                    "примирять",
-                    "новое начало",
+                    "строить",
                     "мир",
-                    "строить"
+                    "направлять",
+                    "обновлять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erneuern»?",
                 "choices": [
                     "правление",
+                    "строить",
                     "обновлять",
-                    "мир",
-                    "мудрость"
+                    "новое начало"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «versöhnen»?",
                 "choices": [
                     "примирять",
                     "мир",
-                    "правление",
-                    "строить"
+                    "обновлять",
+                    "мудрость"
                 ],
                 "correctIndex": 0
             },
@@ -3262,7 +3262,7 @@
                 "choices": [
                     "мир",
                     "новое начало",
-                    "мудрость",
+                    "примирять",
                     "направлять"
                 ],
                 "correctIndex": 0
@@ -3796,27 +3796,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/cordelia.html
+++ b/output/journeys/cordelia.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["церемония", "власть", "провозглашать", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["правда", "церемония", "провозглашать", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["провозглашать", "церемония", "долг", "верность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "повиноваться", "торжественный", "церемония"], "correct_index": 0}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["церемония", "верность", "провозглашать", "повиноваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["долг", "правда", "провозглашать", "торжественный"], "correct_index": 0}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["верность", "провозглашать", "торжественный", "церемония"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["долг", "повиноваться", "верность", "церемония"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["гнев", "наказание", "покидать", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["наказание", "покидать", "изгонять", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["приданое", "покидать", "гнев", "надежда"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["принимать", "покидать", "наказание", "приданое"], "correct_index": 2}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["изгонять", "чужой", "приданое", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["приданое", "покидать", "принимать", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["чужой", "наказание", "приданое", "принимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["надежда", "изгонять", "принимать", "покидать"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["известие", "страх", "забота", "одиночество"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["известие", "одиночество", "страх", "забота"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["страх", "тоска", "защищать", "известие"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["тоска", "страх", "защищать", "молиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "забота", "одиночество", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["одиночество", "защищать", "забота", "известие"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["тоска", "страдать", "одиночество", "забота"], "correct_index": 0}, {"question": "Что означает немецкое слово «beten»?", "choices": ["тоска", "забота", "молиться", "страдать"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["борьба", "битва", "возвращаться", "спасать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["спасать", "возвращаться", "битва", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["храбрый", "борьба", "побеждать", "спасать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["армия", "битва", "справедливость", "спасать"], "correct_index": 1}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["битва", "храбрый", "спасать", "возвращаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["спасать", "храбрый", "справедливость", "армия"], "correct_index": 2}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["побеждать", "армия", "храбрый", "возвращаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["побеждать", "армия", "храбрый", "битва"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["узнавать", "обнимать", "прощать", "слёзы"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["узнавать", "слёзы", "прощать", "обнимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["узнавать", "прощать", "обнимать", "прощение"], "correct_index": 2}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "слёзы", "раскаяние", "нежный"], "correct_index": 0}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["прощение", "исцелять", "раскаяние", "нежный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["нежный", "слёзы", "раскаяние", "прощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["прощение", "слёзы", "прощать", "нежный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["прощение", "раскаяние", "прощать", "узнавать"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["пленный", "утешать", "достоинство", "тюрьма"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["утешать", "тюрьма", "пленный", "достоинство"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["судьба", "достоинство", "тюрьма", "отважный"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["тюрьма", "утешать", "пленный", "достоинство"], "correct_index": 1}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["отважный", "утешать", "судьба", "пленный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["достоинство", "судьба", "смирение", "отважный"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["достоинство", "смирение", "честь", "судьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["судьба", "достоинство", "честь", "тюрьма"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "жертва", "душа", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "смерть", "душа", "жертва"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["прощание", "спасение", "вечный", "жертва"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["смерть", "конец", "душа", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["жертва", "душа", "конец", "спасение"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "конец", "спасение", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "жертва", "умирать", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["вечный", "спасение", "смерть", "конец"], "correct_index": 1}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["церемония", "провозглашать", "власть", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["власть", "правда", "церемония", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["верность", "торжественный", "церемония", "провозглашать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["провозглашать", "власть", "церемония", "правда"], "correct_index": 1}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["повиноваться", "долг", "провозглашать", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["торжественный", "провозглашать", "церемония", "долг"], "correct_index": 3}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["долг", "правда", "власть", "торжественный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["верность", "торжественный", "церемония", "повиноваться"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["покидать", "изгонять", "гнев", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["покидать", "изгонять", "наказание", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["чужой", "гнев", "принимать", "приданое"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["изгонять", "наказание", "приданое", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["наказание", "надежда", "изгонять", "чужой"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["приданое", "изгонять", "надежда", "чужой"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["изгонять", "принимать", "приданое", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["наказание", "надежда", "покидать", "приданое"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["страх", "забота", "известие", "одиночество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["страх", "одиночество", "известие", "забота"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["известие", "защищать", "забота", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["молиться", "тоска", "страх", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["известие", "страдать", "тоска", "молиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["забота", "защищать", "страх", "одиночество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["страдать", "тоска", "забота", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «beten»?", "choices": ["защищать", "одиночество", "страх", "молиться"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["спасать", "возвращаться", "борьба", "битва"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["возвращаться", "спасать", "битва", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["битва", "спасать", "борьба", "побеждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["возвращаться", "спасать", "справедливость", "битва"], "correct_index": 3}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["храбрый", "побеждать", "битва", "справедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["храбрый", "справедливость", "битва", "борьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["побеждать", "храбрый", "возвращаться", "спасать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["храбрый", "справедливость", "побеждать", "армия"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["прощать", "обнимать", "слёзы", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["прощать", "узнавать", "слёзы", "обнимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["обнимать", "узнавать", "исцелять", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["прощение", "узнавать", "раскаяние", "обнимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["раскаяние", "слёзы", "исцелять", "прощение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "исцелять", "нежный", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["обнимать", "прощать", "узнавать", "нежный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["слёзы", "обнимать", "прощать", "прощение"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["тюрьма", "утешать", "достоинство", "пленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["пленный", "утешать", "достоинство", "тюрьма"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["честь", "отважный", "достоинство", "смирение"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["пленный", "тюрьма", "утешать", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["честь", "отважный", "утешать", "смирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["смирение", "достоинство", "пленный", "отважный"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["судьба", "честь", "отважный", "смирение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["честь", "отважный", "смирение", "утешать"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "жертва", "душа", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "душа", "смерть", "жертва"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["вечный", "жертва", "смерть", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["спасение", "вечный", "душа", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["вечный", "душа", "спасение", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "умирать", "конец", "жертва"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["умирать", "прощание", "жертва", "душа"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["конец", "умирать", "спасение", "жертва"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -471,7 +471,71 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
                             
@@ -481,79 +545,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">повиноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжественный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">повиноваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">торжественный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">торжественный</button>
                             
@@ -561,33 +577,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжественный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">повиноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">повиноваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,31 +600,31 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
@@ -632,31 +632,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">приданое</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">надежда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">принимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">приданое</button>
                             
@@ -664,17 +648,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «fremd»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «fremd»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -686,43 +686,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">приданое</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «aufnehmen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">принимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Hoffnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">приданое</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,15 +735,15 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Sorge»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
                             
@@ -755,11 +755,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
                             
@@ -767,49 +767,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Nachricht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Angst»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">молиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тоска</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -819,45 +819,45 @@
                         <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Sehnsucht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «beten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -870,17 +870,17 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -890,9 +890,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
                             
@@ -902,65 +902,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «retten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">армия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «mutig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «mutig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -972,27 +972,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">храбрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Armee»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">армия</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1005,31 +1005,31 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
                             
@@ -1037,15 +1037,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощение</button>
                             
@@ -1053,49 +1085,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1105,11 +1105,11 @@
                         <div class="quiz-question">Что означает немецкое слово «sanft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
                             
@@ -1117,17 +1117,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Vergebung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1140,8 +1140,24 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «gefangen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">тюрьма</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
@@ -1156,95 +1172,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Würde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отважный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отважный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отважный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
                             
@@ -1252,17 +1204,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отважный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отважный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1297,9 +1297,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
                             
@@ -1307,17 +1307,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Opfer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1327,29 +1327,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Seele»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1361,43 +1361,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Erlösung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1424,8 +1424,8 @@
                 "word": "die Wahrheit",
                 "translation": "правда",
                 "transcription": "[ди ВАР-хайт]",
-                "sentence": "Im Thronsaal von König Lear spricht Cordelia: Die Wahrheit war vor meinen Augen verborgen.",
-                "sentenceTranslation": "В тронном зале короля Лира Корделия говорит: Правда была скрыта от моих глаз.",
+                "sentence": "Cordelia steht unter dem glühenden Kronleuchter des Thronsaals. Das kalte Licht lässt das Wort „die Wahrheit“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Корделия стоит под пылающей люстрой тронного зала. Холодный свет заставляет слово «правда» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1449,8 +1449,8 @@
                 "word": "die Zeremonie",
                 "translation": "церемония",
                 "transcription": "[ди це-ре-мо-НИ]",
-                "sentence": "Im Thronsaal von König Lear spricht Cordelia: Die Zeremonie beginnt im prächtigen Thronsaal.",
-                "sentenceTranslation": "В тронном зале короля Лира Корделия говорит: Церемония начинается в великолепном тронном зале.",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Cordelia über Lears schweren Tisch. Ich atme tief ein und lasse nur das Wort „die Zeremonie“ wieder hinaus.",
+                "sentenceTranslation": "У развернутой карты королевства Корделия склоняется над тяжёлым столом Лира. Я глубоко вдыхаю и выпускаю только слово «церемония».",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehrlichkeit",
@@ -1477,8 +1477,8 @@
                 "word": "verkünden",
                 "translation": "провозглашать",
                 "transcription": "[фер-КЮН-ден]",
-                "sentence": "Im Thronsaal von König Lear spricht Cordelia: Ich verkünde nur die Wahrheit meines Herzens.",
-                "sentenceTranslation": "В тронном зале короля Лира Корделия говорит: Я провозглашаю только правду моего сердца.",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Cordelia die Hände hinter dem Rücken. Ich presse das Wort „verkünden“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Перед каменными статуями предков Корделия сцепляет руки за спиной. Я стискиваю слово «провозглашать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehrlichkeit",
@@ -1505,8 +1505,8 @@
                 "word": "die Macht",
                 "translation": "власть",
                 "transcription": "[ди МАХТ]",
-                "sentence": "Im Thronsaal von König Lear spricht Cordelia: Die Macht bedeutet nichts ohne wahre Liebe.",
-                "sentenceTranslation": "В тронном зале короля Лира Корделия говорит: Власть ничего не значит без истинной любви.",
+                "sentence": "Zwischen flüsternden Höflingen gleitet Cordelia über den kalten Marmorboden. Ich zeichne das Wort „die Macht“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Между шепчущимися придворными Корделия скользит по холодному мраморному полу. Я вывожу слово «власть» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1531,8 +1531,8 @@
                 "word": "gehorchen",
                 "translation": "повиноваться",
                 "transcription": "[ге-ХОР-хен]",
-                "sentence": "Im Thronsaal von König Lear spricht Cordelia: Ich kann der Lüge nicht gehorchen.",
-                "sentenceTranslation": "В тронном зале короля Лира Корделия говорит: Я не могу повиноваться лжи.",
+                "sentence": "Am Rand des purpurnen Teppichs wartet Cordelia auf ein Zeichen des Königs. Mit jeder Faser meines Körpers verspreche ich: Das Wort „gehorchen“ bleibt lebendig.",
+                "sentenceTranslation": "На краю пурпурного ковра Корделия ждёт знака от короля. Каждой клеткой тела я обещаю: слово «повиноваться» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1555,8 +1555,8 @@
                 "word": "die Pflicht",
                 "translation": "долг",
                 "transcription": "[ди ПФЛИХТ]",
-                "sentence": "Im Thronsaal von König Lear spricht Cordelia: Meine Pflicht ist es, ehrlich zu sein.",
-                "sentenceTranslation": "В тронном зале короля Лира Корделия говорит: Мой долг - быть честной.",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Cordelia kurz den Blick. Mit fester Stimme schwöre ich mir: Das Wort „die Pflicht“ wird heute nicht verraten.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Корделия на миг опускает взгляд. Твёрдым голосом я клянусь себе: слово «долг» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1579,8 +1579,8 @@
                 "word": "feierlich",
                 "translation": "торжественный",
                 "transcription": "[ФАЙ-ер-лих]",
-                "sentence": "Im Thronsaal von König Lear spricht Cordelia: Dieser feierliche Moment wird zur Tragödie.",
-                "sentenceTranslation": "В тронном зале короля Лира Корделия говорит: Этот торжественный момент становится трагедией.",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Cordelia das gespannte Antlitz des Hofes. Ich presse das Wort „feierlich“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "За позолоченной балюстрадой Корделия наблюдает за напряжёнными лицами двора. Я стискиваю слово «торжественный» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehrlichkeit",
@@ -1603,8 +1603,8 @@
                 "word": "die Treue",
                 "translation": "верность",
                 "transcription": "[ди ТРОЙ-е]",
-                "sentence": "Im Thronsaal von König Lear spricht Cordelia: Meine Treue gilt der Wahrheit und der echten Liebe.",
-                "sentenceTranslation": "В тронном зале короля Лира Корделия говорит: Моя верность принадлежит правде и истинной любви.",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Cordelia langsam die Stimme. Das Echo des Wortes „die Treue“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В отблесках открытых жаровен Корделия медленно поднимает голос. Эхо слова «верность» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1629,8 +1629,8 @@
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
                     "церемония",
-                    "власть",
                     "провозглашать",
+                    "власть",
                     "правда"
                 ],
                 "correctIndex": 3
@@ -1638,72 +1638,72 @@
             {
                 "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
+                    "власть",
                     "правда",
                     "церемония",
-                    "провозглашать",
-                    "власть"
+                    "провозглашать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
-                    "провозглашать",
-                    "церемония",
-                    "долг",
-                    "верность"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Macht»?",
-                "choices": [
-                    "власть",
-                    "повиноваться",
-                    "торжественный",
-                    "церемония"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «gehorchen»?",
-                "choices": [
-                    "церемония",
                     "верность",
-                    "провозглашать",
-                    "повиноваться"
+                    "торжественный",
+                    "церемония",
+                    "провозглашать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Pflicht»?",
+                "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "долг",
-                    "правда",
                     "провозглашать",
-                    "торжественный"
+                    "власть",
+                    "церемония",
+                    "правда"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «gehorchen»?",
+                "choices": [
+                    "повиноваться",
+                    "долг",
+                    "провозглашать",
+                    "правда"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Pflicht»?",
+                "choices": [
+                    "торжественный",
+                    "провозглашать",
+                    "церемония",
+                    "долг"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «feierlich»?",
                 "choices": [
-                    "верность",
-                    "провозглашать",
-                    "торжественный",
-                    "церемония"
+                    "долг",
+                    "правда",
+                    "власть",
+                    "торжественный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
-                    "долг",
-                    "повиноваться",
                     "верность",
-                    "церемония"
+                    "торжественный",
+                    "церемония",
+                    "повиноваться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -1716,8 +1716,8 @@
                 "word": "verstoßen",
                 "translation": "изгонять",
                 "transcription": "[фер-ШТО-сен]",
-                "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Der König verstößt mich aus seinem Herzen.",
-                "sentenceTranslation": "На причале перед отъездом во Францию Корделия клянётся: Король изгоняет меня из своего сердца.",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Cordelia zwischen gepackten Kisten. Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Корделия замирает среди нагруженных ящиков. Каждой клеткой тела я обещаю: слово «изгонять» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1746,8 +1746,8 @@
                 "word": "verlassen",
                 "translation": "покидать",
                 "transcription": "[фер-ЛА-сен]",
-                "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Schweren Herzens verlasse ich mein Vaterland.",
-                "sentenceTranslation": "На причале перед отъездом во Францию Корделия клянётся: С тяжёлым сердцем я покидаю родину.",
+                "sentence": "Auf der windigen Freitreppe blickt Cordelia zum schweigenden Hof hinunter. Ich atme tief ein und lasse nur das Wort „verlassen“ wieder hinaus.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Корделия смотрит вниз на молчаливый двор. Я глубоко вдыхаю и выпускаю только слово «покидать».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1770,8 +1770,8 @@
                 "word": "der Zorn",
                 "translation": "гнев",
                 "transcription": "[дер ЦОРН]",
-                "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Sein Zorn ist grenzenlos und blind.",
-                "sentenceTranslation": "На причале перед отъездом во Францию Корделия клянётся: Его гнев безграничен и слеп.",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Cordelia den Reisemantel enger. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Zorn“ bleibt lebendig.",
+                "sentenceTranslation": "Среди оставленных слуг Корделия плотнее запахивает дорожный плащ. Каждой клеткой тела я обещаю: слово «гнев» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1796,8 +1796,8 @@
                 "word": "die Strafe",
                 "translation": "наказание",
                 "transcription": "[ди ШТРА-фе]",
-                "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Diese Strafe ist der Preis für meine Ehrlichkeit.",
-                "sentenceTranslation": "На причале перед отъездом во Францию Корделия клянётся: Это наказание - цена моей честности.",
+                "sentence": "Am dunklen Pferdestall streicht Cordelia einem nervösen Tier über die Mähne. Ich presse das Wort „die Strafe“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Корделия гладит гриву нервного коня. Я стискиваю слово «наказание» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1824,8 +1824,8 @@
                 "word": "fremd",
                 "translation": "чужой",
                 "transcription": "[ФРЕМД]",
-                "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Ich bin jetzt fremd in meinem eigenen Land.",
-                "sentenceTranslation": "На причале перед отъездом во Францию Корделия клянётся: Я теперь чужая в своей собственной стране.",
+                "sentence": "Vor dem knarrenden Fallgatter tastet Cordelia ein letztes Mal nach dem Haustor. Mein Atem zeichnet das Wort „fremd“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Корделия в последний раз касается родной двери. Моё дыхание рисует слово «чужой» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Frankreich",
@@ -1848,8 +1848,8 @@
                 "word": "die Mitgift",
                 "translation": "приданое",
                 "transcription": "[ди МИТ-гифт]",
-                "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Ohne Mitgift bin ich reicher an Ehre.",
-                "sentenceTranslation": "На причале перед отъездом во Францию Корделия клянётся: Без приданого я богаче честью.",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Cordelia den Ring an der Hand. Ich zeichne das Wort „die Mitgift“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Среди разбросанных свитков Корделия вертит кольцо на пальце. Я черчу слово «приданое» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Frankreich",
@@ -1872,8 +1872,8 @@
                 "word": "aufnehmen",
                 "translation": "принимать",
                 "transcription": "[АУФ-не-мен]",
-                "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Der König von Frankreich nimmt mich liebevoll auf.",
-                "sentenceTranslation": "На причале перед отъездом во Францию Корделия клянётся: Король Франции принимает меня с любовью.",
+                "sentence": "Am leeren Bankettisch zählt Cordelia die verlöschenden Kerzen. Mein Atem zeichnet das Wort „aufnehmen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У пустого банкетного стола Корделия пересчитывает гаснущие свечи. Моё дыхание рисует слово «принимать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Frankreich",
@@ -1896,8 +1896,8 @@
                 "word": "die Hoffnung",
                 "translation": "надежда",
                 "transcription": "[ди ХОФ-нунг]",
-                "sentence": "Auf dem Kai vor der Abreise nach Frankreich schwört Cordelia: Die Hoffnung auf Versöhnung stirbt nie in meinem Herzen.",
-                "sentenceTranslation": "На причале перед отъездом во Францию Корделия клянётся: Надежда на примирение никогда не умирает в моём сердце.",
+                "sentence": "Zwischen schweigenden Wachen geht Cordelia auf den kalten Hof hinaus. Ich atme tief ein und lasse nur das Wort „die Hoffnung“ wieder hinaus.",
+                "sentenceTranslation": "Между молчаливыми стражниками Корделия выходит на холодный двор. Я глубоко вдыхаю и выпускаю только слово «надежда».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1920,82 +1920,82 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "гнев",
-                    "наказание",
-                    "покидать",
-                    "изгонять"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verlassen»?",
-                "choices": [
-                    "наказание",
                     "покидать",
                     "изгонять",
-                    "гнев"
+                    "гнев",
+                    "наказание"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «verlassen»?",
+                "choices": [
+                    "покидать",
+                    "изгонять",
+                    "наказание",
+                    "гнев"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "приданое",
-                    "покидать",
+                    "чужой",
                     "гнев",
-                    "надежда"
+                    "принимать",
+                    "приданое"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "принимать",
-                    "покидать",
-                    "наказание",
-                    "приданое"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «fremd»?",
-                "choices": [
                     "изгонять",
-                    "чужой",
+                    "наказание",
                     "приданое",
                     "покидать"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «fremd»?",
+                "choices": [
+                    "наказание",
+                    "надежда",
+                    "изгонять",
+                    "чужой"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Mitgift»?",
                 "choices": [
                     "приданое",
-                    "покидать",
-                    "принимать",
-                    "изгонять"
+                    "изгонять",
+                    "надежда",
+                    "чужой"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «aufnehmen»?",
                 "choices": [
-                    "чужой",
-                    "наказание",
+                    "изгонять",
+                    "принимать",
                     "приданое",
-                    "принимать"
+                    "наказание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Hoffnung»?",
                 "choices": [
+                    "наказание",
                     "надежда",
-                    "изгонять",
-                    "принимать",
-                    "покидать"
+                    "покидать",
+                    "приданое"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2008,8 +2008,8 @@
                 "word": "die Sorge",
                 "translation": "забота",
                 "transcription": "[ди ЗОР-ге]",
-                "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Die Sorge um meinen Vater lässt mich nicht schlafen.",
-                "sentenceTranslation": "Во французском изгнании Корделия вспоминает Лира: Забота об отце не даёт мне спать.",
+                "sentence": "Im zugigen Seitenflügel lauscht Cordelia dem Heulen der Küstenwinde. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Sorge“ bleibt lebendig.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Корделия слушает вой прибрежного ветра. Каждой клеткой тела я обещаю: слово «забота» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2031,8 +2031,8 @@
                 "word": "die Einsamkeit",
                 "translation": "одиночество",
                 "transcription": "[ди АЙН-зам-кайт]",
-                "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: In der Einsamkeit denke ich an ihn.",
-                "sentenceTranslation": "Во французском изгнании Корделия вспоминает Лира: В одиночестве я думаю о нём.",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Cordelia einen zerknitterten Brief. Mein Atem zeichnet das Wort „die Einsamkeit“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед дымным камином замка Корделия складывает измятый лист. Моё дыхание рисует слово «одиночество» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2055,8 +2055,8 @@
                 "word": "die Nachricht",
                 "translation": "известие",
                 "transcription": "[ди НАХ-рихт]",
-                "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Schreckliche Nachrichten erreichen mich aus England.",
-                "sentenceTranslation": "Во французском изгнании Корделия вспоминает Лира: Ужасные известия доходят до меня из Англии.",
+                "sentence": "Unter farblosen Wandteppichen schreitet Cordelia rastlos auf und ab. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Nachricht“ gehört mir.",
+                "sentenceTranslation": "Под выцветшими гобеленами Корделия беспокойно меряет шагами зал. Буря за окнами усиливает клятву: слово «известие» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "beten",
@@ -2079,8 +2079,8 @@
                 "word": "die Angst",
                 "translation": "страх",
                 "transcription": "[ди АНГСТ]",
-                "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Die Angst um meinen Vater wächst täglich.",
-                "sentenceTranslation": "Во французском изгнании Корделия вспоминает Лира: Страх за отца растёт с каждым днём.",
+                "sentence": "An der schmalen Fensterluke zählt Cordelia die Fackeln auf dem Hof. Ich halte das Wort „die Angst“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У узкой бойницы Корделия считает факелы на дворе. Я держу слово «страх» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2103,8 +2103,8 @@
                 "word": "leiden",
                 "translation": "страдать",
                 "transcription": "[ЛАЙ-ден]",
-                "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Er muss furchtbar leiden ohne mich.",
-                "sentenceTranslation": "Во французском изгнании Корделия вспоминает Лира: Он должно быть ужасно страдает без меня.",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Cordelia nach frischen Botschaften. Das Echo des Wortes „leiden“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Корделия ищет свежие вести. Эхо слова «страдать» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2130,8 +2130,8 @@
                 "word": "beschützen",
                 "translation": "защищать",
                 "transcription": "[бе-ШЮ-цен]",
-                "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Ich kann ihn aus der Ferne nicht beschützen.",
-                "sentenceTranslation": "Во французском изгнании Корделия вспоминает Лира: Я не могу защитить его издалека.",
+                "sentence": "Im stillen Kapellenraum kniet Cordelia vor der kalten Steinfigur. Ich atme tief ein und lasse nur das Wort „beschützen“ wieder hinaus.",
+                "sentenceTranslation": "В тихой капелле Корделия преклоняет колени перед холодной каменной фигурой. Я глубоко вдыхаю и выпускаю только слово «защищать».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2157,8 +2157,8 @@
                 "word": "die Sehnsucht",
                 "translation": "тоска",
                 "transcription": "[ди ЗЕН-зухт]",
-                "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Die Sehnsucht nach Versöhnung erfüllt mein Herz.",
-                "sentenceTranslation": "Во французском изгнании Корделия вспоминает Лира: Тоска по примирению наполняет моё сердце.",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Cordelia die Laterne fest. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Sehnsucht“ gehört mir.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Корделия крепко держит фонарь. Буря за окнами усиливает клятву: слово «тоска» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "beten",
@@ -2181,8 +2181,8 @@
                 "word": "beten",
                 "translation": "молиться",
                 "transcription": "[БЕ-тен]",
-                "sentence": "Im französischen Exil erinnert sich Cordelia an Lear: Jeden Tag bete ich für seine Sicherheit.",
-                "sentenceTranslation": "Во французском изгнании Корделия вспоминает Лира: Каждый день я молюсь за его безопасность.",
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Cordelia eine fiebrige Antwort. Selbst wenn die Welt zerfällt, bleibt das Wort „beten“ mein Nordstern.",
+                "sentenceTranslation": "В тени высоких стен Корделия пишет лихорадочный ответ. Даже если мир распадается, слово «молиться» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "beten",
@@ -2206,19 +2206,19 @@
             {
                 "question": "Что означает немецкое слово «die Sorge»?",
                 "choices": [
-                    "известие",
                     "страх",
                     "забота",
+                    "известие",
                     "одиночество"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
-                    "известие",
-                    "одиночество",
                     "страх",
+                    "одиночество",
+                    "известие",
                     "забота"
                 ],
                 "correctIndex": 1
@@ -2226,62 +2226,62 @@
             {
                 "question": "Что означает немецкое слово «die Nachricht»?",
                 "choices": [
-                    "страх",
-                    "тоска",
+                    "известие",
                     "защищать",
-                    "известие"
+                    "забота",
+                    "страдать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Angst»?",
                 "choices": [
+                    "молиться",
                     "тоска",
                     "страх",
-                    "защищать",
+                    "страдать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «leiden»?",
+                "choices": [
+                    "известие",
+                    "страдать",
+                    "тоска",
                     "молиться"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «leiden»?",
-                "choices": [
-                    "страдать",
-                    "забота",
-                    "одиночество",
-                    "защищать"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
-                    "одиночество",
-                    "защищать",
                     "забота",
-                    "известие"
+                    "защищать",
+                    "страх",
+                    "одиночество"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Sehnsucht»?",
                 "choices": [
-                    "тоска",
                     "страдать",
-                    "одиночество",
-                    "забота"
+                    "тоска",
+                    "забота",
+                    "страх"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beten»?",
                 "choices": [
-                    "тоска",
-                    "забота",
-                    "молиться",
-                    "страдать"
+                    "защищать",
+                    "одиночество",
+                    "страх",
+                    "молиться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2294,8 +2294,8 @@
                 "word": "zurückkehren",
                 "translation": "возвращаться",
                 "transcription": "[цу-РЮК-ке-рен]",
-                "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Mit einer Armee kehre ich zurück, meinen Vater zu retten.",
-                "sentenceTranslation": "Во главе французской армии у Дувра Корделия восклицает: С армией я возвращаюсь спасти моего отца.",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Cordelia gegen den Wind. Das kalte Licht lässt das Wort „zurückkehren“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Корделия упирается в ветер. Холодный свет заставляет слово «возвращаться» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2320,8 +2320,8 @@
                 "word": "der Kampf",
                 "translation": "борьба",
                 "transcription": "[дер КАМПФ]",
-                "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Dieser Kampf ist für die Ehre meines Vaters.",
-                "sentenceTranslation": "Во главе французской армии у Дувра Корделия восклицает: Эта борьба за честь моего отца.",
+                "sentence": "Unter einem zerrissenen Banner schützt Cordelia die Augen vor den Blitzen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Kampf“ darf nicht vergehen.",
+                "sentenceTranslation": "Под разорванным знаменем Корделия прикрывает глаза от молний. Я шепчу стражам судьбы: слово «борьба» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2346,8 +2346,8 @@
                 "word": "retten",
                 "translation": "спасать",
                 "transcription": "[РЕ-тен]",
-                "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Ich muss meinen Vater vor seinen grausamen Töchtern retten.",
-                "sentenceTranslation": "Во главе французской армии у Дувра Корделия восклицает: Я должна спасти отца от его жестоких дочерей.",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Cordelia Deckung vor dem Donner. Ich flüstere den Wächtern des Schicksals zu: Das Wort „retten“ darf nicht vergehen.",
+                "sentenceTranslation": "У поваленного дерева Корделия ищет укрытия от грома. Я шепчу стражам судьбы: слово «спасать» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2370,8 +2370,8 @@
                 "word": "die Schlacht",
                 "translation": "битва",
                 "transcription": "[ди ШЛАХТ]",
-                "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Diese Schlacht entscheidet über das Schicksal des Königreichs.",
-                "sentenceTranslation": "Во главе французской армии у Дувра Корделия восклицает: Эта битва решает судьбу королевства.",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Cordelia durch den Schlamm. Mit fester Stimme schwöre ich mir: Das Wort „die Schlacht“ wird heute nicht verraten.",
+                "sentenceTranslation": "Между пенящимися лужами Корделия пробирается через грязь. Твёрдым голосом я клянусь себе: слово «битва» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2393,8 +2393,8 @@
                 "word": "mutig",
                 "translation": "храбрый",
                 "transcription": "[МУ-тиг]",
-                "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Sei mutig, mein Herz, für die gerechte Sache.",
-                "sentenceTranslation": "Во главе французской армии у Дувра Корделия восклицает: Будь храбрым, моё сердце, ради правого дела.",
+                "sentence": "Vor einem zuckenden Himmel hebt Cordelia die Arme trotzig an. Ich atme tief ein und lasse nur das Wort „mutig“ wieder hinaus.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Корделия упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «храбрый».",
                 "visual_hint": "📚",
                 "themes": [
                     "kämpfen",
@@ -2417,8 +2417,8 @@
                 "word": "die Gerechtigkeit",
                 "translation": "справедливость",
                 "transcription": "[ди ге-РЕХ-тиг-кайт]",
-                "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Die Gerechtigkeit führt meine Klinge.",
-                "sentenceTranslation": "Во главе французской армии у Дувра Корделия восклицает: Справедливость ведёт мой клинок.",
+                "sentence": "Unter dem durchtränkten Umhang presst Cordelia den Atem gegen die Kälte. Selbst wenn die Welt zerfällt, bleibt das Wort „die Gerechtigkeit“ mein Nordstern.",
+                "sentenceTranslation": "Под промокшим плащом Корделия прижимает дыхание к груди, спасаясь от холода. Даже если мир распадается, слово «справедливость» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2442,8 +2442,8 @@
                 "word": "siegen",
                 "translation": "побеждать",
                 "transcription": "[ЗИ-ген]",
-                "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Die Liebe wird über den Hass siegen.",
-                "sentenceTranslation": "Во главе французской армии у Дувра Корделия восклицает: Любовь победит ненависть.",
+                "sentence": "Am kläglichen Feuerrest wärmt Cordelia zitternde Finger. Wie ein stilles Gebet legt sich das Wort „siegen“ auf meine Lippen.",
+                "sentenceTranslation": "У жалких огненных углей Корделия греет дрожащие пальцы. Как тихая молитва слово «побеждать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2466,8 +2466,8 @@
                 "word": "die Armee",
                 "translation": "армия",
                 "transcription": "[ди ар-МЭ]",
-                "sentence": "Mit der französischen Armee vor Dover ruft Cordelia: Diese Armee kämpft für Gerechtigkeit und Liebe.",
-                "sentenceTranslation": "Во главе французской армии у Дувра Корделия восклицает: Эта армия сражается за справедливость и любовь.",
+                "sentence": "Zwischen heulenden Hunden ruft Cordelia gegen den tosenden Sturm an. Ich zeichne das Wort „die Armee“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Среди воющих псов Корделия перекрикивает беснующуюся бурю. Я черчу слово «армия» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "kämpfen",
@@ -2491,18 +2491,18 @@
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
-                    "борьба",
-                    "битва",
+                    "спасать",
                     "возвращаться",
-                    "спасать"
+                    "борьба",
+                    "битва"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "спасать",
                     "возвращаться",
+                    "спасать",
                     "битва",
                     "борьба"
                 ],
@@ -2511,62 +2511,62 @@
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
-                    "храбрый",
+                    "битва",
+                    "спасать",
                     "борьба",
-                    "побеждать",
-                    "спасать"
+                    "побеждать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Schlacht»?",
                 "choices": [
-                    "армия",
-                    "битва",
+                    "возвращаться",
+                    "спасать",
                     "справедливость",
-                    "спасать"
+                    "битва"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «mutig»?",
                 "choices": [
-                    "битва",
                     "храбрый",
-                    "спасать",
-                    "возвращаться"
+                    "побеждать",
+                    "битва",
+                    "справедливость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "спасать",
                     "храбрый",
                     "справедливость",
-                    "армия"
+                    "битва",
+                    "борьба"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
                     "побеждать",
-                    "армия",
                     "храбрый",
-                    "возвращаться"
+                    "возвращаться",
+                    "спасать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Armee»?",
                 "choices": [
-                    "побеждать",
-                    "армия",
                     "храбрый",
-                    "битва"
+                    "справедливость",
+                    "побеждать",
+                    "армия"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2579,8 +2579,8 @@
                 "word": "verzeihen",
                 "translation": "прощать",
                 "transcription": "[фер-ЦАЙ-ен]",
-                "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Ich verzeihe dir alles, mein lieber Vater.",
-                "sentenceTranslation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Я прощаю тебе всё, мой дорогой отец.",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Cordelia bei der flackernden Kerze. Wie ein stilles Gebet legt sich das Wort „verzeihen“ auf meine Lippen.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Корделия сидит у мерцающей свечи. Как тихая молитва слово «прощать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2604,8 +2604,8 @@
                 "word": "die Tränen",
                 "translation": "слёзы",
                 "transcription": "[ди ТРЕ-нен]",
-                "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Unsere Tränen waschen den Schmerz fort.",
-                "sentenceTranslation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Наши слёзы смывают боль.",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Cordelia über ein altes Wappen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Tränen“ gehört mir.",
+                "sentenceTranslation": "Среди помятых доспехов Корделия гладит старый герб. Буря за окнами усиливает клятву: слово «слёзы» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "heilen",
@@ -2628,8 +2628,8 @@
                 "word": "umarmen",
                 "translation": "обнимать",
                 "transcription": "[ум-АР-мен]",
-                "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Lass mich dich umarmen und deine Tränen trocknen.",
-                "sentenceTranslation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Позволь мне обнять тебя и вытереть твои слёзы.",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Cordelia fast den Kopf. Ich presse das Wort „umarmen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "О низкую балку хижины Корделия едва не ударяется головой. Я стискиваю слово «обнимать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "erkennen",
@@ -2656,8 +2656,8 @@
                 "word": "erkennen",
                 "translation": "узнавать",
                 "transcription": "[ер-КЕН-нен]",
-                "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Erkennst du mich, dein Kind Cordelia?",
-                "sentenceTranslation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Узнаёшь ли ты меня, твоё дитя Корделия?",
+                "sentence": "Neben der schlafenden Wache flüstert Cordelia in die schwere Nacht. Ich zeichne das Wort „erkennen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Рядом со спящим стражем Корделия шепчет в тяжёлую ночь. Я вывожу слово «узнавать» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2685,8 +2685,8 @@
                 "word": "heilen",
                 "translation": "исцелять",
                 "transcription": "[ХАЙ-лен]",
-                "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Meine Liebe wird deine Wunden heilen.",
-                "sentenceTranslation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Моя любовь исцелит твои раны.",
+                "sentence": "Vor dem einfachen Feldbett betrachtet Cordelia die Narben vergangener Schlachten. Ich umarme das Wort „heilen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Перед грубой походной койкой Корделия разглядывает шрамы прошлых битв. Я обнимаю слово «исцелять», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "heilen",
@@ -2709,8 +2709,8 @@
                 "word": "die Reue",
                 "translation": "раскаяние",
                 "transcription": "[ди РОЙ-е]",
-                "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Deine Reue ist nicht nötig, nur deine Liebe.",
-                "sentenceTranslation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Твоё раскаяние не нужно, только твоя любовь.",
+                "sentence": "Im Geruch von feuchtem Stroh legt Cordelia den Mantel zur Seite. Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В запахе влажной соломы Корделия откладывает плащ в сторону. Я черчу слово «раскаяние» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2734,8 +2734,8 @@
                 "word": "sanft",
                 "translation": "нежный",
                 "transcription": "[ЗАНФТ]",
-                "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Sei sanft zu dir selbst, lieber Vater.",
-                "sentenceTranslation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Будь нежен к себе, дорогой отец.",
+                "sentence": "Auf dem wackligen Holztisch ordnet Cordelia zerlesene Briefe. Ich zeichne das Wort „sanft“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На шатком деревянном столе Корделия раскладывает зачитанные письма. Я черчу слово «нежный» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "heilen",
@@ -2758,8 +2758,8 @@
                 "word": "die Vergebung",
                 "translation": "прощение",
                 "transcription": "[ди фер-ГЕ-бунг]",
-                "sentence": "In der armseligen Hütte, wo Lear tobt, hält Cordelia seine Hände: Die Vergebung ist der Schlüssel zum Frieden.",
-                "sentenceTranslation": "В убогой хижине, где метётся Лир, Корделия держит его руки: Прощение - ключ к покою.",
+                "sentence": "Am Eingang der Hütte späht Cordelia nach einem vertrauten Schatten. Ich zeichne das Wort „die Vergebung“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У входа в хижину Корделия высматривает знакомую тень. Я черчу слово «прощение» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "heilen",
@@ -2783,69 +2783,69 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "узнавать",
-                    "обнимать",
                     "прощать",
-                    "слёзы"
+                    "обнимать",
+                    "слёзы",
+                    "узнавать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Tränen»?",
                 "choices": [
+                    "прощать",
                     "узнавать",
                     "слёзы",
-                    "прощать",
+                    "обнимать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «umarmen»?",
+                "choices": [
+                    "обнимать",
+                    "узнавать",
+                    "исцелять",
+                    "раскаяние"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «erkennen»?",
+                "choices": [
+                    "прощение",
+                    "узнавать",
+                    "раскаяние",
                     "обнимать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «umarmen»?",
+                "question": "Что означает немецкое слово «heilen»?",
                 "choices": [
-                    "узнавать",
-                    "прощать",
-                    "обнимать",
+                    "раскаяние",
+                    "слёзы",
+                    "исцелять",
                     "прощение"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «erkennen»?",
+                "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "узнавать",
-                    "слёзы",
                     "раскаяние",
-                    "нежный"
+                    "исцелять",
+                    "нежный",
+                    "узнавать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «heilen»?",
-                "choices": [
-                    "прощение",
-                    "исцелять",
-                    "раскаяние",
-                    "нежный"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Reue»?",
-                "choices": [
-                    "нежный",
-                    "слёзы",
-                    "раскаяние",
-                    "прощать"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «sanft»?",
                 "choices": [
-                    "прощение",
-                    "слёзы",
+                    "обнимать",
                     "прощать",
+                    "узнавать",
                     "нежный"
                 ],
                 "correctIndex": 3
@@ -2853,12 +2853,12 @@
             {
                 "question": "Что означает немецкое слово «die Vergebung»?",
                 "choices": [
-                    "прощение",
-                    "раскаяние",
+                    "слёзы",
+                    "обнимать",
                     "прощать",
-                    "узнавать"
+                    "прощение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2871,8 +2871,8 @@
                 "word": "gefangen",
                 "translation": "пленный",
                 "transcription": "[ге-ФАН-ген]",
-                "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Obwohl gefangen, bin ich frei in meinem Herzen.",
-                "sentenceTranslation": "После поражения на поле под Дувром Корделия говорит как пленница: Хотя я в плену, в сердце я свободна.",
+                "sentence": "Auf den weißen Klippen von Dover blickt Cordelia in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „gefangen“ mein Nordstern.",
+                "sentenceTranslation": "На белых скалах Дувра Корделия смотрит в вздыбленный пролив. Даже если мир распадается, слово «пленный» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gerechtigkeit",
@@ -2895,8 +2895,8 @@
                 "word": "das Gefängnis",
                 "translation": "тюрьма",
                 "transcription": "[дас ге-ФЭНГ-нис]",
-                "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Dieses Gefängnis kann meine Liebe nicht einsperren.",
-                "sentenceTranslation": "После поражения на поле под Дувром Корделия говорит как пленница: Эта тюрьма не может запереть мою любовь.",
+                "sentence": "Zwischen flatternden Feldzeichen richtet Cordelia den Helm. Ich umarme das Wort „das Gefängnis“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Среди хлопающих штандартов Корделия поправляет шлем. Я обнимаю слово «тюрьма», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2918,8 +2918,8 @@
                 "word": "die Würde",
                 "translation": "достоинство",
                 "transcription": "[ди ВЮР-де]",
-                "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Mit Würde trage ich mein Schicksal.",
-                "sentenceTranslation": "После поражения на поле под Дувром Корделия говорит как пленница: С достоинством я несу свою судьбу.",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Cordelia Marschrouten in den Sand. Selbst wenn die Welt zerfällt, bleibt das Wort „die Würde“ mein Nordstern.",
+                "sentenceTranslation": "У французского костра Корделия рисует в песке путь марша. Даже если мир распадается, слово «достоинство» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2941,8 +2941,8 @@
                 "word": "trösten",
                 "translation": "утешать",
                 "transcription": "[ТРЁС-тен]",
-                "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Lass mich dich trösten in dieser dunklen Stunde.",
-                "sentenceTranslation": "После поражения на поле под Дувром Корделия говорит как пленница: Позволь мне утешить тебя в этот тёмный час.",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Cordelia das Siegel. Ich halte das Wort „trösten“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Корделия проверяет печати. Я держу слово «утешать» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2966,8 +2966,8 @@
                 "word": "tapfer",
                 "translation": "отважный",
                 "transcription": "[ТАП-фер]",
-                "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Ich bleibe tapfer für dich, Vater.",
-                "sentenceTranslation": "После поражения на поле под Дувром Корделия говорит как пленница: Я остаюсь отважной ради тебя, отец.",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Cordelia dem dumpfen Meer. Ich umarme das Wort „tapfer“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Корделия слушает глухой шум моря. Я обнимаю слово «отважный», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gerechtigkeit",
@@ -2990,8 +2990,8 @@
                 "word": "die Demut",
                 "translation": "смирение",
                 "transcription": "[ди ДЕ-мут]",
-                "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: In der Demut finden wir wahre Größe.",
-                "sentenceTranslation": "После поражения на поле под Дувром Корделия говорит как пленница: В смирении мы находим истинное величие.",
+                "sentence": "Auf dem sandigen Trainingsplatz übt Cordelia das Ziehen des Schwerts. Das kalte Licht lässt das Wort „die Demut“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На песчаном плацу Корделия отрабатывает выхват меча. Холодный свет заставляет слово «смирение» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gerechtigkeit",
@@ -3014,8 +3014,8 @@
                 "word": "das Schicksal",
                 "translation": "судьба",
                 "transcription": "[дас ШИК-заль]",
-                "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Unser Schicksal ist miteinander verwoben.",
-                "sentenceTranslation": "После поражения на поле под Дувром Корделия говорит как пленница: Наши судьбы переплетены.",
+                "sentence": "Zwischen pochenden Trommeln hebt Cordelia das Banner der Hoffnung. Ich presse das Wort „das Schicksal“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под гул барабанов Корделия поднимает знамя надежды. Я стискиваю слово «судьба» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3038,8 +3038,8 @@
                 "word": "die Ehre",
                 "translation": "честь",
                 "transcription": "[ди Э-ре]",
-                "sentence": "Nach der Niederlage auf dem Feld von Dover spricht Cordelia als Gefangene: Unsere Ehre bleibt unbefleckt.",
-                "sentenceTranslation": "После поражения на поле под Дувром Корделия говорит как пленница: Наша честь остаётся незапятнанной.",
+                "sentence": "Am Morgennebel der Küste legt Cordelia die Hand auf das pochende Herz. Selbst wenn die Welt zerfällt, bleibt das Wort „die Ehre“ mein Nordstern.",
+                "sentenceTranslation": "В утреннем тумане побережья Корделия кладёт ладонь на бьющееся сердце. Даже если мир распадается, слово «честь» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3064,82 +3064,82 @@
             {
                 "question": "Что означает немецкое слово «gefangen»?",
                 "choices": [
-                    "пленный",
+                    "тюрьма",
                     "утешать",
                     "достоинство",
-                    "тюрьма"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «das Gefängnis»?",
-                "choices": [
-                    "утешать",
-                    "тюрьма",
-                    "пленный",
-                    "достоинство"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Würde»?",
-                "choices": [
-                    "судьба",
-                    "достоинство",
-                    "тюрьма",
-                    "отважный"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «trösten»?",
-                "choices": [
-                    "тюрьма",
-                    "утешать",
-                    "пленный",
-                    "достоинство"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «tapfer»?",
-                "choices": [
-                    "отважный",
-                    "утешать",
-                    "судьба",
                     "пленный"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Demut»?",
-                "choices": [
-                    "достоинство",
-                    "судьба",
-                    "смирение",
-                    "отважный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «das Schicksal»?",
-                "choices": [
-                    "достоинство",
-                    "смирение",
-                    "честь",
-                    "судьба"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Ehre»?",
+                "question": "Что означает немецкое слово «das Gefängnis»?",
                 "choices": [
-                    "судьба",
+                    "пленный",
+                    "утешать",
                     "достоинство",
-                    "честь",
                     "тюрьма"
                 ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Würde»?",
+                "choices": [
+                    "честь",
+                    "отважный",
+                    "достоинство",
+                    "смирение"
+                ],
                 "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «trösten»?",
+                "choices": [
+                    "пленный",
+                    "тюрьма",
+                    "утешать",
+                    "судьба"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «tapfer»?",
+                "choices": [
+                    "честь",
+                    "отважный",
+                    "утешать",
+                    "смирение"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Demut»?",
+                "choices": [
+                    "смирение",
+                    "достоинство",
+                    "пленный",
+                    "отважный"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «das Schicksal»?",
+                "choices": [
+                    "судьба",
+                    "честь",
+                    "отважный",
+                    "смирение"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Ehre»?",
+                "choices": [
+                    "честь",
+                    "отважный",
+                    "смирение",
+                    "утешать"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -3152,8 +3152,8 @@
                 "word": "der Tod",
                 "translation": "смерть",
                 "transcription": "[дер ТОД]",
-                "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Der Tod trennt uns nur für kurze Zeit.",
-                "sentenceTranslation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Смерть разлучает нас лишь ненадолго.",
+                "sentence": "Im feuchten Kerker stützt Cordelia sich an den tropfenden Stein. Ich atme tief ein und lasse nur das Wort „der Tod“ wieder hinaus.",
+                "sentenceTranslation": "В сыром подземелье Корделия опирается на сочащийся камень. Я глубоко вдыхаю и выпускаю только слово «смерть».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3179,8 +3179,8 @@
                 "word": "sterben",
                 "translation": "умирать",
                 "transcription": "[ШТЕР-бен]",
-                "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Wenn ich sterben muss, sterbe ich mit reinem Herzen.",
-                "sentenceTranslation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Если я должна умереть, я умру с чистым сердцем.",
+                "sentence": "Unter der trüben Laterne zählt Cordelia die eisernen Ringe der Kette. Ich flüstere den Wächtern des Schicksals zu: Das Wort „sterben“ darf nicht vergehen.",
+                "sentenceTranslation": "Под мутным фонарём Корделия пересчитывает железные кольца цепи. Я шепчу стражам судьбы: слово «умирать» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3206,8 +3206,8 @@
                 "word": "das Opfer",
                 "translation": "жертва",
                 "transcription": "[дас ОП-фер]",
-                "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Ich bin das Opfer der Wahrheit und Liebe.",
-                "sentenceTranslation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Я жертва правды и любви.",
+                "sentence": "Neben der schweren Holztür horcht Cordelia auf entferntes Schluchzen. Ich halte das Wort „das Opfer“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У тяжёлой двери Корделия прислушивается к далёким рыданиям. Я держу слово «жертва» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3229,8 +3229,8 @@
                 "word": "die Seele",
                 "translation": "душа",
                 "transcription": "[ди ЗЕ-ле]",
-                "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Meine Seele ist rein vor Gott.",
-                "sentenceTranslation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Моя душа чиста перед Богом.",
+                "sentence": "Auf der kalten Steinbank zieht Cordelia den Mantel enger um die Schultern. Wie ein stilles Gebet legt sich das Wort „die Seele“ auf meine Lippen.",
+                "sentenceTranslation": "На холодной каменной скамье Корделия плотнее кутается в плащ. Как тихая молитва слово «душа» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3252,8 +3252,8 @@
                 "word": "das Ende",
                 "translation": "конец",
                 "transcription": "[дас ЕН-де]",
-                "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Dies ist nicht das Ende, nur ein Übergang.",
-                "sentenceTranslation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Это не конец, только переход.",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Cordelia das Gesicht zum Licht. Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Между тенями решёток Корделия поднимает лицо к свету. Я держу слово «конец» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3278,8 +3278,8 @@
                 "word": "ewig",
                 "translation": "вечный",
                 "transcription": "[Э-виг]",
-                "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Unsere Liebe ist ewig, Vater.",
-                "sentenceTranslation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Наша любовь вечна, отец.",
+                "sentence": "Am rostigen Wassereimer spiegelt Cordelia kurz die eigenen Augen. Das Echo des Wortes „ewig“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У ржавого ведра с водой Корделия на мгновение видит отражение глаз. Эхо слова «вечный» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Abschied",
@@ -3309,8 +3309,8 @@
                 "word": "der Abschied",
                 "translation": "прощание",
                 "transcription": "[дер АБ-шид]",
-                "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Unser Abschied ist nur vorübergehend.",
-                "sentenceTranslation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: Наше прощание лишь временно.",
+                "sentence": "Im dumpfen Hall der Schritte zählt Cordelia den Rhythmus der Wachen. Das Echo des Wortes „der Abschied“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В глухом эхе шагов Корделия отсчитывает ритм часовых. Эхо слова «прощание» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Abschied",
@@ -3344,8 +3344,8 @@
                 "word": "die Erlösung",
                 "translation": "спасение",
                 "transcription": "[ди ер-ЛЁ-зунг]",
-                "sentence": "Im Kerker, den Edmund bewacht, haucht Cordelia: Im Tod finde ich Erlösung und Frieden.",
-                "sentenceTranslation": "В темнице, которую стерёжёт Эдмунд, Корделия шепчет: В смерти я нахожу спасение и покой.",
+                "sentence": "Vor dem verriegelten Fenster zeichnet Cordelia Kreise in den Staub. Ich halte das Wort „die Erlösung“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед заколоченным окном Корделия чертит круги в пыли. Я держу слово «спасение» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3379,8 +3379,8 @@
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
                     "умирать",
-                    "смерть",
                     "душа",
+                    "смерть",
                     "жертва"
                 ],
                 "correctIndex": 0
@@ -3388,62 +3388,62 @@
             {
                 "question": "Что означает немецкое слово «das Opfer»?",
                 "choices": [
-                    "прощание",
-                    "спасение",
                     "вечный",
-                    "жертва"
+                    "жертва",
+                    "смерть",
+                    "умирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Seele»?",
                 "choices": [
-                    "смерть",
-                    "конец",
+                    "спасение",
+                    "вечный",
                     "душа",
-                    "вечный"
+                    "смерть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "жертва",
+                    "вечный",
                     "душа",
-                    "конец",
-                    "спасение"
+                    "спасение",
+                    "конец"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
                     "вечный",
+                    "умирать",
                     "конец",
-                    "спасение",
-                    "умирать"
+                    "жертва"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
+                    "умирать",
                     "прощание",
                     "жертва",
-                    "умирать",
-                    "смерть"
+                    "душа"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Erlösung»?",
                 "choices": [
-                    "вечный",
+                    "конец",
+                    "умирать",
                     "спасение",
-                    "смерть",
-                    "конец"
+                    "жертва"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -3974,27 +3974,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/cornwall.html
+++ b/output/journeys/cornwall.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["стремиться", "желать", "жадность", "честолюбие"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["честолюбие", "стремиться", "желать", "жадность"], "correct_index": 3}, {"question": "Что означает немецкое слово «streben»?", "choices": ["жадность", "стремиться", "захватывать", "желать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["захватывать", "жадность", "желать", "властолюбие"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["жадность", "вожделеть", "захватывать", "стремиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["честолюбие", "желать", "жадный", "жадность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["вожделеть", "властолюбие", "жадность", "стремиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["честолюбие", "вожделеть", "захватывать", "властолюбие"], "correct_index": 2}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "одобрять", "поддерживать", "злоба"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["одобрять", "поддерживать", "жестокость", "злоба"], "correct_index": 3}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["поддерживать", "поощрять", "жестокость", "одобрять"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["жестокость", "поддерживать", "суровость", "подстрекать"], "correct_index": 1}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["злоба", "жестокость", "подстрекать", "одобрять"], "correct_index": 2}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["жестокость", "поощрять", "суровость", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жестокость", "поощрять", "одобрять", "суровость"], "correct_index": 3}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["тирания", "угнетение", "страх", "подавлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["страх", "угнетение", "подавлять", "тирания"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["страх", "порабощать", "принуждать", "подавлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["угнетение", "тирания", "подавлять", "порабощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["угнетение", "порабощать", "брутальный", "произвол"], "correct_index": 1}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["произвол", "подавлять", "брутальный", "принуждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["брутальный", "угнетение", "порабощать", "произвол"], "correct_index": 3}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["тирания", "подавлять", "брутальный", "страх"], "correct_index": 2}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказывать", "гнев", "наказание", "карать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["наказывать", "наказание", "гнев", "карать"], "correct_index": 2}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["наказание", "гнев", "унижать", "карать"], "correct_index": 3}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["мучить", "наказывать", "гнев", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "наказывать", "наказание", "карать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["гнев", "унижать", "карать", "мучить"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["мучить", "наказывать", "карать", "унижать"], "correct_index": 0}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытать", "кровь", "садизм", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытка", "пытать", "садизм", "кровь"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["садизм", "ослеплять", "кровь", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["ослеплять", "кровь", "садизм", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["пытка", "кровь", "ослеплять", "калечить"], "correct_index": 3}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["кровь", "калечить", "садизм", "ослеплять"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["пытка", "кровь", "выкалывать", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["пытать", "садизм", "пытка", "мука"], "correct_index": 3}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["удивление", "боль", "кровоточить", "рана"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["рана", "боль", "удивление", "кровоточить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["рана", "ослаблять", "удивление", "кровоточить"], "correct_index": 2}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["боль", "раненый", "ослаблять", "кровоточить"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["рана", "боль", "кровоточить", "раненый"], "correct_index": 3}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["кровоточить", "страдать", "удивление", "ослаблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["боль", "ослаблять", "удивление", "страдать"], "correct_index": 3}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["конец", "смерть", "умирать", "возмездие"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["смерть", "умирать", "конец", "возмездие"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["хрипеть", "конец", "проклинать", "кара"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["проклинать", "кара", "умирать", "хрипеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["смерть", "конец", "издыхать", "хрипеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "издыхать", "хрипеть", "конец"], "correct_index": 0}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["хрипеть", "возмездие", "конец", "издыхать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["проклинать", "хрипеть", "смерть", "кара"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["желать", "честолюбие", "жадность", "стремиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["стремиться", "желать", "честолюбие", "жадность"], "correct_index": 3}, {"question": "Что означает немецкое слово «streben»?", "choices": ["вожделеть", "жадный", "стремиться", "жадность"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["властолюбие", "захватывать", "желать", "жадный"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["жадный", "стремиться", "вожделеть", "захватывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["желать", "захватывать", "стремиться", "жадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["жадность", "желать", "вожделеть", "властолюбие"], "correct_index": 3}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["жадный", "желать", "захватывать", "честолюбие"], "correct_index": 2}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["поддерживать", "одобрять", "злоба", "жестокость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["одобрять", "злоба", "жестокость", "поддерживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["суровость", "поддерживать", "поощрять", "одобрять"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["поддерживать", "злоба", "подстрекать", "суровость"], "correct_index": 0}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["подстрекать", "злоба", "поддерживать", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["поощрять", "одобрять", "подстрекать", "поддерживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["подстрекать", "поощрять", "одобрять", "суровость"], "correct_index": 3}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["тирания", "подавлять", "угнетение", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["подавлять", "тирания", "угнетение", "страх"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["страх", "подавлять", "угнетение", "принуждать"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["подавлять", "брутальный", "тирания", "принуждать"], "correct_index": 0}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["порабощать", "брутальный", "страх", "произвол"], "correct_index": 0}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["принуждать", "брутальный", "тирания", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["произвол", "тирания", "угнетение", "порабощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["страх", "тирания", "брутальный", "угнетение"], "correct_index": 2}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "наказывать", "гнев", "карать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["карать", "гнев", "наказание", "наказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["мучить", "наказывать", "гнев", "карать"], "correct_index": 3}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["унижать", "наказывать", "наказание", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["мучить", "гнев", "карать", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["унижать", "гнев", "карать", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["карать", "гнев", "унижать", "мучить"], "correct_index": 3}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["кровь", "садизм", "пытка", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытать", "садизм", "пытка", "кровь"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["выкалывать", "пытка", "кровь", "мука"], "correct_index": 2}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["пытать", "кровь", "садизм", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["ослеплять", "пытка", "мука", "калечить"], "correct_index": 3}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["калечить", "ослеплять", "пытать", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["ослеплять", "пытать", "садизм", "выкалывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["садизм", "пытка", "пытать", "мука"], "correct_index": 3}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["боль", "кровоточить", "удивление", "рана"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["удивление", "рана", "кровоточить", "боль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["кровоточить", "удивление", "страдать", "рана"], "correct_index": 1}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["раненый", "страдать", "рана", "кровоточить"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["раненый", "рана", "страдать", "удивление"], "correct_index": 0}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["страдать", "рана", "боль", "ослаблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["удивление", "рана", "страдать", "кровоточить"], "correct_index": 2}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "возмездие", "конец", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["смерть", "конец", "умирать", "возмездие"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["проклинать", "конец", "кара", "издыхать"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["проклинать", "хрипеть", "умирать", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["издыхать", "хрипеть", "возмездие", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["смерть", "возмездие", "кара", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["издыхать", "кара", "умирать", "хрипеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["издыхать", "смерть", "кара", "умирать"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Амбициозный герцог</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,17 +465,17 @@
             <div class="quiz-phase-container active" data-phase="ambitious_duke">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Ehrgeiz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -485,11 +485,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
                             
@@ -497,17 +497,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «streben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -517,61 +517,61 @@
                         <div class="quiz-question">Что означает немецкое слово «verlangen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">захватывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">властолюбие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -581,13 +581,13 @@
                         <div class="quiz-question">Что означает немецкое слово «ergreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,33 +600,33 @@
             <div class="quiz-phase-container" data-phase="cruel_husband">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -636,43 +636,11 @@
                         <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">суровость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">суровость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подстрекать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
                             
@@ -680,17 +648,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">суровость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поощрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">суровость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -700,7 +700,7 @@
                         <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
                             
@@ -725,27 +725,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -757,57 +757,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">принуждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подавлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unterdrücken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «zwingen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">произвол</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">принуждать</button>
                             
@@ -815,17 +767,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unterdrücken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">тирания</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">принуждать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «zwingen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">принуждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">тирания</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">произвол</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">порабощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -835,13 +835,13 @@
                         <div class="quiz-question">Что означает немецкое слово «brutal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,29 +854,13 @@
             <div class="quiz-phase-container" data-phase="punishment">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
@@ -886,15 +870,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «bestrafen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
                             
@@ -906,61 +906,61 @@
                         <div class="quiz-question">Что означает немецкое слово «züchtigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,31 +973,31 @@
             <div class="quiz-phase-container" data-phase="torturer">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
                             
@@ -1009,57 +1009,25 @@
                         <div class="quiz-question">Что означает немецкое слово «das Blut»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
                             
@@ -1069,17 +1037,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мука</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">калечить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1089,11 +1089,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
                             
@@ -1112,11 +1112,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Wunde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кровоточить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
                             
@@ -1124,33 +1124,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">удивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1160,11 +1160,11 @@
                         <div class="quiz-question">Что означает немецкое слово «bluten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раненый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослаблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
                             
@@ -1172,17 +1172,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раненый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1192,11 +1192,11 @@
                         <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
                             
@@ -1204,17 +1204,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,17 +1227,17 @@
             <div class="quiz-phase-container" data-phase="death">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1249,9 +1249,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
                             
@@ -1263,13 +1263,13 @@
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1281,6 +1281,54 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «röcheln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
@@ -1291,65 +1339,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хрипеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «röcheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1376,8 +1376,8 @@
                 "word": "der Ehrgeiz",
                 "translation": "честолюбие",
                 "transcription": "[дер ЭР-гайц]",
-                "sentence": "In Glosters Schloss plant Herzog Cornwall: Mein Ehrgeiz kennt keine Grenzen mehr.",
-                "sentenceTranslation": "В замке Глостера герцог Корнуолл замышляет: Моё честолюбие не знает больше границ.",
+                "sentence": "In der Waffenkammer betrachtet Cornwall gierig die ausgestellten Kronjuwelen. Das Echo des Wortes „der Ehrgeiz“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В оружейной Корнуолл жадно рассматривает выставленные коронные драгоценности. Эхо слова «честолюбие» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehrgeiz",
@@ -1400,8 +1400,8 @@
                 "word": "die Gier",
                 "translation": "жадность",
                 "transcription": "[ди ГИР]",
-                "sentence": "In Glosters Schloss plant Herzog Cornwall: Die Gier nach Macht verzehrt meine Seele.",
-                "sentenceTranslation": "В замке Глостера герцог Корнуолл замышляет: Жадность к власти пожирает мою душу.",
+                "sentence": "Vor der Karte Englands fährt Cornwall mit dem Dolch über neue Grenzen. Mein Atem zeichnet das Wort „die Gier“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед картой Англии Корнуолл проводит кинжалом новые границы. Моё дыхание рисует слово «жадность» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1424,8 +1424,8 @@
                 "word": "streben",
                 "translation": "стремиться",
                 "transcription": "[ШТРЕ-бен]",
-                "sentence": "In Glosters Schloss plant Herzog Cornwall: Ich strebe nach absoluter Kontrolle.",
-                "sentenceTranslation": "В замке Глостера герцог Корнуолл замышляет: Я стремлюсь к абсолютному контролю.",
+                "sentence": "Zwischen knienden Vasallen lässt Cornwall die Finger über den Thronsessel gleiten. Ich presse das Wort „streben“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди преклонивших колено вассалов Корнуолл проводит пальцами по тронному креслу. Я стискиваю слово «стремиться» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehrgeiz",
@@ -1448,8 +1448,8 @@
                 "word": "verlangen",
                 "translation": "желать",
                 "transcription": "[фер-ЛАН-ген]",
-                "sentence": "In Glosters Schloss plant Herzog Cornwall: Ich verlange mehr als mir zusteht.",
-                "sentenceTranslation": "В замке Глостера герцог Корнуолл замышляет: Я желаю больше, чем мне положено.",
+                "sentence": "Am hohen Fenster misst Cornwall den Abstand zur Hauptstadt. Mein Atem zeichnet das Wort „verlangen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У высокого окна Корнуолл вымеряет расстояние до столицы. Моё дыхание рисует слово «желать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1474,8 +1474,8 @@
                 "word": "begehren",
                 "translation": "вожделеть",
                 "transcription": "[бе-ГЕ-рен]",
-                "sentence": "In Glosters Schloss plant Herzog Cornwall: Ich begehre die Krone für mich selbst.",
-                "sentenceTranslation": "В замке Глостера герцог Корнуолл замышляет: Я вожделею корону для себя.",
+                "sentence": "Neben dem schwelenden Kamin testet Cornwall das Gewicht eines Schwertes. Ich flüstere den Wächtern des Schicksals zu: Das Wort „begehren“ darf nicht vergehen.",
+                "sentenceTranslation": "У тлеющего камина Корнуолл взвешивает на руке меч. Я шепчу стражам судьбы: слово «вожделеть» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1502,8 +1502,8 @@
                 "word": "gierig",
                 "translation": "жадный",
                 "transcription": "[ГИ-риг]",
-                "sentence": "In Glosters Schloss plant Herzog Cornwall: Gierig greife ich nach jedem Stück Macht.",
-                "sentenceTranslation": "В замке Глостера герцог Корнуолл замышляет: Жадно я хватаюсь за каждый кусок власти.",
+                "sentence": "Auf dem Turnierplatz lässt Cornwall seine Reiter zu später Stunde antreten. Selbst wenn die Welt zerfällt, bleibt das Wort „gierig“ mein Nordstern.",
+                "sentenceTranslation": "На турнирной площадке Корнуолл строит всадников поздним вечером. Даже если мир распадается, слово «жадный» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehrgeiz",
@@ -1526,8 +1526,8 @@
                 "word": "die Herrschsucht",
                 "translation": "властолюбие",
                 "transcription": "[ди ХЕР-зухт]",
-                "sentence": "In Glosters Schloss plant Herzog Cornwall: Die Herrschsucht bestimmt all meine Taten.",
-                "sentenceTranslation": "В замке Глостера герцог Корнуолл замышляет: Властолюбие определяет все мои поступки.",
+                "sentence": "Zwischen Pergamentrollen überdenkt Cornwall geheime Bündnisse. Wie ein stilles Gebet legt sich das Wort „die Herrschsucht“ auf meine Lippen.",
+                "sentenceTranslation": "Среди свитков пергамента Корнуолл обдумывает тайные союзы. Как тихая молитва слово «властолюбие» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehrgeiz",
@@ -1550,8 +1550,8 @@
                 "word": "ergreifen",
                 "translation": "захватывать",
                 "transcription": "[ер-ГРАЙ-фен]",
-                "sentence": "In Glosters Schloss plant Herzog Cornwall: Ich ergreife jede Gelegenheit zur Macht.",
-                "sentenceTranslation": "В замке Глостера герцог Корнуолл замышляет: Я захватываю каждую возможность власти.",
+                "sentence": "Im Spiegel der Audienzhalle probt Cornwall das Lächeln eines Herrschers. Ich umarme das Wort „ergreifen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В зеркале аудиенц-зала Корнуолл репетирует улыбку правителя. Я обнимаю слово «захватывать», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehrgeiz",
@@ -1575,19 +1575,19 @@
             {
                 "question": "Что означает немецкое слово «der Ehrgeiz»?",
                 "choices": [
-                    "стремиться",
                     "желать",
+                    "честолюбие",
                     "жадность",
-                    "честолюбие"
+                    "стремиться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Gier»?",
                 "choices": [
-                    "честолюбие",
                     "стремиться",
                     "желать",
+                    "честолюбие",
                     "жадность"
                 ],
                 "correctIndex": 3
@@ -1595,60 +1595,60 @@
             {
                 "question": "Что означает немецкое слово «streben»?",
                 "choices": [
-                    "жадность",
+                    "вожделеть",
+                    "жадный",
                     "стремиться",
-                    "захватывать",
-                    "желать"
+                    "жадность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verlangen»?",
                 "choices": [
+                    "властолюбие",
                     "захватывать",
-                    "жадность",
                     "желать",
-                    "властолюбие"
+                    "жадный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "жадность",
-                    "вожделеть",
-                    "захватывать",
-                    "стремиться"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «gierig»?",
-                "choices": [
-                    "честолюбие",
-                    "желать",
                     "жадный",
-                    "жадность"
+                    "стремиться",
+                    "вожделеть",
+                    "захватывать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «gierig»?",
+                "choices": [
+                    "желать",
+                    "захватывать",
+                    "стремиться",
+                    "жадный"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Herrschsucht»?",
                 "choices": [
-                    "вожделеть",
-                    "властолюбие",
                     "жадность",
-                    "стремиться"
+                    "желать",
+                    "вожделеть",
+                    "властолюбие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ergreifen»?",
                 "choices": [
-                    "честолюбие",
-                    "вожделеть",
+                    "жадный",
+                    "желать",
                     "захватывать",
-                    "властолюбие"
+                    "честолюбие"
                 ],
                 "correctIndex": 2
             }
@@ -1663,8 +1663,8 @@
                 "word": "die Grausamkeit",
                 "translation": "жестокость",
                 "transcription": "[ди ГРАУ-зам-кайт]",
-                "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Die Grausamkeit meiner Frau gefällt mir.",
-                "sentenceTranslation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Жестокость моей жены мне нравится.",
+                "sentence": "Neben Regans vergiftetem Lächeln hebt Cornwall den Kelch zum Spott. Ich umarme das Wort „die Grausamkeit“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Рядом с ядовитой улыбкой Реганы Корнуолл поднимает кубок насмешки. Я обнимаю слово «жестокость», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bosheit",
@@ -1698,8 +1698,8 @@
                 "word": "die Bosheit",
                 "translation": "злоба",
                 "transcription": "[ди БОС-хайт]",
-                "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Unsere Bosheit macht uns zum perfekten Paar.",
-                "sentenceTranslation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Наша злоба делает нас идеальной парой.",
+                "sentence": "Auf der Galerie des Schlosses applaudiert Cornwall den Demütigungen des Königs. Ich umarme das Wort „die Bosheit“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "На галерее замка Корнуолл аплодирует унижениям короля. Я обнимаю слово «злоба», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bosheit",
@@ -1726,8 +1726,8 @@
                 "word": "billigen",
                 "translation": "одобрять",
                 "transcription": "[БИ-ли-ген]",
-                "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Ich billige alle ihre grausamen Pläne.",
-                "sentenceTranslation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Я одобряю все её жестокие планы.",
+                "sentence": "Zwischen eingeschüchterten Dienern greift Cornwall nach der Peitsche. Das kalte Licht lässt das Wort „billigen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Среди запуганных слуг Корнуолл тянется к плётке. Холодный свет заставляет слово «одобрять» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bosheit",
@@ -1750,8 +1750,8 @@
                 "word": "unterstützen",
                 "translation": "поддерживать",
                 "transcription": "[ун-тер-ШТЮ-цен]",
-                "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Ich unterstütze ihre Unmenschlichkeit.",
-                "sentenceTranslation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Я поддерживаю её бесчеловечность.",
+                "sentence": "Am hohen Lehnsessel sitzt Cornwall mit kalter Zufriedenheit. Ich zeichne das Wort „unterstützen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В высоком кресле-ленном Корнуолл сидит с холодным довольством. Я черчу слово «поддерживать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1773,8 +1773,8 @@
                 "word": "anstacheln",
                 "translation": "подстрекать",
                 "transcription": "[АН-шта-хельн]",
-                "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Ich stachle sie zu größerer Grausamkeit an.",
-                "sentenceTranslation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Я подстрекаю её к большей жестокости.",
+                "sentence": "Vor dem Bannerschrank zerreißt Cornwall einen höflichen Bittbrief. Selbst wenn die Welt zerfällt, bleibt das Wort „anstacheln“ mein Nordstern.",
+                "sentenceTranslation": "Перед шкафом со штандартами Корнуолл разрывает вежливое прошение. Даже если мир распадается, слово «подстрекать» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bosheit",
@@ -1797,8 +1797,8 @@
                 "word": "ermutigen",
                 "translation": "поощрять",
                 "transcription": "[ер-МУ-ти-ген]",
-                "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Ich ermutige ihre dunkelsten Impulse.",
-                "sentenceTranslation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: Я поощряю её самые тёмные импульсы.",
+                "sentence": "Unter stürmischen Trommeln befiehlt Cornwall den Wachen näherzukommen. Das Echo des Wortes „ermutigen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Под грохот барабанов Корнуолл приказывает стражам подойти ближе. Эхо слова «поощрять» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bosheit",
@@ -1821,8 +1821,8 @@
                 "word": "die Härte",
                 "translation": "суровость",
                 "transcription": "[ди ХЕР-те]",
-                "sentence": "In Regans Gemächern zeigt Cornwall seiner Frau die Härte: Mit eiserner Härte regieren wir zusammen.",
-                "sentenceTranslation": "В покоях Реганы Корнуолл демонстрирует жене свою жестокость: С железной суровостью мы правим вместе.",
+                "sentence": "Im Schatten der Folterkammer tauscht Cornwall mit Regan heimliche Blicke. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Härte“ darf nicht vergehen.",
+                "sentenceTranslation": "В тени пыточной Корнуолл обменивается с Реганой тайными взглядами. Я шепчу стражам судьбы: слово «суровость» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bosheit",
@@ -1851,29 +1851,29 @@
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "жестокость",
-                    "одобрять",
                     "поддерживать",
-                    "злоба"
+                    "одобрять",
+                    "злоба",
+                    "жестокость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
                     "одобрять",
-                    "поддерживать",
+                    "злоба",
                     "жестокость",
-                    "злоба"
+                    "поддерживать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «billigen»?",
                 "choices": [
+                    "суровость",
                     "поддерживать",
                     "поощрять",
-                    "жестокость",
                     "одобрять"
                 ],
                 "correctIndex": 3
@@ -1881,37 +1881,37 @@
             {
                 "question": "Что означает немецкое слово «unterstützen»?",
                 "choices": [
-                    "жестокость",
                     "поддерживать",
-                    "суровость",
-                    "подстрекать"
+                    "злоба",
+                    "подстрекать",
+                    "суровость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «anstacheln»?",
                 "choices": [
-                    "злоба",
-                    "жестокость",
                     "подстрекать",
-                    "одобрять"
+                    "злоба",
+                    "поддерживать",
+                    "жестокость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ermutigen»?",
                 "choices": [
-                    "жестокость",
                     "поощрять",
-                    "суровость",
-                    "злоба"
+                    "одобрять",
+                    "подстрекать",
+                    "поддерживать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Härte»?",
                 "choices": [
-                    "жестокость",
+                    "подстрекать",
                     "поощрять",
                     "одобрять",
                     "суровость"
@@ -1929,8 +1929,8 @@
                 "word": "die Tyrannei",
                 "translation": "тирания",
                 "transcription": "[ди тю-ра-НАЙ]",
-                "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Meine Tyrannei erstickt jeden Widerstand.",
-                "sentenceTranslation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Моя тирания душит любое сопротивление.",
+                "sentence": "Auf dem Burghof verteilt Cornwall neue, erbarmungslose Dekrete. Ich zeichne das Wort „die Tyrannei“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На замковом дворе Корнуолл раздаёт новые беспощадные указы. Я вывожу слово «тирания» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Furcht",
@@ -1953,8 +1953,8 @@
                 "word": "die Unterdrückung",
                 "translation": "угнетение",
                 "transcription": "[ди ун-тер-ДРЮ-кунг]",
-                "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Die Unterdrückung ist mein Herrschaftsmittel.",
-                "sentenceTranslation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Угнетение - моё средство правления.",
+                "sentence": "Vor gefesselten Gefangenen lässt Cornwall die Streitkolben prüfen. Mein Atem zeichnet das Wort „die Unterdrückung“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед связанными пленниками Корнуолл приказывает проверить боевые булавы. Моё дыхание рисует слово «угнетение» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Furcht",
@@ -1977,8 +1977,8 @@
                 "word": "die Furcht",
                 "translation": "страх",
                 "transcription": "[ди ФУРХТ]",
-                "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Durch Furcht halte ich alle unter Kontrolle.",
-                "sentenceTranslation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Страхом я держу всех под контролем.",
+                "sentence": "Zwischen klirrenden Ketten schreitet Cornwall mit schwerem Schritt. Ich halte das Wort „die Furcht“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Среди звенящих цепей Корнуолл идёт тяжёлым шагом. Я держу слово «страх» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Furcht",
@@ -2002,8 +2002,8 @@
                 "word": "unterdrücken",
                 "translation": "подавлять",
                 "transcription": "[ун-тер-ДРЮ-кен]",
-                "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Ich unterdrücke jeden freien Gedanken.",
-                "sentenceTranslation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Я подавляю любую свободную мысль.",
+                "sentence": "Am schwarzen Banner der Macht schwört Cornwall sich ewige Herrschaft. Mein Atem zeichnet das Wort „unterdrücken“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У чёрного знамени власти Корнуолл клянётся вечным господством. Моё дыхание рисует слово «подавлять» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2025,8 +2025,8 @@
                 "word": "knechten",
                 "translation": "порабощать",
                 "transcription": "[КНЕХ-тен]",
-                "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Ich knechte alle, die mir unterstehen.",
-                "sentenceTranslation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Я порабощаю всех, кто мне подчинён.",
+                "sentence": "Auf dem Gerichtspodest stützt Cornwall sich auf den Stab aus Eisen. Ich presse das Wort „knechten“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На судейском помосте Корнуолл опирается на железный посох. Я стискиваю слово «порабощать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Furcht",
@@ -2049,8 +2049,8 @@
                 "word": "zwingen",
                 "translation": "принуждать",
                 "transcription": "[ЦВИН-ген]",
-                "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Ich zwinge alle zu absolutem Gehorsam.",
-                "sentenceTranslation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Я принуждаю всех к абсолютному послушанию.",
+                "sentence": "Unter den Blicken eingeschüchterter Edelleute reißt Cornwall das Urteil an sich. Ich zeichne das Wort „zwingen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под взглядами запуганных дворян Корнуолл присваивает себе право суда. Я вывожу слово «принуждать» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2073,8 +2073,8 @@
                 "word": "die Willkür",
                 "translation": "произвол",
                 "transcription": "[ди ВИЛЬ-кюр]",
-                "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Meine Willkür ist das einzige Gesetz.",
-                "sentenceTranslation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Мой произвол - единственный закон.",
+                "sentence": "An der Treppe zum Kerker verteilt Cornwall grausame Befehle. Ich umarme das Wort „die Willkür“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "У лестницы в темницу Корнуолл раздаёт жестокие приказы. Я обнимаю слово «произвол», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Furcht",
@@ -2097,8 +2097,8 @@
                 "word": "brutal",
                 "translation": "брутальный",
                 "transcription": "[бру-ТАЛЬ]",
-                "sentence": "Während Lear vor der Burg um Einlass fleht, prahlt Cornwall: Brutal zerschlage ich jeden Widerstand.",
-                "sentenceTranslation": "Пока Лир умоляет впустить его в замок, Корнуолл хвастается: Брутально я сокрушаю любое сопротивление.",
+                "sentence": "Im düsteren Thronsaal schlägt Cornwall mit der Faust auf die Armlehne. Ich halte das Wort „brutal“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В мрачном тронном зале Корнуолл бьёт кулаком по подлокотнику. Я держу слово «брутальный» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Furcht",
@@ -2123,79 +2123,79 @@
                 "question": "Что означает немецкое слово «die Tyrannei»?",
                 "choices": [
                     "тирания",
+                    "подавлять",
                     "угнетение",
-                    "страх",
-                    "подавлять"
+                    "страх"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Unterdrückung»?",
                 "choices": [
-                    "страх",
-                    "угнетение",
                     "подавлять",
-                    "тирания"
+                    "тирания",
+                    "угнетение",
+                    "страх"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Furcht»?",
                 "choices": [
                     "страх",
-                    "порабощать",
-                    "принуждать",
-                    "подавлять"
+                    "подавлять",
+                    "угнетение",
+                    "принуждать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «unterdrücken»?",
                 "choices": [
-                    "угнетение",
-                    "тирания",
                     "подавлять",
-                    "порабощать"
+                    "брутальный",
+                    "тирания",
+                    "принуждать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «knechten»?",
                 "choices": [
-                    "угнетение",
                     "порабощать",
                     "брутальный",
+                    "страх",
                     "произвол"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «zwingen»?",
                 "choices": [
-                    "произвол",
-                    "подавлять",
+                    "принуждать",
                     "брутальный",
-                    "принуждать"
+                    "тирания",
+                    "страх"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Willkür»?",
                 "choices": [
-                    "брутальный",
+                    "произвол",
+                    "тирания",
                     "угнетение",
-                    "порабощать",
-                    "произвол"
+                    "порабощать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «brutal»?",
                 "choices": [
+                    "страх",
                     "тирания",
-                    "подавлять",
                     "брутальный",
-                    "страх"
+                    "угнетение"
                 ],
                 "correctIndex": 2
             }
@@ -2210,8 +2210,8 @@
                 "word": "die Strafe",
                 "translation": "наказание",
                 "transcription": "[ди ШТРА-фе]",
-                "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Die Strafe für Widerspruch ist hart.",
-                "sentenceTranslation": "Перед стенами замка Глостера Корнуолл приказывает: Наказание за возражение сурово.",
+                "sentence": "Vor den geschockten Höflingen deutet Cornwall auf die leeren Holzkolben. Wie ein stilles Gebet legt sich das Wort „die Strafe“ auf meine Lippen.",
+                "sentenceTranslation": "Перед потрясёнными придворными Корнуолл указывает на пустые колодки. Как тихая молитва слово «наказание» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2238,8 +2238,8 @@
                 "word": "der Zorn",
                 "translation": "гнев",
                 "transcription": "[дер ЦОРН]",
-                "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Mein Zorn kennt keine Barmherzigkeit.",
-                "sentenceTranslation": "Перед стенами замка Глостера Корнуолл приказывает: Мой гнев не знает милосердия.",
+                "sentence": "Auf dem nassen Hof befiehlt Cornwall die Fesselung des Widerspenstigen. Mit fester Stimme schwöre ich mir: Das Wort „der Zorn“ wird heute nicht verraten.",
+                "sentenceTranslation": "На мокром дворе Корнуолл приказывает заковать непокорного. Твёрдым голосом я клянусь себе: слово «гнев» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2264,8 +2264,8 @@
                 "word": "bestrafen",
                 "translation": "карать",
                 "transcription": "[бе-ШТРА-фен]",
-                "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Ich bestrafe Kent für seine Frechheit.",
-                "sentenceTranslation": "Перед стенами замка Глостера Корнуолл приказывает: Я караю Кента за его дерзость.",
+                "sentence": "Neben Regans spöttischem Blick wirft Cornwall das Urteil in die Luft. Ich flüstere den Wächtern des Schicksals zu: Das Wort „bestrafen“ darf nicht vergehen.",
+                "sentenceTranslation": "Рядом с насмешливым взглядом Реганы Корнуолл бросает приговор в воздух. Я шепчу стражам судьбы: слово «карать» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2290,8 +2290,8 @@
                 "word": "züchtigen",
                 "translation": "наказывать",
                 "transcription": "[ЦЮХ-ти-ген]",
-                "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Öffentlich züchtige ich die Widerspenstigen.",
-                "sentenceTranslation": "Перед стенами замка Глостера Корнуолл приказывает: Публично я наказываю непокорных.",
+                "sentence": "Am Werkzeugtisch der Garde prüft Cornwall die scharfen Nägel. Ich presse das Wort „züchtigen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У верстака стражи Корнуолл проверяет острые гвозди. Я стискиваю слово «наказывать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Strafe",
@@ -2316,8 +2316,8 @@
                 "word": "demütigen",
                 "translation": "унижать",
                 "transcription": "[де-МЮ-ти-ген]",
-                "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Ich demütige ihn vor aller Augen.",
-                "sentenceTranslation": "Перед стенами замка Глостера Корнуолл приказывает: Я унижаю его на глазах у всех.",
+                "sentence": "Vor den verschreckten Dienern lächelt Cornwall über das Flehen um Gnade. Ich flüstere den Wächtern des Schicksals zu: Das Wort „demütigen“ darf nicht vergehen.",
+                "sentenceTranslation": "Перед перепуганными слугами Корнуолл улыбается мольбам о пощаде. Я шепчу стражам судьбы: слово «унижать» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Strafe",
@@ -2347,8 +2347,8 @@
                 "word": "erniedrigen",
                 "translation": "унижать",
                 "transcription": "[ер-НИД-ри-ген]",
-                "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Ich erniedrige den treuen Diener.",
-                "sentenceTranslation": "Перед стенами замка Глостера Корнуолл приказывает: Я унижаю верного слугу.",
+                "sentence": "Unter Donnerhall befiehlt Cornwall das Opfer in den Regen zu stellen. Selbst wenn die Welt zerfällt, bleibt das Wort „erniedrigen“ mein Nordstern.",
+                "sentenceTranslation": "Под раскаты грома Корнуолл приказывает поставить жертву под дождь. Даже если мир распадается, слово «унижать» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Strafe",
@@ -2376,8 +2376,8 @@
                 "word": "quälen",
                 "translation": "мучить",
                 "transcription": "[КВЕ-лен]",
-                "sentence": "Vor den Mauern von Glosters Burg befiehlt Cornwall: Es bereitet mir Freude, ihn zu quälen.",
-                "sentenceTranslation": "Перед стенами замка Глостера Корнуолл приказывает: Мне доставляет радость мучить его.",
+                "sentence": "Auf dem Steinboden hinterlässt Cornwall Spuren von Blut und Wasser. Ich halte das Wort „quälen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На каменном полу Корнуолл оставляет следы крови и воды. Я держу слово «мучить» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2401,29 +2401,29 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
+                    "наказание",
                     "наказывать",
                     "гнев",
-                    "наказание",
                     "карать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "наказывать",
-                    "наказание",
+                    "карать",
                     "гнев",
-                    "карать"
+                    "наказание",
+                    "наказывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bestrafen»?",
                 "choices": [
-                    "наказание",
+                    "мучить",
+                    "наказывать",
                     "гнев",
-                    "унижать",
                     "карать"
                 ],
                 "correctIndex": 3
@@ -2431,9 +2431,9 @@
             {
                 "question": "Что означает немецкое слово «züchtigen»?",
                 "choices": [
-                    "мучить",
+                    "унижать",
                     "наказывать",
-                    "гнев",
+                    "наказание",
                     "унижать"
                 ],
                 "correctIndex": 1
@@ -2441,32 +2441,32 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "унижать",
-                    "наказывать",
-                    "наказание",
-                    "карать"
+                    "мучить",
+                    "гнев",
+                    "карать",
+                    "унижать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
-                    "гнев",
                     "унижать",
+                    "гнев",
                     "карать",
-                    "мучить"
+                    "наказание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
-                    "мучить",
-                    "наказывать",
                     "карать",
-                    "унижать"
+                    "гнев",
+                    "унижать",
+                    "мучить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2479,8 +2479,8 @@
                 "word": "die Folter",
                 "translation": "пытка",
                 "transcription": "[ди ФОЛЬ-тер]",
-                "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Die Folter ist mein liebstes Werkzeug.",
-                "sentenceTranslation": "В застенках Глостера Корнуолл готовит пытку: Пытка - мой любимый инструмент.",
+                "sentence": "Im düsteren Saal bindet Cornwall den Grafen an den eichenen Stuhl. Mit fester Stimme schwöre ich mir: Das Wort „die Folter“ wird heute nicht verraten.",
+                "sentenceTranslation": "В мрачном зале Корнуолл приковывает графа к дубовому креслу. Твёрдым голосом я клянусь себе: слово «пытка» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -2511,8 +2511,8 @@
                 "word": "der Sadismus",
                 "translation": "садизм",
                 "transcription": "[дер за-ДИС-мус]",
-                "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Mein Sadismus kennt keine Grenzen.",
-                "sentenceTranslation": "В застенках Глостера Корнуолл готовит пытку: Мой садизм не знает границ.",
+                "sentence": "Neben knirschenden Seilen entfachen Regans Diener das Feuer, während Cornwall zuschaut. Ich zeichne das Wort „der Sadismus“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под скрип канатов слуги Реганы раздувают огонь, пока Корнуолл наблюдает. Я черчу слово «садизм» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -2538,8 +2538,8 @@
                 "word": "das Blut",
                 "translation": "кровь",
                 "transcription": "[дас БЛУТ]",
-                "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Das Blut des Grafen befleckt meine Hände.",
-                "sentenceTranslation": "В застенках Глостера Корнуолл готовит пытку: Кровь графа пятнает мои руки.",
+                "sentence": "Vor der versammelten Ritterschaft lässt Cornwall die Dolche bereitlegen. Ich zeichne das Wort „das Blut“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед собравшимся рыцарством Корнуолл велит приготовить кинжалы. Я черчу слово «кровь» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2561,8 +2561,8 @@
                 "word": "foltern",
                 "translation": "пытать",
                 "transcription": "[ФОЛЬ-терн]",
-                "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Mit Lust foltere ich den alten Mann.",
-                "sentenceTranslation": "В застенках Глостера Корнуолл готовит пытку: С наслаждением я пытаю старика.",
+                "sentence": "Am blutbefleckten Boden tritt Cornwall das Geständnis aus dem Gefangenen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „foltern“ bleibt lebendig.",
+                "sentenceTranslation": "На забрызганном кровью полу Корнуолл выбивает признание из пленника. Каждой клеткой тела я обещаю: слово «пытать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -2589,8 +2589,8 @@
                 "word": "verstümmeln",
                 "translation": "калечить",
                 "transcription": "[фер-ШТЮМ-мельн]",
-                "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Ich verstümmle ihn ohne Erbarmen.",
-                "sentenceTranslation": "В застенках Глостера Корнуолл готовит пытку: Я калечу его без милосердия.",
+                "sentence": "Zwischen aufschreienden Dienern bleibt Cornwall eiskalt und unbewegt. Selbst wenn die Welt zerfällt, bleibt das Wort „verstümmeln“ mein Nordstern.",
+                "sentenceTranslation": "Среди вскрикивающих слуг Корнуолл остаётся ледяным и неподвижным. Даже если мир распадается, слово «калечить» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -2613,8 +2613,8 @@
                 "word": "blenden",
                 "translation": "ослеплять",
                 "transcription": "[БЛЕН-ден]",
-                "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Eigenhändig blende ich Gloucester.",
-                "sentenceTranslation": "В застенках Глостера Корнуолл готовит пытку: Собственноручно я ослепляю Глостера.",
+                "sentence": "Unter Regans Jubel reißt Cornwall das grausame Werk zu Ende. Mein Atem zeichnet das Wort „blenden“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Под ликование Реганы Корнуолл довершает жестокую работу. Моё дыхание рисует слово «ослеплять» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2639,8 +2639,8 @@
                 "word": "ausstechen",
                 "translation": "выкалывать",
                 "transcription": "[АУС-ште-хен]",
-                "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Seine Augen steche ich mit Freude aus.",
-                "sentenceTranslation": "В застенках Глостера Корнуолл готовит пытку: Его глаза я выкалываю с радостью.",
+                "sentence": "Vor den entsetzten Augen des Hofes wischt Cornwall das Blut vom Stiefel. Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus.",
+                "sentenceTranslation": "Перед ужаснувшимися придворными Корнуолл стирает кровь с сапога. Я глубоко вдыхаю и выпускаю только слово «выкалывать».",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -2666,8 +2666,8 @@
                 "word": "die Qual",
                 "translation": "мука",
                 "transcription": "[ди КВАЛЬ]",
-                "sentence": "Im Kerker von Gloster bereitet Cornwall die Folter: Seine Qual bereitet mir Vergnügen.",
-                "sentenceTranslation": "В застенках Глостера Корнуолл готовит пытку: Его мука доставляет мне удовольствие.",
+                "sentence": "Im Nachhall der Schreie richtet Cornwall den Mantel und wendet sich zur Tür. Ich umarme das Wort „die Qual“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В отзвуках криков Корнуолл поправляет плащ и разворачивается к двери. Я обнимаю слово «мука», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -2696,49 +2696,49 @@
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "пытать",
                     "кровь",
                     "садизм",
-                    "пытка"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Sadismus»?",
-                "choices": [
                     "пытка",
-                    "пытать",
-                    "садизм",
-                    "кровь"
+                    "пытать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «der Sadismus»?",
+                "choices": [
+                    "пытать",
+                    "садизм",
+                    "пытка",
+                    "кровь"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «das Blut»?",
                 "choices": [
-                    "садизм",
-                    "ослеплять",
+                    "выкалывать",
+                    "пытка",
                     "кровь",
-                    "пытать"
+                    "мука"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
-                    "ослеплять",
+                    "пытать",
                     "кровь",
                     "садизм",
-                    "пытать"
+                    "ослеплять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verstümmeln»?",
                 "choices": [
-                    "пытка",
-                    "кровь",
                     "ослеплять",
+                    "пытка",
+                    "мука",
                     "калечить"
                 ],
                 "correctIndex": 3
@@ -2746,29 +2746,29 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "кровь",
                     "калечить",
-                    "садизм",
-                    "ослеплять"
+                    "ослеплять",
+                    "пытать",
+                    "пытка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
-                    "пытка",
-                    "кровь",
-                    "выкалывать",
-                    "пытать"
+                    "ослеплять",
+                    "пытать",
+                    "садизм",
+                    "выкалывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
-                    "пытать",
                     "садизм",
                     "пытка",
+                    "пытать",
                     "мука"
                 ],
                 "correctIndex": 3
@@ -2784,8 +2784,8 @@
                 "word": "die Wunde",
                 "translation": "рана",
                 "transcription": "[ди ВУН-де]",
-                "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Die Wunde brennt wie Feuer in meinem Leib.",
-                "sentenceTranslation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Рана горит как огонь в моём теле.",
+                "sentence": "Im dunklen Korridor presst Cornwall die Hand gegen die frische Wunde. Ich atme tief ein und lasse nur das Wort „die Wunde“ wieder hinaus.",
+                "sentenceTranslation": "В тёмном коридоре Корнуолл прижимает руку к свежей ране. Я глубоко вдыхаю и выпускаю только слово «рана».",
                 "visual_hint": "📚",
                 "themes": [
                     "Schmerz",
@@ -2808,8 +2808,8 @@
                 "word": "der Schmerz",
                 "translation": "боль",
                 "transcription": "[дер ШМЕРЦ]",
-                "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Der Schmerz durchbohrt meinen Körper.",
-                "sentenceTranslation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Боль пронзает моё тело.",
+                "sentence": "Auf der Treppe taumelt Cornwall, während das Blut den Stein färbt. Das kalte Licht lässt das Wort „der Schmerz“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На лестнице Корнуолл пошатывается, окрашивая камень кровью. Холодный свет заставляет слово «боль» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2832,8 +2832,8 @@
                 "word": "die Überraschung",
                 "translation": "удивление",
                 "transcription": "[ди ю-бер-РА-шунг]",
-                "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Die Überraschung des Angriffs schockiert mich.",
-                "sentenceTranslation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Неожиданность нападения шокирует меня.",
+                "sentence": "Neben Regans erschrockener Stimme sucht Cornwall Halt am Geländer. Ich zeichne das Wort „die Überraschung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Рядом с испуганным голосом Реганы Корнуолл ищет опоры в перилах. Я вывожу слово «удивление» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Schmerz",
@@ -2856,8 +2856,8 @@
                 "word": "bluten",
                 "translation": "кровоточить",
                 "transcription": "[БЛУ-тен]",
-                "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Ich blute wie ein geschlachtetes Schwein.",
-                "sentenceTranslation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Я кровоточу как зарезанная свинья.",
+                "sentence": "Im Stall greift Cornwall nach einem Sattel, doch die Kräfte schwinden. Ich umarme das Wort „bluten“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В конюшне Корнуолл тянется к седлу, но силы уходят. Я обнимаю слово «кровоточить», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Schmerz",
@@ -2880,8 +2880,8 @@
                 "word": "verwundet",
                 "translation": "раненый",
                 "transcription": "[фер-ВУН-дет]",
-                "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Schwer verwundet sinke ich zu Boden.",
-                "sentenceTranslation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Тяжело раненый я падаю на землю.",
+                "sentence": "Vor dem Tor der Burg hinterlässt Cornwall eine Spur aus rotem Staub. Selbst wenn die Welt zerfällt, bleibt das Wort „verwundet“ mein Nordstern.",
+                "sentenceTranslation": "Перед воротами замка Корнуолл оставляет след из красной пыли. Даже если мир распадается, слово «раненый» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Schmerz",
@@ -2904,8 +2904,8 @@
                 "word": "schwächen",
                 "translation": "ослаблять",
                 "transcription": "[ШВЕ-хен]",
-                "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Die Verletzung schwächt meinen starken Körper.",
-                "sentenceTranslation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Ранение ослабляет моё сильное тело.",
+                "sentence": "Auf dem Hof sinkt Cornwall zwischen erschrockenen Wachen zusammen. Wie ein stilles Gebet legt sich das Wort „schwächen“ auf meine Lippen.",
+                "sentenceTranslation": "На дворе Корнуолл падает среди испуганных стражников. Как тихая молитва слово «ослаблять» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Schmerz",
@@ -2928,8 +2928,8 @@
                 "word": "leiden",
                 "translation": "страдать",
                 "transcription": "[ЛАЙ-ден]",
-                "sentence": "Nachdem Gloucester geblendet ist, taumelt Cornwall blutend durch den Hof: Zum ersten Mal leide ich selbst.",
-                "sentenceTranslation": "Осле слепления Глостера Корнуолл, истекая кровью, шатается по двору: Впервые я сам страдаю.",
+                "sentence": "Unter dem bleiernen Himmel schwört Cornwall Rache mit letzter Kraft. Das kalte Licht lässt das Wort „leiden“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Под свинцовым небом Корнуолл клянётся в мести из последних сил. Холодный свет заставляет слово «страдать» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2956,9 +2956,9 @@
             {
                 "question": "Что означает немецкое слово «die Wunde»?",
                 "choices": [
-                    "удивление",
                     "боль",
                     "кровоточить",
+                    "удивление",
                     "рана"
                 ],
                 "correctIndex": 3
@@ -2966,29 +2966,29 @@
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
-                    "рана",
-                    "боль",
                     "удивление",
-                    "кровоточить"
+                    "рана",
+                    "кровоточить",
+                    "боль"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Überraschung»?",
                 "choices": [
-                    "рана",
-                    "ослаблять",
+                    "кровоточить",
                     "удивление",
-                    "кровоточить"
+                    "страдать",
+                    "рана"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bluten»?",
                 "choices": [
-                    "боль",
                     "раненый",
-                    "ослаблять",
+                    "страдать",
+                    "рана",
                     "кровоточить"
                 ],
                 "correctIndex": 3
@@ -2996,19 +2996,19 @@
             {
                 "question": "Что означает немецкое слово «verwundet»?",
                 "choices": [
+                    "раненый",
                     "рана",
-                    "боль",
-                    "кровоточить",
-                    "раненый"
+                    "страдать",
+                    "удивление"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «schwächen»?",
                 "choices": [
-                    "кровоточить",
                     "страдать",
-                    "удивление",
+                    "рана",
+                    "боль",
                     "ослаблять"
                 ],
                 "correctIndex": 3
@@ -3016,12 +3016,12 @@
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "боль",
-                    "ослаблять",
                     "удивление",
-                    "страдать"
+                    "рана",
+                    "страдать",
+                    "кровоточить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -3034,8 +3034,8 @@
                 "word": "der Tod",
                 "translation": "смерть",
                 "transcription": "[дер ТОД]",
-                "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Der Tod kommt für mich zu früh.",
-                "sentenceTranslation": "Умирая в покоях Реганы, Корнуолл рычит: Смерть приходит ко мне слишком рано.",
+                "sentence": "Im Treppenhaus der Burg bricht Cornwall auf das kalte Steinpodest. Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На лестнице замка Корнуолл рушится на холодную площадку. Моё дыхание рисует слово «смерть» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3061,8 +3061,8 @@
                 "word": "die Vergeltung",
                 "translation": "возмездие",
                 "transcription": "[ди фер-ГЕЛЬ-тунг]",
-                "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Die Vergeltung ereilt mich unerwartet.",
-                "sentenceTranslation": "Умирая в покоях Реганы, Корнуолл рычит: Возмездие настигает меня неожиданно.",
+                "sentence": "Zwischen zerbrochenen Waffen liegt Cornwall und ringt nach Atem. Das kalte Licht lässt das Wort „die Vergeltung“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Среди разбитого оружия Корнуолл лежит, хватая воздух. Холодный свет заставляет слово «возмездие» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ende",
@@ -3085,8 +3085,8 @@
                 "word": "das Ende",
                 "translation": "конец",
                 "transcription": "[дас ЕН-де]",
-                "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Mein Ende kommt durch eines Dieners Hand.",
-                "sentenceTranslation": "Умирая в покоях Реганы, Корнуолл рычит: Мой конец приходит от руки слуги.",
+                "sentence": "Vor Regans entsetztem Blick verliert Cornwall den Griff um das eigene Blut. Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед ужаснувшимся взглядом Реганы Корнуолл теряет хватку на собственной ране. Я держу слово «конец» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3111,8 +3111,8 @@
                 "word": "sterben",
                 "translation": "умирать",
                 "transcription": "[ШТЕР-бен]",
-                "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Ich sterbe ohne Reue für meine Taten.",
-                "sentenceTranslation": "Умирая в покоях Реганы, Корнуолл рычит: Я умираю без раскаяния за свои дела.",
+                "sentence": "Am Fuß der Treppe murmelt Cornwall die letzten Befehle. Ich umarme das Wort „sterben“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "У подножия лестницы Корнуолл бормочет последние приказы. Я обнимаю слово «умирать», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3138,8 +3138,8 @@
                 "word": "verenden",
                 "translation": "издыхать",
                 "transcription": "[фер-ЕН-ден]",
-                "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Wie ein Tier verende ich elend.",
-                "sentenceTranslation": "Умирая в покоях Реганы, Корнуолл рычит: Как зверь я издыхаю жалко.",
+                "sentence": "Auf der kalten Flaggenkiste sinkt Cornwall schwer zusammen. Mein Atem zeichnet das Wort „verenden“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На холодном сундуке со знамёнами Корнуолл тяжело оседает. Моё дыхание рисует слово «издыхать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ende",
@@ -3165,8 +3165,8 @@
                 "word": "verfluchen",
                 "translation": "проклинать",
                 "transcription": "[фер-ФЛУ-хен]",
-                "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Sterbend verfluche ich meine Mörder.",
-                "sentenceTranslation": "Умирая в покоях Реганы, Корнуолл рычит: Умирая, я проклинаю своих убийц.",
+                "sentence": "Neben zerborstenen Fenstern haucht Cornwall den letzten Fluch aus. Mit fester Stimme schwöre ich mir: Das Wort „verfluchen“ wird heute nicht verraten.",
+                "sentenceTranslation": "У разбитых окон Корнуолл выдыхает последний проклятый звук. Твёрдым голосом я клянусь себе: слово «проклинать» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3192,8 +3192,8 @@
                 "word": "röcheln",
                 "translation": "хрипеть",
                 "transcription": "[РЁ-хельн]",
-                "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Röchelnd hauche ich mein Leben aus.",
-                "sentenceTranslation": "Умирая в покоях Реганы, Корнуолл рычит: Хрипя, я испускаю дух.",
+                "sentence": "Unter dem prasselnden Regen verglimmt Cornwalls Leben rasch. Ich halte das Wort „röcheln“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Под проливным дождём жизнь Корнуолл быстро гаснет. Я держу слово «хрипеть» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ende",
@@ -3216,8 +3216,8 @@
                 "word": "die Strafe",
                 "translation": "кара",
                 "transcription": "[ди ШТРА-фе]",
-                "sentence": "Sterbend in Regans Gemächern knurrt Cornwall: Dies ist die gerechte Strafe für meine Grausamkeit.",
-                "sentenceTranslation": "Умирая в покоях Реганы, Корнуолл рычит: Это справедливая кара за мою жестокость.",
+                "sentence": "Im Staub des Hofes starrt Cornwall zum grauen Himmel, bevor die Augen erlöschen. Ich atme tief ein und lasse nur das Wort „die Strafe“ wieder hinaus.",
+                "sentenceTranslation": "В пыли двора Корнуолл смотрит в серое небо, прежде чем глаза угасают. Я глубоко вдыхаю и выпускаю только слово «кара».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3245,19 +3245,19 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "конец",
                     "смерть",
-                    "умирать",
-                    "возмездие"
+                    "возмездие",
+                    "конец",
+                    "умирать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Vergeltung»?",
                 "choices": [
                     "смерть",
-                    "умирать",
                     "конец",
+                    "умирать",
                     "возмездие"
                 ],
                 "correctIndex": 3
@@ -3265,10 +3265,10 @@
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "хрипеть",
-                    "конец",
                     "проклинать",
-                    "кара"
+                    "конец",
+                    "кара",
+                    "издыхать"
                 ],
                 "correctIndex": 1
             },
@@ -3276,51 +3276,51 @@
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
                     "проклинать",
-                    "кара",
+                    "хрипеть",
                     "умирать",
-                    "хрипеть"
+                    "конец"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
-                    "смерть",
-                    "конец",
                     "издыхать",
-                    "хрипеть"
+                    "хрипеть",
+                    "возмездие",
+                    "умирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "проклинать",
-                    "издыхать",
-                    "хрипеть",
-                    "конец"
+                    "смерть",
+                    "возмездие",
+                    "кара",
+                    "проклинать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «röcheln»?",
                 "choices": [
-                    "хрипеть",
-                    "возмездие",
-                    "конец",
-                    "издыхать"
+                    "издыхать",
+                    "кара",
+                    "умирать",
+                    "хрипеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "проклинать",
-                    "хрипеть",
+                    "издыхать",
                     "смерть",
-                    "кара"
+                    "кара",
+                    "умирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -3851,27 +3851,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/edgar.html
+++ b/output/journeys/edgar.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["королевство", "наследник", "доверять", "знать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["доверять", "знать", "наследник", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["знать", "доверять", "честь", "королевство"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["королевство", "граф", "ничего не подозревающий", "доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["доверять", "знать", "честь", "наследник"], "correct_index": 2}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["законный", "знать", "граф", "доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["доверять", "законный", "граф", "честь"], "correct_index": 2}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["ничего не подозревающий", "знать", "наследник", "королевство"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["преследовать", "опасность", "предательство", "бежать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["преследовать", "бежать", "опасность", "предательство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["опасность", "преследовать", "обман", "прятаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["обман", "интрига", "преследовать", "бежать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["обман", "преследовать", "изгнать", "прятаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["опасность", "бежать", "изгнать", "интрига"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["прятаться", "обман", "изгнать", "бежать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["прятаться", "опасность", "обман", "изгнать"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["безумие", "нищий", "голый", "маскировка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["безумие", "нищий", "маскировка", "голый"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["безумный", "маскировка", "безумие", "голый"], "correct_index": 1}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["дрожать", "маскировка", "голый", "безумный"], "correct_index": 2}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["безумие", "голый", "дрожать", "бормотать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["нищий", "голый", "дрожать", "нищета"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["маскировка", "голый", "дрожать", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["безумие", "безумный", "дрожать", "голый"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["страдать", "мёрзнуть", "хижина", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "хижина", "страдать", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "защищать", "молния", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["буря", "хижина", "гром", "мёрзнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["страдать", "защищать", "хижина", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["молния", "защищать", "сопровождать", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["гром", "защищать", "мёрзнуть", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["хижина", "молния", "мёрзнуть", "страдать"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["слепой", "вести", "утёс", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «führen»?", "choices": ["вести", "обманывать", "утёс", "слепой"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["утёс", "утешать", "слепой", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["отчаяние", "спасать", "обманывать", "вести"], "correct_index": 2}, {"question": "Что означает немецкое слово «retten»?", "choices": ["утёс", "спасать", "отчаяние", "хитрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["спасать", "хитрость", "слепой", "вести"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["спасать", "вести", "утешать", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["вести", "хитрость", "обманывать", "отчаяние"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["бой", "разоблачать", "месть", "дуэль"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["дуэль", "бой", "разоблачать", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["справедливость", "месть", "брат", "побеждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["месть", "разоблачать", "меч", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["месть", "побеждать", "меч", "дуэль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["меч", "справедливость", "брат", "разоблачать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["меч", "справедливость", "дуэль", "разоблачать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["меч", "побеждать", "бой", "брат"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["править", "выживать", "будущее", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "править", "будущее", "выживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["порядок", "наследовать", "будущее", "новый"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["наследовать", "править", "ответственность", "выживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["будущее", "новый", "ответственность", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["мудрость", "править", "новый", "порядок"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["ответственность", "новый", "выживать", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «neu»?", "choices": ["порядок", "будущее", "мудрость", "новый"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["наследник", "доверять", "знать", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["доверять", "наследник", "знать", "королевство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["наследник", "королевство", "знать", "граф"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["законный", "знать", "честь", "доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["законный", "наследник", "честь", "граф"], "correct_index": 2}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["наследник", "честь", "законный", "ничего не подозревающий"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["граф", "честь", "наследник", "знать"], "correct_index": 0}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["граф", "законный", "честь", "ничего не подозревающий"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["преследовать", "предательство", "опасность", "бежать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["бежать", "опасность", "предательство", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["бежать", "преследовать", "прятаться", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["обман", "изгнать", "бежать", "преследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["изгнать", "прятаться", "интрига", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["изгнать", "интрига", "преследовать", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["изгнать", "обман", "бежать", "прятаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["бежать", "изгнать", "обман", "предательство"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["нищий", "голый", "маскировка", "безумие"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["маскировка", "безумие", "голый", "нищий"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["дрожать", "маскировка", "голый", "нищета"], "correct_index": 1}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["дрожать", "безумие", "маскировка", "голый"], "correct_index": 3}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["бормотать", "нищий", "дрожать", "безумие"], "correct_index": 0}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["безумный", "дрожать", "нищета", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["дрожать", "голый", "нищета", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["дрожать", "безумный", "бормотать", "нищий"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["мёрзнуть", "хижина", "страдать", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["страдать", "мёрзнуть", "хижина", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["защищать", "страдать", "гром", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["хижина", "сопровождать", "буря", "гром"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["защищать", "страдать", "хижина", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["защищать", "сопровождать", "хижина", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["молния", "гром", "буря", "хижина"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["гром", "страдать", "мёрзнуть", "молния"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["вести", "слепой", "утёс", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «führen»?", "choices": ["утёс", "обманывать", "вести", "слепой"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["утёс", "спасать", "вести", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["слепой", "вести", "обманывать", "утёс"], "correct_index": 2}, {"question": "Что означает немецкое слово «retten»?", "choices": ["спасать", "утешать", "вести", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["слепой", "отчаяние", "хитрость", "утешать"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["обманывать", "утешать", "утёс", "слепой"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["спасать", "отчаяние", "вести", "обманывать"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["разоблачать", "бой", "месть", "дуэль"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["разоблачать", "бой", "дуэль", "месть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "разоблачать", "дуэль", "меч"], "correct_index": 0}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["справедливость", "разоблачать", "меч", "брат"], "correct_index": 1}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["побеждать", "брат", "дуэль", "бой"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["побеждать", "меч", "дуэль", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["брат", "бой", "меч", "дуэль"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["разоблачать", "брат", "месть", "меч"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["выживать", "будущее", "наследовать", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «erben»?", "choices": ["править", "наследовать", "будущее", "выживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["выживать", "мудрость", "будущее", "ответственность"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["править", "мудрость", "выживать", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["порядок", "наследовать", "мудрость", "выживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["порядок", "будущее", "наследовать", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["порядок", "ответственность", "будущее", "выживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «neu»?", "choices": ["наследовать", "новый", "будущее", "порядок"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный сын</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,31 +465,31 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Erbe»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                             
@@ -497,17 +497,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -517,11 +517,11 @@
                         <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ничего не подозревающий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
                             
@@ -533,61 +533,61 @@
                         <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ничего не подозревающий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -606,9 +606,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
                             
@@ -616,81 +616,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прятаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verstecken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прятаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнать</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verstecken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бежать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -700,29 +700,29 @@
                         <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,33 +735,33 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">маскировка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -771,11 +771,27 @@
                         <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
                             
@@ -783,65 +799,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бормотать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бормотать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -851,13 +851,13 @@
                         <div class="quiz-question">Что означает немецкое слово «wahnsinnig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безумный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -874,22 +874,6 @@
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
@@ -902,45 +886,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
                             
@@ -950,31 +902,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
@@ -982,17 +918,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1005,13 +1005,13 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «blind»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
                             
@@ -1021,15 +1021,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «führen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
                             
@@ -1043,11 +1043,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1057,59 +1057,27 @@
                         <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утёс</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
@@ -1117,17 +1085,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1140,13 +1140,13 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
@@ -1156,15 +1156,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
@@ -1172,17 +1172,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">меч</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1192,11 +1192,43 @@
                         <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">брат</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">брат</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бой</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">меч</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
@@ -1204,13 +1236,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Schwert»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
                             
@@ -1220,49 +1252,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Schwert»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Bruder»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">меч</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1275,29 +1275,29 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «überleben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
                             
@@ -1311,73 +1311,25 @@
                         <div class="quiz-question">Что означает немецкое слово «die Zukunft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ответственность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ответственность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ответственность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">новый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ответственность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
                             
@@ -1387,17 +1339,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «neu»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «neu»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1424,8 +1424,8 @@
                 "word": "der Adel",
                 "translation": "знать",
                 "transcription": "[дер А-дель]",
-                "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Der Adel erwartet von mir ehrenhaftes Verhalten.",
-                "sentenceTranslation": "В зале Глостера Эдгар обещает отцу: Знать ожидает от меня достойного поведения.",
+                "sentence": "Edgar steht unter dem glühenden Kronleuchter des Thronsaals. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Adel“ bleibt lebendig.",
+                "sentenceTranslation": "Эдгар стоит под пылающей люстрой тронного зала. Каждой клеткой тела я обещаю: слово «знать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1451,8 +1451,8 @@
                 "word": "der Erbe",
                 "translation": "наследник",
                 "transcription": "[дер ЕР-бе]",
-                "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Als rechtmäßiger Erbe habe ich Pflichten.",
-                "sentenceTranslation": "В зале Глостера Эдгар обещает отцу: Как законный наследник, у меня есть обязанности.",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Edgar über Lears schweren Tisch. Mein Atem zeichnet das Wort „der Erbe“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У развернутой карты королевства Эдгар склоняется над тяжёлым столом Лира. Моё дыхание рисует слово «наследник» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1474,8 +1474,8 @@
                 "word": "das Königreich",
                 "translation": "королевство",
                 "transcription": "[дас КЁ-ниг-райх]",
-                "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Ich diene dem Königreich mit Ehre.",
-                "sentenceTranslation": "В зале Глостера Эдгар обещает отцу: Я служу королевству с честью.",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Edgar die Hände hinter dem Rücken. Wie ein stilles Gebet legt sich das Wort „das Königreich“ auf meine Lippen.",
+                "sentenceTranslation": "Перед каменными статуями предков Эдгар сцепляет руки за спиной. Как тихая молитва слово «королевство» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1498,8 +1498,8 @@
                 "word": "vertrauen",
                 "translation": "доверять",
                 "transcription": "[фер-ТРАУ-ен]",
-                "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Mein Vater vertraut mir vollkommen.",
-                "sentenceTranslation": "В зале Глостера Эдгар обещает отцу: Мой отец полностью мне доверяет.",
+                "sentence": "Zwischen flüsternden Höflingen gleitet Edgar über den kalten Marmorboden. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vertrauen“ gehört mir.",
+                "sentenceTranslation": "Между шепчущимися придворными Эдгар скользит по холодному мраморному полу. Буря за окнами усиливает клятву: слово «доверять» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1524,8 +1524,8 @@
                 "word": "die Ehre",
                 "translation": "честь",
                 "transcription": "[ди Э-ре]",
-                "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Die Ehre der Familie liegt in meinen Händen.",
-                "sentenceTranslation": "В зале Глостера Эдгар обещает отцу: Честь семьи в моих руках.",
+                "sentence": "Am Rand des purpurnen Teppichs wartet Edgar auf ein Zeichen des Königs. Wie ein stilles Gebet legt sich das Wort „die Ehre“ auf meine Lippen.",
+                "sentenceTranslation": "На краю пурпурного ковра Эдгар ждёт знака от короля. Как тихая молитва слово «честь» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1549,8 +1549,8 @@
                 "word": "legitim",
                 "translation": "законный",
                 "transcription": "[ле-ги-ТИМ]",
-                "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Ich bin der legitime Sohn des Grafen.",
-                "sentenceTranslation": "В зале Глостера Эдгар обещает отцу: Я законный сын графа.",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Edgar kurz den Blick. Mit jeder Faser meines Körpers verspreche ich: Das Wort „legitim“ bleibt lebendig.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Эдгар на миг опускает взгляд. Каждой клеткой тела я обещаю: слово «законный» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Erbe",
@@ -1573,8 +1573,8 @@
                 "word": "der Graf",
                 "translation": "граф",
                 "transcription": "[дер ГРАФ]",
-                "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Mein Vater, der Graf, ist ein edler Mann.",
-                "sentenceTranslation": "В зале Глостера Эдгар обещает отцу: Мой отец, граф, благородный человек.",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Edgar das gespannte Antlitz des Hofes. Das kalte Licht lässt das Wort „der Graf“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "За позолоченной балюстрадой Эдгар наблюдает за напряжёнными лицами двора. Холодный свет заставляет слово «граф» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1597,8 +1597,8 @@
                 "word": "ahnungslos",
                 "translation": "ничего не подозревающий",
                 "transcription": "[А-нунгс-лос]",
-                "sentence": "In Glosters Halle verspricht Edgar seinem Vater: Ahnungslos vertraue ich meinem Bruder.",
-                "sentenceTranslation": "В зале Глостера Эдгар обещает отцу: Ничего не подозревая, я доверяю брату.",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Edgar langsam die Stimme. Ich presse das Wort „ahnungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В отблесках открытых жаровен Эдгар медленно поднимает голос. Я стискиваю слово «ничего не подозревающий» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Erbe",
@@ -1625,39 +1625,39 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
-                    "королевство",
                     "наследник",
-                    "доверять",
-                    "знать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Erbe»?",
-                "choices": [
                     "доверять",
                     "знать",
-                    "наследник",
                     "королевство"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «das Königreich»?",
+                "question": "Что означает немецкое слово «der Erbe»?",
                 "choices": [
-                    "знать",
                     "доверять",
-                    "честь",
+                    "наследник",
+                    "знать",
                     "королевство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «das Königreich»?",
+                "choices": [
+                    "наследник",
+                    "королевство",
+                    "знать",
+                    "граф"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
-                    "королевство",
-                    "граф",
-                    "ничего не подозревающий",
+                    "законный",
+                    "знать",
+                    "честь",
                     "доверять"
                 ],
                 "correctIndex": 3
@@ -1665,42 +1665,42 @@
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "доверять",
-                    "знать",
+                    "законный",
+                    "наследник",
                     "честь",
-                    "наследник"
+                    "граф"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «legitim»?",
                 "choices": [
+                    "наследник",
+                    "честь",
                     "законный",
-                    "знать",
-                    "граф",
-                    "доверять"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Graf»?",
-                "choices": [
-                    "доверять",
-                    "законный",
-                    "граф",
-                    "честь"
+                    "ничего не подозревающий"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «ahnungslos»?",
+                "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
-                    "ничего не подозревающий",
-                    "знать",
+                    "граф",
+                    "честь",
                     "наследник",
-                    "королевство"
+                    "знать"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «ahnungslos»?",
+                "choices": [
+                    "граф",
+                    "законный",
+                    "честь",
+                    "ничего не подозревающий"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -1713,8 +1713,8 @@
                 "word": "fliehen",
                 "translation": "бежать",
                 "transcription": "[ФЛИ-ен]",
-                "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Ich muss vor falschen Anschuldigungen fliehen.",
-                "sentenceTranslation": "После предательства Эдмунда Эдгар бежит через лес: Я должен бежать от ложных обвинений.",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Edgar zwischen gepackten Kisten. Selbst wenn die Welt zerfällt, bleibt das Wort „fliehen“ mein Nordstern.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Эдгар замирает среди нагруженных ящиков. Даже если мир распадается, слово «бежать» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1737,8 +1737,8 @@
                 "word": "der Verrat",
                 "translation": "предательство",
                 "transcription": "[дер фер-РАТ]",
-                "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Der Verrat meines Bruders zerstört mein Leben.",
-                "sentenceTranslation": "После предательства Эдмунда Эдгар бежит через лес: Предательство моего брата разрушает мою жизнь.",
+                "sentence": "Auf der windigen Freitreppe blickt Edgar zum schweigenden Hof hinunter. Ich umarme das Wort „der Verrat“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Эдгар смотрит вниз на молчаливый двор. Я обнимаю слово «предательство», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1763,8 +1763,8 @@
                 "word": "die Gefahr",
                 "translation": "опасность",
                 "transcription": "[ди ге-ФАР]",
-                "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Die Gefahr lauert überall um mich herum.",
-                "sentenceTranslation": "После предательства Эдмунда Эдгар бежит через лес: Опасность подстерегает меня повсюду.",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Edgar den Reisemantel enger. Ich zeichne das Wort „die Gefahr“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Среди оставленных слуг Эдгар плотнее запахивает дорожный плащ. Я вывожу слово «опасность» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1788,8 +1788,8 @@
                 "word": "verfolgen",
                 "translation": "преследовать",
                 "transcription": "[фер-ФОЛЬ-ген]",
-                "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Die Soldaten verfolgen mich wie einen Verbrecher.",
-                "sentenceTranslation": "После предательства Эдмунда Эдгар бежит через лес: Солдаты преследуют меня как преступника.",
+                "sentence": "Am dunklen Pferdestall streicht Edgar einem nervösen Tier über die Mähne. Ich zeichne das Wort „verfolgen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Эдгар гладит гриву нервного коня. Я вывожу слово «преследовать» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1812,8 +1812,8 @@
                 "word": "verstecken",
                 "translation": "прятаться",
                 "transcription": "[фер-ШТЕ-кен]",
-                "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Ich muss mich in den Wäldern verstecken.",
-                "sentenceTranslation": "После предательства Эдмунда Эдгар бежит через лес: Я должен прятаться в лесах.",
+                "sentence": "Vor dem knarrenden Fallgatter tastet Edgar ein letztes Mal nach dem Haustor. Das kalte Licht lässt das Wort „verstecken“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Эдгар в последний раз касается родной двери. Холодный свет заставляет слово «прятаться» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1836,8 +1836,8 @@
                 "word": "die Intrige",
                 "translation": "интрига",
                 "transcription": "[ди ин-ТРИ-ге]",
-                "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Edmunds Intrige hat mich zum Geächteten gemacht.",
-                "sentenceTranslation": "После предательства Эдмунда Эдгар бежит через лес: Интрига Эдмунда сделала меня изгоем.",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Edgar den Ring an der Hand. Mein Atem zeichnet das Wort „die Intrige“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Среди разбросанных свитков Эдгар вертит кольцо на пальце. Моё дыхание рисует слово «интрига» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1862,8 +1862,8 @@
                 "word": "der Betrug",
                 "translation": "обман",
                 "transcription": "[дер бе-ТРУГ]",
-                "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Dieser Betrug wird eines Tages aufgedeckt.",
-                "sentenceTranslation": "После предательства Эдмунда Эдгар бежит через лес: Этот обман однажды раскроется.",
+                "sentence": "Am leeren Bankettisch zählt Edgar die verlöschenden Kerzen. Wie ein stilles Gebet legt sich das Wort „der Betrug“ auf meine Lippen.",
+                "sentenceTranslation": "У пустого банкетного стола Эдгар пересчитывает гаснущие свечи. Как тихая молитва слово «обман» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1887,8 +1887,8 @@
                 "word": "verbannen",
                 "translation": "изгнать",
                 "transcription": "[фер-БАН-нен]",
-                "sentence": "Nach Edmunds Verrat flieht Edgar durch den Wald: Mein Vater will mich aus dem Land verbannen.",
-                "sentenceTranslation": "После предательства Эдмунда Эдгар бежит через лес: Мой отец хочет изгнать меня из страны.",
+                "sentence": "Zwischen schweigenden Wachen geht Edgar auf den kalten Hof hinaus. Ich atme tief ein und lasse nur das Wort „verbannen“ wieder hinaus.",
+                "sentenceTranslation": "Между молчаливыми стражниками Эдгар выходит на холодный двор. Я глубоко вдыхаю и выпускаю только слово «изгнать».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1915,8 +1915,8 @@
                 "question": "Что означает немецкое слово «fliehen»?",
                 "choices": [
                     "преследовать",
-                    "опасность",
                     "предательство",
+                    "опасность",
                     "бежать"
                 ],
                 "correctIndex": 3
@@ -1924,72 +1924,72 @@
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "преследовать",
                     "бежать",
                     "опасность",
-                    "предательство"
+                    "предательство",
+                    "преследовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "опасность",
+                    "бежать",
                     "преследовать",
-                    "обман",
-                    "прятаться"
+                    "прятаться",
+                    "опасность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
                     "обман",
-                    "интрига",
-                    "преследовать",
-                    "бежать"
+                    "изгнать",
+                    "бежать",
+                    "преследовать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verstecken»?",
                 "choices": [
-                    "обман",
-                    "преследовать",
                     "изгнать",
-                    "прятаться"
+                    "прятаться",
+                    "интрига",
+                    "обман"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "опасность",
-                    "бежать",
                     "изгнать",
-                    "интрига"
+                    "интрига",
+                    "преследовать",
+                    "предательство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
-                    "прятаться",
-                    "обман",
                     "изгнать",
-                    "бежать"
+                    "обман",
+                    "бежать",
+                    "прятаться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verbannen»?",
                 "choices": [
-                    "прятаться",
-                    "опасность",
+                    "бежать",
+                    "изгнать",
                     "обман",
-                    "изгнать"
+                    "предательство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2002,8 +2002,8 @@
                 "word": "der Wahnsinn",
                 "translation": "безумие",
                 "transcription": "[дер ВАН-зин]",
-                "sentence": "Als armer Tom auf der Heide erklärt Edgar: Ich spiele den Wahnsinn, um zu überleben.",
-                "sentenceTranslation": "Под видом бедного Тома на пустоши Эдгар объясняет: Я играю безумие, чтобы выжить.",
+                "sentence": "Im zugigen Seitenflügel lauscht Edgar dem Heulen der Küstenwinde. Mit fester Stimme schwöre ich mir: Das Wort „der Wahnsinn“ wird heute nicht verraten.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Эдгар слушает вой прибрежного ветра. Твёрдым голосом я клянусь себе: слово «безумие» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2027,8 +2027,8 @@
                 "word": "der Bettler",
                 "translation": "нищий",
                 "transcription": "[дер БЕТ-лер]",
-                "sentence": "Als armer Tom auf der Heide erklärt Edgar: Als Bettler bin ich unsichtbar für meine Feinde.",
-                "sentenceTranslation": "Под видом бедного Тома на пустоши Эдгар объясняет: Как нищий, я невидим для врагов.",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Edgar einen zerknitterten Brief. Ich halte das Wort „der Bettler“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед дымным камином замка Эдгар складывает измятый лист. Я держу слово «нищий» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Elend",
@@ -2054,8 +2054,8 @@
                 "word": "die Verkleidung",
                 "translation": "маскировка",
                 "transcription": "[ди фер-КЛАЙ-дунг]",
-                "sentence": "Als armer Tom auf der Heide erklärt Edgar: Diese Verkleidung ist meine einzige Rettung.",
-                "sentenceTranslation": "Под видом бедного Тома на пустоши Эдгар объясняет: Эта маскировка - моё единственное спасение.",
+                "sentence": "Unter farblosen Wandteppichen schreitet Edgar rastlos auf und ab. Mit fester Stimme schwöre ich mir: Das Wort „die Verkleidung“ wird heute nicht verraten.",
+                "sentenceTranslation": "Под выцветшими гобеленами Эдгар беспокойно меряет шагами зал. Твёрдым голосом я клянусь себе: слово «маскировка» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "List",
@@ -2083,8 +2083,8 @@
                 "word": "nackt",
                 "translation": "голый",
                 "transcription": "[НАКТ]",
-                "sentence": "Als armer Tom auf der Heide erklärt Edgar: Fast nackt wandere ich durch die Wildnis.",
-                "sentenceTranslation": "Под видом бедного Тома на пустоши Эдгар объясняет: Почти голый, я брожу по дикой местности.",
+                "sentence": "An der schmalen Fensterluke zählt Edgar die Fackeln auf dem Hof. Ich presse das Wort „nackt“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У узкой бойницы Эдгар считает факелы на дворе. Я стискиваю слово «голый» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Sturm",
@@ -2111,8 +2111,8 @@
                 "word": "murmeln",
                 "translation": "бормотать",
                 "transcription": "[МУР-мельн]",
-                "sentence": "Als armer Tom auf der Heide erklärt Edgar: Ich murmle Unsinn, um verrückt zu wirken.",
-                "sentenceTranslation": "Под видом бедного Тома на пустоши Эдгар объясняет: Я бормочу чепуху, чтобы казаться сумасшедшим.",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Edgar nach frischen Botschaften. Ich halte das Wort „murmeln“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Эдгар ищет свежие вести. Я держу слово «бормотать» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "arm",
@@ -2135,8 +2135,8 @@
                 "word": "zittern",
                 "translation": "дрожать",
                 "transcription": "[ЦИ-терн]",
-                "sentence": "Als armer Tom auf der Heide erklärt Edgar: Vor Kälte und Angst zittere ich ständig.",
-                "sentenceTranslation": "Под видом бедного Тома на пустоши Эдгар объясняет: От холода и страха я постоянно дрожу.",
+                "sentence": "Im stillen Kapellenraum kniet Edgar vor der kalten Steinfigur. Ich presse das Wort „zittern“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В тихой капелле Эдгар преклоняет колени перед холодной каменной фигурой. Я стискиваю слово «дрожать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2159,8 +2159,8 @@
                 "word": "das Elend",
                 "translation": "нищета",
                 "transcription": "[дас Э-ленд]",
-                "sentence": "Als armer Tom auf der Heide erklärt Edgar: Im Elend lerne ich die wahre Natur des Menschen.",
-                "sentenceTranslation": "Под видом бедного Тома на пустоши Эдгар объясняет: В нищете я познаю истинную природу человека.",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Edgar die Laterne fest. Ich presse das Wort „das Elend“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Эдгар крепко держит фонарь. Я стискиваю слово «нищета» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2183,8 +2183,8 @@
                 "word": "wahnsinnig",
                 "translation": "безумный",
                 "transcription": "[ВАН-зи-ниг]",
-                "sentence": "Als armer Tom auf der Heide erklärt Edgar: Ich gebe vor, wahnsinnig zu sein.",
-                "sentenceTranslation": "Под видом бедного Тома на пустоши Эдгар объясняет: Я притворяюсь безумным.",
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Edgar eine fiebrige Antwort. Mit jeder Faser meines Körpers verspreche ich: Das Wort „wahnsinnig“ bleibt lebendig.",
+                "sentenceTranslation": "В тени высоких стен Эдгар пишет лихорадочный ответ. Каждой клеткой тела я обещаю: слово «безумный» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "arm",
@@ -2208,30 +2208,30 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "безумие",
                     "нищий",
                     "голый",
-                    "маскировка"
+                    "маскировка",
+                    "безумие"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
-                    "безумие",
-                    "нищий",
                     "маскировка",
-                    "голый"
+                    "безумие",
+                    "голый",
+                    "нищий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
-                    "безумный",
+                    "дрожать",
                     "маскировка",
-                    "безумие",
-                    "голый"
+                    "голый",
+                    "нищета"
                 ],
                 "correctIndex": 1
             },
@@ -2239,49 +2239,49 @@
                 "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
                     "дрожать",
+                    "безумие",
                     "маскировка",
-                    "голый",
-                    "безумный"
+                    "голый"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «murmeln»?",
                 "choices": [
-                    "безумие",
-                    "голый",
+                    "бормотать",
+                    "нищий",
                     "дрожать",
-                    "бормотать"
+                    "безумие"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
-                    "нищий",
-                    "голый",
+                    "безумный",
                     "дрожать",
-                    "нищета"
+                    "нищета",
+                    "нищий"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
-                    "маскировка",
-                    "голый",
                     "дрожать",
-                    "нищета"
+                    "голый",
+                    "нищета",
+                    "безумие"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «wahnsinnig»?",
                 "choices": [
-                    "безумие",
-                    "безумный",
                     "дрожать",
-                    "голый"
+                    "безумный",
+                    "бормотать",
+                    "нищий"
                 ],
                 "correctIndex": 1
             }
@@ -2296,8 +2296,8 @@
                 "word": "der Sturm",
                 "translation": "буря",
                 "transcription": "[дер ШТУРМ]",
-                "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Der Sturm tobt über unseren Köpfen.",
-                "sentenceTranslation": "В штормовую ночь Лира Эдгар сопровождает короля: Буря бушует над нашими головами.",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edgar gegen den Wind. Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Эдгар упирается в ветер. Как тихая молитва слово «буря» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2322,8 +2322,8 @@
                 "word": "frieren",
                 "translation": "мёрзнуть",
                 "transcription": "[ФРИ-рен]",
-                "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Wir frieren gemeinsam in dieser kalten Nacht.",
-                "sentenceTranslation": "В штормовую ночь Лира Эдгар сопровождает короля: Мы мёрзнем вместе в эту холодную ночь.",
+                "sentence": "Unter einem zerrissenen Banner schützt Edgar die Augen vor den Blitzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „frieren“ bleibt lebendig.",
+                "sentenceTranslation": "Под разорванным знаменем Эдгар прикрывает глаза от молний. Каждой клеткой тела я обещаю: слово «мёрзнуть» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Elend",
@@ -2353,8 +2353,8 @@
                 "word": "leiden",
                 "translation": "страдать",
                 "transcription": "[ЛАЙ-ден]",
-                "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Der König leidet mehr als ich jemals gelitten habe.",
-                "sentenceTranslation": "В штормовую ночь Лира Эдгар сопровождает короля: Король страдает больше, чем я когда-либо страдал.",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Edgar Deckung vor dem Donner. Ich atme tief ein und lasse nur das Wort „leiden“ wieder hinaus.",
+                "sentenceTranslation": "У поваленного дерева Эдгар ищет укрытия от грома. Я глубоко вдыхаю и выпускаю только слово «страдать».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2380,8 +2380,8 @@
                 "word": "die Hütte",
                 "translation": "хижина",
                 "transcription": "[ди ХЮ-те]",
-                "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: In dieser armseligen Hütte finden wir Zuflucht.",
-                "sentenceTranslation": "В штормовую ночь Лира Эдгар сопровождает короля: В этой жалкой хижине мы находим убежище.",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Edgar durch den Schlamm. Ich umarme das Wort „die Hütte“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Между пенящимися лужами Эдгар пробирается через грязь. Я обнимаю слово «хижина», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Elend",
@@ -2408,8 +2408,8 @@
                 "word": "beschützen",
                 "translation": "защищать",
                 "transcription": "[бе-ШЮ-цен]",
-                "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Heimlich beschütze ich den wahnsinnigen König.",
-                "sentenceTranslation": "В штормовую ночь Лира Эдгар сопровождает короля: Тайно я защищаю безумного короля.",
+                "sentence": "Vor einem zuckenden Himmel hebt Edgar die Arme trotzig an. Mit jeder Faser meines Körpers verspreche ich: Das Wort „beschützen“ bleibt lebendig.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Эдгар упрямо поднимает руки. Каждой клеткой тела я обещаю: слово «защищать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2435,8 +2435,8 @@
                 "word": "begleiten",
                 "translation": "сопровождать",
                 "transcription": "[бе-ГЛАЙ-тен]",
-                "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Als Tom begleite ich Lear durch seine dunkelste Stunde.",
-                "sentenceTranslation": "В штормовую ночь Лира Эдгар сопровождает короля: Как Том, я сопровождаю Лира в его самый тёмный час.",
+                "sentence": "Unter dem durchtränkten Umhang presst Edgar den Atem gegen die Kälte. Mit jeder Faser meines Körpers verspreche ich: Das Wort „begleiten“ bleibt lebendig.",
+                "sentenceTranslation": "Под промокшим плащом Эдгар прижимает дыхание к груди, спасаясь от холода. Каждой клеткой тела я обещаю: слово «сопровождать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beistand",
@@ -2465,8 +2465,8 @@
                 "word": "der Donner",
                 "translation": "гром",
                 "transcription": "[дер ДО-нер]",
-                "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Der Donner übertönt unsere Schreie.",
-                "sentenceTranslation": "В штормовую ночь Лира Эдгар сопровождает короля: Гром заглушает наши крики.",
+                "sentence": "Am kläglichen Feuerrest wärmt Edgar zitternde Finger. Ich zeichne das Wort „der Donner“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У жалких огненных углей Эдгар греет дрожащие пальцы. Я черчу слово «гром» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2489,8 +2489,8 @@
                 "word": "der Blitz",
                 "translation": "молния",
                 "transcription": "[дер БЛИЦ]",
-                "sentence": "In Lears sturmgepeitschter Nacht begleitet Edgar den König: Die Blitze erhellen unser Elend.",
-                "sentenceTranslation": "В штормовую ночь Лира Эдгар сопровождает короля: Молнии освещают нашу нищету.",
+                "sentence": "Zwischen heulenden Hunden ruft Edgar gegen den tosenden Sturm an. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Blitz“ darf nicht vergehen.",
+                "sentenceTranslation": "Среди воющих псов Эдгар перекрикивает беснующуюся бурю. Я шепчу стражам судьбы: слово «молния» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2514,9 +2514,9 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "страдать",
                     "мёрзнуть",
                     "хижина",
+                    "страдать",
                     "буря"
                 ],
                 "correctIndex": 3
@@ -2524,72 +2524,72 @@
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
+                    "страдать",
                     "мёрзнуть",
                     "хижина",
-                    "страдать",
                     "буря"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "страдать",
                     "защищать",
-                    "молния",
-                    "сопровождать"
+                    "страдать",
+                    "гром",
+                    "буря"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
-                    "буря",
                     "хижина",
-                    "гром",
-                    "мёрзнуть"
+                    "сопровождать",
+                    "буря",
+                    "гром"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
+                    "защищать",
                     "страдать",
-                    "защищать",
                     "хижина",
-                    "буря"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «begleiten»?",
-                "choices": [
-                    "молния",
-                    "защищать",
-                    "сопровождать",
-                    "страдать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Donner»?",
-                "choices": [
-                    "гром",
-                    "защищать",
-                    "мёрзнуть",
                     "буря"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Blitz»?",
+                "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
+                    "защищать",
+                    "сопровождать",
                     "хижина",
-                    "молния",
-                    "мёрзнуть",
                     "страдать"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «der Donner»?",
+                "choices": [
+                    "молния",
+                    "гром",
+                    "буря",
+                    "хижина"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «der Blitz»?",
+                "choices": [
+                    "гром",
+                    "страдать",
+                    "мёрзнуть",
+                    "молния"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2602,8 +2602,8 @@
                 "word": "blind",
                 "translation": "слепой",
                 "transcription": "[БЛИНД]",
-                "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Mein blinder Vater erkennt mich nicht.",
-                "sentenceTranslation": "Перед хижиной Эдгар ведёт слепого Глостера: Мой слепой отец не узнаёт меня.",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Edgar bei der flackernden Kerze. Ich atme tief ein und lasse nur das Wort „blind“ wieder hinaus.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Эдгар сидит у мерцающей свечи. Я глубоко вдыхаю и выпускаю только слово «слепой».",
                 "visual_hint": "📚",
                 "themes": [
                     "Klippe",
@@ -2630,8 +2630,8 @@
                 "word": "führen",
                 "translation": "вести",
                 "transcription": "[ФЮ-рен]",
-                "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Ich führe ihn sicher durch die Dunkelheit.",
-                "sentenceTranslation": "Перед хижиной Эдгар ведёт слепого Глостера: Я веду его безопасно сквозь тьму.",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Edgar über ein altes Wappen. Ich atme tief ein und lasse nur das Wort „führen“ wieder hinaus.",
+                "sentenceTranslation": "Среди помятых доспехов Эдгар гладит старый герб. Я глубоко вдыхаю и выпускаю только слово «вести».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2654,8 +2654,8 @@
                 "word": "die Klippe",
                 "translation": "утёс",
                 "transcription": "[ди КЛИ-пе]",
-                "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Er glaubt, wir stehen am Rand der Klippe.",
-                "sentenceTranslation": "Перед хижиной Эдгар ведёт слепого Глостера: Он думает, мы стоим на краю утёса.",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Edgar fast den Kopf. Ich halte das Wort „die Klippe“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "О низкую балку хижины Эдгар едва не ударяется головой. Я держу слово «утёс» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Klippe",
@@ -2678,8 +2678,8 @@
                 "word": "täuschen",
                 "translation": "обманывать",
                 "transcription": "[ТОЙ-шен]",
-                "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Ich täusche ihn, um sein Leben zu retten.",
-                "sentenceTranslation": "Перед хижиной Эдгар ведёт слепого Глостера: Я обманываю его, чтобы спасти его жизнь.",
+                "sentence": "Neben der schlafenden Wache flüstert Edgar in die schwere Nacht. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir.",
+                "sentenceTranslation": "Рядом со спящим стражем Эдгар шепчет в тяжёлую ночь. Буря за окнами усиливает клятву: слово «обманывать» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2705,8 +2705,8 @@
                 "word": "retten",
                 "translation": "спасать",
                 "transcription": "[РЕ-тен]",
-                "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Mit List will ich meinen Vater retten.",
-                "sentenceTranslation": "Перед хижиной Эдгар ведёт слепого Глостера: Хитростью я хочу спасти отца.",
+                "sentence": "Vor dem einfachen Feldbett betrachtet Edgar die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „retten“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед грубой походной койкой Эдгар разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «спасать» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2729,8 +2729,8 @@
                 "word": "die List",
                 "translation": "хитрость",
                 "transcription": "[ди ЛИСТ]",
-                "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Meine List bewahrt ihn vor dem Selbstmord.",
-                "sentenceTranslation": "Перед хижиной Эдгар ведёт слепого Глостера: Моя хитрость спасает его от самоубийства.",
+                "sentence": "Im Geruch von feuchtem Stroh legt Edgar den Mantel zur Seite. Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern.",
+                "sentenceTranslation": "В запахе влажной соломы Эдгар откладывает плащ в сторону. Даже если мир распадается, слово «хитрость» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Klippe",
@@ -2761,8 +2761,8 @@
                 "word": "trösten",
                 "translation": "утешать",
                 "transcription": "[ТРЁС-тен]",
-                "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Als Fremder tröste ich meinen eigenen Vater.",
-                "sentenceTranslation": "Перед хижиной Эдгар ведёт слепого Глостера: Как чужой, я утешаю собственного отца.",
+                "sentence": "Auf dem wackligen Holztisch ordnet Edgar zerlesene Briefe. Ich flüstere den Wächtern des Schicksals zu: Das Wort „trösten“ darf nicht vergehen.",
+                "sentenceTranslation": "На шатком деревянном столе Эдгар раскладывает зачитанные письма. Я шепчу стражам судьбы: слово «утешать» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2786,8 +2786,8 @@
                 "word": "die Verzweiflung",
                 "translation": "отчаяние",
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
-                "sentence": "Vor der Hütte führt Edgar den blinden Gloucester: Seine Verzweiflung bricht mir das Herz.",
-                "sentenceTranslation": "Перед хижиной Эдгар ведёт слепого Глостера: Его отчаяние разбивает мне сердце.",
+                "sentence": "Am Eingang der Hütte späht Edgar nach einem vertrauten Schatten. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Verzweiflung“ gehört mir.",
+                "sentenceTranslation": "У входа в хижину Эдгар высматривает знакомую тень. Буря за окнами усиливает клятву: слово «отчаяние» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2813,82 +2813,82 @@
             {
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
-                    "слепой",
                     "вести",
+                    "слепой",
                     "утёс",
                     "обманывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «führen»?",
                 "choices": [
-                    "вести",
-                    "обманывать",
                     "утёс",
+                    "обманывать",
+                    "вести",
                     "слепой"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Klippe»?",
                 "choices": [
                     "утёс",
-                    "утешать",
-                    "слепой",
-                    "отчаяние"
+                    "спасать",
+                    "вести",
+                    "утешать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
-                    "отчаяние",
-                    "спасать",
+                    "слепой",
+                    "вести",
                     "обманывать",
-                    "вести"
+                    "утёс"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
-                    "утёс",
                     "спасать",
-                    "отчаяние",
-                    "хитрость"
+                    "утешать",
+                    "вести",
+                    "отчаяние"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "спасать",
-                    "хитрость",
                     "слепой",
-                    "вести"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «trösten»?",
-                "choices": [
-                    "спасать",
-                    "вести",
-                    "утешать",
-                    "отчаяние"
+                    "отчаяние",
+                    "хитрость",
+                    "утешать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «trösten»?",
+                "choices": [
+                    "обманывать",
+                    "утешать",
+                    "утёс",
+                    "слепой"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
+                    "спасать",
+                    "отчаяние",
                     "вести",
-                    "хитрость",
-                    "обманывать",
-                    "отчаяние"
+                    "обманывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2901,8 +2901,8 @@
                 "word": "der Kampf",
                 "translation": "бой",
                 "transcription": "[дер КАМПФ]",
-                "sentence": "Auf den Klippen von Dover schwört Edgar: Der Kampf gegen meinen Bruder ist unvermeidlich.",
-                "sentenceTranslation": "На утёсах Дувра Эдгар клянётся: Бой с моим братом неизбежен.",
+                "sentence": "Auf den weißen Klippen von Dover blickt Edgar in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „der Kampf“ mein Nordstern.",
+                "sentenceTranslation": "На белых скалах Дувра Эдгар смотрит в вздыбленный пролив. Даже если мир распадается, слово «бой» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2927,8 +2927,8 @@
                 "word": "das Duell",
                 "translation": "дуэль",
                 "transcription": "[дас ду-ЭЛЬ]",
-                "sentence": "Auf den Klippen von Dover schwört Edgar: In diesem Duell kämpfe ich für die Gerechtigkeit.",
-                "sentenceTranslation": "На утёсах Дувра Эдгар клянётся: В этой дуэли я сражаюсь за справедливость.",
+                "sentence": "Zwischen flatternden Feldzeichen richtet Edgar den Helm. Ich atme tief ein und lasse nur das Wort „das Duell“ wieder hinaus.",
+                "sentenceTranslation": "Среди хлопающих штандартов Эдгар поправляет шлем. Я глубоко вдыхаю и выпускаю только слово «дуэль».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2951,8 +2951,8 @@
                 "word": "die Rache",
                 "translation": "месть",
                 "transcription": "[ди РА-хе]",
-                "sentence": "Auf den Klippen von Dover schwört Edgar: Nicht Rache, sondern Gerechtigkeit leitet meine Klinge.",
-                "sentenceTranslation": "На утёсах Дувра Эдгар клянётся: Не месть, а справедливость ведёт мой клинок.",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Edgar Marschrouten in den Sand. Ich presse das Wort „die Rache“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У французского костра Эдгар рисует в песке путь марша. Я стискиваю слово «месть» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2977,8 +2977,8 @@
                 "word": "enthüllen",
                 "translation": "разоблачать",
                 "transcription": "[энт-ХЮ-лен]",
-                "sentence": "Auf den Klippen von Dover schwört Edgar: Ich enthülle meine wahre Identität.",
-                "sentenceTranslation": "На утёсах Дувра Эдгар клянётся: Я разоблачаю свою истинную личность.",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Edgar das Siegel. Ich halte das Wort „enthüllen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Эдгар проверяет печати. Я держу слово «разоблачать» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bruder",
@@ -3005,8 +3005,8 @@
                 "word": "siegen",
                 "translation": "побеждать",
                 "transcription": "[ЗИ-ген]",
-                "sentence": "Auf den Klippen von Dover schwört Edgar: Die Wahrheit wird über die Lüge siegen.",
-                "sentenceTranslation": "На утёсах Дувра Эдгар клянётся: Правда победит ложь.",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Edgar dem dumpfen Meer. Mein Atem zeichnet das Wort „siegen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Эдгар слушает глухой шум моря. Моё дыхание рисует слово «побеждать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3029,8 +3029,8 @@
                 "word": "die Gerechtigkeit",
                 "translation": "справедливость",
                 "transcription": "[ди ге-РЕХ-тиг-кайт]",
-                "sentence": "Auf den Klippen von Dover schwört Edgar: Die Gerechtigkeit fordert diesen Kampf.",
-                "sentenceTranslation": "На утёсах Дувра Эдгар клянётся: Справедливость требует этого боя.",
+                "sentence": "Auf dem sandigen Trainingsplatz übt Edgar das Ziehen des Schwerts. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Gerechtigkeit“ darf nicht vergehen.",
+                "sentenceTranslation": "На песчаном плацу Эдгар отрабатывает выхват меча. Я шепчу стражам судьбы: слово «справедливость» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3054,8 +3054,8 @@
                 "word": "das Schwert",
                 "translation": "меч",
                 "transcription": "[дас ШВЕРТ]",
-                "sentence": "Auf den Klippen von Dover schwört Edgar: Mein Schwert ist die Waffe der Wahrheit.",
-                "sentenceTranslation": "На утёсах Дувра Эдгар клянётся: Мой меч - оружие правды.",
+                "sentence": "Zwischen pochenden Trommeln hebt Edgar das Banner der Hoffnung. Ich zeichne das Wort „das Schwert“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под гул барабанов Эдгар поднимает знамя надежды. Я вывожу слово «меч» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3077,8 +3077,8 @@
                 "word": "der Bruder",
                 "translation": "брат",
                 "transcription": "[дер БРУ-дер]",
-                "sentence": "Auf den Klippen von Dover schwört Edgar: Mein Bruder muss für seine Verbrechen büßen.",
-                "sentenceTranslation": "На утёсах Дувра Эдгар клянётся: Мой брат должен поплатиться за свои преступления.",
+                "sentence": "Am Morgennebel der Küste legt Edgar die Hand auf das pochende Herz. Wie ein stilles Gebet legt sich das Wort „der Bruder“ auf meine Lippen.",
+                "sentenceTranslation": "В утреннем тумане побережья Эдгар кладёт ладонь на бьющееся сердце. Как тихая молитва слово «брат» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3101,82 +3101,82 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "бой",
                     "разоблачать",
+                    "бой",
                     "месть",
                     "дуэль"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «das Duell»?",
-                "choices": [
-                    "дуэль",
-                    "бой",
-                    "разоблачать",
-                    "месть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Rache»?",
-                "choices": [
-                    "справедливость",
-                    "месть",
-                    "брат",
-                    "побеждать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «enthüllen»?",
+                "question": "Что означает немецкое слово «das Duell»?",
+                "choices": [
+                    "разоблачать",
+                    "бой",
+                    "дуэль",
+                    "месть"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
                     "месть",
                     "разоблачать",
+                    "дуэль",
+                    "меч"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «enthüllen»?",
+                "choices": [
+                    "справедливость",
+                    "разоблачать",
                     "меч",
-                    "справедливость"
+                    "брат"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
-                    "месть",
                     "побеждать",
-                    "меч",
-                    "дуэль"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Gerechtigkeit»?",
-                "choices": [
-                    "меч",
-                    "справедливость",
                     "брат",
-                    "разоблачать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «das Schwert»?",
-                "choices": [
-                    "меч",
-                    "справедливость",
                     "дуэль",
-                    "разоблачать"
+                    "бой"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Bruder»?",
+                "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "меч",
                     "побеждать",
-                    "бой",
-                    "брат"
+                    "меч",
+                    "дуэль",
+                    "справедливость"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «das Schwert»?",
+                "choices": [
+                    "брат",
+                    "бой",
+                    "меч",
+                    "дуэль"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Bruder»?",
+                "choices": [
+                    "разоблачать",
+                    "брат",
+                    "месть",
+                    "меч"
+                ],
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -3189,8 +3189,8 @@
                 "word": "überleben",
                 "translation": "выживать",
                 "transcription": "[ю-бер-ЛЕ-бен]",
-                "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Ich habe alle Prüfungen überlebt.",
-                "sentenceTranslation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Я пережил все испытания.",
+                "sentence": "Im feuchten Kerker stützt Edgar sich an den tropfenden Stein. Ich halte das Wort „überleben“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В сыром подземелье Эдгар опирается на сочащийся камень. Я держу слово «выживать» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3212,8 +3212,8 @@
                 "word": "erben",
                 "translation": "наследовать",
                 "transcription": "[ЭР-бен]",
-                "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Nun erbe ich Titel und Verantwortung.",
-                "sentenceTranslation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Теперь я наследую титул и ответственность.",
+                "sentence": "Unter der trüben Laterne zählt Edgar die eisernen Ringe der Kette. Mit fester Stimme schwöre ich mir: Das Wort „erben“ wird heute nicht verraten.",
+                "sentenceTranslation": "Под мутным фонарём Эдгар пересчитывает железные кольца цепи. Твёрдым голосом я клянусь себе: слово «наследовать» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3236,8 +3236,8 @@
                 "word": "die Zukunft",
                 "translation": "будущее",
                 "transcription": "[ди ЦУ-кунфт]",
-                "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Die Zukunft des Königreichs liegt in unseren Händen.",
-                "sentenceTranslation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Будущее королевства в наших руках.",
+                "sentence": "Neben der schweren Holztür horcht Edgar auf entferntes Schluchzen. Das Echo des Wortes „die Zukunft“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У тяжёлой двери Эдгар прислушивается к далёким рыданиям. Эхо слова «будущее» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3259,8 +3259,8 @@
                 "word": "regieren",
                 "translation": "править",
                 "transcription": "[ре-ГИ-рен]",
-                "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Mit Weisheit werde ich regieren.",
-                "sentenceTranslation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: С мудростью я буду править.",
+                "sentence": "Auf der kalten Steinbank zieht Edgar den Mantel enger um die Schultern. Ich atme tief ein und lasse nur das Wort „regieren“ wieder hinaus.",
+                "sentenceTranslation": "На холодной каменной скамье Эдгар плотнее кутается в плащ. Я глубоко вдыхаю и выпускаю только слово «править».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3285,8 +3285,8 @@
                 "word": "die Weisheit",
                 "translation": "мудрость",
                 "transcription": "[ди ВАЙС-хайт]",
-                "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Durch Leiden habe ich Weisheit erlangt.",
-                "sentenceTranslation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Через страдания я обрёл мудрость.",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Edgar das Gesicht zum Licht. Ich halte das Wort „die Weisheit“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Между тенями решёток Эдгар поднимает лицо к свету. Я держу слово «мудрость» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Erbe",
@@ -3319,8 +3319,8 @@
                 "word": "die Ordnung",
                 "translation": "порядок",
                 "transcription": "[ди ОРД-нунг]",
-                "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Neue Ordnung muss aus dem Chaos entstehen.",
-                "sentenceTranslation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Новый порядок должен возникнуть из хаоса.",
+                "sentence": "Am rostigen Wassereimer spiegelt Edgar kurz die eigenen Augen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ordnung“ bleibt lebendig.",
+                "sentenceTranslation": "У ржавого ведра с водой Эдгар на мгновение видит отражение глаз. Каждой клеткой тела я обещаю: слово «порядок» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Erbe",
@@ -3343,8 +3343,8 @@
                 "word": "die Verantwortung",
                 "translation": "ответственность",
                 "transcription": "[ди фер-АНТ-вор-тунг]",
-                "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Die Verantwortung für alle wiegt schwer.",
-                "sentenceTranslation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Ответственность за всех тяжела.",
+                "sentence": "Im dumpfen Hall der Schritte zählt Edgar den Rhythmus der Wachen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Verantwortung“ darf nicht vergehen.",
+                "sentenceTranslation": "В глухом эхе шагов Эдгар отсчитывает ритм часовых. Я шепчу стражам судьбы: слово «ответственность» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Erbe",
@@ -3367,8 +3367,8 @@
                 "word": "neu",
                 "translation": "новый",
                 "transcription": "[НОЙ]",
-                "sentence": "Nach dem Sieg über Edmund vor Lears Hof erklärt Edgar: Eine neue Ära beginnt für unser Land.",
-                "sentenceTranslation": "После победы над Эдмундом перед двором Лира Эдгар объявляет: Новая эра начинается для нашей страны.",
+                "sentence": "Vor dem verriegelten Fenster zeichnet Edgar Kreise in den Staub. Mit fester Stimme schwöre ich mir: Das Wort „neu“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед заколоченным окном Эдгар чертит круги в пыли. Твёрдым голосом я клянусь себе: слово «новый» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Erbe",
@@ -3392,82 +3392,82 @@
             {
                 "question": "Что означает немецкое слово «überleben»?",
                 "choices": [
-                    "править",
                     "выживать",
                     "будущее",
-                    "наследовать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «erben»?",
-                "choices": [
                     "наследовать",
-                    "править",
-                    "будущее",
-                    "выживать"
+                    "править"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Zukunft»?",
+                "question": "Что означает немецкое слово «erben»?",
                 "choices": [
-                    "порядок",
+                    "править",
                     "наследовать",
                     "будущее",
-                    "новый"
+                    "выживать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Zukunft»?",
+                "choices": [
+                    "выживать",
+                    "мудрость",
+                    "будущее",
+                    "ответственность"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
-                    "наследовать",
                     "править",
-                    "ответственность",
-                    "выживать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Weisheit»?",
-                "choices": [
-                    "будущее",
-                    "новый",
-                    "ответственность",
-                    "мудрость"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Ordnung»?",
-                "choices": [
                     "мудрость",
-                    "править",
-                    "новый",
-                    "порядок"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Verantwortung»?",
-                "choices": [
-                    "ответственность",
-                    "новый",
                     "выживать",
                     "наследовать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «neu»?",
+                "question": "Что означает немецкое слово «die Weisheit»?",
+                "choices": [
+                    "порядок",
+                    "наследовать",
+                    "мудрость",
+                    "выживать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Ordnung»?",
                 "choices": [
                     "порядок",
                     "будущее",
-                    "мудрость",
-                    "новый"
+                    "наследовать",
+                    "мудрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Verantwortung»?",
+                "choices": [
+                    "порядок",
+                    "ответственность",
+                    "будущее",
+                    "выживать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «neu»?",
+                "choices": [
+                    "наследовать",
+                    "новый",
+                    "будущее",
+                    "порядок"
+                ],
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -3998,27 +3998,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/edmund.html
+++ b/output/journeys/edmund.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["амбиция", "зависть", "обделённый", "бастард"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["бастард", "обделённый", "зависть", "амбиция"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["обделённый", "амбиция", "зависть", "природа"], "correct_index": 1}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["обделённый", "бастард", "месть", "внебрачный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "внебрачный", "возвышаться", "амбиция"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["амбиция", "бастард", "природа", "возвышаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["месть", "обделённый", "внебрачный", "природа"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["амбиция", "зависть", "природа", "внебрачный"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["интриговать", "обвинять", "план", "подделывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["обвинять", "план", "подделывать", "интриговать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["интриговать", "письмо", "обвинять", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["обман", "лгать", "подделывать", "план"], "correct_index": 3}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["подделывать", "письмо", "манипулировать", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["лгать", "обвинять", "письмо", "план"], "correct_index": 2}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["лгать", "письмо", "подделывать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["обман", "обвинять", "манипулировать", "интриговать"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["торжествовать", "успех", "наследовать", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["торжествовать", "изгонять", "успех", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erben»?", "choices": ["успех", "выигрывать", "награда", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["успех", "торжествовать", "победа", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["изгонять", "награда", "выигрывать", "наследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["награда", "победа", "успех", "выигрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["выигрывать", "награда", "торжествовать", "вытеснять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["наследовать", "изгонять", "победа", "успех"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["власть", "союз", "объединяться", "завоёвывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["союз", "объединяться", "завоёвывать", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоёвывать", "соблазнять", "господствовать", "объединяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["господствовать", "власть", "объединяться", "союз"], "correct_index": 3}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["завоевание", "соблазнять", "завоёвывать", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["объединяться", "завоевание", "власть", "союз"], "correct_index": 1}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["объединяться", "господствовать", "союз", "завоевание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["завоёвывать", "господствовать", "завоевание", "альянс"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["жестокость", "предавать", "ослеплять", "доносить"], "correct_index": 1}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["жестокость", "доносить", "ослеплять", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "пытка", "выдавать", "жертвовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["жертвовать", "жестокость", "пытка", "доносить"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["ослеплять", "выдавать", "жестокость", "беспощадный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["выдавать", "доносить", "пытка", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["жертвовать", "жестокость", "выдавать", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["ослеплять", "беспощадный", "жестокость", "жертвовать"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["соперничество", "завлекать", "играть", "любовная связь"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["играть", "любовная связь", "завлекать", "соперничество"], "correct_index": 3}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["любовная связь", "соперничество", "похоть", "играть"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["завлекать", "играть", "соперничество", "жонглировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["жонглировать", "похоть", "играть", "завлекать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["использовать", "соперничество", "жонглировать", "похоть"], "correct_index": 0}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["интрига", "жонглировать", "играть", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["играть", "использовать", "интрига", "любовная связь"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["падать", "дуэль", "поражение", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["дуэль", "падать", "поражение", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["проигрывать", "признаваться", "поражение", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["поражение", "проигрывать", "конец", "падать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["конец", "падение", "сожалеть", "проигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["дуэль", "признаваться", "конец", "падение"], "correct_index": 3}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["поражение", "дуэль", "признаваться", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["сожалеть", "поражение", "конец", "падение"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["обделённый", "амбиция", "зависть", "бастард"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["зависть", "обделённый", "амбиция", "бастард"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["природа", "амбиция", "возвышаться", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["обделённый", "амбиция", "месть", "природа"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["природа", "возвышаться", "месть", "внебрачный"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["внебрачный", "обделённый", "возвышаться", "бастард"], "correct_index": 2}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["природа", "внебрачный", "возвышаться", "зависть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["амбиция", "зависть", "природа", "внебрачный"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["подделывать", "обвинять", "план", "интриговать"], "correct_index": 0}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["обвинять", "подделывать", "план", "интриговать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["план", "обвинять", "письмо", "манипулировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["план", "подделывать", "интриговать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["манипулировать", "интриговать", "обвинять", "план"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["лгать", "обман", "письмо", "подделывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["лгать", "манипулировать", "обвинять", "план"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["лгать", "обман", "манипулировать", "обвинять"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["торжествовать", "изгонять", "наследовать", "успех"], "correct_index": 1}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["наследовать", "успех", "изгонять", "торжествовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "вытеснять", "победа", "успех"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["успех", "победа", "торжествовать", "выигрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["успех", "вытеснять", "торжествовать", "выигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["успех", "изгонять", "награда", "вытеснять"], "correct_index": 2}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["наследовать", "торжествовать", "победа", "вытеснять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["успех", "торжествовать", "победа", "выигрывать"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["объединяться", "союз", "власть", "завоёвывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["союз", "завоёвывать", "власть", "объединяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоевание", "соблазнять", "завоёвывать", "господствовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["соблазнять", "господствовать", "союз", "завоёвывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["соблазнять", "власть", "объединяться", "альянс"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["господствовать", "завоевание", "альянс", "объединяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["завоевание", "господствовать", "союз", "альянс"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["завоёвывать", "альянс", "союз", "господствовать"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["предавать", "ослеплять", "жестокость", "доносить"], "correct_index": 0}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "жестокость", "предавать", "доносить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["ослеплять", "выдавать", "жестокость", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["предавать", "доносить", "выдавать", "беспощадный"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["выдавать", "пытка", "доносить", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["выдавать", "жертвовать", "пытка", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["выдавать", "ослеплять", "беспощадный", "жертвовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["жестокость", "предавать", "жертвовать", "беспощадный"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["соперничество", "завлекать", "играть", "любовная связь"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["завлекать", "играть", "соперничество", "любовная связь"], "correct_index": 2}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["похоть", "использовать", "играть", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["похоть", "интрига", "играть", "завлекать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["жонглировать", "похоть", "играть", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["жонглировать", "играть", "завлекать", "использовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["похоть", "жонглировать", "использовать", "завлекать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["использовать", "интрига", "завлекать", "похоть"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["падать", "дуэль", "сожалеть", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "дуэль", "поражение", "сожалеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["дуэль", "сожалеть", "признаваться", "проигрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["поражение", "дуэль", "проигрывать", "признаваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["дуэль", "поражение", "проигрывать", "признаваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["проигрывать", "падать", "падение", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["сожалеть", "проигрывать", "дуэль", "признаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["поражение", "конец", "падение", "проигрывать"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Незаконнорождённый</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -469,11 +469,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Bastard»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">зависть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
                             
@@ -481,17 +481,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Neid»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -501,13 +501,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -519,7 +519,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">возвышаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
@@ -529,49 +545,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">внебрачный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">природа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвышаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">внебрачный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">зависть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,17 +600,17 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «fälschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -622,9 +622,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
                             
@@ -632,49 +632,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «beschuldigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">манипулировать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">лгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интриговать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -686,11 +686,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -702,27 +702,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">манипулировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,49 +735,49 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">торжествовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -789,43 +789,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">награда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -835,11 +835,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
                             
@@ -851,13 +851,13 @@
                         <div class="quiz-question">Что означает немецкое слово «der Sieg»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -870,15 +870,15 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verbünden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
                             
@@ -886,31 +886,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
                             
@@ -918,24 +902,8 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">господствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
@@ -944,7 +912,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -954,13 +954,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Eroberung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">господствовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">завоевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">альянс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -970,29 +970,29 @@
                         <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Allianz»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">альянс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1005,15 +1005,15 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
@@ -1021,47 +1021,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертвовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
@@ -1069,8 +1037,8 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
@@ -1079,7 +1047,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1091,7 +1091,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жертвовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
@@ -1101,33 +1101,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «opfern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жертвовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертвовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1156,40 +1156,8 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verlocken»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
@@ -1198,7 +1166,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verlocken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1214,23 +1214,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «ausnutzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жонглировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">использовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1240,29 +1240,29 @@
                         <div class="quiz-question">Что означает немецкое слово «jonglieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жонглировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Affäre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1283,6 +1283,22 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
@@ -1291,33 +1307,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">признаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1329,75 +1329,75 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">признаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">падение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">падение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1424,8 +1424,8 @@
                 "word": "der Bastard",
                 "translation": "бастард",
                 "transcription": "[дер БАС-тард]",
-                "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Als Bastard habe ich keine Rechte.",
-                "sentenceTranslation": "В замке Глостера Эдмунд тайно клянётся: Как бастард я не имею прав.",
+                "sentence": "Edmund steht unter dem glühenden Kronleuchter des Thronsaals. Mein Atem zeichnet das Wort „der Bastard“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Эдмунд стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «бастард» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1447,8 +1447,8 @@
                 "word": "der Neid",
                 "translation": "зависть",
                 "transcription": "[дер НАЙД]",
-                "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Der Neid auf Edgar verzehrt mich.",
-                "sentenceTranslation": "В замке Глостера Эдмунд тайно клянётся: Зависть к Эдгару пожирает меня.",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Edmund über Lears schweren Tisch. Ich umarme das Wort „der Neid“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "У развернутой карты королевства Эдмунд склоняется над тяжёлым столом Лира. Я обнимаю слово «зависть», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ambition",
@@ -1471,8 +1471,8 @@
                 "word": "die Ambition",
                 "translation": "амбиция",
                 "transcription": "[ди ам-би-ЦИ-он]",
-                "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Meine Ambition kennt keine Grenzen.",
-                "sentenceTranslation": "В замке Глостера Эдмунд тайно клянётся: Моя амбиция не знает границ.",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Edmund die Hände hinter dem Rücken. Das Echo des Wortes „die Ambition“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Перед каменными статуями предков Эдмунд сцепляет руки за спиной. Эхо слова «амбиция» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ambition",
@@ -1495,8 +1495,8 @@
                 "word": "benachteiligt",
                 "translation": "обделённый",
                 "transcription": "[бе-НАХ-тай-лигт]",
-                "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Ich bin von Geburt an benachteiligt.",
-                "sentenceTranslation": "В замке Глостера Эдмунд тайно клянётся: Я обделён с рождения.",
+                "sentence": "Zwischen flüsternden Höflingen gleitet Edmund über den kalten Marmorboden. Ich zeichne das Wort „benachteiligt“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Между шепчущимися придворными Эдмунд скользит по холодному мраморному полу. Я черчу слово «обделённый» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ambition",
@@ -1519,8 +1519,8 @@
                 "word": "die Rache",
                 "translation": "месть",
                 "transcription": "[ди РА-хе]",
-                "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Die Rache an der Gesellschaft ist mein Ziel.",
-                "sentenceTranslation": "В замке Глостера Эдмунд тайно клянётся: Месть обществу - моя цель.",
+                "sentence": "Am Rand des purpurnen Teppichs wartet Edmund auf ein Zeichen des Königs. Mein Atem zeichnet das Wort „die Rache“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На краю пурпурного ковра Эдмунд ждёт знака от короля. Моё дыхание рисует слово «месть» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1545,8 +1545,8 @@
                 "word": "aufsteigen",
                 "translation": "возвышаться",
                 "transcription": "[АУФ-штай-ген]",
-                "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Ich will über alle aufsteigen.",
-                "sentenceTranslation": "В замке Глостера Эдмунд тайно клянётся: Я хочу возвыситься над всеми.",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Edmund kurz den Blick. Ich zeichne das Wort „aufsteigen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Эдмунд на миг опускает взгляд. Я вывожу слово «возвышаться» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ambition",
@@ -1569,8 +1569,8 @@
                 "word": "unehelich",
                 "translation": "внебрачный",
                 "transcription": "[УН-э-е-лих]",
-                "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Meine uneheliche Geburt ist mein Fluch.",
-                "sentenceTranslation": "В замке Глостера Эдмунд тайно клянётся: Моё внебрачное рождение - мой проклятие.",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Edmund das gespannte Antlitz des Hofes. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unehelich“ gehört mir.",
+                "sentenceTranslation": "За позолоченной балюстрадой Эдмунд наблюдает за напряжёнными лицами двора. Буря за окнами усиливает клятву: слово «внебрачный» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ambition",
@@ -1593,8 +1593,8 @@
                 "word": "die Natur",
                 "translation": "природа",
                 "transcription": "[ди на-ТУР]",
-                "sentence": "Im Schloss von Gloucester schwört Edmund heimlich: Die Natur ist meine Göttin, nicht das Gesetz.",
-                "sentenceTranslation": "В замке Глостера Эдмунд тайно клянётся: Природа - моя богиня, не закон.",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Edmund langsam die Stimme. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Natur“ darf nicht vergehen.",
+                "sentenceTranslation": "В отблесках открытых жаровен Эдмунд медленно поднимает голос. Я шепчу стражам судьбы: слово «природа» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1618,9 +1618,9 @@
             {
                 "question": "Что означает немецкое слово «der Bastard»?",
                 "choices": [
+                    "обделённый",
                     "амбиция",
                     "зависть",
-                    "обделённый",
                     "бастард"
                 ],
                 "correctIndex": 3
@@ -1628,20 +1628,20 @@
             {
                 "question": "Что означает немецкое слово «der Neid»?",
                 "choices": [
-                    "бастард",
-                    "обделённый",
                     "зависть",
-                    "амбиция"
+                    "обделённый",
+                    "амбиция",
+                    "бастард"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ambition»?",
                 "choices": [
-                    "обделённый",
+                    "природа",
                     "амбиция",
-                    "зависть",
-                    "природа"
+                    "возвышаться",
+                    "месть"
                 ],
                 "correctIndex": 1
             },
@@ -1649,41 +1649,41 @@
                 "question": "Что означает немецкое слово «benachteiligt»?",
                 "choices": [
                     "обделённый",
-                    "бастард",
+                    "амбиция",
                     "месть",
-                    "внебрачный"
+                    "природа"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "месть",
-                    "внебрачный",
+                    "природа",
                     "возвышаться",
-                    "амбиция"
+                    "месть",
+                    "внебрачный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufsteigen»?",
                 "choices": [
-                    "амбиция",
-                    "бастард",
-                    "природа",
-                    "возвышаться"
+                    "внебрачный",
+                    "обделённый",
+                    "возвышаться",
+                    "бастард"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «unehelich»?",
                 "choices": [
-                    "месть",
-                    "обделённый",
+                    "природа",
                     "внебрачный",
-                    "природа"
+                    "возвышаться",
+                    "зависть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Natur»?",
@@ -1706,8 +1706,8 @@
                 "word": "fälschen",
                 "translation": "подделывать",
                 "transcription": "[ФЕЛЬ-шен]",
-                "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Ich fälsche Edgars Brief perfekt.",
-                "sentenceTranslation": "В своей комнате Эдмунд подписывает фальшивое письмо: Я идеально подделываю письмо Эдгара.",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Edmund zwischen gepackten Kisten. Mit fester Stimme schwöre ich mir: Das Wort „fälschen“ wird heute nicht verraten.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Эдмунд замирает среди нагруженных ящиков. Твёрдым голосом я клянусь себе: слово «подделывать» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "beschuldigen",
@@ -1730,8 +1730,8 @@
                 "word": "intrigieren",
                 "translation": "интриговать",
                 "transcription": "[ин-три-ГИ-рен]",
-                "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Ich intrigiere gegen meinen Bruder.",
-                "sentenceTranslation": "В своей комнате Эдмунд подписывает фальшивое письмо: Я интригую против брата.",
+                "sentence": "Auf der windigen Freitreppe blickt Edmund zum schweigenden Hof hinunter. Ich zeichne das Wort „intrigieren“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Эдмунд смотрит вниз на молчаливый двор. Я вывожу слово «интриговать» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "beschuldigen",
@@ -1754,8 +1754,8 @@
                 "word": "beschuldigen",
                 "translation": "обвинять",
                 "transcription": "[бе-ШУЛЬ-ди-ген]",
-                "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Ich beschuldige Edgar des Verrats.",
-                "sentenceTranslation": "В своей комнате Эдмунд подписывает фальшивое письмо: Я обвиняю Эдгара в предательстве.",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Edmund den Reisemantel enger. Ich flüstere den Wächtern des Schicksals zu: Das Wort „beschuldigen“ darf nicht vergehen.",
+                "sentenceTranslation": "Среди оставленных слуг Эдмунд плотнее запахивает дорожный плащ. Я шепчу стражам судьбы: слово «обвинять» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "beschuldigen",
@@ -1780,8 +1780,8 @@
                 "word": "der Plan",
                 "translation": "план",
                 "transcription": "[дер ПЛАН]",
-                "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Mein Plan wird perfekt ausgeführt.",
-                "sentenceTranslation": "В своей комнате Эдмунд подписывает фальшивое письмо: Мой план выполняется идеально.",
+                "sentence": "Am dunklen Pferdestall streicht Edmund einem nervösen Tier über die Mähne. Ich presse das Wort „der Plan“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Эдмунд гладит гриву нервного коня. Я стискиваю слово «план» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Hinterlist",
@@ -1808,8 +1808,8 @@
                 "word": "manipulieren",
                 "translation": "манипулировать",
                 "transcription": "[ма-ни-пу-ЛИ-рен]",
-                "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Ich manipuliere meinen Vater geschickt.",
-                "sentenceTranslation": "В своей комнате Эдмунд подписывает фальшивое письмо: Я ловко манипулирую отцом.",
+                "sentence": "Vor dem knarrenden Fallgatter tastet Edmund ein letztes Mal nach dem Haustor. Mit fester Stimme schwöre ich mir: Das Wort „manipulieren“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Эдмунд в последний раз касается родной двери. Твёрдым голосом я клянусь себе: слово «манипулировать» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "beschuldigen",
@@ -1832,8 +1832,8 @@
                 "word": "der Brief",
                 "translation": "письмо",
                 "transcription": "[дер БРИФ]",
-                "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Der gefälschte Brief ist mein Beweis.",
-                "sentenceTranslation": "В своей комнате Эдмунд подписывает фальшивое письмо: Поддельное письмо - моё доказательство.",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Edmund den Ring an der Hand. Ich umarme das Wort „der Brief“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Среди разбросанных свитков Эдмунд вертит кольцо на пальце. Я обнимаю слово «письмо», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1856,8 +1856,8 @@
                 "word": "lügen",
                 "translation": "лгать",
                 "transcription": "[ЛЮ-ген]",
-                "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Ich lüge ohne mit der Wimper zu zucken.",
-                "sentenceTranslation": "В своей комнате Эдмунд подписывает фальшивое письмо: Я лгу не моргнув глазом.",
+                "sentence": "Am leeren Bankettisch zählt Edmund die verlöschenden Kerzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „lügen“ bleibt lebendig.",
+                "sentenceTranslation": "У пустого банкетного стола Эдмунд пересчитывает гаснущие свечи. Каждой клеткой тела я обещаю: слово «лгать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1880,8 +1880,8 @@
                 "word": "die Täuschung",
                 "translation": "обман",
                 "transcription": "[ди ТОЙ-шунг]",
-                "sentence": "In seiner Kammer unterschreibt Edmund den falschen Brief: Die Täuschung ist vollkommen.",
-                "sentenceTranslation": "В своей комнате Эдмунд подписывает фальшивое письмо: Обман совершенен.",
+                "sentence": "Zwischen schweigenden Wachen geht Edmund auf den kalten Hof hinaus. Das Echo des Wortes „die Täuschung“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Между молчаливыми стражниками Эдмунд выходит на холодный двор. Эхо слова «обман» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Täuschung",
@@ -1910,19 +1910,19 @@
             {
                 "question": "Что означает немецкое слово «fälschen»?",
                 "choices": [
-                    "интриговать",
+                    "подделывать",
                     "обвинять",
                     "план",
-                    "подделывать"
+                    "интриговать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «intrigieren»?",
                 "choices": [
                     "обвинять",
-                    "план",
                     "подделывать",
+                    "план",
                     "интриговать"
                 ],
                 "correctIndex": 3
@@ -1930,40 +1930,40 @@
             {
                 "question": "Что означает немецкое слово «beschuldigen»?",
                 "choices": [
-                    "интриговать",
-                    "письмо",
+                    "план",
                     "обвинять",
-                    "обман"
+                    "письмо",
+                    "манипулировать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
-                    "обман",
-                    "лгать",
+                    "план",
                     "подделывать",
-                    "план"
+                    "интриговать",
+                    "обвинять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «manipulieren»?",
                 "choices": [
-                    "подделывать",
-                    "письмо",
                     "манипулировать",
-                    "обман"
+                    "интриговать",
+                    "обвинять",
+                    "план"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
                     "лгать",
-                    "обвинять",
+                    "обман",
                     "письмо",
-                    "план"
+                    "подделывать"
                 ],
                 "correctIndex": 2
             },
@@ -1971,21 +1971,21 @@
                 "question": "Что означает немецкое слово «lügen»?",
                 "choices": [
                     "лгать",
-                    "письмо",
-                    "подделывать",
-                    "обвинять"
+                    "манипулировать",
+                    "обвинять",
+                    "план"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
+                    "лгать",
                     "обман",
-                    "обвинять",
                     "манипулировать",
-                    "интриговать"
+                    "обвинять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -1998,8 +1998,8 @@
                 "word": "vertreiben",
                 "translation": "изгонять",
                 "transcription": "[фер-ТРАЙ-бен]",
-                "sentence": "Im Saal, den Regan hält, prahlt Edmund: Ich vertreibe Edgar aus seinem Erbe.",
-                "sentenceTranslation": "В зале, который удерживает Регана, Эдмунд хвастается: Я изгоняю Эдгара из его наследства.",
+                "sentence": "Im zugigen Seitenflügel lauscht Edmund dem Heulen der Küstenwinde. Das Echo des Wortes „vertreiben“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Эдмунд слушает вой прибрежного ветра. Эхо слова «изгонять» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2026,8 +2026,8 @@
                 "word": "triumphieren",
                 "translation": "торжествовать",
                 "transcription": "[три-ум-ФИ-рен]",
-                "sentence": "Im Saal, den Regan hält, prahlt Edmund: Ich triumphiere über meinen Bruder.",
-                "sentenceTranslation": "В зале, который удерживает Регана, Эдмунд хвастается: Я торжествую над братом.",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Edmund einen zerknitterten Brief. Ich halte das Wort „triumphieren“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед дымным камином замка Эдмунд складывает измятый лист. Я держу слово «торжествовать» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "erben",
@@ -2050,8 +2050,8 @@
                 "word": "erben",
                 "translation": "наследовать",
                 "transcription": "[ЭР-бен]",
-                "sentence": "Im Saal, den Regan hält, prahlt Edmund: Nun erbe ich alles, was Edgar zustand.",
-                "sentenceTranslation": "В зале, который удерживает Регана, Эдмунд хвастается: Теперь я наследую всё, что полагалось Эдгару.",
+                "sentence": "Unter farblosen Wandteppichen schreitet Edmund rastlos auf und ab. Ich zeichne das Wort „erben“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под выцветшими гобеленами Эдмунд беспокойно меряет шагами зал. Я черчу слово «наследовать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2074,8 +2074,8 @@
                 "word": "der Erfolg",
                 "translation": "успех",
                 "transcription": "[дер эр-ФОЛЬГ]",
-                "sentence": "Im Saal, den Regan hält, prahlt Edmund: Mein Erfolg ist vollkommen.",
-                "sentenceTranslation": "В зале, который удерживает Регана, Эдмунд хвастается: Мой успех полный.",
+                "sentence": "An der schmalen Fensterluke zählt Edmund die Fackeln auf dem Hof. Wie ein stilles Gebet legt sich das Wort „der Erfolg“ auf meine Lippen.",
+                "sentenceTranslation": "У узкой бойницы Эдмунд считает факелы на дворе. Как тихая молитва слово «успех» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "erben",
@@ -2098,8 +2098,8 @@
                 "word": "gewinnen",
                 "translation": "выигрывать",
                 "transcription": "[ге-ВИН-нен]",
-                "sentence": "Im Saal, den Regan hält, prahlt Edmund: Ich gewinne alles durch List.",
-                "sentenceTranslation": "В зале, который удерживает Регана, Эдмунд хвастается: Я выигрываю всё хитростью.",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Edmund nach frischen Botschaften. Ich umarme das Wort „gewinnen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Эдмунд ищет свежие вести. Я обнимаю слово «выигрывать», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2121,8 +2121,8 @@
                 "word": "die Belohnung",
                 "translation": "награда",
                 "transcription": "[ди бе-ЛО-нунг]",
-                "sentence": "Im Saal, den Regan hält, prahlt Edmund: Die Belohnung für meine Intrige ist groß.",
-                "sentenceTranslation": "В зале, который удерживает Регана, Эдмунд хвастается: Награда за мою интригу велика.",
+                "sentence": "Im stillen Kapellenraum kniet Edmund vor der kalten Steinfigur. Ich zeichne das Wort „die Belohnung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В тихой капелле Эдмунд преклоняет колени перед холодной каменной фигурой. Я вывожу слово «награда» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "erben",
@@ -2145,8 +2145,8 @@
                 "word": "verdrängen",
                 "translation": "вытеснять",
                 "transcription": "[фер-ДРЕН-ген]",
-                "sentence": "Im Saal, den Regan hält, prahlt Edmund: Ich verdränge den rechtmäßigen Erben.",
-                "sentenceTranslation": "В зале, который удерживает Регана, Эдмунд хвастается: Я вытесняю законного наследника.",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Edmund die Laterne fest. Das kalte Licht lässt das Wort „verdrängen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Эдмунд крепко держит фонарь. Холодный свет заставляет слово «вытеснять» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "erben",
@@ -2169,8 +2169,8 @@
                 "word": "der Sieg",
                 "translation": "победа",
                 "transcription": "[дер ЗИГ]",
-                "sentence": "Im Saal, den Regan hält, prahlt Edmund: Der Sieg über Edgar ist süß.",
-                "sentenceTranslation": "В зале, который удерживает Регана, Эдмунд хвастается: Победа над Эдгаром сладка.",
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Edmund eine fiebrige Antwort. Ich zeichne das Wort „der Sieg“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В тени высоких стен Эдмунд пишет лихорадочный ответ. Я вывожу слово «победа» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "erben",
@@ -2195,68 +2195,68 @@
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
                     "торжествовать",
-                    "успех",
+                    "изгонять",
                     "наследовать",
-                    "изгонять"
+                    "успех"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «triumphieren»?",
                 "choices": [
-                    "торжествовать",
-                    "изгонять",
+                    "наследовать",
                     "успех",
-                    "наследовать"
+                    "изгонять",
+                    "торжествовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
-                    "успех",
-                    "выигрывать",
-                    "награда",
-                    "наследовать"
+                    "наследовать",
+                    "вытеснять",
+                    "победа",
+                    "успех"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Erfolg»?",
                 "choices": [
                     "успех",
-                    "торжествовать",
                     "победа",
-                    "наследовать"
+                    "торжествовать",
+                    "выигрывать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «gewinnen»?",
                 "choices": [
-                    "изгонять",
-                    "награда",
-                    "выигрывать",
-                    "наследовать"
+                    "успех",
+                    "вытеснять",
+                    "торжествовать",
+                    "выигрывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Belohnung»?",
                 "choices": [
-                    "награда",
-                    "победа",
                     "успех",
-                    "выигрывать"
+                    "изгонять",
+                    "награда",
+                    "вытеснять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verdrängen»?",
                 "choices": [
-                    "выигрывать",
-                    "награда",
+                    "наследовать",
                     "торжествовать",
+                    "победа",
                     "вытеснять"
                 ],
                 "correctIndex": 3
@@ -2264,10 +2264,10 @@
             {
                 "question": "Что означает немецкое слово «der Sieg»?",
                 "choices": [
-                    "наследовать",
-                    "изгонять",
+                    "успех",
+                    "торжествовать",
                     "победа",
-                    "успех"
+                    "выигрывать"
                 ],
                 "correctIndex": 2
             }
@@ -2282,8 +2282,8 @@
                 "word": "verbünden",
                 "translation": "объединяться",
                 "transcription": "[фер-БЮН-ден]",
-                "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Ich verbünde mich mit den bösen Schwestern.",
-                "sentenceTranslation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Я объединяюсь со злыми сёстрами.",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edmund gegen den Wind. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbünden“ gehört mir.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Эдмунд упирается в ветер. Буря за окнами усиливает клятву: слово «объединяться» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Macht",
@@ -2306,8 +2306,8 @@
                 "word": "die Macht",
                 "translation": "власть",
                 "transcription": "[ди МАХТ]",
-                "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Die Macht über das Königreich ist nah.",
-                "sentenceTranslation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Власть над королевством близка.",
+                "sentence": "Unter einem zerrissenen Banner schützt Edmund die Augen vor den Blitzen. Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Под разорванным знаменем Эдмунд прикрывает глаза от молний. Я обнимаю слово «власть», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2332,8 +2332,8 @@
                 "word": "erobern",
                 "translation": "завоёвывать",
                 "transcription": "[эр-О-берн]",
-                "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Wir erobern das Reich gemeinsam.",
-                "sentenceTranslation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Мы завоёвываем королевство вместе.",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Edmund Deckung vor dem Donner. Das kalte Licht lässt das Wort „erobern“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "У поваленного дерева Эдмунд ищет укрытия от грома. Холодный свет заставляет слово «завоёвывать» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2357,8 +2357,8 @@
                 "word": "das Bündnis",
                 "translation": "союз",
                 "transcription": "[дас БЮНД-нис]",
-                "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Unser Bündnis ist stark und grausam.",
-                "sentenceTranslation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Наш союз силён и жесток.",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Edmund durch den Schlamm. Das kalte Licht lässt das Wort „das Bündnis“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Между пенящимися лужами Эдмунд пробирается через грязь. Холодный свет заставляет слово «союз» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bündnis",
@@ -2385,8 +2385,8 @@
                 "word": "verführen",
                 "translation": "соблазнять",
                 "transcription": "[фер-ФЮ-рен]",
-                "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Ich verführe beide Schwestern gleichzeitig.",
-                "sentenceTranslation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Я соблазняю обеих сестёр одновременно.",
+                "sentence": "Vor einem zuckenden Himmel hebt Edmund die Arme trotzig an. Ich umarme das Wort „verführen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Эдмунд упрямо поднимает руки. Я обнимаю слово «соблазнять», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Macht",
@@ -2413,8 +2413,8 @@
                 "word": "die Eroberung",
                 "translation": "завоевание",
                 "transcription": "[ди эр-О-бе-рунг]",
-                "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Die Eroberung des Throns ist mein Ziel.",
-                "sentenceTranslation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Завоевание трона - моя цель.",
+                "sentence": "Unter dem durchtränkten Umhang presst Edmund den Atem gegen die Kälte. Ich halte das Wort „die Eroberung“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Под промокшим плащом Эдмунд прижимает дыхание к груди, спасаясь от холода. Я держу слово «завоевание» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Macht",
@@ -2437,8 +2437,8 @@
                 "word": "beherrschen",
                 "translation": "господствовать",
                 "transcription": "[бе-ХЕР-шен]",
-                "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Ich beherrsche das Spiel der Macht.",
-                "sentenceTranslation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Я господствую в игре власти.",
+                "sentence": "Am kläglichen Feuerrest wärmt Edmund zitternde Finger. Ich presse das Wort „beherrschen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У жалких огненных углей Эдмунд греет дрожащие пальцы. Я стискиваю слово «господствовать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2461,8 +2461,8 @@
                 "word": "die Allianz",
                 "translation": "альянс",
                 "transcription": "[ди а-ли-АНЦС]",
-                "sentence": "Während die Schwestern über Lear beraten, versichert Edmund: Unsere Allianz wird alle Feinde vernichten.",
-                "sentenceTranslation": "Пока сёстры совещаются о Лире, Эдмунд уверяет: Наш альянс уничтожит всех врагов.",
+                "sentence": "Zwischen heulenden Hunden ruft Edmund gegen den tosenden Sturm an. Ich presse das Wort „die Allianz“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди воющих псов Эдмунд перекрикивает беснующуюся бурю. Я стискиваю слово «альянс» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Macht",
@@ -2486,70 +2486,70 @@
             {
                 "question": "Что означает немецкое слово «verbünden»?",
                 "choices": [
-                    "власть",
-                    "союз",
                     "объединяться",
+                    "союз",
+                    "власть",
                     "завоёвывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
                     "союз",
-                    "объединяться",
                     "завоёвывать",
-                    "власть"
+                    "власть",
+                    "объединяться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
-                    "завоёвывать",
+                    "завоевание",
                     "соблазнять",
-                    "господствовать",
-                    "объединяться"
+                    "завоёвывать",
+                    "господствовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
+                    "соблазнять",
                     "господствовать",
-                    "власть",
-                    "объединяться",
-                    "союз"
+                    "союз",
+                    "завоёвывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
-                    "завоевание",
                     "соблазнять",
-                    "завоёвывать",
-                    "власть"
+                    "власть",
+                    "объединяться",
+                    "альянс"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Eroberung»?",
                 "choices": [
-                    "объединяться",
+                    "господствовать",
                     "завоевание",
-                    "власть",
-                    "союз"
+                    "альянс",
+                    "объединяться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beherrschen»?",
                 "choices": [
-                    "объединяться",
+                    "завоевание",
                     "господствовать",
                     "союз",
-                    "завоевание"
+                    "альянс"
                 ],
                 "correctIndex": 1
             },
@@ -2557,11 +2557,11 @@
                 "question": "Что означает немецкое слово «die Allianz»?",
                 "choices": [
                     "завоёвывать",
-                    "господствовать",
-                    "завоевание",
-                    "альянс"
+                    "альянс",
+                    "союз",
+                    "господствовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2574,8 +2574,8 @@
                 "word": "verraten",
                 "translation": "предавать",
                 "transcription": "[фер-РА-тен]",
-                "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Ich verrate meinen eigenen Vater.",
-                "sentenceTranslation": "Перед воротами Глостера Эдмунд продаёт отца: Я предаю собственного отца.",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Edmund bei der flackernden Kerze. Mein Atem zeichnet das Wort „verraten“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Эдмунд сидит у мерцающей свечи. Моё дыхание рисует слово «предавать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2602,8 +2602,8 @@
                 "word": "blenden",
                 "translation": "ослеплять",
                 "transcription": "[БЛЕН-ден]",
-                "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Sie blenden ihn auf meinen Hinweis.",
-                "sentenceTranslation": "Перед воротами Глостера Эдмунд продаёт отца: Они ослепляют его по моей наводке.",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Edmund über ein altes Wappen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen.",
+                "sentenceTranslation": "Среди помятых доспехов Эдмунд гладит старый герб. Я шепчу стражам судьбы: слово «ослеплять» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2628,8 +2628,8 @@
                 "word": "die Grausamkeit",
                 "translation": "жестокость",
                 "transcription": "[ди ГРАУ-зам-кайт]",
-                "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Meine Grausamkeit kennt keine Grenzen.",
-                "sentenceTranslation": "Перед воротами Глостера Эдмунд продаёт отца: Моя жестокость не знает границ.",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Edmund fast den Kopf. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Grausamkeit“ gehört mir.",
+                "sentenceTranslation": "О низкую балку хижины Эдмунд едва не ударяется головой. Буря за окнами усиливает клятву: слово «жестокость» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bosheit",
@@ -2663,8 +2663,8 @@
                 "word": "denunzieren",
                 "translation": "доносить",
                 "transcription": "[де-нун-ЦИ-рен]",
-                "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Ich denunziere meinen Vater als Verräter.",
-                "sentenceTranslation": "Перед воротами Глостера Эдмунд продаёт отца: Я доношу на отца как на предателя.",
+                "sentence": "Neben der schlafenden Wache flüstert Edmund in die schwere Nacht. Ich presse das Wort „denunzieren“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Рядом со спящим стражем Эдмунд шепчет в тяжёлую ночь. Я стискиваю слово «доносить» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Grausamkeit",
@@ -2687,8 +2687,8 @@
                 "word": "ausliefern",
                 "translation": "выдавать",
                 "transcription": "[АУС-ли-ферн]",
-                "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Ich liefere ihn seinen Feinden aus.",
-                "sentenceTranslation": "Перед воротами Глостера Эдмунд продаёт отца: Я выдаю его врагам.",
+                "sentence": "Vor dem einfachen Feldbett betrachtet Edmund die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „ausliefern“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед грубой походной койкой Эдмунд разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «выдавать» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Grausamkeit",
@@ -2713,8 +2713,8 @@
                 "word": "die Folter",
                 "translation": "пытка",
                 "transcription": "[ди ФОЛЬ-тер]",
-                "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Die Folter meines Vaters stört mich nicht.",
-                "sentenceTranslation": "Перед воротами Глостера Эдмунд продаёт отца: Пытка моего отца меня не тревожит.",
+                "sentence": "Im Geruch von feuchtem Stroh legt Edmund den Mantel zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Folter“ bleibt lebendig.",
+                "sentenceTranslation": "В запахе влажной соломы Эдмунд откладывает плащ в сторону. Каждой клеткой тела я обещаю: слово «пытка» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -2745,8 +2745,8 @@
                 "word": "opfern",
                 "translation": "жертвовать",
                 "transcription": "[ОП-ферн]",
-                "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Ich opfere ihn für meine Ambitionen.",
-                "sentenceTranslation": "Перед воротами Глостера Эдмунд продаёт отца: Я жертвую им ради своих амбиций.",
+                "sentence": "Auf dem wackligen Holztisch ordnet Edmund zerlesene Briefe. Das kalte Licht lässt das Wort „opfern“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На шатком деревянном столе Эдмунд раскладывает зачитанные письма. Холодный свет заставляет слово «жертвовать» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Grausamkeit",
@@ -2769,8 +2769,8 @@
                 "word": "erbarmungslos",
                 "translation": "беспощадный",
                 "transcription": "[эр-БАР-мунгс-лос]",
-                "sentence": "Vor den Toren von Gloucester verkauft Edmund seinen Vater: Erbarmungslos verfolge ich mein Ziel.",
-                "sentenceTranslation": "Перед воротами Глостера Эдмунд продаёт отца: Беспощадно я преследую свою цель.",
+                "sentence": "Am Eingang der Hütte späht Edmund nach einem vertrauten Schatten. Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У входа в хижину Эдмунд высматривает знакомую тень. Я стискиваю слово «беспощадный» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Grausamkeit",
@@ -2801,58 +2801,58 @@
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "жестокость",
                     "предавать",
                     "ослеплять",
+                    "жестокость",
                     "доносить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "жестокость",
-                    "доносить",
                     "ослеплять",
+                    "жестокость",
+                    "предавать",
+                    "доносить"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Grausamkeit»?",
+                "choices": [
+                    "ослеплять",
+                    "выдавать",
+                    "жестокость",
                     "предавать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Grausamkeit»?",
-                "choices": [
-                    "жестокость",
-                    "пытка",
-                    "выдавать",
-                    "жертвовать"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «denunzieren»?",
                 "choices": [
-                    "жертвовать",
-                    "жестокость",
-                    "пытка",
-                    "доносить"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «ausliefern»?",
-                "choices": [
-                    "ослеплять",
+                    "предавать",
+                    "доносить",
                     "выдавать",
-                    "жестокость",
                     "беспощадный"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «ausliefern»?",
+                "choices": [
+                    "выдавать",
+                    "пытка",
+                    "доносить",
+                    "жестокость"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
                     "выдавать",
-                    "доносить",
+                    "жертвовать",
                     "пытка",
                     "жестокость"
                 ],
@@ -2861,22 +2861,22 @@
             {
                 "question": "Что означает немецкое слово «opfern»?",
                 "choices": [
-                    "жертвовать",
-                    "жестокость",
                     "выдавать",
-                    "ослеплять"
+                    "ослеплять",
+                    "беспощадный",
+                    "жертвовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
-                    "ослеплять",
-                    "беспощадный",
                     "жестокость",
-                    "жертвовать"
+                    "предавать",
+                    "жертвовать",
+                    "беспощадный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2889,8 +2889,8 @@
                 "word": "die Liebschaft",
                 "translation": "любовная связь",
                 "transcription": "[ди ЛИБ-шафт]",
-                "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Meine Liebschaft mit beiden Schwestern ist gefährlich.",
-                "sentenceTranslation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Моя любовная связь с обеими сёстрами опасна.",
+                "sentence": "Auf den weißen Klippen von Dover blickt Edmund in den aufgewühlten Kanal. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Liebschaft“ gehört mir.",
+                "sentenceTranslation": "На белых скалах Дувра Эдмунд смотрит в вздыбленный пролив. Буря за окнами усиливает клятву: слово «любовная связь» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Liebschaft",
@@ -2914,8 +2914,8 @@
                 "word": "die Rivalität",
                 "translation": "соперничество",
                 "transcription": "[ди ри-ва-ли-ТЕТ]",
-                "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ihre Rivalität spielt mir in die Hände.",
-                "sentenceTranslation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Их соперничество играет мне на руку.",
+                "sentence": "Zwischen flatternden Feldzeichen richtet Edmund den Helm. Ich halte das Wort „die Rivalität“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Среди хлопающих штандартов Эдмунд поправляет шлем. Я держу слово «соперничество» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Liebschaft",
@@ -2942,8 +2942,8 @@
                 "word": "spielen",
                 "translation": "играть",
                 "transcription": "[ШПИ-лен]",
-                "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ich spiele mit ihren Gefühlen.",
-                "sentenceTranslation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Я играю с их чувствами.",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Edmund Marschrouten in den Sand. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „spielen“ gehört mir.",
+                "sentenceTranslation": "У французского костра Эдмунд рисует в песке путь марша. Буря за окнами усиливает клятву: слово «играть» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2965,8 +2965,8 @@
                 "word": "verlocken",
                 "translation": "завлекать",
                 "transcription": "[фер-ЛО-кен]",
-                "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ich verlocke sie mit falschen Versprechen.",
-                "sentenceTranslation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Я завлекаю их ложными обещаниями.",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Edmund das Siegel. Ich flüstere den Wächtern des Schicksals zu: Das Wort „verlocken“ darf nicht vergehen.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Эдмунд проверяет печати. Я шепчу стражам судьбы: слово «завлекать» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Liebschaft",
@@ -2989,8 +2989,8 @@
                 "word": "die Lust",
                 "translation": "похоть",
                 "transcription": "[ди ЛУСТ]",
-                "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ihre Lust macht sie blind.",
-                "sentenceTranslation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Их похоть делает их слепыми.",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Edmund dem dumpfen Meer. Ich presse das Wort „die Lust“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Эдмунд слушает глухой шум моря. Я стискиваю слово «похоть» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Liebschaft",
@@ -3017,8 +3017,8 @@
                 "word": "ausnutzen",
                 "translation": "использовать",
                 "transcription": "[АУС-нут-цен]",
-                "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ich nutze ihre Leidenschaft aus.",
-                "sentenceTranslation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Я использую их страсть.",
+                "sentence": "Auf dem sandigen Trainingsplatz übt Edmund das Ziehen des Schwerts. Ich atme tief ein und lasse nur das Wort „ausnutzen“ wieder hinaus.",
+                "sentenceTranslation": "На песчаном плацу Эдмунд отрабатывает выхват меча. Я глубоко вдыхаю и выпускаю только слово «использовать».",
                 "visual_hint": "📚",
                 "themes": [
                     "Liebschaft",
@@ -3041,8 +3041,8 @@
                 "word": "jonglieren",
                 "translation": "жонглировать",
                 "transcription": "[жон-ГЛИ-рен]",
-                "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Ich jongliere mit zwei gefährlichen Frauen.",
-                "sentenceTranslation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Я жонглирую двумя опасными женщинами.",
+                "sentence": "Zwischen pochenden Trommeln hebt Edmund das Banner der Hoffnung. Das kalte Licht lässt das Wort „jonglieren“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Под гул барабанов Эдмунд поднимает знамя надежды. Холодный свет заставляет слово «жонглировать» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Liebschaft",
@@ -3065,8 +3065,8 @@
                 "word": "die Affäre",
                 "translation": "интрига",
                 "transcription": "[ди а-ФЕ-ре]",
-                "sentence": "Zwischen den Lagern von Goneril und Regan flüstert Edmund: Diese Affäre wird tödlich enden.",
-                "sentenceTranslation": "Между лагерями Гонериль и Реганы Эдмунд шепчет: Эта интрига закончится смертью.",
+                "sentence": "Am Morgennebel der Küste legt Edmund die Hand auf das pochende Herz. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Affäre“ darf nicht vergehen.",
+                "sentenceTranslation": "В утреннем тумане побережья Эдмунд кладёт ладонь на бьющееся сердце. Я шепчу стражам судьбы: слово «интрига» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Liebschaft",
@@ -3101,32 +3101,32 @@
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
-                    "играть",
-                    "любовная связь",
                     "завлекать",
-                    "соперничество"
+                    "играть",
+                    "соперничество",
+                    "любовная связь"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «spielen»?",
                 "choices": [
-                    "любовная связь",
-                    "соперничество",
                     "похоть",
-                    "играть"
+                    "использовать",
+                    "играть",
+                    "интрига"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verlocken»?",
                 "choices": [
-                    "завлекать",
+                    "похоть",
+                    "интрига",
                     "играть",
-                    "соперничество",
-                    "жонглировать"
+                    "завлекать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
@@ -3134,39 +3134,39 @@
                     "жонглировать",
                     "похоть",
                     "играть",
-                    "завлекать"
+                    "соперничество"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ausnutzen»?",
                 "choices": [
-                    "использовать",
-                    "соперничество",
                     "жонглировать",
-                    "похоть"
+                    "играть",
+                    "завлекать",
+                    "использовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «jonglieren»?",
                 "choices": [
-                    "интрига",
+                    "похоть",
                     "жонглировать",
-                    "играть",
-                    "соперничество"
+                    "использовать",
+                    "завлекать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Affäre»?",
                 "choices": [
-                    "играть",
                     "использовать",
                     "интрига",
-                    "любовная связь"
+                    "завлекать",
+                    "похоть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -3179,8 +3179,8 @@
                 "word": "das Duell",
                 "translation": "дуэль",
                 "transcription": "[дас ду-ЭЛЬ]",
-                "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Das Duell mit Edgar ist mein Ende.",
-                "sentenceTranslation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Дуэль с Эдгаром - мой конец.",
+                "sentence": "Im feuchten Kerker stützt Edmund sich an den tropfenden Stein. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Duell“ gehört mir.",
+                "sentenceTranslation": "В сыром подземелье Эдмунд опирается на сочащийся камень. Буря за окнами усиливает клятву: слово «дуэль» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3203,8 +3203,8 @@
                 "word": "fallen",
                 "translation": "падать",
                 "transcription": "[ФАЛ-лен]",
-                "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Ich falle von seinem gerechten Schwert.",
-                "sentenceTranslation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Я падаю от его справедливого меча.",
+                "sentence": "Unter der trüben Laterne zählt Edmund die eisernen Ringe der Kette. Ich zeichne das Wort „fallen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под мутным фонарём Эдмунд пересчитывает железные кольца цепи. Я черчу слово «падать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3228,8 +3228,8 @@
                 "word": "bereuen",
                 "translation": "сожалеть",
                 "transcription": "[бе-РОЙ-ен]",
-                "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Am Ende bereue ich meine Taten.",
-                "sentenceTranslation": "В лагере Олбани перед дуэлью Эдмунд признаёт: В конце я сожалею о своих делах.",
+                "sentence": "Neben der schweren Holztür horcht Edmund auf entferntes Schluchzen. Das Echo des Wortes „bereuen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У тяжёлой двери Эдмунд прислушивается к далёким рыданиям. Эхо слова «сожалеть» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3254,8 +3254,8 @@
                 "word": "die Niederlage",
                 "translation": "поражение",
                 "transcription": "[ди НИ-дер-ла-ге]",
-                "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Die Niederlage ist vollkommen.",
-                "sentenceTranslation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Поражение полное.",
+                "sentence": "Auf der kalten Steinbank zieht Edmund den Mantel enger um die Schultern. Ich zeichne das Wort „die Niederlage“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На холодной каменной скамье Эдмунд плотнее кутается в плащ. Я черчу слово «поражение» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Duell",
@@ -3282,8 +3282,8 @@
                 "word": "verlieren",
                 "translation": "проигрывать",
                 "transcription": "[фер-ЛИ-рен]",
-                "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Ich verliere alles, was ich gewann.",
-                "sentenceTranslation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Я проигрываю всё, что выиграл.",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Edmund das Gesicht zum Licht. Mit fester Stimme schwöre ich mir: Das Wort „verlieren“ wird heute nicht verraten.",
+                "sentenceTranslation": "Между тенями решёток Эдмунд поднимает лицо к свету. Твёрдым голосом я клянусь себе: слово «проигрывать» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3307,8 +3307,8 @@
                 "word": "der Untergang",
                 "translation": "падение",
                 "transcription": "[дер УН-тер-ганг]",
-                "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Mein Untergang ist gerecht.",
-                "sentenceTranslation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Моё падение справедливо.",
+                "sentence": "Am rostigen Wassereimer spiegelt Edmund kurz die eigenen Augen. Ich halte das Wort „der Untergang“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У ржавого ведра с водой Эдмунд на мгновение видит отражение глаз. Я держу слово «падение» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Duell",
@@ -3331,8 +3331,8 @@
                 "word": "gestehen",
                 "translation": "признаваться",
                 "transcription": "[ге-ШТЕ-ен]",
-                "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Ich gestehe alle meine Verbrechen.",
-                "sentenceTranslation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Я признаюсь во всех преступлениях.",
+                "sentence": "Im dumpfen Hall der Schritte zählt Edmund den Rhythmus der Wachen. Das Echo des Wortes „gestehen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В глухом эхе шагов Эдмунд отсчитывает ритм часовых. Эхо слова «признаваться» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3354,8 +3354,8 @@
                 "word": "das Ende",
                 "translation": "конец",
                 "transcription": "[дас ЭН-де]",
-                "sentence": "Im Feldlager von Albany vor dem Duell erkennt Edmund: Das Ende kommt schnell und gerecht.",
-                "sentenceTranslation": "В лагере Олбани перед дуэлью Эдмунд признаёт: Конец приходит быстро и справедливо.",
+                "sentence": "Vor dem verriegelten Fenster zeichnet Edmund Kreise in den Staub. Ich atme tief ein und lasse nur das Wort „das Ende“ wieder hinaus.",
+                "sentenceTranslation": "Перед заколоченным окном Эдмунд чертит круги в пыли. Я глубоко вдыхаю и выпускаю только слово «конец».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3383,80 +3383,80 @@
                 "choices": [
                     "падать",
                     "дуэль",
-                    "поражение",
-                    "сожалеть"
+                    "сожалеть",
+                    "поражение"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
-                    "дуэль",
                     "падать",
+                    "дуэль",
                     "поражение",
                     "сожалеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "проигрывать",
+                    "дуэль",
+                    "сожалеть",
                     "признаваться",
-                    "поражение",
-                    "сожалеть"
+                    "проигрывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
                     "поражение",
+                    "дуэль",
                     "проигрывать",
-                    "конец",
-                    "падать"
+                    "признаваться"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verlieren»?",
                 "choices": [
-                    "конец",
-                    "падение",
-                    "сожалеть",
-                    "проигрывать"
+                    "дуэль",
+                    "поражение",
+                    "проигрывать",
+                    "признаваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Untergang»?",
                 "choices": [
-                    "дуэль",
-                    "признаваться",
-                    "конец",
-                    "падение"
+                    "проигрывать",
+                    "падать",
+                    "падение",
+                    "сожалеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «gestehen»?",
                 "choices": [
-                    "поражение",
+                    "сожалеть",
+                    "проигрывать",
                     "дуэль",
-                    "признаваться",
-                    "конец"
+                    "признаваться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "сожалеть",
                     "поражение",
                     "конец",
-                    "падение"
+                    "падение",
+                    "проигрывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -3987,27 +3987,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/fool.html
+++ b/output/journeys/fool.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "мудрость", "шутить", "печаль"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["шут", "шутить", "печаль", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["печаль", "забава", "остроумие", "умный"], "correct_index": 0}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["умный", "остроумие", "шутить", "печаль"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["мудрость", "остроумие", "печаль", "забава"], "correct_index": 3}, {"question": "Что означает немецкое слово «klug»?", "choices": ["остроумие", "шут", "скучать", "умный"], "correct_index": 3}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["шут", "скучать", "печаль", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["мудрость", "остроумие", "забава", "шутить"], "correct_index": 1}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["горький", "шутка", "предупреждение", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["правда", "предупреждение", "шутка", "горький"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["горький", "шутка", "дразнить", "предупреждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["дразнить", "насмехаться", "шутка", "горький"], "correct_index": 3}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["правда", "насмехаться", "предупреждение", "горький"], "correct_index": 1}, {"question": "Что означает немецкое слово «necken»?", "choices": ["дразнить", "шутка", "предупреждение", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["предупреждение", "раскрывать", "правда", "шутка"], "correct_index": 1}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["предчувствие", "загадка", "пророчество", "предсказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["загадка", "предчувствие", "предсказывать", "пророчество"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["предчувствие", "загадка", "предчувствовать", "знамение"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["знамение", "предсказывать", "загадка", "предчувствовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["толковать", "знамение", "предчувствовать", "загадочный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["предчувствовать", "знамение", "предсказывать", "загадка"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["предсказывать", "толковать", "знамение", "предчувствовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадка", "предчувствие", "загадочный", "предсказывать"], "correct_index": 2}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["дружба", "безумие", "сопровождать", "мёрзнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["мёрзнуть", "дружба", "сопровождать", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["петь", "безумие", "сопровождать", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["дружба", "сопровождать", "петь", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «singen»?", "choices": ["верный", "петь", "дружба", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["сопровождать", "петь", "дрожать", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["петь", "безумие", "мёрзнуть", "верный"], "correct_index": 3}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["песня", "напевать", "ирония", "утешение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["ирония", "напевать", "утешение", "песня"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["свистеть", "рифма", "ирония", "напевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «summen»?", "choices": ["напевать", "звучать", "мелодия", "ирония"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["напевать", "звучать", "мелодия", "рифма"], "correct_index": 2}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["свистеть", "песня", "рифма", "утешение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["утешение", "напевать", "рифма", "звучать"], "correct_index": 2}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["звучать", "свистеть", "ирония", "мелодия"], "correct_index": 0}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["бренность", "размышлять", "философия", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["бренность", "судьба", "размышлять", "философия"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["смысл", "размышлять", "бренность", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["философия", "преходящий", "бренность", "размышлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["преходящий", "бренность", "смысл", "познавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["познавать", "смысл", "преходящий", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["преходящий", "философия", "бренность", "познавать"], "correct_index": 0}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["исчезать", "пустота", "тайна", "растворяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["растворяться", "пустота", "тайна", "исчезать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["туман", "загадочный", "пустота", "уходить"], "correct_index": 2}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["тайна", "загадочный", "растворяться", "туман"], "correct_index": 2}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["бесследно", "туман", "исчезать", "тайна"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["уходить", "тайна", "туман", "загадочный"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["бесследно", "тайна", "пустота", "загадочный"], "correct_index": 3}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["уходить", "исчезать", "растворяться", "туман"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["мудрость", "шутить", "шут", "печаль"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["шутить", "печаль", "шут", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["печаль", "шут", "остроумие", "забава"], "correct_index": 0}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["забава", "шут", "шутить", "остроумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["шут", "шутить", "забава", "мудрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «klug»?", "choices": ["скучать", "остроумие", "умный", "мудрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["шут", "скучать", "шутить", "остроумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["умный", "шут", "остроумие", "скучать"], "correct_index": 2}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "шутка", "горький", "предупреждение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["правда", "шутка", "предупреждение", "горький"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["предупреждение", "правда", "шутка", "горький"], "correct_index": 0}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["шутка", "горький", "предупреждение", "насмехаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["правда", "шутка", "насмехаться", "дразнить"], "correct_index": 2}, {"question": "Что означает немецкое слово «necken»?", "choices": ["правда", "дразнить", "шутка", "предупреждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["раскрывать", "горький", "дразнить", "шутка"], "correct_index": 0}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["предсказывать", "пророчество", "предчувствие", "загадка"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["загадка", "предсказывать", "пророчество", "предчувствие"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["загадка", "предчувствие", "толковать", "загадочный"], "correct_index": 1}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["предсказывать", "толковать", "загадка", "пророчество"], "correct_index": 0}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["загадка", "пророчество", "толковать", "знамение"], "correct_index": 2}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["загадка", "предчувствовать", "толковать", "пророчество"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["загадка", "предчувствовать", "знамение", "толковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадочный", "предчувствие", "предсказывать", "пророчество"], "correct_index": 0}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["сопровождать", "безумие", "мёрзнуть", "дружба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["дружба", "сопровождать", "безумие", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["сопровождать", "верный", "дрожать", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "дрожать", "безумие", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «singen»?", "choices": ["петь", "сопровождать", "верный", "дрожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["верный", "сопровождать", "дрожать", "дружба"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["безумие", "сопровождать", "верный", "дружба"], "correct_index": 2}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["напевать", "песня", "ирония", "утешение"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["утешение", "песня", "напевать", "ирония"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["ирония", "мелодия", "напевать", "звучать"], "correct_index": 0}, {"question": "Что означает немецкое слово «summen»?", "choices": ["мелодия", "напевать", "утешение", "рифма"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["мелодия", "звучать", "утешение", "свистеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["звучать", "свистеть", "напевать", "песня"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["ирония", "мелодия", "рифма", "утешение"], "correct_index": 2}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["мелодия", "рифма", "напевать", "звучать"], "correct_index": 3}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["философия", "размышлять", "судьба", "бренность"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["философия", "судьба", "бренность", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["преходящий", "философия", "смысл", "бренность"], "correct_index": 3}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["бренность", "познавать", "преходящий", "размышлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["познавать", "преходящий", "размышлять", "философия"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["размышлять", "бренность", "познавать", "смысл"], "correct_index": 3}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["философия", "преходящий", "судьба", "бренность"], "correct_index": 1}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["растворяться", "пустота", "исчезать", "тайна"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["тайна", "пустота", "растворяться", "исчезать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["исчезать", "пустота", "бесследно", "уходить"], "correct_index": 1}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["растворяться", "уходить", "тайна", "исчезать"], "correct_index": 0}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["тайна", "туман", "исчезать", "бесследно"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["бесследно", "туман", "пустота", "уходить"], "correct_index": 1}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["пустота", "исчезать", "загадочный", "бесследно"], "correct_index": 2}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["уходить", "тайна", "растворяться", "исчезать"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Королевский шут</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,15 +465,15 @@
             <div class="quiz-phase-container active" data-phase="jester">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
                             
@@ -485,11 +485,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
@@ -503,11 +503,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">остроумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -517,45 +517,45 @@
                         <div class="quiz-question">Что означает немецкое слово «scherzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «klug»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">забава</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">скучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «klug»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -569,25 +569,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">скучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Witz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">остроумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скучать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,47 +600,15 @@
             <div class="quiz-phase-container" data-phase="bitter_truths">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Scherz»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дразнить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
                             
@@ -648,13 +616,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Scherz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
                             
@@ -664,47 +648,63 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дразнить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «necken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дразнить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дразнить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
                             
@@ -719,17 +719,17 @@
             <div class="quiz-phase-container" data-phase="prophecies">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Prophezeiung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">загадка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -741,57 +741,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Vorahnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vorhersagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знамение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
                             
@@ -799,17 +767,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «vorhersagen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «ahnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -819,29 +819,29 @@
                         <div class="quiz-question">Что означает немецкое слово «das Omen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">знамение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -858,59 +858,27 @@
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">петь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
@@ -918,17 +886,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «singen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">петь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -938,29 +938,29 @@
                         <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,13 +973,13 @@
             <div class="quiz-phase-container" data-phase="songs">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Lied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
                             
@@ -989,47 +989,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Trost»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ironie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">напевать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «summen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
                             
@@ -1037,15 +1005,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Ironie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «summen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мелодия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">рифма</button>
                             
@@ -1053,17 +1037,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мелодия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">свистеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">звучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1073,29 +1073,29 @@
                         <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">рифма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «klingen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мелодия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,17 +1108,17 @@
             <div class="quiz-phase-container" data-phase="wisdom">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Philosophie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1128,29 +1128,29 @@
                         <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Vergänglichkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смысл</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преходящий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1160,41 +1160,9 @@
                         <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преходящий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преходящий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">познавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смысл</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">познавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">преходящий</button>
                             
@@ -1204,17 +1172,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">преходящий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">философия</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">смысл</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vergänglich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преходящий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преходящий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">познавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,77 +1227,13 @@
             <div class="quiz-phase-container" data-phase="vanishing">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verschwinden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">туман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
                             
@@ -1307,33 +1243,97 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">туман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бесследно</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">уходить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бесследно</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бесследно</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1345,11 +1345,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1376,8 +1376,8 @@
                 "word": "der Narr",
                 "translation": "шут",
                 "transcription": "[дер НАР]",
-                "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Als Narr sage ich die Wahrheit durch Scherze.",
-                "sentenceTranslation": "В тронном зале Лира шут пляшет рядом с Корделией: Как шут я говорю правду через шутки.",
+                "sentence": "Im grellen Licht des Thronsaals schlägt Fool die Laute an. Ich presse das Wort „der Narr“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В ярком свете тронного зала Шут ударяет по струнам лютни. Я стискиваю слово «шут» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1400,8 +1400,8 @@
                 "word": "die Weisheit",
                 "translation": "мудрость",
                 "transcription": "[ди ВАЙС-хайт]",
-                "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Hinter meinen Späßen verbirgt sich Weisheit.",
-                "sentenceTranslation": "В тронном зале Лира шут пляшет рядом с Корделией: За моими шутками скрывается мудрость.",
+                "sentence": "Neben Lears Krone balanciert Fool auf einem Fuß. Ich atme tief ein und lasse nur das Wort „die Weisheit“ wieder hinaus.",
+                "sentenceTranslation": "Рядом с короной Лира Шут балансирует на одной ноге. Я глубоко вдыхаю и выпускаю только слово «мудрость».",
                 "visual_hint": "📚",
                 "themes": [
                     "Erbe",
@@ -1434,8 +1434,8 @@
                 "word": "die Trauer",
                 "translation": "печаль",
                 "transcription": "[ди ТРАУ-ер]",
-                "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Die Trauer um Корделия macht mich stumm.",
-                "sentenceTranslation": "В тронном зале Лира шут пляшет рядом с Корделией: Печаль о Корделии делает меня немым.",
+                "sentence": "Zwischen Hofdamen und Rittern wirbelt Fool mit flatterndem Schellenkleid. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Trauer“ bleibt lebendig.",
+                "sentenceTranslation": "Между дамами двора и рыцарями Шут кружится в звенящем костюме. Каждой клеткой тела я обещаю: слово «печаль» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1460,8 +1460,8 @@
                 "word": "scherzen",
                 "translation": "шутить",
                 "transcription": "[ШЕР-цен]",
-                "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Ich scherze, um den Schmerz zu verbergen.",
-                "sentenceTranslation": "В тронном зале Лира шут пляшет рядом с Корделией: Я шучу, чтобы скрыть боль.",
+                "sentence": "Vor dem königlichen Podest verzieht Fool die Maske zum Spott. Ich zeichne das Wort „scherzen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед королевским помостом Шут кривит маску насмешки. Я черчу слово «шутить» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Narr",
@@ -1484,8 +1484,8 @@
                 "word": "der Spaß",
                 "translation": "забава",
                 "transcription": "[дер ШПАС]",
-                "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Der Spaß ist meine Maske vor der Welt.",
-                "sentenceTranslation": "В тронном зале Лира шут пляшет рядом с Корделией: Забава - моя маска перед миром.",
+                "sentence": "Am Bankettisch jongliert Fool mit goldenen Pokalen. Selbst wenn die Welt zerfällt, bleibt das Wort „der Spaß“ mein Nordstern.",
+                "sentenceTranslation": "У банкетного стола Шут жонглирует золотыми кубками. Даже если мир распадается, слово «забава» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Narr",
@@ -1508,8 +1508,8 @@
                 "word": "klug",
                 "translation": "умный",
                 "transcription": "[КЛУГ]",
-                "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Ich bin klüger als alle bei Hofe.",
-                "sentenceTranslation": "В тронном зале Лира шут пляшет рядом с Корделией: Я умнее всех при дворе.",
+                "sentence": "Zwischen Lachern und Seufzern zeichnet Fool Grimassen in die Luft. Das kalte Licht lässt das Wort „klug“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Среди смеха и вздохов Шут рисует в воздухе гримасы. Холодный свет заставляет слово «умный» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Narr",
@@ -1532,8 +1532,8 @@
                 "word": "vermissen",
                 "translation": "скучать",
                 "transcription": "[фер-МИ-сен]",
-                "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Ich vermisse die süße Корделия sehr.",
-                "sentenceTranslation": "В тронном зале Лира шут пляшет рядом с Корделией: Я очень скучаю по милой Корделии.",
+                "sentence": "Im Schatten der Säulen lauscht Fool den leisen Worten Cordelias. Mein Atem zeichnet das Wort „vermissen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тени колонн Шут прислушивается к тихим словам Корделии. Моё дыхание рисует слово «скучать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Narr",
@@ -1556,8 +1556,8 @@
                 "word": "der Witz",
                 "translation": "остроумие",
                 "transcription": "[дер ВИТЦ]",
-                "sentence": "Im Thronsaal von Lear tanzt der Narr neben Cordelia: Mein Witz ist scharf wie ein Schwert.",
-                "sentenceTranslation": "В тронном зале Лира шут пляшет рядом с Корделией: Моё остроумие остро как меч.",
+                "sentence": "Auf der Marmorstufe lässt Fool ein Glöckchen über den Boden tanzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Witz“ bleibt lebendig.",
+                "sentenceTranslation": "На мраморной ступени Шут пускает колокольчик плясать по полу. Каждой клеткой тела я обещаю: слово «остроумие» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Narr",
@@ -1581,19 +1581,19 @@
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "шут",
                     "мудрость",
                     "шутить",
+                    "шут",
                     "печаль"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "шут",
                     "шутить",
                     "печаль",
+                    "шут",
                     "мудрость"
                 ],
                 "correctIndex": 3
@@ -1602,61 +1602,61 @@
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
                     "печаль",
-                    "забава",
+                    "шут",
                     "остроумие",
-                    "умный"
+                    "забава"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «scherzen»?",
                 "choices": [
-                    "умный",
-                    "остроумие",
+                    "забава",
+                    "шут",
                     "шутить",
-                    "печаль"
+                    "остроумие"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Spaß»?",
                 "choices": [
-                    "мудрость",
-                    "остроумие",
-                    "печаль",
-                    "забава"
+                    "шут",
+                    "шутить",
+                    "забава",
+                    "мудрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «klug»?",
                 "choices": [
-                    "остроумие",
-                    "шут",
                     "скучать",
-                    "умный"
+                    "остроумие",
+                    "умный",
+                    "мудрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vermissen»?",
                 "choices": [
                     "шут",
                     "скучать",
-                    "печаль",
-                    "мудрость"
+                    "шутить",
+                    "остроумие"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Witz»?",
                 "choices": [
-                    "мудрость",
+                    "умный",
+                    "шут",
                     "остроумие",
-                    "забава",
-                    "шутить"
+                    "скучать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -1669,8 +1669,8 @@
                 "word": "die Wahrheit",
                 "translation": "правда",
                 "transcription": "[ди ВАР-хайт]",
-                "sentence": "Unter Gonerils kaltem Blick singt der Narr: Die Wahrheit verpacke ich in lustige Lieder.",
-                "sentenceTranslation": "Под холодным взглядом Гонериль шут поёт: Правду я заворачиваю в весёлые песни.",
+                "sentence": "Vor Lears Ohr flüstert Fool mit funkelndem Blick die spöttische Wahrheit. Mit fester Stimme schwöre ich mir: Das Wort „die Wahrheit“ wird heute nicht verraten.",
+                "sentenceTranslation": "У самого уха Лира Шут с блеском в глазах шепчет язвительную правду. Твёрдым голосом я клянусь себе: слово «правда» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1694,8 +1694,8 @@
                 "word": "der Scherz",
                 "translation": "шутка",
                 "transcription": "[дер ШЕРЦ]",
-                "sentence": "Unter Gonerils kaltem Blick singt der Narr: Jeder Scherz enthält eine bittere Lehre.",
-                "sentenceTranslation": "Под холодным взглядом Гонериль шут поёт: Каждая шутка содержит горький урок.",
+                "sentence": "Auf dem Hofbalkon zeigt Fool mit der Laute auf die heuchlerischen Schwestern. Ich presse das Wort „der Scherz“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На дворцовом балконе Шут указывает лютней на лицемерных сестёр. Я стискиваю слово «шутка» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Scherz",
@@ -1718,8 +1718,8 @@
                 "word": "die Warnung",
                 "translation": "предупреждение",
                 "transcription": "[ди ВАР-нунг]",
-                "sentence": "Unter Gonerils kaltem Blick singt der Narr: Meine Warnung kommt als Rätsel verkleidet.",
-                "sentenceTranslation": "Под холодным взглядом Гонериль шут поёт: Моё предупреждение приходит замаскированным под загадку.",
+                "sentence": "Zwischen umgestoßenen Bechern sammelt Fool die Lügen wie Perlen auf. Ich zeichne das Wort „die Warnung“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Среди опрокинутых кубков Шут собирает ложь словно жемчуг. Я черчу слово «предупреждение» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Scherz",
@@ -1742,8 +1742,8 @@
                 "word": "bitter",
                 "translation": "горький",
                 "transcription": "[БИ-тер]",
-                "sentence": "Unter Gonerils kaltem Blick singt der Narr: Die Wahrheit schmeckt bitter wie Galle.",
-                "sentenceTranslation": "Под холодным взглядом Гонериль шут поёт: Правда горька как желчь.",
+                "sentence": "An Lears Seite zeichnet Fool mit Kreide eine Krone auf den Boden. Wie ein stilles Gebet legt sich das Wort „bitter“ auf meine Lippen.",
+                "sentenceTranslation": "Рядом с Лиром Шут мелом рисует корону на полу. Как тихая молитва слово «горький» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Scherz",
@@ -1766,8 +1766,8 @@
                 "word": "spotten",
                 "translation": "насмехаться",
                 "transcription": "[ШПО-тен]",
-                "sentence": "Unter Gonerils kaltem Blick singt der Narr: Ich spotte über die Torheit der Mächtigen.",
-                "sentenceTranslation": "Под холодным взглядом Гонериль шут поёт: Я насмехаюсь над глупостью сильных.",
+                "sentence": "Im Gedränge der Höflinge spielt Fool eine schrille Warnmelodie. Mit fester Stimme schwöre ich mir: Das Wort „spotten“ wird heute nicht verraten.",
+                "sentenceTranslation": "В толчее придворных Шут играет пронзительную мелодию предупреждения. Твёрдым голосом я клянусь себе: слово «насмехаться» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Scherz",
@@ -1791,8 +1791,8 @@
                 "word": "necken",
                 "translation": "дразнить",
                 "transcription": "[НЕ-кен]",
-                "sentence": "Unter Gonerils kaltem Blick singt der Narr: Ich necke den König mit der Wahrheit.",
-                "sentenceTranslation": "Под холодным взглядом Гонериль шут поёт: Я дразню короля правдой.",
+                "sentence": "Auf den Stufen zum Thron zieht Fool die Stirn in tiefe Falten. Ich presse das Wort „necken“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На ступенях, ведущих к трону, Шут морщит лоб глубокими складками. Я стискиваю слово «дразнить» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Scherz",
@@ -1815,8 +1815,8 @@
                 "word": "enthüllen",
                 "translation": "раскрывать",
                 "transcription": "[энт-ХЮ-лен]",
-                "sentence": "Unter Gonerils kaltem Blick singt der Narr: Spielerisch enthülle ich seine Fehler.",
-                "sentenceTranslation": "Под холодным взглядом Гонериль шут поёт: Играючи я раскрываю его ошибки.",
+                "sentence": "Neben dem Tränenstrom des Königs wischt Fool die Schminke vom Gesicht. Ich zeichne das Wort „enthüllen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Рядом с потоками слёз короля Шут стирает грим с лица. Я черчу слово «раскрывать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bruder",
@@ -1844,72 +1844,72 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "горький",
+                    "правда",
                     "шутка",
-                    "предупреждение",
-                    "правда"
+                    "горький",
+                    "предупреждение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Scherz»?",
                 "choices": [
                     "правда",
-                    "предупреждение",
                     "шутка",
+                    "предупреждение",
                     "горький"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Warnung»?",
                 "choices": [
-                    "горький",
+                    "предупреждение",
+                    "правда",
                     "шутка",
-                    "дразнить",
-                    "предупреждение"
+                    "горький"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bitter»?",
                 "choices": [
-                    "дразнить",
-                    "насмехаться",
                     "шутка",
-                    "горький"
+                    "горький",
+                    "предупреждение",
+                    "насмехаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «spotten»?",
                 "choices": [
                     "правда",
+                    "шутка",
                     "насмехаться",
-                    "предупреждение",
-                    "горький"
+                    "дразнить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «necken»?",
                 "choices": [
+                    "правда",
                     "дразнить",
                     "шутка",
-                    "предупреждение",
-                    "правда"
+                    "предупреждение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «enthüllen»?",
                 "choices": [
-                    "предупреждение",
                     "раскрывать",
-                    "правда",
+                    "горький",
+                    "дразнить",
                     "шутка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -1922,8 +1922,8 @@
                 "word": "die Prophezeiung",
                 "translation": "пророчество",
                 "transcription": "[ди про-фе-ЦАЙ-унг]",
-                "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Meine Prophezeiung wird wahr werden.",
-                "sentenceTranslation": "На продуваемой бурей пустоши шут пророчит: Моё пророчество сбудется.",
+                "sentence": "Unter dem Sternenzelt deutet Fool mit dem Stab die funkelnden Zeichen. Das kalte Licht lässt das Wort „die Prophezeiung“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Под звёздным шатром Шут посохом указывает на мерцающие знаки. Холодный свет заставляет слово «пророчество» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Prophezeiung",
@@ -1946,8 +1946,8 @@
                 "word": "das Rätsel",
                 "translation": "загадка",
                 "transcription": "[дас РЕТ-зель]",
-                "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: In Rätseln spreche ich von der Zukunft.",
-                "sentenceTranslation": "На продуваемой бурей пустоши шут пророчит: В загадках я говорю о будущем.",
+                "sentence": "Auf den Mauern des Schlosses rezitiert Fool Verse von kommenden Stürmen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Rätsel“ darf nicht vergehen.",
+                "sentenceTranslation": "На стенах замка Шут декламирует стихи о грядущих бурях. Я шепчу стражам судьбы: слово «загадка» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Prophezeiung",
@@ -1970,8 +1970,8 @@
                 "word": "die Vorahnung",
                 "translation": "предчувствие",
                 "transcription": "[ди ФОР-а-нунг]",
-                "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Eine dunkle Vorahnung erfüllt mein Herz.",
-                "sentenceTranslation": "На продуваемой бурей пустоши шут пророчит: Тёмное предчувствие наполняет моё сердце.",
+                "sentence": "Zwischen Rauch und Kerzenduft schleudert Fool rätselhafte Reime. Mit fester Stimme schwöre ich mir: Das Wort „die Vorahnung“ wird heute nicht verraten.",
+                "sentenceTranslation": "Среди дыма и аромата свечей Шут бросает загадочные рифмы. Твёрдым голосом я клянусь себе: слово «предчувствие» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Prophezeiung",
@@ -1994,8 +1994,8 @@
                 "word": "vorhersagen",
                 "translation": "предсказывать",
                 "transcription": "[ФОР-хер-за-ген]",
-                "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Ich sage das kommende Unheil vorher.",
-                "sentenceTranslation": "На продуваемой бурей пустоши шут пророчит: Я предсказываю грядущую беду.",
+                "sentence": "Am Brunnen des Hofes wirft Fool Kiesel, um die Zukunft zu spiegeln. Ich atme tief ein und lasse nur das Wort „vorhersagen“ wieder hinaus.",
+                "sentenceTranslation": "У дворцового фонтана Шут бросает гальку, чтобы отразить будущее. Я глубоко вдыхаю и выпускаю только слово «предсказывать».",
                 "visual_hint": "📚",
                 "themes": [
                     "Prophezeiung",
@@ -2018,8 +2018,8 @@
                 "word": "deuten",
                 "translation": "толковать",
                 "transcription": "[ДОЙ-тен]",
-                "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Die Zeichen deute ich besser als alle.",
-                "sentenceTranslation": "На продуваемой бурей пустоши шут пророчит: Знаки я толкую лучше всех.",
+                "sentence": "Vor erstaunten Dienern zeichnet Fool Kreise in den Staub. Ich presse das Wort „deuten“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Перед поражёнными слугами Шут чертит круги в пыли. Я стискиваю слово «толковать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Prophezeiung",
@@ -2042,8 +2042,8 @@
                 "word": "ahnen",
                 "translation": "предчувствовать",
                 "transcription": "[А-нен]",
-                "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Ich ahne das schlimme Ende voraus.",
-                "sentenceTranslation": "На продуваемой бурей пустоши шут пророчит: Я предчувствую плохой конец.",
+                "sentence": "Auf der Markttreppe singt Fool von Königen, die zu Bettlern werden. Mit fester Stimme schwöre ich mir: Das Wort „ahnen“ wird heute nicht verraten.",
+                "sentenceTranslation": "На рыночной лестнице Шут поёт о королях, становящихся нищими. Твёрдым голосом я клянусь себе: слово «предчувствовать» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Prophezeiung",
@@ -2066,8 +2066,8 @@
                 "word": "das Omen",
                 "translation": "знамение",
                 "transcription": "[дас О-мен]",
-                "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Jedes Omen zeigt auf Untergang.",
-                "sentenceTranslation": "На продуваемой бурей пустоши шут пророчит: Каждое знамение указывает на гибель.",
+                "sentence": "Neben einem reisenden Pilger deutet Fool in den flammenden Himmel. Mit fester Stimme schwöre ich mir: Das Wort „das Omen“ wird heute nicht verraten.",
+                "sentenceTranslation": "Рядом со странствующим пилигримом Шут указывает на пылающее небо. Твёрдым голосом я клянусь себе: слово «знамение» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Prophezeiung",
@@ -2090,8 +2090,8 @@
                 "word": "rätselhaft",
                 "translation": "загадочный",
                 "transcription": "[РЕТ-зель-хафт]",
-                "sentence": "Auf der sturmgepeitschten Heide prophezeit der Narr: Meine Worte bleiben rätselhaft und wahr.",
-                "sentenceTranslation": "На продуваемой бурей пустоши шут пророчит: Мои слова остаются загадочными и правдивыми.",
+                "sentence": "Im Gewitterlicht zählt Fool die Schläge, die die Zukunft ankündigen. Ich zeichne das Wort „rätselhaft“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В свете грозы Шут отсчитывает удары, возвещающие будущее. Я черчу слово «загадочный» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Geheimnis",
@@ -2119,82 +2119,82 @@
             {
                 "question": "Что означает немецкое слово «die Prophezeiung»?",
                 "choices": [
-                    "предчувствие",
-                    "загадка",
+                    "предсказывать",
                     "пророчество",
-                    "предсказывать"
+                    "предчувствие",
+                    "загадка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Rätsel»?",
                 "choices": [
                     "загадка",
-                    "предчувствие",
                     "предсказывать",
-                    "пророчество"
+                    "пророчество",
+                    "предчувствие"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Vorahnung»?",
                 "choices": [
+                    "загадка",
                     "предчувствие",
-                    "загадка",
-                    "предчувствовать",
-                    "знамение"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «vorhersagen»?",
-                "choices": [
-                    "знамение",
-                    "предсказывать",
-                    "загадка",
-                    "предчувствовать"
+                    "толковать",
+                    "загадочный"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «deuten»?",
+                "question": "Что означает немецкое слово «vorhersagen»?",
                 "choices": [
+                    "предсказывать",
                     "толковать",
-                    "знамение",
-                    "предчувствовать",
-                    "загадочный"
+                    "загадка",
+                    "пророчество"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «deuten»?",
+                "choices": [
+                    "загадка",
+                    "пророчество",
+                    "толковать",
+                    "знамение"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ahnen»?",
                 "choices": [
+                    "загадка",
                     "предчувствовать",
-                    "знамение",
-                    "предсказывать",
-                    "загадка"
+                    "толковать",
+                    "пророчество"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Omen»?",
                 "choices": [
-                    "предсказывать",
-                    "толковать",
+                    "загадка",
+                    "предчувствовать",
                     "знамение",
-                    "предчувствовать"
+                    "толковать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
-                    "загадка",
-                    "предчувствие",
                     "загадочный",
-                    "предсказывать"
+                    "предчувствие",
+                    "предсказывать",
+                    "пророчество"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2207,8 +2207,8 @@
                 "word": "der Wahnsinn",
                 "translation": "безумие",
                 "transcription": "[дер ВАН-зин]",
-                "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Im Wahnsinn finden wir uns als Brüder.",
-                "sentenceTranslation": "В хижине шут разделяет безумие Лира: В безумии мы находим друг друга как братья.",
+                "sentence": "In der sturmgepeitschten Heide drückt Fool Lear die klammen Hände. Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На залитой бурей пустоши Шут сжимает озябшие руки Лира. Моё дыхание рисует слово «безумие» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2232,8 +2232,8 @@
                 "word": "die Freundschaft",
                 "translation": "дружба",
                 "transcription": "[ди ФРОЙНД-шафт]",
-                "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Unsere Freundschaft überdauert den Sturm.",
-                "sentenceTranslation": "В хижине шут разделяет безумие Лира: Наша дружба переживёт бурю.",
+                "sentence": "Zwischen zerrissenen Zelten singt Fool ein trostloses Wiegenlied. Ich umarme das Wort „die Freundschaft“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Среди разорванных шатров Шут поёт безутешную колыбельную. Я обнимаю слово «дружба», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Freundschaft",
@@ -2256,8 +2256,8 @@
                 "word": "begleiten",
                 "translation": "сопровождать",
                 "transcription": "[бе-ГЛАЙ-тен]",
-                "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Treu begleite ich meinen verrückten König.",
-                "sentenceTranslation": "В хижине шут разделяет безумие Лира: Верно я сопровождаю своего безумного короля.",
+                "sentence": "Am umgestürzten Wagen schirmt Fool den König vor der Peitsche des Regens. Ich presse das Wort „begleiten“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У перевёрнутой повозки Шут заслоняет короля от кнута дождя. Я стискиваю слово «сопровождать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beistand",
@@ -2286,8 +2286,8 @@
                 "word": "frieren",
                 "translation": "мёрзнуть",
                 "transcription": "[ФРИ-рен]",
-                "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Wir frieren gemeinsam in der kalten Nacht.",
-                "sentenceTranslation": "В хижине шут разделяет безумие Лира: Мы мёрзнем вместе в холодную ночь.",
+                "sentence": "Unter dem knarzenden Dach der Hütte sitzt Fool dicht an Lear gedrängt. Ich flüstere den Wächtern des Schicksals zu: Das Wort „frieren“ darf nicht vergehen.",
+                "sentenceTranslation": "Под скрипучей крышей хижины Шут сидит вплотную к Лиру. Я шепчу стражам судьбы: слово «мёрзнуть» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Elend",
@@ -2317,8 +2317,8 @@
                 "word": "singen",
                 "translation": "петь",
                 "transcription": "[ЗИН-ген]",
-                "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Ich singe, um seine Angst zu lindern.",
-                "sentenceTranslation": "В хижине шут разделяет безумие Лира: Я пою, чтобы облегчить его страх.",
+                "sentence": "Vor der tobenden Nacht schreit Fool seine Possen gegen den Wind. Ich zeichne das Wort „singen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Перед бушующей ночью Шут выкрикивает свои шутки наперекор ветру. Я вывожу слово «петь» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2340,8 +2340,8 @@
                 "word": "zittern",
                 "translation": "дрожать",
                 "transcription": "[ЦИ-терн]",
-                "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Vor Kälte zittern wir wie Espenlaub.",
-                "sentenceTranslation": "В хижине шут разделяет безумие Лира: От холода мы дрожим как осиновый лист.",
+                "sentence": "Am aufgeweichten Boden zeichnet Fool mit Stock und Witz ein Schutzschild. Ich atme tief ein und lasse nur das Wort „zittern“ wieder hinaus.",
+                "sentenceTranslation": "На размокшей земле Шут рисует палкой и шутками защитный круг. Я глубоко вдыхаю и выпускаю только слово «дрожать».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2364,8 +2364,8 @@
                 "word": "treu",
                 "translation": "верный",
                 "transcription": "[ТРОЙ]",
-                "sentence": "In der Hütte teilt der Narr Lears Wahnsinn: Ich bleibe treu, wenn alle anderen fliehen.",
-                "sentenceTranslation": "В хижине шут разделяет безумие Лира: Я остаюсь верным, когда все остальные бегут.",
+                "sentence": "In der Finsternis des Waldes zündet Fool einen letzten Funken Mut an. Ich umarme das Wort „treu“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В темноте леса Шут зажигает последний огонёк мужества. Я обнимаю слово «верный», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Freundschaft",
@@ -2393,72 +2393,72 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "дружба",
-                    "безумие",
                     "сопровождать",
-                    "мёрзнуть"
+                    "безумие",
+                    "мёрзнуть",
+                    "дружба"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Freundschaft»?",
                 "choices": [
-                    "мёрзнуть",
                     "дружба",
                     "сопровождать",
-                    "безумие"
+                    "безумие",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "петь",
-                    "безумие",
                     "сопровождать",
+                    "верный",
+                    "дрожать",
                     "мёрзнуть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "дружба",
-                    "сопровождать",
-                    "петь",
-                    "мёрзнуть"
+                    "мёрзнуть",
+                    "дрожать",
+                    "безумие",
+                    "сопровождать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «singen»?",
                 "choices": [
-                    "верный",
                     "петь",
-                    "дружба",
-                    "безумие"
+                    "сопровождать",
+                    "верный",
+                    "дрожать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
+                    "верный",
                     "сопровождать",
-                    "петь",
                     "дрожать",
-                    "безумие"
+                    "дружба"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
-                    "петь",
                     "безумие",
-                    "мёрзнуть",
-                    "верный"
+                    "сопровождать",
+                    "верный",
+                    "дружба"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2471,8 +2471,8 @@
                 "word": "das Lied",
                 "translation": "песня",
                 "transcription": "[дас ЛИД]",
-                "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Mein Lied erzählt von vergangenen Tagen.",
-                "sentenceTranslation": "Во время возвращения Корделии в Дувр шут тихо поёт: Моя песня рассказывает о прошлых днях.",
+                "sentence": "Im warmen Schein der Hütte summt Fool eine Melodie über verlorene Kronen. Mein Atem zeichnet das Wort „das Lied“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тёплом свете хижины Шут напевает мелодию о потерянных коронах. Моё дыхание рисует слово «песня» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ironie",
@@ -2495,8 +2495,8 @@
                 "word": "der Trost",
                 "translation": "утешение",
                 "transcription": "[дер ТРОСТ]",
-                "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Mit Liedern bringe ich kleinen Trost.",
-                "sentenceTranslation": "Во время возвращения Корделии в Дувр шут тихо поёт: Песнями я приношу малое утешение.",
+                "sentence": "Neben Lear legt Fool den Kopf auf die Knie und schaukelt im Takt. Ich zeichne das Wort „der Trost“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Рядом с Лиром Шут кладёт голову на колени и покачивается в такт. Я черчу слово «утешение» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ironie",
@@ -2519,8 +2519,8 @@
                 "word": "die Ironie",
                 "translation": "ирония",
                 "transcription": "[ди и-ро-НИ]",
-                "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Die Ironie ist meine letzte Waffe.",
-                "sentenceTranslation": "Во время возвращения Корделии в Дувр шут тихо поёт: Ирония - моё последнее оружие.",
+                "sentence": "Vor der knisternden Feuerstelle klatscht Fool den Rhythmus in die Hände. Ich atme tief ein und lasse nur das Wort „die Ironie“ wieder hinaus.",
+                "sentenceTranslation": "Перед потрескивающим огнём Шут отбивает ритм ладонями. Я глубоко вдыхаю и выпускаю только слово «ирония».",
                 "visual_hint": "📚",
                 "themes": [
                     "Ironie",
@@ -2543,8 +2543,8 @@
                 "word": "summen",
                 "translation": "напевать",
                 "transcription": "[ЗУ-мен]",
-                "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Leise summe ich alte Melodien.",
-                "sentenceTranslation": "Во время возвращения Корделии в Дувр шут тихо поёт: Тихо я напеваю старые мелодии.",
+                "sentence": "Auf dem Holzbalken sitzt Fool und schwingt die Beine zur Melodie. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „summen“ gehört mir.",
+                "sentenceTranslation": "На деревянной балке Шут сидит и качает ногами в такт песне. Буря за окнами усиливает клятву: слово «напевать» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ironie",
@@ -2567,8 +2567,8 @@
                 "word": "die Melodie",
                 "translation": "мелодия",
                 "transcription": "[ди ме-ло-ДИ]",
-                "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Die Melodie erinnert an bessere Zeiten.",
-                "sentenceTranslation": "Во время возвращения Корделии в Дувр шут тихо поёт: Мелодия напоминает о лучших временах.",
+                "sentence": "Zwischen Schlafenden senkt Fool die Stimme zu einem flüsternden Refrain. Wie ein stilles Gebet legt sich das Wort „die Melodie“ auf meine Lippen.",
+                "sentenceTranslation": "Среди спящих Шут понижает голос до шёпотного припева. Как тихая молитва слово «мелодия» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ironie",
@@ -2591,8 +2591,8 @@
                 "word": "pfeifen",
                 "translation": "свистеть",
                 "transcription": "[ПФАЙ-фен]",
-                "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Ich pfeife gegen die Dunkelheit an.",
-                "sentenceTranslation": "Во время возвращения Корделии в Дувр шут тихо поёт: Я свищу против темноты.",
+                "sentence": "Am offenen Feld singt Fool gegen das Heulen der Nacht. Ich umarme das Wort „pfeifen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "На открытом поле Шут поёт наперекор вою ночи. Я обнимаю слово «свистеть», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ironie",
@@ -2615,8 +2615,8 @@
                 "word": "der Reim",
                 "translation": "рифма",
                 "transcription": "[дер РАЙМ]",
-                "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Jeder Reim verbirgt eine tiefe Wahrheit.",
-                "sentenceTranslation": "Во время возвращения Корделии в Дувр шут тихо поёт: Каждая рифма скрывает глубокую правду.",
+                "sentence": "In der Morgendämmerung stimmt Fool ein hoffnungsvolles Lied an. Selbst wenn die Welt zerfällt, bleibt das Wort „der Reim“ mein Nordstern.",
+                "sentenceTranslation": "На рассвете Шут заводит песню надежды. Даже если мир распадается, слово «рифма» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ironie",
@@ -2639,8 +2639,8 @@
                 "word": "klingen",
                 "translation": "звучать",
                 "transcription": "[КЛИН-ген]",
-                "sentence": "Bei Cordelias Rückkehr nach Dover singt der Narr leise: Meine Worte klingen lustig, doch sind traurig.",
-                "sentenceTranslation": "Во время возвращения Корделии в Дувр шут тихо поёт: Мои слова звучат весело, но печальны.",
+                "sentence": "Über Lear gebeugt beendet Fool das Lied mit einem sanften Kuss auf die Stirn. Ich presse das Wort „klingen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Наклонившись над Лиром, Шут завершает песню мягким поцелуем в лоб. Я стискиваю слово «звучать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ironie",
@@ -2664,82 +2664,82 @@
             {
                 "question": "Что означает немецкое слово «das Lied»?",
                 "choices": [
-                    "песня",
                     "напевать",
+                    "песня",
                     "ирония",
                     "утешение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Trost»?",
                 "choices": [
-                    "ирония",
-                    "напевать",
                     "утешение",
-                    "песня"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Ironie»?",
-                "choices": [
-                    "свистеть",
-                    "рифма",
-                    "ирония",
-                    "напевать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «summen»?",
-                "choices": [
+                    "песня",
                     "напевать",
-                    "звучать",
-                    "мелодия",
                     "ирония"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Melodie»?",
+                "question": "Что означает немецкое слово «die Ironie»?",
                 "choices": [
-                    "напевать",
-                    "звучать",
+                    "ирония",
                     "мелодия",
-                    "рифма"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «pfeifen»?",
-                "choices": [
-                    "свистеть",
-                    "песня",
-                    "рифма",
-                    "утешение"
+                    "напевать",
+                    "звучать"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «summen»?",
+                "choices": [
+                    "мелодия",
+                    "напевать",
+                    "утешение",
+                    "рифма"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Melodie»?",
+                "choices": [
+                    "мелодия",
+                    "звучать",
+                    "утешение",
+                    "свистеть"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «pfeifen»?",
+                "choices": [
+                    "звучать",
+                    "свистеть",
+                    "напевать",
+                    "песня"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «der Reim»?",
                 "choices": [
-                    "утешение",
-                    "напевать",
+                    "ирония",
+                    "мелодия",
                     "рифма",
-                    "звучать"
+                    "утешение"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «klingen»?",
                 "choices": [
-                    "звучать",
-                    "свистеть",
-                    "ирония",
-                    "мелодия"
+                    "мелодия",
+                    "рифма",
+                    "напевать",
+                    "звучать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2752,8 +2752,8 @@
                 "word": "die Philosophie",
                 "translation": "философия",
                 "transcription": "[ди фи-ло-зо-ФИ]",
-                "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Meine Philosophie ist einfach: Alles ist Narretei.",
-                "sentenceTranslation": "После перехода в Дувр шут размышляет: Моя философия проста: всё - глупость.",
+                "sentence": "Im verlassenen Hof sitzt Fool auf einem leeren Fass und denkt laut nach. Selbst wenn die Welt zerfällt, bleibt das Wort „die Philosophie“ mein Nordstern.",
+                "sentenceTranslation": "На пустынном дворе Шут сидит на пустой бочке и размышляет вслух. Даже если мир распадается, слово «философия» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Philosophie",
@@ -2776,8 +2776,8 @@
                 "word": "das Schicksal",
                 "translation": "судьба",
                 "transcription": "[дас ШИК-заль]",
-                "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Das Schicksal macht Narren aus uns allen.",
-                "sentenceTranslation": "После перехода в Дувр шут размышляет: Судьба делает дураков из всех нас.",
+                "sentence": "Unter einer nackten Eiche zählt Fool die Fehler der Mächtigen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Schicksal“ darf nicht vergehen.",
+                "sentenceTranslation": "Под обнажённым дубом Шут пересчитывает ошибки власть имущих. Я шепчу стражам судьбы: слово «судьба» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2800,8 +2800,8 @@
                 "word": "die Vergänglichkeit",
                 "translation": "бренность",
                 "transcription": "[ди фер-ГЕНГ-лих-кайт]",
-                "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Die Vergänglichkeit der Macht ist offenbar.",
-                "sentenceTranslation": "После перехода в Дувр шут размышляет: Бренность власти очевидна.",
+                "sentence": "Am stillen Bachlauf wirft Fool Steine, um die Zeit zu messen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Vergänglichkeit“ gehört mir.",
+                "sentenceTranslation": "У тихого ручья Шут бросает камни, чтобы измерить время. Буря за окнами усиливает клятву: слово «бренность» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Philosophie",
@@ -2824,8 +2824,8 @@
                 "word": "nachdenken",
                 "translation": "размышлять",
                 "transcription": "[НАХ-ден-кен]",
-                "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Ich denke nach über des Lebens Sinn.",
-                "sentenceTranslation": "После перехода в Дувр шут размышляет: Я размышляю о смысле жизни.",
+                "sentence": "Neben einer verlassenen Bühne probt Fool Zeilen über Narrheit und Macht. Das kalte Licht lässt das Wort „nachdenken“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "У заброшенной сцены Шут репетирует строки о глупости и власти. Холодный свет заставляет слово «размышлять» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Philosophie",
@@ -2850,8 +2850,8 @@
                 "word": "erkennen",
                 "translation": "познавать",
                 "transcription": "[ер-КЕН-нен]",
-                "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Ich erkenne die Wahrheit hinter dem Schein.",
-                "sentenceTranslation": "После перехода в Дувр шут размышляет: Я познаю правду за видимостью.",
+                "sentence": "Auf dem Dachboden der Burg sortiert Fool Erinnerungen wie alte Kostüme. Ich atme tief ein und lasse nur das Wort „erkennen“ wieder hinaus.",
+                "sentenceTranslation": "На чердаке замка Шут раскладывает воспоминания как старые костюмы. Я глубоко вдыхаю и выпускаю только слово «познавать».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2879,8 +2879,8 @@
                 "word": "der Sinn",
                 "translation": "смысл",
                 "transcription": "[дер ЗИН]",
-                "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Der Sinn des Lebens ist ein schlechter Witz.",
-                "sentenceTranslation": "После перехода в Дувр шут размышляет: Смысл жизни - плохая шутка.",
+                "sentence": "Vor einem Spiegel ohne Glas betrachtet Fool das eigene müde Gesicht. Selbst wenn die Welt zerfällt, bleibt das Wort „der Sinn“ mein Nordstern.",
+                "sentenceTranslation": "Перед зеркалом без стекла Шут разглядывает собственное усталое лицо. Даже если мир распадается, слово «смысл» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Philosophie",
@@ -2903,8 +2903,8 @@
                 "word": "vergänglich",
                 "translation": "преходящий",
                 "transcription": "[фер-ГЕНГ-лих]",
-                "sentence": "Nach dem Marsch nach Dover sinniert der Narr: Alles ist vergänglich, nur die Torheit bleibt.",
-                "sentenceTranslation": "После перехода в Дувр шут размышляет: Всё преходяще, только глупость остаётся.",
+                "sentence": "Im ersten Morgenlicht schreibt Fool letzte Sprüche auf Pergament. Ich atme tief ein und lasse nur das Wort „vergänglich“ wieder hinaus.",
+                "sentenceTranslation": "В первом утреннем свете Шут записывает последние остроты на пергамент. Я глубоко вдыхаю и выпускаю только слово «преходящий».",
                 "visual_hint": "📚",
                 "themes": [
                     "Philosophie",
@@ -2928,39 +2928,39 @@
             {
                 "question": "Что означает немецкое слово «die Philosophie»?",
                 "choices": [
-                    "бренность",
-                    "размышлять",
                     "философия",
-                    "судьба"
+                    "размышлять",
+                    "судьба",
+                    "бренность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
-                    "бренность",
+                    "философия",
                     "судьба",
-                    "размышлять",
-                    "философия"
+                    "бренность",
+                    "размышлять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Vergänglichkeit»?",
                 "choices": [
+                    "преходящий",
+                    "философия",
                     "смысл",
-                    "размышлять",
-                    "бренность",
-                    "судьба"
+                    "бренность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «nachdenken»?",
                 "choices": [
-                    "философия",
-                    "преходящий",
                     "бренность",
+                    "познавать",
+                    "преходящий",
                     "размышлять"
                 ],
                 "correctIndex": 3
@@ -2968,32 +2968,32 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
+                    "познавать",
                     "преходящий",
-                    "бренность",
-                    "смысл",
-                    "познавать"
+                    "размышлять",
+                    "философия"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Sinn»?",
                 "choices": [
+                    "размышлять",
+                    "бренность",
                     "познавать",
-                    "смысл",
-                    "преходящий",
-                    "размышлять"
+                    "смысл"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vergänglich»?",
                 "choices": [
-                    "преходящий",
                     "философия",
-                    "бренность",
-                    "познавать"
+                    "преходящий",
+                    "судьба",
+                    "бренность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -3006,8 +3006,8 @@
                 "word": "verschwinden",
                 "translation": "исчезать",
                 "transcription": "[фер-ШВИН-ден]",
-                "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Ich verschwinde wie ein Traum im Morgen.",
-                "sentenceTranslation": "Незадолго до пленения Корделии шут исчезает: Я исчезаю как сон поутру.",
+                "sentence": "Im Nebel des Morgens löst sich Fool zwischen den Zelten der Armee auf. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verschwinden“ gehört mir.",
+                "sentenceTranslation": "В утреннем тумане Шут растворяется между шатрами армии. Буря за окнами усиливает клятву: слово «исчезать» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3029,8 +3029,8 @@
                 "word": "das Geheimnis",
                 "translation": "тайна",
                 "transcription": "[дас ге-ХАЙМ-нис]",
-                "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Mein Verschwinden bleibt ein ewiges Geheimnis.",
-                "sentenceTranslation": "Незадолго до пленения Корделии шут исчезает: Моё исчезновение остаётся вечной тайной.",
+                "sentence": "Auf dem verlassenen Pfad lässt Fool nur ein Glöckchen zurück. Ich presse das Wort „das Geheimnis“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На пустой тропе Шут оставляет лишь один колокольчик. Я стискиваю слово «тайна» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3052,8 +3052,8 @@
                 "word": "die Leere",
                 "translation": "пустота",
                 "transcription": "[ди ЛЕ-ре]",
-                "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Ich hinterlasse nur Leere und Erinnerung.",
-                "sentenceTranslation": "Незадолго до пленения Корделии шут исчезает: Я оставляю только пустоту и воспоминание.",
+                "sentence": "Zwischen verstreuten Karten verschwindet Fool hinter einem Wandteppich. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leere“ bleibt lebendig.",
+                "sentenceTranslation": "Среди разбросанных карт Шут исчезает за гобеленом. Каждой клеткой тела я обещаю: слово «пустота» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Geheimnis",
@@ -3076,8 +3076,8 @@
                 "word": "sich auflösen",
                 "translation": "растворяться",
                 "transcription": "[зих АУФ-лё-зен]",
-                "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Ich löse mich auf wie Nebel im Wind.",
-                "sentenceTranslation": "Незадолго до пленения Корделии шут исчезает: Я растворяюсь как туман на ветру.",
+                "sentence": "Am Rand des Schlachtfelds weht Fools bunter Schal davon. Ich zeichne das Wort „sich auflösen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На краю поля битвы уносит пёстрый шарф Шут. Я вывожу слово «растворяться» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Geheimnis",
@@ -3100,8 +3100,8 @@
                 "word": "spurlos",
                 "translation": "бесследно",
                 "transcription": "[ШПУР-лос]",
-                "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Spurlos gehe ich aus dieser Welt.",
-                "sentenceTranslation": "Незадолго до пленения Корделии шут исчезает: Бесследно я ухожу из этого мира.",
+                "sentence": "Unter den Blicken der Soldaten verbeugt sich Fool und geht ohne Abschied. Ich umarme das Wort „spurlos“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Под взглядами солдат Шут кланяется и уходит без прощания. Я обнимаю слово «бесследно», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Geheimnis",
@@ -3124,8 +3124,8 @@
                 "word": "der Nebel",
                 "translation": "туман",
                 "transcription": "[дер НЕ-бель]",
-                "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Im Nebel verliere ich mich für immer.",
-                "sentenceTranslation": "Незадолго до пленения Корделии шут исчезает: В тумане я теряюсь навсегда.",
+                "sentence": "Auf der Treppe der Burg bleibt Fools Schellenstab einsam liegen. Ich atme tief ein und lasse nur das Wort „der Nebel“ wieder hinaus.",
+                "sentenceTranslation": "На лестнице замка одиноко остаётся жезл с бубенчиками Шут. Я глубоко вдыхаю и выпускаю только слово «туман».",
                 "visual_hint": "📚",
                 "themes": [
                     "Geheimnis",
@@ -3148,8 +3148,8 @@
                 "word": "rätselhaft",
                 "translation": "загадочный",
                 "transcription": "[РЕТ-зель-хафт]",
-                "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Mein Ende bleibt rätselhaft und stumm.",
-                "sentenceTranslation": "Незадолго до пленения Корделии шут исчезает: Мой конец остаётся загадочным и немым.",
+                "sentence": "Im Rauschen des Meeres verliert sich Fools Stimme wie ein ferner Traum. Ich umarme das Wort „rätselhaft“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В шуме моря голос Шут растворяется как далёкий сон. Я обнимаю слово «загадочный», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Geheimnis",
@@ -3176,8 +3176,8 @@
                 "word": "fortgehen",
                 "translation": "уходить",
                 "transcription": "[ФОРТ-ге-ен]",
-                "sentence": "Kurz vor Cordelias Gefangennahme verschwindet der Narr: Ich gehe fort, wenn keiner es bemerkt.",
-                "sentenceTranslation": "Незадолго до пленения Корделии шут исчезает: Я ухожу, когда никто не замечает.",
+                "sentence": "Vor der aufgehenden Sonne wirft Fool einen letzten Schatten und verblasst. Ich zeichne das Wort „fortgehen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед восходящим солнцем Шут бросает последнюю тень и растворяется. Я черчу слово «уходить» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Geheimnis",
@@ -3201,80 +3201,80 @@
             {
                 "question": "Что означает немецкое слово «verschwinden»?",
                 "choices": [
-                    "исчезать",
+                    "растворяться",
                     "пустота",
-                    "тайна",
-                    "растворяться"
+                    "исчезать",
+                    "тайна"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Geheimnis»?",
                 "choices": [
-                    "растворяться",
-                    "пустота",
                     "тайна",
+                    "пустота",
+                    "растворяться",
                     "исчезать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Leere»?",
-                "choices": [
-                    "туман",
-                    "загадочный",
-                    "пустота",
-                    "уходить"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «sich auflösen»?",
-                "choices": [
-                    "тайна",
-                    "загадочный",
-                    "растворяться",
-                    "туман"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «spurlos»?",
-                "choices": [
-                    "бесследно",
-                    "туман",
-                    "исчезать",
-                    "тайна"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Nebel»?",
+                "question": "Что означает немецкое слово «die Leere»?",
                 "choices": [
+                    "исчезать",
+                    "пустота",
+                    "бесследно",
+                    "уходить"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «sich auflösen»?",
+                "choices": [
+                    "растворяться",
                     "уходить",
                     "тайна",
-                    "туман",
-                    "загадочный"
+                    "исчезать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «spurlos»?",
+                "choices": [
+                    "тайна",
+                    "туман",
+                    "исчезать",
+                    "бесследно"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Nebel»?",
+                "choices": [
+                    "бесследно",
+                    "туман",
+                    "пустота",
+                    "уходить"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
-                    "бесследно",
-                    "тайна",
                     "пустота",
-                    "загадочный"
+                    "исчезать",
+                    "загадочный",
+                    "бесследно"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «fortgehen»?",
                 "choices": [
                     "уходить",
-                    "исчезать",
+                    "тайна",
                     "растворяться",
-                    "туман"
+                    "исчезать"
                 ],
                 "correctIndex": 0
             }
@@ -3807,27 +3807,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/gloucester.html
+++ b/output/journeys/gloucester.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["доверять", "граф", "знать", "служить"], "correct_index": 2}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["граф", "доверять", "служить", "знать"], "correct_index": 2}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["доверять", "служить", "праведный", "уважать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["уважать", "праведный", "граф", "честь"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["долг", "служить", "праведный", "честь"], "correct_index": 3}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["знать", "праведный", "уважать", "доверять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["праведный", "долг", "знать", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «achten»?", "choices": ["честь", "уважать", "долг", "знать"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["письмо", "верить", "обман", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["обман", "верить", "письмо", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "простодушный", "письмо", "ловушка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["подозревать", "простодушный", "обман", "верить"], "correct_index": 2}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["ловушка", "простодушный", "верить", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["верить", "подозревать", "обман", "письмо"], "correct_index": 1}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["верить", "обманывать", "легковерный", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["верить", "ловушка", "письмо", "обман"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["заблуждение", "сожалеть", "изгонять", "проклинать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["заблуждение", "сожалеть", "изгонять", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "проклинать", "гнать", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["несправедливость", "слепой", "изгонять", "заблуждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «blind»?", "choices": ["несправедливость", "сожалеть", "слепой", "проклинать"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["несправедливость", "слепой", "гнать", "заблуждение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["сожалеть", "несправедливость", "слепой", "заблуждение"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["сострадание", "рисковать", "помогать", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["помогать", "сострадание", "рисковать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["осмеливаться", "измена", "рисковать", "сострадание"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["помогать", "тайно", "измена", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["тайно", "сострадание", "рисковать", "осмеливаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["защищать", "опасность", "сострадание", "помогать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["тайно", "осмеливаться", "измена", "рисковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["тайно", "сострадание", "осмеливаться", "опасность"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "боль", "темнота", "пытка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["боль", "пытка", "ослеплять", "темнота"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["боль", "месть", "слепнуть", "пытка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["темнота", "ослеплять", "боль", "слепнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["ослеплять", "темнота", "пытка", "кричать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["кричать", "месть", "слепнуть", "темнота"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "пытка", "слепнуть", "боль"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["прыгать", "отчаяние", "пропасть", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «springen»?", "choices": ["пропасть", "прыгать", "отчаяние", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["избавлять", "обман", "прыгать", "сдаваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["прыгать", "падать", "пропасть", "сдаваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["отчаяние", "прыгать", "сдаваться", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["падать", "безнадёжность", "обман", "пропасть"], "correct_index": 1}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["избавлять", "сдаваться", "падать", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["прыгать", "сдаваться", "отчаяние", "избавлять"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["осознание", "прощать", "умирать", "узнавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["узнавать", "осознание", "умирать", "прощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "обнимать", "сердце", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["узнавать", "примирение", "прощать", "осознание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "прощать", "сердце", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["обнимать", "осознание", "прощать", "примирение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["обнимать", "примирение", "прощать", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["примирение", "раскаяние", "обнимать", "сердце"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["знать", "доверять", "граф", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["доверять", "служить", "граф", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["граф", "доверять", "праведный", "долг"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["граф", "знать", "долг", "честь"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["честь", "доверять", "праведный", "знать"], "correct_index": 0}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["граф", "праведный", "честь", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["честь", "долг", "уважать", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «achten»?", "choices": ["доверять", "уважать", "праведный", "служить"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["письмо", "обман", "верить", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["верить", "обман", "обманывать", "письмо"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["простодушный", "письмо", "обманывать", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["обман", "письмо", "верить", "простодушный"], "correct_index": 0}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["обман", "подозревать", "ловушка", "простодушный"], "correct_index": 3}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["ловушка", "легковерный", "письмо", "подозревать"], "correct_index": 3}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["простодушный", "обман", "легковерный", "письмо"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["письмо", "обман", "ловушка", "простодушный"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["проклинать", "заблуждение", "изгонять", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["заблуждение", "проклинать", "изгонять", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "заблуждение", "гнать", "слепой"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["слепой", "гнать", "изгонять", "заблуждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «blind»?", "choices": ["несправедливость", "слепой", "сожалеть", "заблуждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["гнать", "сожалеть", "проклинать", "слепой"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["заблуждение", "сожалеть", "проклинать", "несправедливость"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["сострадание", "помогать", "опасность", "рисковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["рисковать", "опасность", "помогать", "сострадание"], "correct_index": 3}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["защищать", "измена", "рисковать", "помогать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["рисковать", "измена", "осмеливаться", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["тайно", "осмеливаться", "рисковать", "помогать"], "correct_index": 0}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["защищать", "опасность", "тайно", "измена"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["тайно", "измена", "рисковать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["осмеливаться", "опасность", "измена", "защищать"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["темнота", "пытка", "ослеплять", "боль"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["темнота", "боль", "ослеплять", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["боль", "слепнуть", "ослеплять", "темнота"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["пытка", "месть", "темнота", "кричать"], "correct_index": 2}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["месть", "кричать", "пытка", "темнота"], "correct_index": 1}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["кричать", "слепнуть", "темнота", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "боль", "ослеплять", "пытка"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["обман", "прыгать", "отчаяние", "пропасть"], "correct_index": 2}, {"question": "Что означает немецкое слово «springen»?", "choices": ["обман", "прыгать", "пропасть", "отчаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["падать", "прыгать", "избавлять", "обман"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["избавлять", "пропасть", "сдаваться", "безнадёжность"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["пропасть", "отчаяние", "безнадёжность", "сдаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["сдаваться", "прыгать", "отчаяние", "безнадёжность"], "correct_index": 3}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["падать", "сдаваться", "обман", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["избавлять", "безнадёжность", "обман", "прыгать"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "умирать", "прощать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "умирать", "осознание", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["раскаяние", "сердце", "умирать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["осознание", "умирать", "узнавать", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "сердце", "узнавать", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["сердце", "обнимать", "прощать", "раскаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["сердце", "осознание", "примирение", "прощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["узнавать", "прощать", "сердце", "обнимать"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный граф</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,15 +465,15 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                             
@@ -481,15 +481,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
                             
@@ -497,31 +497,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">уважать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                             
@@ -529,17 +529,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -549,13 +549,13 @@
                         <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -565,11 +565,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                             
@@ -581,13 +581,13 @@
                         <div class="quiz-question">Что означает немецкое слово «achten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -606,9 +606,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
@@ -616,63 +616,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «glauben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">простодушный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">простодушный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «arglos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">простодушный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
@@ -680,17 +648,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «arglos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">легковерный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -700,29 +700,29 @@
                         <div class="quiz-question">Что означает немецкое слово «leichtgläubig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -739,29 +739,29 @@
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -773,11 +773,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -787,9 +787,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
@@ -799,31 +799,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «blind»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
                             
@@ -831,17 +815,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,33 +854,33 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «helfen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -890,13 +890,13 @@
                         <div class="quiz-question">Что означает немецкое слово «riskieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -906,11 +906,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">измена</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">осмеливаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
@@ -924,11 +924,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">осмеливаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -942,41 +942,41 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тайно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">измена</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">измена</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «wagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">измена</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -989,33 +989,33 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1027,41 +1027,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Dunkelheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
                             
@@ -1069,17 +1053,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erblinden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1091,11 +1091,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,17 +1108,17 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1128,91 +1128,11 @@
                         <div class="quiz-question">Что означает немецкое слово «springen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Abgrund»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Hoffnungslosigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
@@ -1220,17 +1140,97 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erlösen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">избавлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Abgrund»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">безнадёжность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Hoffnungslosigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">избавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erlösen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1243,13 +1243,45 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
@@ -1259,49 +1291,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">примирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1313,59 +1313,59 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">примирение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">примирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">примирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1392,8 +1392,8 @@
                 "word": "der Adel",
                 "translation": "знать",
                 "transcription": "[дер А-дель]",
-                "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Als Adel diene ich meinem König treu.",
-                "sentenceTranslation": "В замке Глостера старый граф уверяет короля Лира: Как знать я верно служу своему королю.",
+                "sentence": "Gloucester steht unter dem glühenden Kronleuchter des Thronsaals. Selbst wenn die Welt zerfällt, bleibt das Wort „der Adel“ mein Nordstern.",
+                "sentenceTranslation": "Глостер стоит под пылающей люстрой тронного зала. Даже если мир распадается, слово «знать» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1419,8 +1419,8 @@
                 "word": "dienen",
                 "translation": "служить",
                 "transcription": "[ДИ-нен]",
-                "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Ich diene dem König seit vielen Jahren.",
-                "sentenceTranslation": "В замке Глостера старый граф уверяет короля Лира: Я служу королю много лет.",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Gloucester über Lears schweren Tisch. Mit fester Stimme schwöre ich mir: Das Wort „dienen“ wird heute nicht verraten.",
+                "sentenceTranslation": "У развернутой карты королевства Глостер склоняется над тяжёлым столом Лира. Твёрдым голосом я клянусь себе: слово «служить» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1443,8 +1443,8 @@
                 "word": "vertrauen",
                 "translation": "доверять",
                 "transcription": "[фер-ТРАУ-ен]",
-                "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Ich vertraue beiden Söhnen gleich.",
-                "sentenceTranslation": "В замке Глостера старый граф уверяет короля Лира: Я доверяю обоим сыновьям одинаково.",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Gloucester die Hände hinter dem Rücken. Ich atme tief ein und lasse nur das Wort „vertrauen“ wieder hinaus.",
+                "sentenceTranslation": "Перед каменными статуями предков Глостер сцепляет руки за спиной. Я глубоко вдыхаю и выпускаю только слово «доверять».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1469,8 +1469,8 @@
                 "word": "der Graf",
                 "translation": "граф",
                 "transcription": "[дер ГРАФ]",
-                "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Als Graf habe ich große Verantwortung.",
-                "sentenceTranslation": "В замке Глостера старый граф уверяет короля Лира: Как граф я несу большую ответственность.",
+                "sentence": "Zwischen flüsternden Höflingen gleitet Gloucester über den kalten Marmorboden. Ich zeichne das Wort „der Graf“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Между шепчущимися придворными Глостер скользит по холодному мраморному полу. Я вывожу слово «граф» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1493,8 +1493,8 @@
                 "word": "die Ehre",
                 "translation": "честь",
                 "transcription": "[ди Э-ре]",
-                "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Meine Ehre ist mein höchstes Gut.",
-                "sentenceTranslation": "В замке Глостера старый граф уверяет короля Лира: Моя честь - моё высшее благо.",
+                "sentence": "Am Rand des purpurnen Teppichs wartet Gloucester auf ein Zeichen des Königs. Ich zeichne das Wort „die Ehre“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На краю пурпурного ковра Глостер ждёт знака от короля. Я вывожу слово «честь» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1518,8 +1518,8 @@
                 "word": "rechtschaffen",
                 "translation": "праведный",
                 "transcription": "[РЕХТ-ша-фен]",
-                "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Ich bin ein rechtschaffener Mann.",
-                "sentenceTranslation": "В замке Глостера старый граф уверяет короля Лира: Я праведный человек.",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Gloucester kurz den Blick. Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Глостер на миг опускает взгляд. Я стискиваю слово «праведный» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Adel",
@@ -1546,8 +1546,8 @@
                 "word": "die Pflicht",
                 "translation": "долг",
                 "transcription": "[ди ПФЛИХТ]",
-                "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Meine Pflicht ruft mich zum König.",
-                "sentenceTranslation": "В замке Глостера старый граф уверяет короля Лира: Мой долг зовёт меня к королю.",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Gloucester das gespannte Antlitz des Hofes. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Pflicht“ gehört mir.",
+                "sentenceTranslation": "За позолоченной балюстрадой Глостер наблюдает за напряжёнными лицами двора. Буря за окнами усиливает клятву: слово «долг» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1570,8 +1570,8 @@
                 "word": "achten",
                 "translation": "уважать",
                 "transcription": "[АХ-тен]",
-                "sentence": "Im Schloss von Gloucester versichert der alte Graf König Lear: Ich achte beide Söhne, Edgar und Edmund.",
-                "sentenceTranslation": "В замке Глостера старый граф уверяет короля Лира: Я уважаю обоих сыновей, Эдгара и Эдмунда.",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Gloucester langsam die Stimme. Ich zeichne das Wort „achten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В отблесках открытых жаровен Глостер медленно поднимает голос. Я вывожу слово «уважать» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Adel",
@@ -1595,69 +1595,69 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
-                    "доверять",
-                    "граф",
                     "знать",
-                    "служить"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «dienen»?",
-                "choices": [
+                    "доверять",
                     "граф",
-                    "доверять",
-                    "служить",
-                    "знать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «vertrauen»?",
-                "choices": [
-                    "доверять",
-                    "служить",
-                    "праведный",
-                    "уважать"
+                    "служить"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «dienen»?",
+                "choices": [
+                    "доверять",
+                    "служить",
+                    "граф",
+                    "знать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «vertrauen»?",
+                "choices": [
+                    "граф",
+                    "доверять",
+                    "праведный",
+                    "долг"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
-                    "уважать",
-                    "праведный",
                     "граф",
+                    "знать",
+                    "долг",
                     "честь"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "долг",
-                    "служить",
+                    "честь",
+                    "доверять",
                     "праведный",
-                    "честь"
+                    "знать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
-                    "знать",
+                    "граф",
                     "праведный",
-                    "уважать",
-                    "доверять"
+                    "честь",
+                    "знать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
-                    "праведный",
+                    "честь",
                     "долг",
-                    "знать",
+                    "уважать",
                     "служить"
                 ],
                 "correctIndex": 1
@@ -1665,10 +1665,10 @@
             {
                 "question": "Что означает немецкое слово «achten»?",
                 "choices": [
-                    "честь",
+                    "доверять",
                     "уважать",
-                    "долг",
-                    "знать"
+                    "праведный",
+                    "служить"
                 ],
                 "correctIndex": 1
             }
@@ -1683,8 +1683,8 @@
                 "word": "der Brief",
                 "translation": "письмо",
                 "transcription": "[дер БРИФ]",
-                "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Dieser Brief beweist Edgars Verrat.",
-                "sentenceTranslation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Это письмо доказывает предательство Эдгара.",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Gloucester zwischen gepackten Kisten. Das kalte Licht lässt das Wort „der Brief“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Глостер замирает среди нагруженных ящиков. Холодный свет заставляет слово «письмо» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1707,8 +1707,8 @@
                 "word": "glauben",
                 "translation": "верить",
                 "transcription": "[ГЛАУ-бен]",
-                "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich glaube Edmunds Lügen sofort.",
-                "sentenceTranslation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я сразу верю лжи Эдмунда.",
+                "sentence": "Auf der windigen Freitreppe blickt Gloucester zum schweigenden Hof hinunter. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „glauben“ gehört mir.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Глостер смотрит вниз на молчаливый двор. Буря за окнами усиливает клятву: слово «верить» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1730,8 +1730,8 @@
                 "word": "täuschen",
                 "translation": "обманывать",
                 "transcription": "[ТОЙ-шен]",
-                "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Edmund täuscht mich mit falschen Beweisen.",
-                "sentenceTranslation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Эдмунд обманывает меня ложными доказательствами.",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Gloucester den Reisemantel enger. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir.",
+                "sentenceTranslation": "Среди оставленных слуг Глостер плотнее запахивает дорожный плащ. Буря за окнами усиливает клятву: слово «обманывать» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1757,8 +1757,8 @@
                 "word": "der Betrug",
                 "translation": "обман",
                 "transcription": "[дер бе-ТРУГ]",
-                "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich erkenne den Betrug nicht.",
-                "sentenceTranslation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я не распознаю обман.",
+                "sentence": "Am dunklen Pferdestall streicht Gloucester einem nervösen Tier über die Mähne. Ich zeichne das Wort „der Betrug“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Глостер гладит гриву нервного коня. Я черчу слово «обман» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1782,8 +1782,8 @@
                 "word": "arglos",
                 "translation": "простодушный",
                 "transcription": "[АРГ-лос]",
-                "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich bin zu arglos für solche Intrigen.",
-                "sentenceTranslation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я слишком простодушен для таких интриг.",
+                "sentence": "Vor dem knarrenden Fallgatter tastet Gloucester ein letztes Mal nach dem Haustor. Ich zeichne das Wort „arglos“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Глостер в последний раз касается родной двери. Я вывожу слово «простодушный» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Brief",
@@ -1806,8 +1806,8 @@
                 "word": "verdächtigen",
                 "translation": "подозревать",
                 "transcription": "[фер-ДЕХ-ти-ген]",
-                "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich verdächtige meinen guten Sohn Edgar.",
-                "sentenceTranslation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я подозреваю моего доброго сына Эдгара.",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Gloucester den Ring an der Hand. Selbst wenn die Welt zerfällt, bleibt das Wort „verdächtigen“ mein Nordstern.",
+                "sentenceTranslation": "Среди разбросанных свитков Глостер вертит кольцо на пальце. Даже если мир распадается, слово «подозревать» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1830,8 +1830,8 @@
                 "word": "leichtgläubig",
                 "translation": "легковерный",
                 "transcription": "[ЛАЙХТ-глой-биг]",
-                "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich bin zu leichtgläubig für diese Welt.",
-                "sentenceTranslation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я слишком легковерен для этого мира.",
+                "sentence": "Am leeren Bankettisch zählt Gloucester die verlöschenden Kerzen. Mein Atem zeichnet das Wort „leichtgläubig“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У пустого банкетного стола Глостер пересчитывает гаснущие свечи. Моё дыхание рисует слово «легковерный» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Brief",
@@ -1854,8 +1854,8 @@
                 "word": "die Falle",
                 "translation": "ловушка",
                 "transcription": "[ди ФА-ле]",
-                "sentence": "Als Edmund den Brief präsentiert, vertraut Gloucester Gonerils Hof: Ich tappe blind in Edmunds Falle.",
-                "sentenceTranslation": "Когда Эдмунд показывает письмо, Глостер доверяет придворным Гонериль: Я слепо попадаю в ловушку Эдмунда.",
+                "sentence": "Zwischen schweigenden Wachen geht Gloucester auf den kalten Hof hinaus. Ich presse das Wort „die Falle“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Между молчаливыми стражниками Глостер выходит на холодный двор. Я стискиваю слово «ловушка» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Brief",
@@ -1884,8 +1884,8 @@
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
                     "письмо",
-                    "верить",
                     "обман",
+                    "верить",
                     "обманывать"
                 ],
                 "correctIndex": 0
@@ -1893,72 +1893,72 @@
             {
                 "question": "Что означает немецкое слово «glauben»?",
                 "choices": [
-                    "обман",
                     "верить",
-                    "письмо",
-                    "обманывать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «täuschen»?",
-                "choices": [
+                    "обман",
                     "обманывать",
-                    "простодушный",
-                    "письмо",
-                    "ловушка"
+                    "письмо"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Betrug»?",
+                "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
-                    "подозревать",
                     "простодушный",
-                    "обман",
-                    "верить"
+                    "письмо",
+                    "обманывать",
+                    "обман"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «der Betrug»?",
+                "choices": [
+                    "обман",
+                    "письмо",
+                    "верить",
+                    "простодушный"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «arglos»?",
                 "choices": [
+                    "обман",
+                    "подозревать",
                     "ловушка",
-                    "простодушный",
-                    "верить",
-                    "обман"
+                    "простодушный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verdächtigen»?",
                 "choices": [
-                    "верить",
-                    "подозревать",
-                    "обман",
-                    "письмо"
+                    "ловушка",
+                    "легковерный",
+                    "письмо",
+                    "подозревать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «leichtgläubig»?",
                 "choices": [
-                    "верить",
-                    "обманывать",
+                    "простодушный",
+                    "обман",
                     "легковерный",
-                    "обман"
+                    "письмо"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
-                    "верить",
-                    "ловушка",
                     "письмо",
-                    "обман"
+                    "обман",
+                    "ловушка",
+                    "простодушный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -1971,8 +1971,8 @@
                 "word": "verstoßen",
                 "translation": "изгонять",
                 "transcription": "[фер-ШТО-сен]",
-                "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Ich verstoße meinen unschuldigen Sohn.",
-                "sentenceTranslation": "Во дворе замка Реганы Глостер проклинает сына: Я изгоняю своего невинного сына.",
+                "sentence": "Im zugigen Seitenflügel lauscht Gloucester dem Heulen der Küstenwinde. Ich umarme das Wort „verstoßen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Глостер слушает вой прибрежного ветра. Я обнимаю слово «изгонять», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2001,8 +2001,8 @@
                 "word": "verfluchen",
                 "translation": "проклинать",
                 "transcription": "[фер-ФЛУ-хен]",
-                "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Im Zorn verfluche ich Edgar.",
-                "sentenceTranslation": "Во дворе замка Реганы Глостер проклинает сына: В гневе я проклинаю Эдгара.",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Gloucester einen zerknitterten Brief. Ich zeichne das Wort „verfluchen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед дымным камином замка Глостер складывает измятый лист. Я черчу слово «проклинать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2028,8 +2028,8 @@
                 "word": "bereuen",
                 "translation": "сожалеть",
                 "transcription": "[бе-РОЙ-ен]",
-                "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Später werde ich diese Tat bitter bereuen.",
-                "sentenceTranslation": "Во дворе замка Реганы Глостер проклинает сына: Позже я горько пожалею об этом поступке.",
+                "sentence": "Unter farblosen Wandteppichen schreitet Gloucester rastlos auf und ab. Das kalte Licht lässt das Wort „bereuen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Под выцветшими гобеленами Глостер беспокойно меряет шагами зал. Холодный свет заставляет слово «сожалеть» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2054,8 +2054,8 @@
                 "word": "der Irrtum",
                 "translation": "заблуждение",
                 "transcription": "[дер ИР-тум]",
-                "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Mein Irrtum zerstört meine Familie.",
-                "sentenceTranslation": "Во дворе замка Реганы Глостер проклинает сына: Моё заблуждение разрушает мою семью.",
+                "sentence": "An der schmalen Fensterluke zählt Gloucester die Fackeln auf dem Hof. Ich halte das Wort „der Irrtum“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У узкой бойницы Глостер считает факелы на дворе. Я держу слово «заблуждение» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2078,8 +2078,8 @@
                 "word": "blind",
                 "translation": "слепой",
                 "transcription": "[БЛИНД]",
-                "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Ich bin blind für die Wahrheit.",
-                "sentenceTranslation": "Во дворе замка Реганы Глостер проклинает сына: Я слеп к правде.",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Gloucester nach frischen Botschaften. Wie ein stilles Gebet legt sich das Wort „blind“ auf meine Lippen.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Глостер ищет свежие вести. Как тихая молитва слово «слепой» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Klippe",
@@ -2106,8 +2106,8 @@
                 "word": "jagen",
                 "translation": "гнать",
                 "transcription": "[Я-ген]",
-                "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Ich jage meinen Sohn fort wie einen Verbrecher.",
-                "sentenceTranslation": "Во дворе замка Реганы Глостер проклинает сына: Я гоню сына прочь как преступника.",
+                "sentence": "Im stillen Kapellenraum kniet Gloucester vor der kalten Steinfigur. Mit jeder Faser meines Körpers verspreche ich: Das Wort „jagen“ bleibt lebendig.",
+                "sentenceTranslation": "В тихой капелле Глостер преклоняет колени перед холодной каменной фигурой. Каждой клеткой тела я обещаю: слово «гнать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gefahr",
@@ -2135,8 +2135,8 @@
                 "word": "die Ungerechtigkeit",
                 "translation": "несправедливость",
                 "transcription": "[ди УН-ге-рех-тиг-кайт]",
-                "sentence": "Im Hof von Regans Burg verflucht Gloucester seinen Sohn: Ich begehe große Ungerechtigkeit.",
-                "sentenceTranslation": "Во дворе замка Реганы Глостер проклинает сына: Я совершаю большую несправедливость.",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Gloucester die Laterne fest. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ungerechtigkeit“ bleibt lebendig.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Глостер крепко держит фонарь. Каждой клеткой тела я обещаю: слово «несправедливость» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ungerechtigkeit",
@@ -2164,10 +2164,10 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
+                    "проклинать",
                     "заблуждение",
-                    "сожалеть",
                     "изгонять",
-                    "проклинать"
+                    "сожалеть"
                 ],
                 "correctIndex": 2
             },
@@ -2175,27 +2175,27 @@
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
                     "заблуждение",
-                    "сожалеть",
+                    "проклинать",
                     "изгонять",
-                    "проклинать"
+                    "сожалеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
                     "сожалеть",
-                    "проклинать",
+                    "заблуждение",
                     "гнать",
-                    "изгонять"
+                    "слепой"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Irrtum»?",
                 "choices": [
-                    "несправедливость",
                     "слепой",
+                    "гнать",
                     "изгонять",
                     "заблуждение"
                 ],
@@ -2205,31 +2205,31 @@
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
                     "несправедливость",
-                    "сожалеть",
                     "слепой",
-                    "проклинать"
+                    "сожалеть",
+                    "заблуждение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
-                    "несправедливость",
-                    "слепой",
                     "гнать",
-                    "заблуждение"
+                    "сожалеть",
+                    "проклинать",
+                    "слепой"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
+                    "заблуждение",
                     "сожалеть",
-                    "несправедливость",
-                    "слепой",
-                    "заблуждение"
+                    "проклинать",
+                    "несправедливость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2242,8 +2242,8 @@
                 "word": "helfen",
                 "translation": "помогать",
                 "transcription": "[ХЕЛЬ-фен]",
-                "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Heimlich helfe ich dem verstoßenen König.",
-                "sentenceTranslation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Тайно я помогаю изгнанному королю.",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Gloucester gegen den Wind. Das Echo des Wortes „helfen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Глостер упирается в ветер. Эхо слова «помогать» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2265,8 +2265,8 @@
                 "word": "das Mitleid",
                 "translation": "сострадание",
                 "transcription": "[дас МИТ-лайд]",
-                "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Mitleid erfüllt mein Herz für Lear.",
-                "sentenceTranslation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Сострадание наполняет моё сердце к Лиру.",
+                "sentence": "Unter einem zerrissenen Banner schützt Gloucester die Augen vor den Blitzen. Selbst wenn die Welt zerfällt, bleibt das Wort „das Mitleid“ mein Nordstern.",
+                "sentenceTranslation": "Под разорванным знаменем Глостер прикрывает глаза от молний. Даже если мир распадается, слово «сострадание» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2288,8 +2288,8 @@
                 "word": "riskieren",
                 "translation": "рисковать",
                 "transcription": "[рис-КИ-рен]",
-                "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Ich riskiere alles für den alten König.",
-                "sentenceTranslation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Я рискую всем ради старого короля.",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Gloucester Deckung vor dem Donner. Selbst wenn die Welt zerfällt, bleibt das Wort „riskieren“ mein Nordstern.",
+                "sentenceTranslation": "У поваленного дерева Глостер ищет укрытия от грома. Даже если мир распадается, слово «рисковать» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mitleid",
@@ -2312,8 +2312,8 @@
                 "word": "die Gefahr",
                 "translation": "опасность",
                 "transcription": "[ди ге-ФАР]",
-                "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Die Gefahr der Entdeckung ist groß.",
-                "sentenceTranslation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Опасность разоблачения велика.",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Gloucester durch den Schlamm. Das kalte Licht lässt das Wort „die Gefahr“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Между пенящимися лужами Глостер пробирается через грязь. Холодный свет заставляет слово «опасность» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2337,8 +2337,8 @@
                 "word": "heimlich",
                 "translation": "тайно",
                 "transcription": "[ХАЙМ-лих]",
-                "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Ich handle heimlich gegen die neuen Herrscher.",
-                "sentenceTranslation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Я действую тайно против новых правителей.",
+                "sentence": "Vor einem zuckenden Himmel hebt Gloucester die Arme trotzig an. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „heimlich“ gehört mir.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Глостер упрямо поднимает руки. Буря за окнами усиливает клятву: слово «тайно» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mitleid",
@@ -2361,8 +2361,8 @@
                 "word": "schützen",
                 "translation": "защищать",
                 "transcription": "[ШЮ-цен]",
-                "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Ich will den wahnsinnigen König schützen.",
-                "sentenceTranslation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Я хочу защитить безумного короля.",
+                "sentence": "Unter dem durchtränkten Umhang presst Gloucester den Atem gegen die Kälte. Mit jeder Faser meines Körpers verspreche ich: Das Wort „schützen“ bleibt lebendig.",
+                "sentenceTranslation": "Под промокшим плащом Глостер прижимает дыхание к груди, спасаясь от холода. Каждой клеткой тела я обещаю: слово «защищать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mitleid",
@@ -2387,8 +2387,8 @@
                 "word": "der Verrat",
                 "translation": "измена",
                 "transcription": "[дер фер-РАТ]",
-                "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Meine Hilfe gilt als Verrat.",
-                "sentenceTranslation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Моя помощь считается изменой.",
+                "sentence": "Am kläglichen Feuerrest wärmt Gloucester zitternde Finger. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Verrat“ gehört mir.",
+                "sentenceTranslation": "У жалких огненных углей Глостер греет дрожащие пальцы. Буря за окнами усиливает клятву: слово «измена» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2413,8 +2413,8 @@
                 "word": "wagen",
                 "translation": "осмеливаться",
                 "transcription": "[ВА-ген]",
-                "sentence": "In der Nacht auf der Heide hilft Gloucester dem wahnsinnigen Lear: Ich wage es, gegen die Töchter zu handeln.",
-                "sentenceTranslation": "В ночи на пустоши Глостер помогает обезумевшему Лиру: Я осмеливаюсь действовать против дочерей.",
+                "sentence": "Zwischen heulenden Hunden ruft Gloucester gegen den tosenden Sturm an. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „wagen“ gehört mir.",
+                "sentenceTranslation": "Среди воющих псов Глостер перекрикивает беснующуюся бурю. Буря за окнами усиливает клятву: слово «осмеливаться» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2438,38 +2438,38 @@
                 "question": "Что означает немецкое слово «helfen»?",
                 "choices": [
                     "сострадание",
-                    "рисковать",
                     "помогать",
-                    "опасность"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «das Mitleid»?",
-                "choices": [
-                    "помогать",
-                    "сострадание",
-                    "рисковать",
-                    "опасность"
+                    "опасность",
+                    "рисковать"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «das Mitleid»?",
+                "choices": [
+                    "рисковать",
+                    "опасность",
+                    "помогать",
+                    "сострадание"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «riskieren»?",
                 "choices": [
-                    "осмеливаться",
+                    "защищать",
                     "измена",
                     "рисковать",
-                    "сострадание"
+                    "помогать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "помогать",
-                    "тайно",
+                    "рисковать",
                     "измена",
+                    "осмеливаться",
                     "опасность"
                 ],
                 "correctIndex": 3
@@ -2478,9 +2478,9 @@
                 "question": "Что означает немецкое слово «heimlich»?",
                 "choices": [
                     "тайно",
-                    "сострадание",
+                    "осмеливаться",
                     "рисковать",
-                    "осмеливаться"
+                    "помогать"
                 ],
                 "correctIndex": 0
             },
@@ -2489,8 +2489,8 @@
                 "choices": [
                     "защищать",
                     "опасность",
-                    "сострадание",
-                    "помогать"
+                    "тайно",
+                    "измена"
                 ],
                 "correctIndex": 0
             },
@@ -2498,21 +2498,21 @@
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
                     "тайно",
-                    "осмеливаться",
                     "измена",
-                    "рисковать"
+                    "рисковать",
+                    "опасность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «wagen»?",
                 "choices": [
-                    "тайно",
-                    "сострадание",
                     "осмеливаться",
-                    "опасность"
+                    "опасность",
+                    "измена",
+                    "защищать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2525,8 +2525,8 @@
                 "word": "blenden",
                 "translation": "ослеплять",
                 "transcription": "[БЛЕН-ден]",
-                "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Sie blenden mich für meinen Verrat.",
-                "sentenceTranslation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Они ослепляют меня за мою измену.",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Gloucester bei der flackernden Kerze. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „blenden“ gehört mir.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Глостер сидит у мерцающей свечи. Буря за окнами усиливает клятву: слово «ослеплять» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2551,8 +2551,8 @@
                 "word": "die Folter",
                 "translation": "пытка",
                 "transcription": "[ди ФОЛЬ-тер]",
-                "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Die Folter ist grausam und erbarmungslos.",
-                "sentenceTranslation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Пытка жестока и беспощадна.",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Gloucester über ein altes Wappen. Ich presse das Wort „die Folter“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди помятых доспехов Глостер гладит старый герб. Я стискиваю слово «пытка» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -2583,8 +2583,8 @@
                 "word": "der Schmerz",
                 "translation": "боль",
                 "transcription": "[дер ШМЕРЦ]",
-                "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Der Schmerz durchbohrt meine Seele.",
-                "sentenceTranslation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Боль пронзает мою душу.",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Gloucester fast den Kopf. Ich umarme das Wort „der Schmerz“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "О низкую балку хижины Глостер едва не ударяется головой. Я обнимаю слово «боль», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2607,8 +2607,8 @@
                 "word": "die Dunkelheit",
                 "translation": "темнота",
                 "transcription": "[ди ДУН-кель-хайт]",
-                "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Ewige Dunkelheit umgibt mich nun.",
-                "sentenceTranslation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Вечная темнота окружает меня теперь.",
+                "sentence": "Neben der schlafenden Wache flüstert Gloucester in die schwere Nacht. Ich presse das Wort „die Dunkelheit“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Рядом со спящим стражем Глостер шепчет в тяжёлую ночь. Я стискиваю слово «темнота» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2630,8 +2630,8 @@
                 "word": "schreien",
                 "translation": "кричать",
                 "transcription": "[ШРАЙ-ен]",
-                "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Ich schreie vor unerträglichem Schmerz.",
-                "sentenceTranslation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Я кричу от невыносимой боли.",
+                "sentence": "Vor dem einfachen Feldbett betrachtet Gloucester die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „schreien“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед грубой походной койкой Глостер разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «кричать» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Folter",
@@ -2658,8 +2658,8 @@
                 "word": "erblinden",
                 "translation": "слепнуть",
                 "transcription": "[ер-БЛИН-ден]",
-                "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Ich erblinde durch ihre Grausamkeit.",
-                "sentenceTranslation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Я слепну от их жестокости.",
+                "sentence": "Im Geruch von feuchtem Stroh legt Gloucester den Mantel zur Seite. Ich flüstere den Wächtern des Schicksals zu: Das Wort „erblinden“ darf nicht vergehen.",
+                "sentenceTranslation": "В запахе влажной соломы Глостер откладывает плащ в сторону. Я шепчу стражам судьбы: слово «слепнуть» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2681,8 +2681,8 @@
                 "word": "die Rache",
                 "translation": "месть",
                 "transcription": "[ди РА-хе]",
-                "sentence": "Im finsteren Kerker der Burg lassen Regan und Cornwall Gloucester leiden: Dies ist ihre Rache für meine Treue.",
-                "sentenceTranslation": "В тёмном застенке замка Реганы и Корнуолла Глостер страдает: Это их месть за мою верность.",
+                "sentence": "Auf dem wackligen Holztisch ordnet Gloucester zerlesene Briefe. Wie ein stilles Gebet legt sich das Wort „die Rache“ auf meine Lippen.",
+                "sentenceTranslation": "На шатком деревянном столе Глостер раскладывает зачитанные письма. Как тихая молитва слово «месть» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2708,70 +2708,70 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "ослеплять",
-                    "боль",
                     "темнота",
-                    "пытка"
+                    "пытка",
+                    "ослеплять",
+                    "боль"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
+                    "темнота",
                     "боль",
-                    "пытка",
                     "ослеплять",
-                    "темнота"
+                    "пытка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
                     "боль",
-                    "месть",
                     "слепнуть",
-                    "пытка"
+                    "ослеплять",
+                    "темнота"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Dunkelheit»?",
                 "choices": [
+                    "пытка",
+                    "месть",
                     "темнота",
-                    "ослеплять",
-                    "боль",
-                    "слепнуть"
+                    "кричать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
-                    "ослеплять",
-                    "темнота",
+                    "месть",
+                    "кричать",
                     "пытка",
-                    "кричать"
+                    "темнота"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erblinden»?",
                 "choices": [
                     "кричать",
-                    "месть",
                     "слепнуть",
-                    "темнота"
+                    "темнота",
+                    "пытка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
                     "месть",
-                    "пытка",
-                    "слепнуть",
-                    "боль"
+                    "боль",
+                    "ослеплять",
+                    "пытка"
                 ],
                 "correctIndex": 0
             }
@@ -2786,8 +2786,8 @@
                 "word": "die Verzweiflung",
                 "translation": "отчаяние",
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
-                "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Die Verzweiflung treibt mich zum Abgrund.",
-                "sentenceTranslation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Отчаяние гонит меня к пропасти.",
+                "sentence": "Auf den weißen Klippen von Dover blickt Gloucester in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „die Verzweiflung“ mein Nordstern.",
+                "sentenceTranslation": "На белых скалах Дувра Глостер смотрит в вздыбленный пролив. Даже если мир распадается, слово «отчаяние» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2812,8 +2812,8 @@
                 "word": "springen",
                 "translation": "прыгать",
                 "transcription": "[ШПРИН-ген]",
-                "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Ich will von den Klippen springen.",
-                "sentenceTranslation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Я хочу прыгнуть со скал.",
+                "sentence": "Zwischen flatternden Feldzeichen richtet Gloucester den Helm. Das Echo des Wortes „springen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Среди хлопающих штандартов Глостер поправляет шлем. Эхо слова «прыгать» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2835,8 +2835,8 @@
                 "word": "die Täuschung",
                 "translation": "обман",
                 "transcription": "[ди ТОЙ-шунг]",
-                "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Edgars liebevolle Täuschung rettet mich.",
-                "sentenceTranslation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Любящий обман Эдгара спасает меня.",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Gloucester Marschrouten in den Sand. Ich halte das Wort „die Täuschung“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У французского костра Глостер рисует в песке путь марша. Я держу слово «обман» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Täuschung",
@@ -2864,8 +2864,8 @@
                 "word": "der Abgrund",
                 "translation": "пропасть",
                 "transcription": "[дер АБ-грунд]",
-                "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Der Abgrund ruft nach mir.",
-                "sentenceTranslation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Пропасть зовёт меня.",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Gloucester das Siegel. Ich halte das Wort „der Abgrund“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Глостер проверяет печати. Я держу слово «пропасть» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Täuschung",
@@ -2888,8 +2888,8 @@
                 "word": "aufgeben",
                 "translation": "сдаваться",
                 "transcription": "[АУФ-ге-бен]",
-                "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Ich will das Leben aufgeben.",
-                "sentenceTranslation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Я хочу отказаться от жизни.",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Gloucester dem dumpfen Meer. Das kalte Licht lässt das Wort „aufgeben“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Глостер слушает глухой шум моря. Холодный свет заставляет слово «сдаваться» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Abschied",
@@ -2916,8 +2916,8 @@
                 "word": "die Hoffnungslosigkeit",
                 "translation": "безнадёжность",
                 "transcription": "[ди ХОФ-нунгс-ло-зиг-кайт]",
-                "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Die Hoffnungslosigkeit erdrückt mich.",
-                "sentenceTranslation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Безнадёжность давит меня.",
+                "sentence": "Auf dem sandigen Trainingsplatz übt Gloucester das Ziehen des Schwerts. Mein Atem zeichnet das Wort „die Hoffnungslosigkeit“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На песчаном плацу Глостер отрабатывает выхват меча. Моё дыхание рисует слово «безнадёжность» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Täuschung",
@@ -2940,8 +2940,8 @@
                 "word": "stürzen",
                 "translation": "падать",
                 "transcription": "[ШТЮР-цен]",
-                "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Ich glaube, von hohen Klippen zu stürzen.",
-                "sentenceTranslation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Я верю, что падаю с высоких скал.",
+                "sentence": "Zwischen pochenden Trommeln hebt Gloucester das Banner der Hoffnung. Das kalte Licht lässt das Wort „stürzen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Под гул барабанов Глостер поднимает знамя надежды. Холодный свет заставляет слово «падать» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2964,8 +2964,8 @@
                 "word": "erlösen",
                 "translation": "избавлять",
                 "transcription": "[ер-ЛЁ-зен]",
-                "sentence": "An den Klippen von Dover führt armer Tom den blinden Gloucester: Der Tod soll mich von der Schuld erlösen.",
-                "sentenceTranslation": "На утёсах Дувра бедный Том ведёт слепого Глостера: Смерть должна избавить меня от вины.",
+                "sentence": "Am Morgennebel der Küste legt Gloucester die Hand auf das pochende Herz. Ich presse das Wort „erlösen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В утреннем тумане побережья Глостер кладёт ладонь на бьющееся сердце. Я стискиваю слово «избавлять» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Täuschung",
@@ -2989,82 +2989,82 @@
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
+                    "обман",
                     "прыгать",
                     "отчаяние",
-                    "пропасть",
-                    "обман"
+                    "пропасть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «springen»?",
                 "choices": [
-                    "пропасть",
+                    "обман",
                     "прыгать",
-                    "отчаяние",
-                    "обман"
+                    "пропасть",
+                    "отчаяние"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
-                    "избавлять",
-                    "обман",
+                    "падать",
                     "прыгать",
-                    "сдаваться"
+                    "избавлять",
+                    "обман"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Abgrund»?",
                 "choices": [
-                    "прыгать",
-                    "падать",
+                    "избавлять",
                     "пропасть",
-                    "сдаваться"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «aufgeben»?",
-                "choices": [
-                    "отчаяние",
-                    "прыгать",
                     "сдаваться",
-                    "обман"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Hoffnungslosigkeit»?",
-                "choices": [
-                    "падать",
-                    "безнадёжность",
-                    "обман",
-                    "пропасть"
+                    "безнадёжность"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «aufgeben»?",
+                "choices": [
+                    "пропасть",
+                    "отчаяние",
+                    "безнадёжность",
+                    "сдаваться"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Hoffnungslosigkeit»?",
+                "choices": [
+                    "сдаваться",
+                    "прыгать",
+                    "отчаяние",
+                    "безнадёжность"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «stürzen»?",
                 "choices": [
-                    "избавлять",
-                    "сдаваться",
                     "падать",
+                    "сдаваться",
+                    "обман",
                     "отчаяние"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erlösen»?",
                 "choices": [
-                    "прыгать",
-                    "сдаваться",
-                    "отчаяние",
-                    "избавлять"
+                    "избавлять",
+                    "безнадёжность",
+                    "обман",
+                    "прыгать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -3077,8 +3077,8 @@
                 "word": "erkennen",
                 "translation": "узнавать",
                 "transcription": "[ер-КЕН-нен]",
-                "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Endlich erkenne ich meinen treuen Edgar.",
-                "sentenceTranslation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Наконец я узнаю моего верного Эдгара.",
+                "sentence": "Im feuchten Kerker stützt Gloucester sich an den tropfenden Stein. Ich umarme das Wort „erkennen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В сыром подземелье Глостер опирается на сочащийся камень. Я обнимаю слово «узнавать», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3106,8 +3106,8 @@
                 "word": "vergeben",
                 "translation": "прощать",
                 "transcription": "[фер-ГЕ-бен]",
-                "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Edgar vergibt mir meine Blindheit.",
-                "sentenceTranslation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Эдгар прощает мне мою слепоту.",
+                "sentence": "Unter der trüben Laterne zählt Gloucester die eisernen Ringe der Kette. Ich zeichne das Wort „vergeben“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под мутным фонарём Глостер пересчитывает железные кольца цепи. Я черчу слово «прощать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3131,8 +3131,8 @@
                 "word": "sterben",
                 "translation": "умирать",
                 "transcription": "[ШТЕР-бен]",
-                "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Ich sterbe vor Freude und Kummer.",
-                "sentenceTranslation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Я умираю от радости и горя.",
+                "sentence": "Neben der schweren Holztür horcht Gloucester auf entferntes Schluchzen. Ich halte das Wort „sterben“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У тяжёлой двери Глостер прислушивается к далёким рыданиям. Я держу слово «умирать» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3158,8 +3158,8 @@
                 "word": "die Erkenntnis",
                 "translation": "осознание",
                 "transcription": "[ди ер-КЕНТ-нис]",
-                "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Die späte Erkenntnis bricht mein Herz.",
-                "sentenceTranslation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Позднее осознание разбивает моё сердце.",
+                "sentence": "Auf der kalten Steinbank zieht Gloucester den Mantel enger um die Schultern. Das Echo des Wortes „die Erkenntnis“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На холодной каменной скамье Глостер плотнее кутается в плащ. Эхо слова «осознание» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3184,8 +3184,8 @@
                 "word": "die Reue",
                 "translation": "раскаяние",
                 "transcription": "[ди РОЙ-е]",
-                "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Die Reue überwältigt meine Seele.",
-                "sentenceTranslation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Раскаяние переполняет мою душу.",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Gloucester das Gesicht zum Licht. Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Между тенями решёток Глостер поднимает лицо к свету. Я черчу слово «раскаяние» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3209,8 +3209,8 @@
                 "word": "umarmen",
                 "translation": "обнимать",
                 "transcription": "[ум-АР-мен]",
-                "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Ein letztes Mal umarme ich meinen Sohn.",
-                "sentenceTranslation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: В последний раз я обнимаю сына.",
+                "sentence": "Am rostigen Wassereimer spiegelt Gloucester kurz die eigenen Augen. Wie ein stilles Gebet legt sich das Wort „umarmen“ auf meine Lippen.",
+                "sentenceTranslation": "У ржавого ведра с водой Глостер на мгновение видит отражение глаз. Как тихая молитва слово «обнимать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "erkennen",
@@ -3237,8 +3237,8 @@
                 "word": "die Versöhnung",
                 "translation": "примирение",
                 "transcription": "[ди фер-ЗЁ-нунг]",
-                "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Die Versöhnung kommt zu spät.",
-                "sentenceTranslation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Примирение приходит слишком поздно.",
+                "sentence": "Im dumpfen Hall der Schritte zählt Gloucester den Rhythmus der Wachen. Mein Atem zeichnet das Wort „die Versöhnung“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В глухом эхе шагов Глостер отсчитывает ритм часовых. Моё дыхание рисует слово «примирение» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3260,8 +3260,8 @@
                 "word": "das Herz",
                 "translation": "сердце",
                 "transcription": "[дас ХЕРЦ]",
-                "sentence": "Nach der Rettung in Dover erkennt Gloucester in Edgars Armen: Mein Herz zerbricht vor Glück und Leid.",
-                "sentenceTranslation": "После спасения в Дувре Глостер узнаёт Эдгара в его объятиях: Моё сердце разрывается от счастья и горя.",
+                "sentence": "Vor dem verriegelten Fenster zeichnet Gloucester Kreise in den Staub. Ich halte das Wort „das Herz“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед заколоченным окном Глостер чертит круги в пыли. Я держу слово «сердце» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3285,82 +3285,82 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "осознание",
-                    "прощать",
-                    "умирать",
-                    "узнавать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «vergeben»?",
-                "choices": [
                     "узнавать",
-                    "осознание",
                     "умирать",
-                    "прощать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «sterben»?",
-                "choices": [
-                    "умирать",
-                    "обнимать",
-                    "сердце",
-                    "прощать"
+                    "прощать",
+                    "осознание"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «vergeben»?",
+                "choices": [
+                    "прощать",
+                    "умирать",
+                    "осознание",
+                    "узнавать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «sterben»?",
+                "choices": [
+                    "раскаяние",
+                    "сердце",
+                    "умирать",
+                    "узнавать"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
+                    "осознание",
+                    "умирать",
                     "узнавать",
-                    "примирение",
-                    "прощать",
-                    "осознание"
+                    "раскаяние"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
                     "раскаяние",
-                    "прощать",
                     "сердце",
-                    "осознание"
+                    "узнавать",
+                    "прощать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
+                    "сердце",
                     "обнимать",
-                    "осознание",
                     "прощать",
-                    "примирение"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Versöhnung»?",
-                "choices": [
-                    "обнимать",
-                    "примирение",
-                    "прощать",
-                    "осознание"
+                    "раскаяние"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «die Versöhnung»?",
+                "choices": [
+                    "сердце",
+                    "осознание",
+                    "примирение",
+                    "прощать"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
-                    "примирение",
-                    "раскаяние",
-                    "обнимать",
-                    "сердце"
+                    "узнавать",
+                    "прощать",
+                    "сердце",
+                    "обнимать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -3891,27 +3891,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/goneril.html
+++ b/output/journeys/goneril.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["наследство", "лицемерить", "ложь", "клясться"], "correct_index": 2}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["клясться", "ложь", "наследство", "лицемерить"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["состояние", "обманывать", "лицемерить", "наследство"], "correct_index": 3}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["состояние", "лицемерить", "наследство", "ложь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["льстить", "наследство", "лицемерить", "жадность"], "correct_index": 3}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["ложь", "обманывать", "наследство", "лицемерить"], "correct_index": 1}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["клясться", "состояние", "льстить", "наследство"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["состояние", "клясться", "наследство", "ложь"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["править", "власть", "трон", "приказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["приказывать", "править", "трон", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["господство", "править", "приказывать", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["приказывать", "завоёвывать", "трон", "подчинять"], "correct_index": 2}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["приказывать", "господство", "завоёвывать", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["завоёвывать", "подчинять", "трон", "господство"], "correct_index": 3}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["власть", "управлять", "господство", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["управлять", "власть", "подчинять", "завоёвывать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "изгонять", "месть", "жестокий"], "correct_index": 0}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["унижать", "жестокий", "месть", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["жестокий", "отказывать", "презирать", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["изгонять", "отказывать", "ограничивать", "презирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["жестокий", "презирать", "отказывать", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["месть", "презирать", "отказывать", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["мучить", "жестокий", "ограничивать", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["презирать", "ограничивать", "изгонять", "унижать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["отвергать", "запирать", "буря", "безжалостный"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["запирать", "безжалостный", "буря", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["безжалостный", "беспощадный", "холод", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["отвергать", "запирать", "беспощадный", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["безжалостный", "беспощадный", "холод", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["безжалостный", "беспощадный", "ожесточаться", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["безжалостный", "холод", "буря", "ожесточаться"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["предавать", "ненавидеть", "ссориться", "раздор"], "correct_index": 2}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["ссориться", "ненавидеть", "раздор", "предавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["изменять", "ненавидеть", "предавать", "раздор"], "correct_index": 3}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["ссориться", "ненавидеть", "предавать", "разрушать"], "correct_index": 1}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["изменять", "ненавидеть", "разрушать", "ссориться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["презрение", "предавать", "изменять", "разрушать"], "correct_index": 0}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["изменять", "ненавидеть", "раздор", "разрушать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["изменять", "страсть", "раздор", "ссориться"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["бороться", "ревность", "желать", "соперничать"], "correct_index": 1}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["ревность", "бороться", "желать", "соперничать"], "correct_index": 3}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["убивать", "ревность", "бороться", "яд"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["яд", "убивать", "интрига", "желать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["устранять", "желать", "яд", "бороться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["устранять", "ревность", "яд", "соперничать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["желать", "устранять", "интрига", "соперничать"], "correct_index": 2}, {"question": "Что означает немецкое слово «morden»?", "choices": ["ревность", "желать", "убивать", "бороться"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["отравлять", "отчаяние", "умирать", "вина"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отравлять", "отчаяние", "умирать", "вина"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "отравлять", "вина", "ад"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["умирать", "вина", "отравлять", "ад"], "correct_index": 1}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["уничтожать", "ад", "вина", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["отчаяние", "вина", "погибель", "уничтожать"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["умирать", "сожалеть", "погибель", "вина"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["ад", "отчаяние", "отравлять", "вина"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["клясться", "ложь", "наследство", "лицемерить"], "correct_index": 1}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["лицемерить", "наследство", "ложь", "клясться"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["клясться", "состояние", "лицемерить", "наследство"], "correct_index": 3}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["состояние", "обманывать", "лицемерить", "клясться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["наследство", "обманывать", "лицемерить", "жадность"], "correct_index": 3}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["лицемерить", "обманывать", "льстить", "наследство"], "correct_index": 1}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["наследство", "состояние", "льстить", "лицемерить"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["жадность", "ложь", "состояние", "льстить"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "трон", "править", "приказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["власть", "приказывать", "править", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["трон", "приказывать", "править", "господство"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["приказывать", "трон", "править", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["трон", "господство", "завоёвывать", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["править", "управлять", "завоёвывать", "господство"], "correct_index": 3}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["управлять", "завоёвывать", "господство", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["трон", "править", "завоёвывать", "подчинять"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "жестокий", "изгонять", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["унижать", "месть", "жестокий", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["жестокий", "ограничивать", "отказывать", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["отказывать", "ограничивать", "изгонять", "презирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["жестокий", "месть", "презирать", "ограничивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["ограничивать", "отказывать", "унижать", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["унижать", "мучить", "презирать", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["презирать", "ограничивать", "жестокий", "мучить"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["буря", "безжалостный", "запирать", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "отвергать", "безжалостный", "запирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["безжалостный", "буря", "ожесточаться", "беспощадный"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["буря", "ожесточаться", "безжалостный", "запирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["холод", "запирать", "буря", "ожесточаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["отвергать", "запирать", "буря", "беспощадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["беспощадный", "ожесточаться", "запирать", "безжалостный"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["раздор", "ненавидеть", "ссориться", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["предавать", "ссориться", "раздор", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["ссориться", "раздор", "изменять", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["раздор", "презрение", "ненавидеть", "страсть"], "correct_index": 2}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["изменять", "ненавидеть", "разрушать", "презрение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["ссориться", "презрение", "предавать", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["разрушать", "предавать", "изменять", "презрение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["презрение", "изменять", "раздор", "страсть"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["ревность", "соперничать", "бороться", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["бороться", "желать", "соперничать", "ревность"], "correct_index": 2}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["интрига", "бороться", "ревность", "убивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["интрига", "желать", "соперничать", "ревность"], "correct_index": 1}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["устранять", "интрига", "бороться", "соперничать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["бороться", "яд", "соперничать", "устранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["яд", "интрига", "ревность", "устранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «morden»?", "choices": ["ревность", "соперничать", "устранять", "убивать"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["вина", "умирать", "отчаяние", "отравлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отравлять", "умирать", "отчаяние", "вина"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["вина", "сожалеть", "умирать", "отравлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["вина", "отравлять", "ад", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["вина", "ад", "отчаяние", "уничтожать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["уничтожать", "ад", "вина", "погибель"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "отчаяние", "умирать", "отравлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["умирать", "вина", "сожалеть", "ад"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Лесть и обман</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,24 +465,8 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Lüge»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «schwören»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
@@ -497,13 +481,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «schwören»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Erbe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
                             
@@ -513,17 +513,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -533,9 +533,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
                             
@@ -549,25 +549,9 @@
                         <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">льстить</button>
                             
@@ -577,17 +561,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">льстить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Vermögen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">состояние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">льстить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,15 +600,15 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">приказывать</button>
                             
@@ -616,49 +616,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «befehlen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">господство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -668,13 +668,13 @@
                         <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -684,11 +684,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подчинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
                             
@@ -696,33 +696,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">управлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">господство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">управлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подчинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -741,25 +741,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
@@ -773,9 +773,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
@@ -783,15 +783,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ограничивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
                             
@@ -799,15 +799,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verweigern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ограничивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
@@ -815,31 +831,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verweigern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ограничивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
@@ -855,9 +855,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -870,33 +870,33 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -908,75 +908,75 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ожесточаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verschließen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ожесточаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ожесточаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verhärten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -993,27 +993,11 @@
                         <div class="quiz-question">Что означает немецкое слово «streiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
                             
@@ -1021,33 +1005,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страсть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1063,55 +1063,55 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">разрушать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Leidenschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страсть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страсть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1124,65 +1124,65 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Eifersucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">убивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">убивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1194,59 +1194,59 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Gift»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">яд</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">устранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «morden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">устранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">убивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1259,31 +1259,31 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vergiften»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
                             
@@ -1291,40 +1291,56 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Schuld»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ад</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vernichten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
@@ -1333,55 +1349,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">погибель</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">погибель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Hölle»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">погибель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Hölle»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1408,8 +1408,8 @@
                 "word": "die Lüge",
                 "translation": "ложь",
                 "transcription": "[ди ЛЮ-ге]",
-                "sentence": "Im Thronsaal von König Lear haucht Goneril: Die Lüge klingt süßer als die Wahrheit.",
-                "sentenceTranslation": "В тронном зале короля Лира Гонериль шепчет: Ложь звучит слаще правды.",
+                "sentence": "Goneril steht unter dem glühenden Kronleuchter des Thronsaals. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Lüge“ bleibt lebendig.",
+                "sentenceTranslation": "Гонерилья стоит под пылающей люстрой тронного зала. Каждой клеткой тела я обещаю: слово «ложь» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1431,8 +1431,8 @@
                 "word": "schwören",
                 "translation": "клясться",
                 "transcription": "[ШВЁ-рен]",
-                "sentence": "Im Thronsaal von König Lear haucht Goneril: Ich schwöre, dass ich Euch mehr liebe als mein Leben.",
-                "sentenceTranslation": "В тронном зале короля Лира Гонериль шепчет: Я клянусь, что люблю вас больше жизни.",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Goneril über Lears schweren Tisch. Ich flüstere den Wächtern des Schicksals zu: Das Wort „schwören“ darf nicht vergehen.",
+                "sentenceTranslation": "У развернутой карты королевства Гонерилья склоняется над тяжёлым столом Лира. Я шепчу стражам судьбы: слово «клясться» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1454,8 +1454,8 @@
                 "word": "das Erbe",
                 "translation": "наследство",
                 "transcription": "[дас ЕР-бе]",
-                "sentence": "Im Thronsaal von König Lear haucht Goneril: Das Erbe ist endlich mein.",
-                "sentenceTranslation": "В тронном зале короля Лира Гонериль шепчет: Наследство наконец моё.",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Goneril die Hände hinter dem Rücken. Mit jeder Faser meines Körpers verspreche ich: Das Wort „das Erbe“ bleibt lebendig.",
+                "sentenceTranslation": "Перед каменными статуями предков Гонерилья сцепляет руки за спиной. Каждой клеткой тела я обещаю: слово «наследство» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1477,8 +1477,8 @@
                 "word": "heucheln",
                 "translation": "лицемерить",
                 "transcription": "[ХОЙ-хельн]",
-                "sentence": "Im Thronsaal von König Lear haucht Goneril: Ich muss vor meinem Vater heucheln.",
-                "sentenceTranslation": "В тронном зале короля Лира Гонериль шепчет: Я должна лицемерить перед отцом.",
+                "sentence": "Zwischen flüsternden Höflingen gleitet Goneril über den kalten Marmorboden. Ich umarme das Wort „heucheln“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Между шепчущимися придворными Гонерилья скользит по холодному мраморному полу. Я обнимаю слово «лицемерить», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Erbe",
@@ -1501,8 +1501,8 @@
                 "word": "die Gier",
                 "translation": "жадность",
                 "transcription": "[ди ГИР]",
-                "sentence": "Im Thronsaal von König Lear haucht Goneril: Die Gier nach Macht treibt mich an.",
-                "sentenceTranslation": "В тронном зале короля Лира Гонериль шепчет: Жадность к власти движет мной.",
+                "sentence": "Am Rand des purpurnen Teppichs wartet Goneril auf ein Zeichen des Königs. Ich zeichne das Wort „die Gier“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На краю пурпурного ковра Гонерилья ждёт знака от короля. Я черчу слово «жадность» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1525,8 +1525,8 @@
                 "word": "täuschen",
                 "translation": "обманывать",
                 "transcription": "[ТОЙ-шен]",
-                "sentence": "Im Thronsaal von König Lear haucht Goneril: Ich täusche meinen alten Vater leicht.",
-                "sentenceTranslation": "В тронном зале короля Лира Гонериль шепчет: Я легко обманываю старого отца.",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Goneril kurz den Blick. Mit jeder Faser meines Körpers verspreche ich: Das Wort „täuschen“ bleibt lebendig.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Гонерилья на миг опускает взгляд. Каждой клеткой тела я обещаю: слово «обманывать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1552,8 +1552,8 @@
                 "word": "schmeicheln",
                 "translation": "льстить",
                 "transcription": "[ШМАЙ-хельн]",
-                "sentence": "Im Thronsaal von König Lear haucht Goneril: Mit süßen Worten schmeichle ich ihm.",
-                "sentenceTranslation": "В тронном зале короля Лира Гонериль шепчет: Сладкими словами я льщу ему.",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Goneril das gespannte Antlitz des Hofes. Das Echo des Wortes „schmeicheln“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "За позолоченной балюстрадой Гонерилья наблюдает за напряжёнными лицами двора. Эхо слова «льстить» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1575,8 +1575,8 @@
                 "word": "das Vermögen",
                 "translation": "состояние",
                 "transcription": "[дас фер-МЁ-ген]",
-                "sentence": "Im Thronsaal von König Lear haucht Goneril: Sein ganzes Vermögen wird mir gehören.",
-                "sentenceTranslation": "В тронном зале короля Лира Гонериль шепчет: Всё его состояние будет моим.",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Goneril langsam die Stimme. Ich umarme das Wort „das Vermögen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В отблесках открытых жаровен Гонерилья медленно поднимает голос. Я обнимаю слово «состояние», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Erbe",
@@ -1600,28 +1600,28 @@
             {
                 "question": "Что означает немецкое слово «die Lüge»?",
                 "choices": [
-                    "наследство",
-                    "лицемерить",
-                    "ложь",
-                    "клясться"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «schwören»?",
-                "choices": [
                     "клясться",
                     "ложь",
                     "наследство",
                     "лицемерить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «schwören»?",
+                "choices": [
+                    "лицемерить",
+                    "наследство",
+                    "ложь",
+                    "клясться"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Erbe»?",
                 "choices": [
+                    "клясться",
                     "состояние",
-                    "обманывать",
                     "лицемерить",
                     "наследство"
                 ],
@@ -1631,17 +1631,17 @@
                 "question": "Что означает немецкое слово «heucheln»?",
                 "choices": [
                     "состояние",
+                    "обманывать",
                     "лицемерить",
-                    "наследство",
-                    "ложь"
+                    "клясться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gier»?",
                 "choices": [
-                    "льстить",
                     "наследство",
+                    "обманывать",
                     "лицемерить",
                     "жадность"
                 ],
@@ -1650,32 +1650,32 @@
             {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
-                    "ложь",
+                    "лицемерить",
                     "обманывать",
-                    "наследство",
-                    "лицемерить"
+                    "льстить",
+                    "наследство"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schmeicheln»?",
                 "choices": [
-                    "клясться",
+                    "наследство",
                     "состояние",
                     "льстить",
-                    "наследство"
+                    "лицемерить"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Vermögen»?",
                 "choices": [
+                    "жадность",
+                    "ложь",
                     "состояние",
-                    "клясться",
-                    "наследство",
-                    "ложь"
+                    "льстить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -1688,8 +1688,8 @@
                 "word": "die Macht",
                 "translation": "власть",
                 "transcription": "[ди МАХТ]",
-                "sentence": "In ihrem Palast in Albany prahlt Goneril: Die Macht über das halbe Königreich ist mein.",
-                "sentenceTranslation": "В своём дворце в Олбани Гонериль хвастается: Власть над половиной королевства моя.",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Goneril zwischen gepackten Kisten. Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Гонерилья замирает среди нагруженных ящиков. Я обнимаю слово «власть», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1714,8 +1714,8 @@
                 "word": "herrschen",
                 "translation": "править",
                 "transcription": "[ХЕР-шен]",
-                "sentence": "In ihrem Palast in Albany prahlt Goneril: Jetzt herrsche ich über meine Länder.",
-                "sentenceTranslation": "В своём дворце в Олбани Гонериль хвастается: Теперь я правлю своими землями.",
+                "sentence": "Auf der windigen Freitreppe blickt Goneril zum schweigenden Hof hinunter. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „herrschen“ gehört mir.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Гонерилья смотрит вниз на молчаливый двор. Буря за окнами усиливает клятву: слово «править» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1739,8 +1739,8 @@
                 "word": "befehlen",
                 "translation": "приказывать",
                 "transcription": "[бе-ФЕ-лен]",
-                "sentence": "In ihrem Palast in Albany prahlt Goneril: Ich befehle, und alle gehorchen mir.",
-                "sentenceTranslation": "В своём дворце в Олбани Гонериль хвастается: Я приказываю, и все подчиняются мне.",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Goneril den Reisemantel enger. Das Echo des Wortes „befehlen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Среди оставленных слуг Гонерилья плотнее запахивает дорожный плащ. Эхо слова «приказывать» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1762,8 +1762,8 @@
                 "word": "der Thron",
                 "translation": "трон",
                 "transcription": "[дер ТРОН]",
-                "sentence": "In ihrem Palast in Albany prahlt Goneril: Der Thron meines Vaters wird bald leer sein.",
-                "sentenceTranslation": "В своём дворце в Олбани Гонериль хвастается: Трон моего отца скоро опустеет.",
+                "sentence": "Am dunklen Pferdestall streicht Goneril einem nervösen Tier über die Mähne. Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Гонерилья гладит гриву нервного коня. Моё дыхание рисует слово «трон» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1786,8 +1786,8 @@
                 "word": "erobern",
                 "translation": "завоёвывать",
                 "transcription": "[ер-О-берн]",
-                "sentence": "In ihrem Palast in Albany prahlt Goneril: Ich erobere, was mir zusteht.",
-                "sentenceTranslation": "В своём дворце в Олбани Гонериль хвастается: Я завоёвываю то, что мне положено.",
+                "sentence": "Vor dem knarrenden Fallgatter tastet Goneril ein letztes Mal nach dem Haustor. Mit jeder Faser meines Körpers verspreche ich: Das Wort „erobern“ bleibt lebendig.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Гонерилья в последний раз касается родной двери. Каждой клеткой тела я обещаю: слово «завоёвывать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1811,8 +1811,8 @@
                 "word": "die Herrschaft",
                 "translation": "господство",
                 "transcription": "[ди ХЕР-шафт]",
-                "sentence": "In ihrem Palast in Albany prahlt Goneril: Die Herrschaft über alle ist mein Ziel.",
-                "sentenceTranslation": "В своём дворце в Олбани Гонериль хвастается: Господство над всеми - моя цель.",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Goneril den Ring an der Hand. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Herrschaft“ gehört mir.",
+                "sentenceTranslation": "Среди разбросанных свитков Гонерилья вертит кольцо на пальце. Буря за окнами усиливает клятву: слово «господство» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Herrschaft",
@@ -1840,8 +1840,8 @@
                 "word": "regieren",
                 "translation": "управлять",
                 "transcription": "[ре-ГИ-рен]",
-                "sentence": "In ihrem Palast in Albany prahlt Goneril: Ich werde mit eiserner Hand regieren.",
-                "sentenceTranslation": "В своём дворце в Олбани Гонериль хвастается: Я буду управлять железной рукой.",
+                "sentence": "Am leeren Bankettisch zählt Goneril die verlöschenden Kerzen. Mit fester Stimme schwöre ich mir: Das Wort „regieren“ wird heute nicht verraten.",
+                "sentenceTranslation": "У пустого банкетного стола Гонерилья пересчитывает гаснущие свечи. Твёрдым голосом я клянусь себе: слово «управлять» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1866,8 +1866,8 @@
                 "word": "unterwerfen",
                 "translation": "подчинять",
                 "transcription": "[ун-тер-ВЕР-фен]",
-                "sentence": "In ihrem Palast in Albany prahlt Goneril: Alle müssen sich mir unterwerfen.",
-                "sentenceTranslation": "В своём дворце в Олбани Гонериль хвастается: Все должны мне подчиниться.",
+                "sentence": "Zwischen schweigenden Wachen geht Goneril auf den kalten Hof hinaus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „unterwerfen“ bleibt lebendig.",
+                "sentenceTranslation": "Между молчаливыми стражниками Гонерилья выходит на холодный двор. Каждой клеткой тела я обещаю: слово «подчинять» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1890,59 +1890,59 @@
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "править",
                     "власть",
                     "трон",
+                    "править",
                     "приказывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
+                    "власть",
                     "приказывать",
                     "править",
-                    "трон",
-                    "власть"
+                    "трон"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «befehlen»?",
                 "choices": [
-                    "господство",
-                    "править",
+                    "трон",
                     "приказывать",
-                    "власть"
+                    "править",
+                    "господство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
                     "приказывать",
-                    "завоёвывать",
                     "трон",
-                    "подчинять"
+                    "править",
+                    "власть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
-                    "приказывать",
+                    "трон",
                     "господство",
                     "завоёвывать",
-                    "трон"
+                    "власть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
+                    "править",
+                    "управлять",
                     "завоёвывать",
-                    "подчинять",
-                    "трон",
                     "господство"
                 ],
                 "correctIndex": 3
@@ -1950,22 +1950,22 @@
             {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
-                    "власть",
                     "управлять",
+                    "завоёвывать",
                     "господство",
-                    "править"
+                    "власть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «unterwerfen»?",
                 "choices": [
-                    "управлять",
-                    "власть",
-                    "подчинять",
-                    "завоёвывать"
+                    "трон",
+                    "править",
+                    "завоёвывать",
+                    "подчинять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -1978,8 +1978,8 @@
                 "word": "demütigen",
                 "translation": "унижать",
                 "transcription": "[де-МЮ-ти-ген]",
-                "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich demütige meinen alten Vater ohne Mitleid.",
-                "sentenceTranslation": "Когда Лир квартирует у неё, Гонериль приказывает: Я унижаю старого отца без жалости.",
+                "sentence": "Im zugigen Seitenflügel lauscht Goneril dem Heulen der Küstenwinde. Ich zeichne das Wort „demütigen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Гонерилья слушает вой прибрежного ветра. Я вывожу слово «унижать» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Strafe",
@@ -2009,8 +2009,8 @@
                 "word": "grausam",
                 "translation": "жестокий",
                 "transcription": "[ГРАУ-зам]",
-                "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich bin grausam zu dem, der mir alles gab.",
-                "sentenceTranslation": "Когда Лир квартирует у неё, Гонериль приказывает: Я жестока к тому, кто дал мне всё.",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Goneril einen zerknitterten Brief. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „grausam“ gehört mir.",
+                "sentenceTranslation": "Перед дымным камином замка Гонерилья складывает измятый лист. Буря за окнами усиливает клятву: слово «жестокий» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "demütigen",
@@ -2033,8 +2033,8 @@
                 "word": "die Rache",
                 "translation": "месть",
                 "transcription": "[ди РА-хе]",
-                "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Die Rache für Jahre der Unterwerfung.",
-                "sentenceTranslation": "Когда Лир квартирует у неё, Гонериль приказывает: Месть за годы подчинения.",
+                "sentence": "Unter farblosen Wandteppichen schreitet Goneril rastlos auf und ab. Selbst wenn die Welt zerfällt, bleibt das Wort „die Rache“ mein Nordstern.",
+                "sentenceTranslation": "Под выцветшими гобеленами Гонерилья беспокойно меряет шагами зал. Даже если мир распадается, слово «месть» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2059,8 +2059,8 @@
                 "word": "vertreiben",
                 "translation": "изгонять",
                 "transcription": "[фер-ТРАЙ-бен]",
-                "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich vertreibe ihn aus meinem Haus.",
-                "sentenceTranslation": "Когда Лир квартирует у неё, Гонериль приказывает: Я изгоняю его из моего дома.",
+                "sentence": "An der schmalen Fensterluke zählt Goneril die Fackeln auf dem Hof. Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten.",
+                "sentenceTranslation": "У узкой бойницы Гонерилья считает факелы на дворе. Твёрдым голосом я клянусь себе: слово «изгонять» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2087,8 +2087,8 @@
                 "word": "verachten",
                 "translation": "презирать",
                 "transcription": "[фер-АХ-тен]",
-                "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich verachte seine Schwäche und sein Alter.",
-                "sentenceTranslation": "Когда Лир квартирует у неё, Гонериль приказывает: Я презираю его слабость и старость.",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Goneril nach frischen Botschaften. Mit fester Stimme schwöre ich mir: Das Wort „verachten“ wird heute nicht verraten.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Гонерилья ищет свежие вести. Твёрдым голосом я клянусь себе: слово «презирать» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "demütigen",
@@ -2111,8 +2111,8 @@
                 "word": "verweigern",
                 "translation": "отказывать",
                 "transcription": "[фер-ВАЙ-герн]",
-                "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich verweigere ihm jeden Komfort.",
-                "sentenceTranslation": "Когда Лир квартирует у неё, Гонериль приказывает: Я отказываю ему в любом комфорте.",
+                "sentence": "Im stillen Kapellenraum kniet Goneril vor der kalten Steinfigur. Ich zeichne das Wort „verweigern“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В тихой капелле Гонерилья преклоняет колени перед холодной каменной фигурой. Я черчу слово «отказывать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "demütigen",
@@ -2135,8 +2135,8 @@
                 "word": "quälen",
                 "translation": "мучить",
                 "transcription": "[КВЕ-лен]",
-                "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Es macht mir Freude, ihn zu quälen.",
-                "sentenceTranslation": "Когда Лир квартирует у неё, Гонериль приказывает: Мне доставляет радость мучить его.",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Goneril die Laterne fest. Selbst wenn die Welt zerfällt, bleibt das Wort „quälen“ mein Nordstern.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Гонерилья крепко держит фонарь. Даже если мир распадается, слово «мучить» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2159,8 +2159,8 @@
                 "word": "beschränken",
                 "translation": "ограничивать",
                 "transcription": "[бе-ШРЕН-кен]",
-                "sentence": "Als Lear bei ihr Quartier nimmt, befiehlt Goneril: Ich beschränke seine Dienerschaft auf null.",
-                "sentenceTranslation": "Когда Лир квартирует у неё, Гонериль приказывает: Я ограничиваю его свиту до нуля.",
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Goneril eine fiebrige Antwort. Ich presse das Wort „beschränken“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В тени высоких стен Гонерилья пишет лихорадочный ответ. Я стискиваю слово «ограничивать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "demütigen",
@@ -2185,9 +2185,9 @@
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
                     "унижать",
+                    "жестокий",
                     "изгонять",
-                    "месть",
-                    "жестокий"
+                    "месть"
                 ],
                 "correctIndex": 0
             },
@@ -2195,18 +2195,18 @@
                 "question": "Что означает немецкое слово «grausam»?",
                 "choices": [
                     "унижать",
-                    "жестокий",
                     "месть",
+                    "жестокий",
                     "изгонять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
                     "жестокий",
+                    "ограничивать",
                     "отказывать",
-                    "презирать",
                     "месть"
                 ],
                 "correctIndex": 3
@@ -2214,50 +2214,50 @@
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "изгонять",
                     "отказывать",
                     "ограничивать",
+                    "изгонять",
                     "презирать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verachten»?",
                 "choices": [
                     "жестокий",
+                    "месть",
                     "презирать",
+                    "ограничивать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «verweigern»?",
+                "choices": [
+                    "ограничивать",
                     "отказывать",
+                    "унижать",
                     "месть"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «verweigern»?",
-                "choices": [
-                    "месть",
-                    "презирать",
-                    "отказывать",
-                    "унижать"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
+                    "унижать",
                     "мучить",
-                    "жестокий",
-                    "ограничивать",
+                    "презирать",
                     "изгонять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beschränken»?",
                 "choices": [
                     "презирать",
                     "ограничивать",
-                    "изгонять",
-                    "унижать"
+                    "жестокий",
+                    "мучить"
                 ],
                 "correctIndex": 1
             }
@@ -2272,8 +2272,8 @@
                 "word": "verstoßen",
                 "translation": "отвергать",
                 "transcription": "[фер-ШТО-сен]",
-                "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Ich verstoße meinen Vater in die Nacht.",
-                "sentenceTranslation": "Перед воротами своего замка Гонериль выталкивает отца: Я отвергаю отца в ночь.",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Goneril gegen den Wind. Wie ein stilles Gebet legt sich das Wort „verstoßen“ auf meine Lippen.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Гонерилья упирается в ветер. Как тихая молитва слово «отвергать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2302,8 +2302,8 @@
                 "word": "der Sturm",
                 "translation": "буря",
                 "transcription": "[дер ШТУРМ]",
-                "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Der Sturm soll sein neues Zuhause sein.",
-                "sentenceTranslation": "Перед воротами своего замка Гонериль выталкивает отца: Буря пусть будет его новым домом.",
+                "sentence": "Unter einem zerrissenen Banner schützt Goneril die Augen vor den Blitzen. Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Под разорванным знаменем Гонерилья прикрывает глаза от молний. Я обнимаю слово «буря», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2328,8 +2328,8 @@
                 "word": "gnadenlos",
                 "translation": "безжалостный",
                 "transcription": "[ГНА-ден-лос]",
-                "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Ich bin gnadenlos wie der Winter.",
-                "sentenceTranslation": "Перед воротами своего замка Гонериль выталкивает отца: Я безжалостна как зима.",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Goneril Deckung vor dem Donner. Ich halte das Wort „gnadenlos“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У поваленного дерева Гонерилья ищет укрытия от грома. Я держу слово «безжалостный» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Sturm",
@@ -2352,8 +2352,8 @@
                 "word": "verschließen",
                 "translation": "запирать",
                 "transcription": "[фер-ШЛИ-сен]",
-                "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Ich verschließe meine Türen vor ihm.",
-                "sentenceTranslation": "Перед воротами своего замка Гонериль выталкивает отца: Я запираю двери перед ним.",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Goneril durch den Schlamm. Ich presse das Wort „verschließen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Между пенящимися лужами Гонерилья пробирается через грязь. Я стискиваю слово «запирать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2376,8 +2376,8 @@
                 "word": "die Kälte",
                 "translation": "холод",
                 "transcription": "[ди КЕЛ-те]",
-                "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Die Kälte meines Herzens übertrifft den Winter.",
-                "sentenceTranslation": "Перед воротами своего замка Гонериль выталкивает отца: Холод моего сердца превосходит зиму.",
+                "sentence": "Vor einem zuckenden Himmel hebt Goneril die Arme trotzig an. Ich atme tief ein und lasse nur das Wort „die Kälte“ wieder hinaus.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Гонерилья упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «холод».",
                 "visual_hint": "📚",
                 "themes": [
                     "Beistand",
@@ -2403,8 +2403,8 @@
                 "word": "erbarmungslos",
                 "translation": "беспощадный",
                 "transcription": "[ер-БАР-мунгс-лос]",
-                "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Erbarmungslos werfe ich ihn hinaus.",
-                "sentenceTranslation": "Перед воротами своего замка Гонериль выталкивает отца: Беспощадно я выбрасываю его.",
+                "sentence": "Unter dem durchtränkten Umhang presst Goneril den Atem gegen die Kälte. Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под промокшим плащом Гонерилья прижимает дыхание к груди, спасаясь от холода. Я стискиваю слово «беспощадный» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Grausamkeit",
@@ -2434,8 +2434,8 @@
                 "word": "verhärten",
                 "translation": "ожесточаться",
                 "transcription": "[фер-ХЕР-тен]",
-                "sentence": "Vor den Toren ihres Schlosses stößt Goneril den Vater hinaus: Mein Herz verhärtet sich gegen alle Bitten.",
-                "sentenceTranslation": "Перед воротами своего замка Гонериль выталкивает отца: Моё сердце ожесточается против всех просьб.",
+                "sentence": "Am kläglichen Feuerrest wärmt Goneril zitternde Finger. Ich atme tief ein und lasse nur das Wort „verhärten“ wieder hinaus.",
+                "sentenceTranslation": "У жалких огненных углей Гонерилья греет дрожащие пальцы. Я глубоко вдыхаю и выпускаю только слово «ожесточаться».",
                 "visual_hint": "📚",
                 "themes": [
                     "Sturm",
@@ -2459,72 +2459,72 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "отвергать",
-                    "запирать",
                     "буря",
-                    "безжалостный"
+                    "безжалостный",
+                    "запирать",
+                    "отвергать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "запирать",
-                    "безжалостный",
                     "буря",
-                    "отвергать"
+                    "отвергать",
+                    "безжалостный",
+                    "запирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «gnadenlos»?",
                 "choices": [
                     "безжалостный",
-                    "беспощадный",
-                    "холод",
-                    "буря"
+                    "буря",
+                    "ожесточаться",
+                    "беспощадный"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verschließen»?",
                 "choices": [
-                    "отвергать",
-                    "запирать",
-                    "беспощадный",
-                    "холод"
+                    "буря",
+                    "ожесточаться",
+                    "безжалостный",
+                    "запирать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "безжалостный",
-                    "беспощадный",
                     "холод",
-                    "отвергать"
+                    "запирать",
+                    "буря",
+                    "ожесточаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
-                    "безжалостный",
-                    "беспощадный",
-                    "ожесточаться",
-                    "холод"
+                    "отвергать",
+                    "запирать",
+                    "буря",
+                    "беспощадный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verhärten»?",
                 "choices": [
-                    "безжалостный",
-                    "холод",
-                    "буря",
-                    "ожесточаться"
+                    "беспощадный",
+                    "ожесточаться",
+                    "запирать",
+                    "безжалостный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2537,8 +2537,8 @@
                 "word": "streiten",
                 "translation": "ссориться",
                 "transcription": "[ШТРАЙ-тен]",
-                "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Ich streite mit meinem schwachen Mann.",
-                "sentenceTranslation": "В военном лагере Олбани Гонериль ссорится с мужем: Я ссорюсь со своим слабым мужем.",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Goneril bei der flackernden Kerze. Ich atme tief ein und lasse nur das Wort „streiten“ wieder hinaus.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Гонерилья сидит у мерцающей свечи. Я глубоко вдыхаю и выпускаю только слово «ссориться».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2561,8 +2561,8 @@
                 "word": "verraten",
                 "translation": "предавать",
                 "transcription": "[фер-РА-тен]",
-                "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Ich verrate meinen Mann für Edmund.",
-                "sentenceTranslation": "В военном лагере Олбани Гонериль ссорится с мужем: Я предаю мужа ради Эдмунда.",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Goneril über ein altes Wappen. Ich atme tief ein und lasse nur das Wort „verraten“ wieder hinaus.",
+                "sentenceTranslation": "Среди помятых доспехов Гонерилья гладит старый герб. Я глубоко вдыхаю и выпускаю только слово «предавать».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2589,8 +2589,8 @@
                 "word": "die Zwietracht",
                 "translation": "раздор",
                 "transcription": "[ди ЦВИ-трахт]",
-                "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Die Zwietracht zerstört unsere Ehe.",
-                "sentenceTranslation": "В военном лагере Олбани Гонериль ссорится с мужем: Раздор разрушает наш брак.",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Goneril fast den Kopf. Ich zeichne das Wort „die Zwietracht“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "О низкую балку хижины Гонерилья едва не ударяется головой. Я черчу слово «раздор» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Zwietracht",
@@ -2613,8 +2613,8 @@
                 "word": "hassen",
                 "translation": "ненавидеть",
                 "transcription": "[ХА-сен]",
-                "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Ich hasse seine Schwäche und Güte.",
-                "sentenceTranslation": "В военном лагере Олбани Гонериль ссорится с мужем: Я ненавижу его слабость и доброту.",
+                "sentence": "Neben der schlafenden Wache flüstert Goneril in die schwere Nacht. Ich zeichne das Wort „hassen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Рядом со спящим стражем Гонерилья шепчет в тяжёлую ночь. Я черчу слово «ненавидеть» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2637,8 +2637,8 @@
                 "word": "betrügen",
                 "translation": "изменять",
                 "transcription": "[бе-ТРЮ-ген]",
-                "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Ich betrüge ihn mit Edmund.",
-                "sentenceTranslation": "В военном лагере Олбани Гонериль ссорится с мужем: Я изменяю ему с Эдмундом.",
+                "sentence": "Vor dem einfachen Feldbett betrachtet Goneril die Narben vergangener Schlachten. Ich zeichne das Wort „betrügen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед грубой походной койкой Гонерилья разглядывает шрамы прошлых битв. Я черчу слово «изменять» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2664,8 +2664,8 @@
                 "word": "die Verachtung",
                 "translation": "презрение",
                 "transcription": "[ди фер-АХ-тунг]",
-                "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Meine Verachtung für ihn wächst täglich.",
-                "sentenceTranslation": "В военном лагере Олбани Гонериль ссорится с мужем: Моё презрение к нему растёт ежедневно.",
+                "sentence": "Im Geruch von feuchtem Stroh legt Goneril den Mantel zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verachtung“ bleibt lebendig.",
+                "sentenceTranslation": "В запахе влажной соломы Гонерилья откладывает плащ в сторону. Каждой клеткой тела я обещаю: слово «презрение» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Zwietracht",
@@ -2688,8 +2688,8 @@
                 "word": "zerstören",
                 "translation": "разрушать",
                 "transcription": "[цер-ШТЁ-рен]",
-                "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Ich zerstöre alles, was uns verband.",
-                "sentenceTranslation": "В военном лагере Олбани Гонериль ссорится с мужем: Я разрушаю всё, что нас связывало.",
+                "sentence": "Auf dem wackligen Holztisch ordnet Goneril zerlesene Briefe. Ich presse das Wort „zerstören“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На шатком деревянном столе Гонерилья раскладывает зачитанные письма. Я стискиваю слово «разрушать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2711,8 +2711,8 @@
                 "word": "die Leidenschaft",
                 "translation": "страсть",
                 "transcription": "[ди ЛАЙ-ден-шафт]",
-                "sentence": "In Albanys Kriegslager streitet Goneril mit ihrem Mann: Meine Leidenschaft gilt nur Edmund.",
-                "sentenceTranslation": "В военном лагере Олбани Гонериль ссорится с мужем: Моя страсть принадлежит только Эдмунду.",
+                "sentence": "Am Eingang der Hütte späht Goneril nach einem vertrauten Schatten. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leidenschaft“ bleibt lebendig.",
+                "sentenceTranslation": "У входа в хижину Гонерилья высматривает знакомую тень. Каждой клеткой тела я обещаю: слово «страсть» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2735,42 +2735,42 @@
             {
                 "question": "Что означает немецкое слово «streiten»?",
                 "choices": [
-                    "предавать",
+                    "раздор",
                     "ненавидеть",
                     "ссориться",
-                    "раздор"
+                    "предавать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
+                    "предавать",
                     "ссориться",
-                    "ненавидеть",
                     "раздор",
-                    "предавать"
+                    "ненавидеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Zwietracht»?",
                 "choices": [
+                    "ссориться",
+                    "раздор",
                     "изменять",
-                    "ненавидеть",
-                    "предавать",
-                    "раздор"
+                    "ненавидеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
-                    "ссориться",
+                    "раздор",
+                    "презрение",
                     "ненавидеть",
-                    "предавать",
-                    "разрушать"
+                    "страсть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «betrügen»?",
@@ -2778,39 +2778,39 @@
                     "изменять",
                     "ненавидеть",
                     "разрушать",
-                    "ссориться"
+                    "презрение"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Verachtung»?",
                 "choices": [
+                    "ссориться",
                     "презрение",
                     "предавать",
-                    "изменять",
-                    "разрушать"
+                    "ненавидеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «zerstören»?",
                 "choices": [
+                    "разрушать",
+                    "предавать",
                     "изменять",
-                    "ненавидеть",
-                    "раздор",
-                    "разрушать"
+                    "презрение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Leidenschaft»?",
                 "choices": [
+                    "презрение",
                     "изменять",
-                    "страсть",
                     "раздор",
-                    "ссориться"
+                    "страсть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2823,8 +2823,8 @@
                 "word": "die Eifersucht",
                 "translation": "ревность",
                 "transcription": "[ди АЙ-фер-зухт]",
-                "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Die Eifersucht verzehrt mich von innen.",
-                "sentenceTranslation": "В поле под Дувром Гонериль злится на Регану: Ревность пожирает меня изнутри.",
+                "sentence": "Auf den weißen Klippen von Dover blickt Goneril in den aufgewühlten Kanal. Wie ein stilles Gebet legt sich das Wort „die Eifersucht“ auf meine Lippen.",
+                "sentenceTranslation": "На белых скалах Дувра Гонерилья смотрит в вздыбленный пролив. Как тихая молитва слово «ревность» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2846,8 +2846,8 @@
                 "word": "rivalisieren",
                 "translation": "соперничать",
                 "transcription": "[ри-ва-ли-ЗИ-рен]",
-                "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Ich rivalisiere mit meiner Schwester um Edmund.",
-                "sentenceTranslation": "В поле под Дувром Гонериль злится на Регану: Я соперничаю с сестрой за Эдмунда.",
+                "sentence": "Zwischen flatternden Feldzeichen richtet Goneril den Helm. Wie ein stilles Gebet legt sich das Wort „rivalisieren“ auf meine Lippen.",
+                "sentenceTranslation": "Среди хлопающих штандартов Гонерилья поправляет шлем. Как тихая молитва слово «соперничать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Eifersucht",
@@ -2870,8 +2870,8 @@
                 "word": "kämpfen",
                 "translation": "бороться",
                 "transcription": "[КЕМП-фен]",
-                "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Ich kämpfe um das, was ich begehre.",
-                "sentenceTranslation": "В поле под Дувром Гонериль злится на Регану: Я борюсь за то, чего желаю.",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Goneril Marschrouten in den Sand. Selbst wenn die Welt zerfällt, bleibt das Wort „kämpfen“ mein Nordstern.",
+                "sentenceTranslation": "У французского костра Гонерилья рисует в песке путь марша. Даже если мир распадается, слово «бороться» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2896,8 +2896,8 @@
                 "word": "begehren",
                 "translation": "желать",
                 "transcription": "[бе-ГЕ-рен]",
-                "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Ich begehre Edmund mehr als mein Leben.",
-                "sentenceTranslation": "В поле под Дувром Гонериль злится на Регану: Я желаю Эдмунда больше жизни.",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Goneril das Siegel. Mit fester Stimme schwöre ich mir: Das Wort „begehren“ wird heute nicht verraten.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Гонерилья проверяет печати. Твёрдым голосом я клянусь себе: слово «желать» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2924,8 +2924,8 @@
                 "word": "beseitigen",
                 "translation": "устранять",
                 "transcription": "[бе-ЗАЙ-ти-ген]",
-                "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Ich muss meine Schwester beseitigen.",
-                "sentenceTranslation": "В поле под Дувром Гонериль злится на Регану: Я должна устранить свою сестру.",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Goneril dem dumpfen Meer. Ich zeichne das Wort „beseitigen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Гонерилья слушает глухой шум моря. Я черчу слово «устранять» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Eifersucht",
@@ -2948,8 +2948,8 @@
                 "word": "das Gift",
                 "translation": "яд",
                 "transcription": "[дас ГИФТ]",
-                "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Das Gift ist bereit für meine Schwester.",
-                "sentenceTranslation": "В поле под Дувром Гонериль злится на Регану: Яд готов для моей сестры.",
+                "sentence": "Auf dem sandigen Trainingsplatz übt Goneril das Ziehen des Schwerts. Ich zeichne das Wort „das Gift“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На песчаном плацу Гонерилья отрабатывает выхват меча. Я вывожу слово «яд» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Eifersucht",
@@ -2972,8 +2972,8 @@
                 "word": "die Intrige",
                 "translation": "интрига",
                 "transcription": "[ди ин-ТРИ-ге]",
-                "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Meine Intrige wird sie vernichten.",
-                "sentenceTranslation": "В поле под Дувром Гонериль злится на Регану: Моя интрига уничтожит её.",
+                "sentence": "Zwischen pochenden Trommeln hebt Goneril das Banner der Hoffnung. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Intrige“ darf nicht vergehen.",
+                "sentenceTranslation": "Под гул барабанов Гонерилья поднимает знамя надежды. Я шепчу стражам судьбы: слово «интрига» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2998,8 +2998,8 @@
                 "word": "morden",
                 "translation": "убивать",
                 "transcription": "[МОР-ден]",
-                "sentence": "Im Feldlager vor Dover grollt Goneril gegen Regan: Ich bin bereit zu morden für meine Lust.",
-                "sentenceTranslation": "В поле под Дувром Гонериль злится на Регану: Я готова убивать ради своей страсти.",
+                "sentence": "Am Morgennebel der Küste legt Goneril die Hand auf das pochende Herz. Wie ein stilles Gebet legt sich das Wort „morden“ auf meine Lippen.",
+                "sentenceTranslation": "В утреннем тумане побережья Гонерилья кладёт ладонь на бьющееся сердце. Как тихая молитва слово «убивать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3023,82 +3023,82 @@
             {
                 "question": "Что означает немецкое слово «die Eifersucht»?",
                 "choices": [
-                    "бороться",
                     "ревность",
-                    "желать",
-                    "соперничать"
+                    "соперничать",
+                    "бороться",
+                    "желать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «rivalisieren»?",
                 "choices": [
-                    "ревность",
                     "бороться",
                     "желать",
-                    "соперничать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «kämpfen»?",
-                "choices": [
-                    "убивать",
-                    "ревность",
-                    "бороться",
-                    "яд"
+                    "соперничать",
+                    "ревность"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «kämpfen»?",
+                "choices": [
+                    "интрига",
+                    "бороться",
+                    "ревность",
+                    "убивать"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "яд",
-                    "убивать",
                     "интрига",
-                    "желать"
+                    "желать",
+                    "соперничать",
+                    "ревность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beseitigen»?",
                 "choices": [
                     "устранять",
-                    "желать",
-                    "яд",
-                    "бороться"
+                    "интрига",
+                    "бороться",
+                    "соперничать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Gift»?",
                 "choices": [
-                    "устранять",
-                    "ревность",
+                    "бороться",
                     "яд",
-                    "соперничать"
+                    "соперничать",
+                    "устранять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "желать",
-                    "устранять",
+                    "яд",
                     "интрига",
-                    "соперничать"
+                    "ревность",
+                    "устранять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «morden»?",
                 "choices": [
                     "ревность",
-                    "желать",
-                    "убивать",
-                    "бороться"
+                    "соперничать",
+                    "устранять",
+                    "убивать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -3111,8 +3111,8 @@
                 "word": "vergiften",
                 "translation": "отравлять",
                 "transcription": "[фер-ГИФ-тен]",
-                "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Ich vergifte erst meine Schwester, dann mich selbst.",
-                "sentenceTranslation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Я отравляю сначала сестру, потом себя.",
+                "sentence": "Im feuchten Kerker stützt Goneril sich an den tropfenden Stein. Das Echo des Wortes „vergiften“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В сыром подземелье Гонерилья опирается на сочащийся камень. Эхо слова «отравлять» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3134,8 +3134,8 @@
                 "word": "die Verzweiflung",
                 "translation": "отчаяние",
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
-                "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Die Verzweiflung führt mich zum Tod.",
-                "sentenceTranslation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Отчаяние ведёт меня к смерти.",
+                "sentence": "Unter der trüben Laterne zählt Goneril die eisernen Ringe der Kette. Das Echo des Wortes „die Verzweiflung“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Под мутным фонарём Гонерилья пересчитывает железные кольца цепи. Эхо слова «отчаяние» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3160,8 +3160,8 @@
                 "word": "sterben",
                 "translation": "умирать",
                 "transcription": "[ШТЕР-бен]",
-                "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Ich sterbe durch meine eigene Hand.",
-                "sentenceTranslation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Я умираю от своей собственной руки.",
+                "sentence": "Neben der schweren Holztür horcht Goneril auf entferntes Schluchzen. Ich zeichne das Wort „sterben“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У тяжёлой двери Гонерилья прислушивается к далёким рыданиям. Я черчу слово «умирать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3187,8 +3187,8 @@
                 "word": "die Schuld",
                 "translation": "вина",
                 "transcription": "[ди ШУЛЬД]",
-                "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Die Schuld erdrückt mich am Ende.",
-                "sentenceTranslation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Вина давит меня в конце.",
+                "sentence": "Auf der kalten Steinbank zieht Goneril den Mantel enger um die Schultern. Ich halte das Wort „die Schuld“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На холодной каменной скамье Гонерилья плотнее кутается в плащ. Я держу слово «вина» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3210,8 +3210,8 @@
                 "word": "vernichten",
                 "translation": "уничтожать",
                 "transcription": "[фер-НИХ-тен]",
-                "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Ich vernichte mich selbst durch meine Bosheit.",
-                "sentenceTranslation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Я уничтожаю себя своим злом.",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Goneril das Gesicht zum Licht. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vernichten“ gehört mir.",
+                "sentenceTranslation": "Между тенями решёток Гонерилья поднимает лицо к свету. Буря за окнами усиливает клятву: слово «уничтожать» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3233,8 +3233,8 @@
                 "word": "das Verderben",
                 "translation": "погибель",
                 "transcription": "[дас фер-ДЕР-бен]",
-                "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Das Verderben holt mich ein.",
-                "sentenceTranslation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Погибель настигает меня.",
+                "sentence": "Am rostigen Wassereimer spiegelt Goneril kurz die eigenen Augen. Mein Atem zeichnet das Wort „das Verderben“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У ржавого ведра с водой Гонерилья на мгновение видит отражение глаз. Моё дыхание рисует слово «погибель» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Verzweiflung",
@@ -3257,8 +3257,8 @@
                 "word": "bereuen",
                 "translation": "сожалеть",
                 "transcription": "[бе-РОЙ-ен]",
-                "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Zu spät bereue ich meine Taten.",
-                "sentenceTranslation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Слишком поздно я сожалею о своих делах.",
+                "sentence": "Im dumpfen Hall der Schritte zählt Goneril den Rhythmus der Wachen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „bereuen“ darf nicht vergehen.",
+                "sentenceTranslation": "В глухом эхе шагов Гонерилья отсчитывает ритм часовых. Я шепчу стражам судьбы: слово «сожалеть» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3283,8 +3283,8 @@
                 "word": "die Hölle",
                 "translation": "ад",
                 "transcription": "[ди ХЁ-ле]",
-                "sentence": "Allein in ihrem Zelt nach Regans Tod flüstert Goneril: Die Hölle wartet auf meine schwarze Seele.",
-                "sentenceTranslation": "Одна в своём шатре после смерти Реганы Гонериль шепчет: Ад ждёт мою чёрную душу.",
+                "sentence": "Vor dem verriegelten Fenster zeichnet Goneril Kreise in den Staub. Selbst wenn die Welt zerfällt, bleibt das Wort „die Hölle“ mein Nordstern.",
+                "sentenceTranslation": "Перед заколоченным окном Гонерилья чертит круги в пыли. Даже если мир распадается, слово «ад» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3307,82 +3307,82 @@
             {
                 "question": "Что означает немецкое слово «vergiften»?",
                 "choices": [
-                    "отравлять",
-                    "отчаяние",
+                    "вина",
                     "умирать",
-                    "вина"
+                    "отчаяние",
+                    "отравлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
                     "отравлять",
-                    "отчаяние",
                     "умирать",
+                    "отчаяние",
                     "вина"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "умирать",
-                    "отравлять",
                     "вина",
-                    "ад"
+                    "сожалеть",
+                    "умирать",
+                    "отравлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Schuld»?",
                 "choices": [
-                    "умирать",
                     "вина",
                     "отравлять",
-                    "ад"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «vernichten»?",
-                "choices": [
-                    "уничтожать",
                     "ад",
-                    "вина",
                     "отчаяние"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «das Verderben»?",
+                "question": "Что означает немецкое слово «vernichten»?",
                 "choices": [
-                    "отчаяние",
                     "вина",
-                    "погибель",
+                    "ад",
+                    "отчаяние",
                     "уничтожать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «das Verderben»?",
+                "choices": [
+                    "уничтожать",
+                    "ад",
+                    "вина",
+                    "погибель"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "умирать",
                     "сожалеть",
-                    "погибель",
-                    "вина"
+                    "отчаяние",
+                    "умирать",
+                    "отравлять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Hölle»?",
                 "choices": [
-                    "ад",
-                    "отчаяние",
-                    "отравлять",
-                    "вина"
+                    "умирать",
+                    "вина",
+                    "сожалеть",
+                    "ад"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -3913,27 +3913,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/kent.html
+++ b/output/journeys/kent.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["мужество", "верность", "возражать", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["верность", "возражать", "защищать", "мужество"], "correct_index": 3}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["искренний", "возражать", "мужество", "предупреждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["предупреждать", "справедливый", "защищать", "искренний"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["слуга", "справедливый", "искренний", "возражать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["справедливый", "слуга", "искренний", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["предупреждать", "искренний", "верность", "мужество"], "correct_index": 0}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["справедливый", "мужество", "защищать", "предупреждать"], "correct_index": 0}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["изгнанный", "гнев", "несправедливость", "изгнание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["изгнанный", "изгнание", "гнев", "несправедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["наказание", "изгнанный", "гнев", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["изгнание", "наказание", "гнев", "изгнанный"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["изгнанный", "гнев", "возвращаться", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возвращаться", "прощание", "несправедливость", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["изгнанный", "гнев", "возвращаться", "изгнание"], "correct_index": 2}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["хитрость", "переодевание", "неузнанный", "притворяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["неузнанный", "притворяться", "переодевание", "хитрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["наниматься", "борода", "неузнанный", "изменять"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["борода", "переодевание", "неузнанный", "притворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["изменять", "хитрость", "борода", "наниматься"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["наниматься", "хитрость", "верный", "борода"], "correct_index": 3}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["верный", "хитрость", "борода", "наниматься"], "correct_index": 3}, {"question": "Что означает немецкое слово «treu»?", "choices": ["переодевание", "изменять", "верный", "хитрость"], "correct_index": 2}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["опасность", "охранять", "защита", "служба"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["охранять", "защита", "служба", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["стража", "опасность", "охранять", "защита"], "correct_index": 1}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["защита", "охранять", "советовать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["сражаться", "охранять", "стража", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «raten»?", "choices": ["служба", "стража", "охранять", "советовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["опасность", "защита", "советовать", "стража"], "correct_index": 3}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "сковывать", "стойкость", "унижение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["наказание", "стойкость", "унижение", "сковывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["унижение", "колодка", "стойкость", "выдерживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["сковывать", "унижение", "выдерживать", "колодка"], "correct_index": 0}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["терпеть", "стойкость", "выдерживать", "позор"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["выдерживать", "наказание", "сковывать", "колодка"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["унижение", "сковывать", "стойкость", "выдерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["позор", "выдерживать", "стойкость", "унижение"], "correct_index": 0}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "сопровождать", "утешать", "поддержка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["поддержка", "буря", "утешать", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["сопровождать", "выдерживать", "утешать", "холод"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["убежище", "холод", "утешать", "поддержка"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["сопровождать", "буря", "утешать", "убежище"], "correct_index": 3}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["убежище", "выдерживать", "утешать", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["утешать", "холод", "поддержка", "выдерживать"], "correct_index": 1}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "плакать", "вечный", "прощание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "плакать", "вечный", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["скорбь", "вечный", "сдаваться", "плакать"], "correct_index": 1}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["сдаваться", "плакать", "следовать", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["скорбь", "сдаваться", "следовать", "истощение"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["скорбь", "смерть", "плакать", "сдаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["истощение", "скорбь", "плакать", "сдаваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["истощение", "плакать", "сдаваться", "следовать"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["возражать", "мужество", "защищать", "верность"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "верность", "возражать", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["искренний", "возражать", "верность", "мужество"], "correct_index": 1}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["искренний", "защищать", "предупреждать", "слуга"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["мужество", "искренний", "справедливый", "возражать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["верность", "защищать", "возражать", "слуга"], "correct_index": 3}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["предупреждать", "искренний", "мужество", "справедливый"], "correct_index": 0}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["возражать", "справедливый", "слуга", "верность"], "correct_index": 1}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["несправедливость", "изгнание", "гнев", "изгнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["гнев", "изгнание", "несправедливость", "изгнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["гнев", "несправедливость", "изгнание", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["изгнанный", "прощание", "изгнание", "возвращаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["наказание", "прощание", "изгнание", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возвращаться", "изгнанный", "гнев", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["несправедливость", "возвращаться", "гнев", "изгнанный"], "correct_index": 1}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["хитрость", "переодевание", "неузнанный", "притворяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["притворяться", "хитрость", "неузнанный", "переодевание"], "correct_index": 1}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["притворяться", "переодевание", "неузнанный", "изменять"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["притворяться", "верный", "неузнанный", "хитрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["неузнанный", "хитрость", "изменять", "наниматься"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["верный", "неузнанный", "борода", "притворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["изменять", "переодевание", "наниматься", "неузнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["верный", "наниматься", "изменять", "притворяться"], "correct_index": 0}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["защита", "опасность", "служба", "охранять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["опасность", "охранять", "защита", "служба"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["защита", "опасность", "сражаться", "служба"], "correct_index": 1}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["опасность", "охранять", "сражаться", "служба"], "correct_index": 1}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["сражаться", "советовать", "опасность", "охранять"], "correct_index": 0}, {"question": "Что означает немецкое слово «raten»?", "choices": ["стража", "советовать", "служба", "охранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["служба", "защита", "стража", "охранять"], "correct_index": 2}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "стойкость", "унижение", "сковывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["наказание", "сковывать", "стойкость", "унижение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["унижение", "позор", "терпеть", "стойкость"], "correct_index": 3}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["терпеть", "наказание", "сковывать", "колодка"], "correct_index": 2}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["терпеть", "позор", "стойкость", "колодка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["сковывать", "выдерживать", "колодка", "позор"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["сковывать", "выдерживать", "терпеть", "позор"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["наказание", "колодка", "позор", "выдерживать"], "correct_index": 2}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["сопровождать", "утешать", "буря", "поддержка"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["буря", "поддержка", "утешать", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["сопровождать", "буря", "холод", "убежище"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["сопровождать", "выдерживать", "утешать", "поддержка"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["убежище", "буря", "поддержка", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["выдерживать", "буря", "холод", "поддержка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["поддержка", "холод", "убежище", "сопровождать"], "correct_index": 1}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "вечный", "плакать", "прощание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["вечный", "смерть", "плакать", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["плакать", "сдаваться", "скорбь", "вечный"], "correct_index": 3}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["истощение", "вечный", "прощание", "плакать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["скорбь", "истощение", "вечный", "плакать"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["вечный", "истощение", "скорбь", "сдаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["смерть", "вечный", "сдаваться", "скорбь"], "correct_index": 3}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["смерть", "следовать", "сдаваться", "прощание"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Верность королю</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,8 +465,24 @@
             <div class="quiz-phase-container active" data-phase="loyalty">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
@@ -481,22 +497,6 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «widersprechen»?</div>
                         <div class="quiz-choices">
@@ -505,39 +505,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">искренний</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
                             
@@ -545,17 +545,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -569,25 +569,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">искренний</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «gerecht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,61 +600,13 @@
             <div class="quiz-phase-container" data-phase="banishment">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Verbannung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verbannt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
@@ -664,17 +616,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verbannt»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -686,9 +686,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
@@ -696,17 +696,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,17 +735,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die List»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">переодевание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -755,9 +755,9 @@
                         <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наниматься</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
                             
@@ -767,15 +767,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «vorgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наниматься</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
                             
@@ -783,65 +815,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наниматься</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наниматься</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наниматься</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наниматься</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «treu»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,8 +854,24 @@
             <div class="quiz-phase-container" data-phase="service">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Dienst»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
@@ -870,33 +886,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -906,13 +906,13 @@
                         <div class="quiz-question">Что означает немецкое слово «bewachen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">советовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -924,43 +924,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">советовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «raten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">стража</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">советовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Wache»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">советовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Wache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">советовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">стража</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -979,22 +979,6 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
@@ -1005,31 +989,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Standhaftigkeit»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Standhaftigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «fesseln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">колодка</button>
                             
@@ -1043,25 +1043,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">колодка</button>
                             
@@ -1069,33 +1053,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ausharren»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">колодка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «ausharren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">позор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">позор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,15 +1108,15 @@
             <div class="quiz-phase-container" data-phase="storm_companion">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
                             
@@ -1124,13 +1124,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Beistand»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
@@ -1146,11 +1146,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">убежище</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1160,9 +1160,9 @@
                         <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
@@ -1172,33 +1172,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">убежище</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1208,13 +1208,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">убежище</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1233,9 +1233,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
@@ -1243,31 +1243,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
                             
@@ -1275,33 +1291,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Erschöpfung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">истощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1311,11 +1311,11 @@
                         <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
                             
@@ -1323,33 +1323,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «folgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">следовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">следовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1376,8 +1376,8 @@
                 "word": "die Treue",
                 "translation": "верность",
                 "transcription": "[ди ТРОЙ-е]",
-                "sentence": "Im Thronsaal von Lear kniet Kent: Die Treue zu meinem König ist unerschütterlich.",
-                "sentenceTranslation": "В тронном зале Лира Кент преклоняется: Верность моему королю непоколебима.",
+                "sentence": "Mitten im Tumult der Thronfeier tritt Kent vor den Königsthron. Ich zeichne das Wort „die Treue“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Посреди суматохи тронной церемонии Кент выходит к королевскому трону. Я вывожу слово «верность» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1400,8 +1400,8 @@
                 "word": "der Mut",
                 "translation": "мужество",
                 "transcription": "[дер МУТ]",
-                "sentence": "Im Thronsaal von Lear kniet Kent: Der Mut fordert mich, die Wahrheit zu sagen.",
-                "sentenceTranslation": "В тронном зале Лира Кент преклоняется: Мужество требует от меня говорить правду.",
+                "sentence": "Zwischen scharfgezogenen Schwertern stellt sich Kent vor die jüngste Tochter. Ich halte das Wort „der Mut“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Между обнажёнными мечами Кент встаёт перед младшей дочерью. Я держу слово «мужество» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1424,8 +1424,8 @@
                 "word": "widersprechen",
                 "translation": "возражать",
                 "transcription": "[ВИ-дер-шпре-хен]",
-                "sentence": "Im Thronsaal von Lear kniet Kent: Ich widerspreche dem König für seine eigene Ehre.",
-                "sentenceTranslation": "В тронном зале Лира Кент преклоняется: Я возражаю королю ради его же чести.",
+                "sentence": "Vor der erstaunten Ritterschar reißt Kent sein Wappen vom Brustpanzer. Ich presse das Wort „widersprechen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Перед изумлёнными рыцарями Кент срывает герб с нагрудника. Я стискиваю слово «возражать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1448,8 +1448,8 @@
                 "word": "verteidigen",
                 "translation": "защищать",
                 "transcription": "[фер-ТАЙ-ди-ген]",
-                "sentence": "Im Thronsaal von Lear kniet Kent: Ich verteidige Корделия gegen Ungerechtigkeit.",
-                "sentenceTranslation": "В тронном зале Лира Кент преклоняется: Я защищаю Корделию от несправедливости.",
+                "sentence": "Unter den strengen Blicken des Hofes schlägt Kent die Faust auf das Geländer. Ich flüstere den Wächtern des Schicksals zu: Das Wort „verteidigen“ darf nicht vergehen.",
+                "sentenceTranslation": "Под строгими взглядами двора Кент бьёт кулаком по перилам. Я шепчу стражам судьбы: слово «защищать» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1473,8 +1473,8 @@
                 "word": "aufrichtig",
                 "translation": "искренний",
                 "transcription": "[АУФ-рих-тиг]",
-                "sentence": "Im Thronsaal von Lear kniet Kent: Ich bin aufrichtig, auch wenn es gefährlich ist.",
-                "sentenceTranslation": "В тронном зале Лира Кент преклоняется: Я искренен, даже если это опасно.",
+                "sentence": "Neben Lears Stab kniet Kent und hebt unbeirrbar den Kopf. Das Echo des Wortes „aufrichtig“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У посоха Лира Кент встаёт на колено и упрямо поднимает голову. Эхо слова «искренний» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mut",
@@ -1497,8 +1497,8 @@
                 "word": "der Diener",
                 "translation": "слуга",
                 "transcription": "[дер ДИ-нер]",
-                "sentence": "Im Thronsaal von Lear kniet Kent: Als treuer Diener spreche ich offen.",
-                "sentenceTranslation": "В тронном зале Лира Кент преклоняется: Как верный слуга, я говорю открыто.",
+                "sentence": "Auf den Stufen zur Thronrampe breitet Kent schützend die Arme aus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Diener“ bleibt lebendig.",
+                "sentenceTranslation": "На ступенях ведущих к трону Кент защитно разводит руки. Каждой клеткой тела я обещаю: слово «слуга» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1521,8 +1521,8 @@
                 "word": "warnen",
                 "translation": "предупреждать",
                 "transcription": "[ВАР-нен]",
-                "sentence": "Im Thronsaal von Lear kniet Kent: Ich warne den König vor seinem Fehler.",
-                "sentenceTranslation": "В тронном зале Лира Кент преклоняется: Я предупреждаю короля об его ошибке.",
+                "sentence": "Zwischen höfischen Fanfaren ruft Kent seine Warnung gegen das Hofgeflüster. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „warnen“ gehört mir.",
+                "sentenceTranslation": "Среди придворных фанфар Кент выкрикивает предупреждение против шёпота двора. Буря за окнами усиливает клятву: слово «предупреждать» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mut",
@@ -1545,8 +1545,8 @@
                 "word": "gerecht",
                 "translation": "справедливый",
                 "transcription": "[ге-РЕХТ]",
-                "sentence": "Im Thronsaal von Lear kniet Kent: Ich kämpfe für das, was gerecht ist.",
-                "sentenceTranslation": "В тронном зале Лира Кент преклоняется: Я борюсь за то, что справедливо.",
+                "sentence": "Im Schatten des Königsbanners legt Kent die Hand auf das Herz. Ich presse das Wort „gerecht“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В тени королевского знамени Кент кладёт руку на сердце. Я стискиваю слово «справедливый» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Mut",
@@ -1570,82 +1570,82 @@
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
+                    "возражать",
+                    "мужество",
+                    "защищать",
+                    "верность"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Mut»?",
+                "choices": [
                     "мужество",
                     "верность",
                     "возражать",
                     "защищать"
                 ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Mut»?",
-                "choices": [
-                    "верность",
-                    "возражать",
-                    "защищать",
-                    "мужество"
-                ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «widersprechen»?",
                 "choices": [
                     "искренний",
                     "возражать",
-                    "мужество",
-                    "предупреждать"
+                    "верность",
+                    "мужество"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verteidigen»?",
                 "choices": [
-                    "предупреждать",
-                    "справедливый",
+                    "искренний",
                     "защищать",
-                    "искренний"
+                    "предупреждать",
+                    "слуга"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufrichtig»?",
                 "choices": [
-                    "слуга",
-                    "справедливый",
+                    "мужество",
                     "искренний",
+                    "справедливый",
                     "возражать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
-                    "справедливый",
-                    "слуга",
-                    "искренний",
-                    "защищать"
+                    "верность",
+                    "защищать",
+                    "возражать",
+                    "слуга"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «warnen»?",
                 "choices": [
                     "предупреждать",
                     "искренний",
-                    "верность",
-                    "мужество"
+                    "мужество",
+                    "справедливый"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «gerecht»?",
                 "choices": [
+                    "возражать",
                     "справедливый",
-                    "мужество",
-                    "защищать",
-                    "предупреждать"
+                    "слуга",
+                    "верность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -1658,8 +1658,8 @@
                 "word": "die Verbannung",
                 "translation": "изгнание",
                 "transcription": "[ди фер-БА-нунг]",
-                "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Die Verbannung ist der Preis für meine Ehrlichkeit.",
-                "sentenceTranslation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Изгнание - цена моей честности.",
+                "sentence": "Auf den kalten Stufen des Hofes hört Kent das Urteil der Verbannung. Ich zeichne das Wort „die Verbannung“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На холодных ступенях двора Кент слышит приговор об изгнании. Я черчу слово «изгнание» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ungerechtigkeit",
@@ -1683,8 +1683,8 @@
                 "word": "die Ungerechtigkeit",
                 "translation": "несправедливость",
                 "transcription": "[ди УН-ге-рех-тиг-кайт]",
-                "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Diese Ungerechtigkeit werde ich nicht akzeptieren.",
-                "sentenceTranslation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Эту несправедливость я не приму.",
+                "sentence": "Zwischen abziehenden Soldaten hält Kent nur den Reisestock in der Hand. Wie ein stilles Gebet legt sich das Wort „die Ungerechtigkeit“ auf meine Lippen.",
+                "sentenceTranslation": "Среди расходящихся солдат Кент сжимает в руке лишь дорожный посох. Как тихая молитва слово «несправедливость» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ungerechtigkeit",
@@ -1711,8 +1711,8 @@
                 "word": "der Zorn",
                 "translation": "гнев",
                 "transcription": "[дер ЦОРН]",
-                "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Der Zorn des Königs trifft mich ungerecht.",
-                "sentenceTranslation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Гнев короля поражает меня несправедливо.",
+                "sentence": "Vor dem geschlossenen Burgtor wirft Kent den Blick noch einmal zurück. Das kalte Licht lässt das Wort „der Zorn“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "У закрытых ворот замка Кент бросает последний взгляд назад. Холодный свет заставляет слово «гнев» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1737,8 +1737,8 @@
                 "word": "verbannt",
                 "translation": "изгнанный",
                 "transcription": "[фер-БАНТ]",
-                "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Verbannt aus dem Land, das ich liebe.",
-                "sentenceTranslation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Изгнан из страны, которую люблю.",
+                "sentence": "Auf dem Regenpflaster bleibt Kent stehen, während die Trommeln schweigen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbannt“ gehört mir.",
+                "sentenceTranslation": "На мокрой мостовой Кент замирает, пока барабаны смолкают. Буря за окнами усиливает клятву: слово «изгнанный» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ungerechtigkeit",
@@ -1761,8 +1761,8 @@
                 "word": "der Abschied",
                 "translation": "прощание",
                 "transcription": "[дер АБ-шид]",
-                "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Der Abschied vom Hof schmerzt mich tief.",
-                "sentenceTranslation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Прощание с двором глубоко ранит меня.",
+                "sentence": "Zwischen verstreuten Reisebündeln befestigt Kent das Schwert am Gürtel. Ich atme tief ein und lasse nur das Wort „der Abschied“ wieder hinaus.",
+                "sentenceTranslation": "Среди разбросанных узлов Кент затягивает меч на поясе. Я глубоко вдыхаю и выпускаю только слово «прощание».",
                 "visual_hint": "📚",
                 "themes": [
                     "Abschied",
@@ -1796,8 +1796,8 @@
                 "word": "die Strafe",
                 "translation": "наказание",
                 "transcription": "[ди ШТРА-фе]",
-                "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Diese Strafe nehme ich mit Würde an.",
-                "sentenceTranslation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Это наказание я принимаю с достоинством.",
+                "sentence": "Unter dem grauen Himmel zieht Kent den Mantelkragen hoch. Ich presse das Wort „die Strafe“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под серым небом Кент поднимает ворот плаща. Я стискиваю слово «наказание» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1824,8 +1824,8 @@
                 "word": "zurückkehren",
                 "translation": "возвращаться",
                 "transcription": "[цу-РЮК-ке-рен]",
-                "sentence": "Vor der Hofpforte, nachdem Lear ihn verstoßen hat, ruft Kent: Ich schwöre, verkleidet zurückzukehren.",
-                "sentenceTranslation": "У ворот дворца, после изгнания Лиром, Кент восклицает: Я клянусь вернуться переодетым.",
+                "sentence": "Vor der trostlosen Landstraße richtet Kent den Blick entschlossen nach vorn. Mein Atem zeichnet das Wort „zurückkehren“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед пустынной дорогой Кент решительно смотрит вперёд. Моё дыхание рисует слово «возвращаться» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1851,59 +1851,59 @@
             {
                 "question": "Что означает немецкое слово «die Verbannung»?",
                 "choices": [
-                    "изгнанный",
-                    "гнев",
                     "несправедливость",
-                    "изгнание"
+                    "изгнание",
+                    "гнев",
+                    "изгнанный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
-                    "изгнанный",
+                    "гнев",
                     "изгнание",
-                    "гнев",
-                    "несправедливость"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Zorn»?",
-                "choices": [
-                    "наказание",
-                    "изгнанный",
-                    "гнев",
-                    "прощание"
+                    "несправедливость",
+                    "изгнанный"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «der Zorn»?",
+                "choices": [
+                    "гнев",
+                    "несправедливость",
+                    "изгнание",
+                    "наказание"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «verbannt»?",
                 "choices": [
+                    "изгнанный",
+                    "прощание",
                     "изгнание",
-                    "наказание",
-                    "гнев",
-                    "изгнанный"
+                    "возвращаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "изгнанный",
-                    "гнев",
-                    "возвращаться",
-                    "прощание"
+                    "наказание",
+                    "прощание",
+                    "изгнание",
+                    "гнев"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
                     "возвращаться",
-                    "прощание",
-                    "несправедливость",
+                    "изгнанный",
+                    "гнев",
                     "наказание"
                 ],
                 "correctIndex": 3
@@ -1911,12 +1911,12 @@
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
-                    "изгнанный",
-                    "гнев",
+                    "несправедливость",
                     "возвращаться",
-                    "изгнание"
+                    "гнев",
+                    "изгнанный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -1929,8 +1929,8 @@
                 "word": "die Verkleidung",
                 "translation": "переодевание",
                 "transcription": "[ди фер-КЛАЙ-дунг]",
-                "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: In Verkleidung diene ich meinem König weiter.",
-                "sentenceTranslation": "Перед замком Гонериль Кент надевает своё маскировочное платье: В переодевании я продолжаю служить королю.",
+                "sentence": "In der verqualmten Herberge streift Kent das grobe Knechtsgewand über. Wie ein stilles Gebet legt sich das Wort „die Verkleidung“ auf meine Lippen.",
+                "sentenceTranslation": "В задымлённой харчевне Кент натягивает грубое платье слуги. Как тихая молитва слово «переодевание» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "List",
@@ -1958,8 +1958,8 @@
                 "word": "die List",
                 "translation": "хитрость",
                 "transcription": "[ди ЛИСТ]",
-                "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Mit List kehre ich an den Hof zurück.",
-                "sentenceTranslation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Хитростью я возвращаюсь ко двору.",
+                "sentence": "Vor einem beschlagenen Spiegel übt Kent die raue Stimme des Kays. Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern.",
+                "sentenceTranslation": "Перед запотевшим зеркалом Кент тренирует хриплый голос Кая. Даже если мир распадается, слово «хитрость» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Klippe",
@@ -1990,8 +1990,8 @@
                 "word": "unerkannt",
                 "translation": "неузнанный",
                 "transcription": "[УН-ер-кант]",
-                "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Unerkannt bleibe ich an seiner Seite.",
-                "sentenceTranslation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Неузнанным я остаюсь рядом с ним.",
+                "sentence": "Unter einem zerknitterten Hut verbirgt Kent die königliche Haltung. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unerkannt“ gehört mir.",
+                "sentenceTranslation": "Под мятой шляпой Кент скрывает королевскую осанку. Буря за окнами усиливает клятву: слово «неузнанный» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "List",
@@ -2014,8 +2014,8 @@
                 "word": "vorgeben",
                 "translation": "притворяться",
                 "transcription": "[ФОР-ге-бен]",
-                "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Ich gebe vor, ein einfacher Mann zu sein.",
-                "sentenceTranslation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Я притворяюсь простым человеком.",
+                "sentence": "Zwischen neugierigen Fuhrknechten studiert Kent die Dienstbefehle. Ich zeichne das Wort „vorgeben“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Среди любопытных возниц Кент изучает служебные приказы. Я вывожу слово «притворяться» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "List",
@@ -2039,8 +2039,8 @@
                 "word": "verstellen",
                 "translation": "изменять",
                 "transcription": "[фер-ШТЕ-лен]",
-                "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Ich verstelle meine Stimme und Haltung.",
-                "sentenceTranslation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Я изменяю свой голос и осанку.",
+                "sentence": "Am Ufer des Hafens wäscht Kent die Spuren des alten Lebens ab. Ich atme tief ein und lasse nur das Wort „verstellen“ wieder hinaus.",
+                "sentenceTranslation": "На пристани Кент смывает следы прежней жизни. Я глубоко вдыхаю и выпускаю только слово «изменять».",
                 "visual_hint": "📚",
                 "themes": [
                     "List",
@@ -2064,8 +2064,8 @@
                 "word": "der Bart",
                 "translation": "борода",
                 "transcription": "[дер БАРТ]",
-                "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Mit falschem Bart bin ich nicht zu erkennen.",
-                "sentenceTranslation": "Перед замком Гонериль Кент надевает своё маскировочное платье: С фальшивой бородой меня не узнать.",
+                "sentence": "Auf dem staubigen Markt prüft Kent die Tragriemen des Gepäcks. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Bart“ darf nicht vergehen.",
+                "sentenceTranslation": "На пыльном рынке Кент проверяет ремни поклажи. Я шепчу стражам судьбы: слово «борода» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "List",
@@ -2088,8 +2088,8 @@
                 "word": "anheuern",
                 "translation": "наниматься",
                 "transcription": "[АН-хой-ерн]",
-                "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Als Кай heuere ich beim König an.",
-                "sentenceTranslation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Как Кай я нанимаюсь к королю.",
+                "sentence": "Im Schatten einer Gasse versteckt Kent den einst glänzenden Siegelring. Das kalte Licht lässt das Wort „anheuern“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "В тени переулка Кент прячет некогда блестящий перстень. Холодный свет заставляет слово «наниматься» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "List",
@@ -2112,8 +2112,8 @@
                 "word": "treu",
                 "translation": "верный",
                 "transcription": "[ТРОЙ]",
-                "sentence": "Vor Gonerils Burg legt Kent seine Verkleidung an: Treu bleibe ich trotz der Verkleidung.",
-                "sentenceTranslation": "Перед замком Гонериль Кент надевает своё маскировочное платье: Верным остаюсь несмотря на переодевание.",
+                "sentence": "Unter einem Wagenrad kauert Kent, bis der Ruf nach Dienern erschallt. Das Echo des Wortes „treu“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Под колесом телеги Кент затаивается, пока не прозвучит зов для слуг. Эхо слова «верный» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Freundschaft",
@@ -2151,18 +2151,18 @@
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "неузнанный",
                     "притворяться",
-                    "переодевание",
-                    "хитрость"
+                    "хитрость",
+                    "неузнанный",
+                    "переодевание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unerkannt»?",
                 "choices": [
-                    "наниматься",
-                    "борода",
+                    "притворяться",
+                    "переодевание",
                     "неузнанный",
                     "изменять"
                 ],
@@ -2171,52 +2171,52 @@
             {
                 "question": "Что означает немецкое слово «vorgeben»?",
                 "choices": [
-                    "борода",
-                    "переодевание",
+                    "притворяться",
+                    "верный",
                     "неузнанный",
-                    "притворяться"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verstellen»?",
-                "choices": [
-                    "изменять",
-                    "хитрость",
-                    "борода",
-                    "наниматься"
+                    "хитрость"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «verstellen»?",
+                "choices": [
+                    "неузнанный",
+                    "хитрость",
+                    "изменять",
+                    "наниматься"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «der Bart»?",
                 "choices": [
-                    "наниматься",
-                    "хитрость",
                     "верный",
-                    "борода"
+                    "неузнанный",
+                    "борода",
+                    "притворяться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «anheuern»?",
                 "choices": [
-                    "верный",
-                    "хитрость",
-                    "борода",
-                    "наниматься"
+                    "изменять",
+                    "переодевание",
+                    "наниматься",
+                    "неузнанный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
-                    "переодевание",
-                    "изменять",
                     "верный",
-                    "хитрость"
+                    "наниматься",
+                    "изменять",
+                    "притворяться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2229,8 +2229,8 @@
                 "word": "der Dienst",
                 "translation": "служба",
                 "transcription": "[дер ДИНСТ]",
-                "sentence": "Als Diener Caius an Lears Seite schwört Kent: Mein Dienst geht über die Verbannung hinaus.",
-                "sentenceTranslation": "В облике слуги Кая при Лире Кент клянётся: Моя служба идёт дальше изгнания.",
+                "sentence": "Im nächtlichen Wachraum poliert Kent schweigend die Rüstung des Königs. Das Echo des Wortes „der Dienst“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В ночной караульной Кент молча полирует королевские доспехи. Эхо слова «служба» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Dienst",
@@ -2253,8 +2253,8 @@
                 "word": "der Schutz",
                 "translation": "защита",
                 "transcription": "[дер ШУТЦ]",
-                "sentence": "Als Diener Caius an Lears Seite schwört Kent: Ich biete Schutz, ohne erkannt zu werden.",
-                "sentenceTranslation": "В облике слуги Кая при Лире Кент клянётся: Я предоставляю защиту, не будучи узнанным.",
+                "sentence": "Neben dem Lager des erschöpften Herrschers hält Kent unbeweglich Wache. Das Echo des Wortes „der Schutz“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У ложа измождённого правителя Кент неподвижно несёт стражу. Эхо слова «защита» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Dienst",
@@ -2277,8 +2277,8 @@
                 "word": "die Gefahr",
                 "translation": "опасность",
                 "transcription": "[ди ге-ФАР]",
-                "sentence": "Als Diener Caius an Lears Seite schwört Kent: Trotz Gefahr bleibe ich beim König.",
-                "sentenceTranslation": "В облике слуги Кая при Лире Кент клянётся: Несмотря на опасность, я остаюсь с королём.",
+                "sentence": "Unter Regenmänteln der Wachen verbirgt Kent seine Narben. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Gefahr“ bleibt lebendig.",
+                "sentenceTranslation": "Под дождевыми плащами стражей Кент скрывает свои шрамы. Каждой клеткой тела я обещаю: слово «опасность» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2302,8 +2302,8 @@
                 "word": "bewachen",
                 "translation": "охранять",
                 "transcription": "[бе-ВА-хен]",
-                "sentence": "Als Diener Caius an Lears Seite schwört Kent: Heimlich bewache ich meinen alten Herrn.",
-                "sentenceTranslation": "В облике слуги Кая при Лире Кент клянётся: Тайно я охраняю своего старого господина.",
+                "sentence": "Am Stalltor sattelt Kent in der Dunkelheit ein trotziges Pferd. Selbst wenn die Welt zerfällt, bleibt das Wort „bewachen“ mein Nordstern.",
+                "sentenceTranslation": "У дверей конюшни Кент в темноте осёдлывает упрямого коня. Даже если мир распадается, слово «охранять» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Dienst",
@@ -2326,8 +2326,8 @@
                 "word": "kämpfen",
                 "translation": "сражаться",
                 "transcription": "[КЕМП-фен]",
-                "sentence": "Als Diener Caius an Lears Seite schwört Kent: Ich kämpfe gegen alle seine Feinde.",
-                "sentenceTranslation": "В облике слуги Кая при Лире Кент клянётся: Я сражаюсь против всех его врагов.",
+                "sentence": "In der Küche der Dienerschaft füllt Kent den dampfenden Becher. Ich zeichne das Wort „kämpfen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В кухне прислуги Кент наполняет дымящийся кубок. Я черчу слово «сражаться» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2352,8 +2352,8 @@
                 "word": "raten",
                 "translation": "советовать",
                 "transcription": "[РА-тен]",
-                "sentence": "Als Diener Caius an Lears Seite schwört Kent: Als Кай rate ich ihm zur Vorsicht.",
-                "sentenceTranslation": "В облике слуги Кая при Лире Кент клянётся: Как Кай я советую ему осторожность.",
+                "sentence": "Vor der Schlafstatt des Königs ordnet Kent die verstreuten Decken. Ich umarme das Wort „raten“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Перед ложем короля Кент раскладывает разбросанные покрывала. Я обнимаю слово «советовать», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Dienst",
@@ -2376,8 +2376,8 @@
                 "word": "die Wache",
                 "translation": "стража",
                 "transcription": "[ди ВА-хе]",
-                "sentence": "Als Diener Caius an Lears Seite schwört Kent: Ich halte Wache über seinen Schlaf.",
-                "sentenceTranslation": "В облике слуги Кая при Лире Кент клянётся: Я держу стражу над его сном.",
+                "sentence": "Auf dem Hof prüft Kent das Zaumzeug, bevor der Morgen graut. Selbst wenn die Welt zerfällt, bleibt das Wort „die Wache“ mein Nordstern.",
+                "sentenceTranslation": "Во дворе Кент проверяет уздечку, пока не рассвело. Даже если мир распадается, слово «стража» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Dienst",
@@ -2401,40 +2401,40 @@
             {
                 "question": "Что означает немецкое слово «der Dienst»?",
                 "choices": [
+                    "защита",
+                    "опасность",
+                    "служба",
+                    "охранять"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Schutz»?",
+                "choices": [
                     "опасность",
                     "охранять",
                     "защита",
                     "служба"
                 ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Schutz»?",
-                "choices": [
-                    "охранять",
-                    "защита",
-                    "служба",
-                    "опасность"
-                ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "стража",
+                    "защита",
                     "опасность",
-                    "охранять",
-                    "защита"
+                    "сражаться",
+                    "служба"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bewachen»?",
                 "choices": [
-                    "защита",
+                    "опасность",
                     "охранять",
-                    "советовать",
-                    "опасность"
+                    "сражаться",
+                    "служба"
                 ],
                 "correctIndex": 1
             },
@@ -2442,31 +2442,31 @@
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
                     "сражаться",
-                    "охранять",
-                    "стража",
-                    "опасность"
+                    "советовать",
+                    "опасность",
+                    "охранять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «raten»?",
                 "choices": [
-                    "служба",
                     "стража",
-                    "охранять",
-                    "советовать"
+                    "советовать",
+                    "служба",
+                    "охранять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Wache»?",
                 "choices": [
-                    "опасность",
+                    "служба",
                     "защита",
-                    "советовать",
-                    "стража"
+                    "стража",
+                    "охранять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2479,8 +2479,8 @@
                 "word": "die Strafe",
                 "translation": "наказание",
                 "transcription": "[ди ШТРА-фе]",
-                "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Diese Strafe erdulde ich für meinen König.",
-                "sentenceTranslation": "Во дворе замка Реганы Кент сидит в колодках: Это наказание я терплю ради короля.",
+                "sentence": "Im Regen der Burgmauer sitzt Kent mit gefesselten Füßen in den harten Hölzern. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Strafe“ darf nicht vergehen.",
+                "sentenceTranslation": "Под дождём у крепостной стены Кент сидит с закреплёнными ногами в жёстких колодках. Я шепчу стражам судьбы: слово «наказание» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2507,8 +2507,8 @@
                 "word": "die Demütigung",
                 "translation": "унижение",
                 "transcription": "[ди де-МЮ-ти-гунг]",
-                "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Die Demütigung macht mich nur stärker.",
-                "sentenceTranslation": "Во дворе замка Реганы Кент сидит в колодках: Унижение делает меня только сильнее.",
+                "sentence": "Neben den Spottliedern der Wachen hält Kent den Kopf stolz erhoben. Ich presse das Wort „die Demütigung“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под насмешливые песни стражи Кент гордо держит голову. Я стискиваю слово «унижение» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Demütigung",
@@ -2531,8 +2531,8 @@
                 "word": "die Standhaftigkeit",
                 "translation": "стойкость",
                 "transcription": "[ди ШТАНД-хаф-тиг-кайт]",
-                "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Mit Standhaftigkeit ertrage ich die Schmach.",
-                "sentenceTranslation": "Во дворе замка Реганы Кент сидит в колодках: Со стойкостью я переношу позор.",
+                "sentence": "Vor dem trüben Mondlicht reibt Kent den schmerzenden Nacken. Ich zeichne das Wort „die Standhaftigkeit“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В тусклом лунном свете Кент растирает затёкшую шею. Я черчу слово «стойкость» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Demütigung",
@@ -2555,8 +2555,8 @@
                 "word": "fesseln",
                 "translation": "сковывать",
                 "transcription": "[ФЕ-сельн]",
-                "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Sie fesseln mich wie einen gemeinen Dieb.",
-                "sentenceTranslation": "Во дворе замка Реганы Кент сидит в колодках: Они сковывают меня как обычного вора.",
+                "sentence": "Zwischen den Pfützen der Nacht starren Kents Schuhe in den Himmel. Selbst wenn die Welt zerfällt, bleibt das Wort „fesseln“ mein Nordstern.",
+                "sentenceTranslation": "Среди ночных луж сапоги Кент устремлены в небо. Даже если мир распадается, слово «сковывать» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Demütigung",
@@ -2579,8 +2579,8 @@
                 "word": "erdulden",
                 "translation": "терпеть",
                 "transcription": "[ер-ДУЛЬ-ден]",
-                "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Ich erdulde die Schande ohne Klage.",
-                "sentenceTranslation": "Во дворе замка Реганы Кент сидит в колодках: Я терплю позор без жалоб.",
+                "sentence": "Am Morgenfrost haucht Kent Eisblumen auf das Holz. Selbst wenn die Welt zerfällt, bleibt das Wort „erdulden“ mein Nordstern.",
+                "sentenceTranslation": "В утренний мороз Кент выдыхает ледяные узоры на дерево. Даже если мир распадается, слово «терпеть» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Demütigung",
@@ -2605,8 +2605,8 @@
                 "word": "der Stock",
                 "translation": "колодка",
                 "transcription": "[дер ШТОК]",
-                "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Im Stock sitze ich die ganze Nacht.",
-                "sentenceTranslation": "Во дворе замка Реганы Кент сидит в колодках: В колодке я сижу всю ночь.",
+                "sentence": "Neben einem verirrten Bauernkind lächelt Kent trotz der Demütigung. Das kalte Licht lässt das Wort „der Stock“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Рядом с заблудившимся крестьянином Кент улыбается несмотря на унижение. Холодный свет заставляет слово «колодка» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Demütigung",
@@ -2629,8 +2629,8 @@
                 "word": "ausharren",
                 "translation": "выдерживать",
                 "transcription": "[АУС-ха-рен]",
-                "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Ich harre aus bis zur Befreiung.",
-                "sentenceTranslation": "Во дворе замка Реганы Кент сидит в колодках: Я выдерживаю до освобождения.",
+                "sentence": "Unter dem grauen Himmel zählt Kent geduldig die Tropfen auf dem Gesicht. Ich flüstere den Wächtern des Schicksals zu: Das Wort „ausharren“ darf nicht vergehen.",
+                "sentenceTranslation": "Под серым небом Кент терпеливо считает капли на лице. Я шепчу стражам судьбы: слово «выдерживать» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Demütigung",
@@ -2655,8 +2655,8 @@
                 "word": "die Schande",
                 "translation": "позор",
                 "transcription": "[ди ШАН-де]",
-                "sentence": "Im Hof von Regans Schloss sitzt Kent im Pranger: Diese Schande ist Cornwall's, nicht meine.",
-                "sentenceTranslation": "Во дворе замка Реганы Кент сидит в колодках: Этот позор Корнуолла, не мой.",
+                "sentence": "Auf dem verlassenen Hof lauscht Kent dem fern rollenden Donner. Das kalte Licht lässt das Wort „die Schande“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На пустынном дворе Кент прислушивается к далёкому грохоту грома. Холодный свет заставляет слово «позор» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2680,9 +2680,9 @@
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
                     "наказание",
-                    "сковывать",
                     "стойкость",
-                    "унижение"
+                    "унижение",
+                    "сковывать"
                 ],
                 "correctIndex": 0
             },
@@ -2690,71 +2690,71 @@
                 "question": "Что означает немецкое слово «die Demütigung»?",
                 "choices": [
                     "наказание",
+                    "сковывать",
                     "стойкость",
-                    "унижение",
-                    "сковывать"
+                    "унижение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Standhaftigkeit»?",
                 "choices": [
                     "унижение",
-                    "колодка",
-                    "стойкость",
-                    "выдерживать"
+                    "позор",
+                    "терпеть",
+                    "стойкость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «fesseln»?",
                 "choices": [
+                    "терпеть",
+                    "наказание",
                     "сковывать",
-                    "унижение",
-                    "выдерживать",
                     "колодка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erdulden»?",
                 "choices": [
                     "терпеть",
+                    "позор",
                     "стойкость",
-                    "выдерживать",
-                    "позор"
+                    "колодка"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Stock»?",
                 "choices": [
-                    "выдерживать",
-                    "наказание",
                     "сковывать",
-                    "колодка"
+                    "выдерживать",
+                    "колодка",
+                    "позор"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ausharren»?",
                 "choices": [
-                    "унижение",
                     "сковывать",
-                    "стойкость",
-                    "выдерживать"
+                    "выдерживать",
+                    "терпеть",
+                    "позор"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Schande»?",
                 "choices": [
+                    "наказание",
+                    "колодка",
                     "позор",
-                    "выдерживать",
-                    "стойкость",
-                    "унижение"
+                    "выдерживать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2767,8 +2767,8 @@
                 "word": "der Sturm",
                 "translation": "буря",
                 "transcription": "[дер ШТУРМ]",
-                "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Im Sturm bleibe ich bei meinem König.",
-                "sentenceTranslation": "На пустоши в бурю Кент поддерживает старого короля: В буре я остаюсь с моим королём.",
+                "sentence": "Mit der Laterne in der Faust sucht Kent nach dem Schatten des Königs. Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen.",
+                "sentenceTranslation": "С фонарём в кулаке Кент ищет тень короля. Как тихая молитва слово «буря» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2793,8 +2793,8 @@
                 "word": "der Beistand",
                 "translation": "поддержка",
                 "transcription": "[дер БАЙ-штанд]",
-                "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Mein Beistand ist alles, was ich bieten kann.",
-                "sentenceTranslation": "На пустоши в бурю Кент поддерживает старого короля: Моя поддержка - всё, что я могу предложить.",
+                "sentence": "Neben dem tobenden Monarchen breitet Kent den Mantel wie ein Schild. Das kalte Licht lässt das Wort „der Beistand“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Рядом с бушующим монархом Кент раскрывает плащ как щит. Холодный свет заставляет слово «поддержка» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beistand",
@@ -2817,8 +2817,8 @@
                 "word": "begleiten",
                 "translation": "сопровождать",
                 "transcription": "[бе-ГЛАЙ-тен]",
-                "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Ich begleite ihn durch Wind und Regen.",
-                "sentenceTranslation": "На пустоши в бурю Кент поддерживает старого короля: Я сопровождаю его сквозь ветер и дождь.",
+                "sentence": "Auf dem überfluteten Pfad hält Kent das Pferd am Zügel. Ich zeichne das Wort „begleiten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На затопленной тропе Кент держит коня за повод. Я вывожу слово «сопровождать» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beistand",
@@ -2847,8 +2847,8 @@
                 "word": "trösten",
                 "translation": "утешать",
                 "transcription": "[ТРЁС-тен]",
-                "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Mit Worten tröste ich den wahnsinnigen König.",
-                "sentenceTranslation": "На пустоши в бурю Кент поддерживает старого короля: Словами я утешаю безумного короля.",
+                "sentence": "Zwischen klatschenden Ästen ruft Kent beruhigende Worte. Mein Atem zeichnet das Wort „trösten“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Среди хлещущих веток Кент говорит успокаивающие слова. Моё дыхание рисует слово «утешать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2872,8 +2872,8 @@
                 "word": "die Zuflucht",
                 "translation": "убежище",
                 "transcription": "[ди ЦУ-флухт]",
-                "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Ich suche Zuflucht für uns beide.",
-                "sentenceTranslation": "На пустоши в бурю Кент поддерживает старого короля: Я ищу убежище для нас обоих.",
+                "sentence": "Vor der klappernden Hütte hebt Kent die Fackel, um den Weg zu zeigen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Zuflucht“ bleibt lebendig.",
+                "sentenceTranslation": "Перед дрожащей хижиной Кент поднимает факел, освещая путь. Каждой клеткой тела я обещаю: слово «убежище» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beistand",
@@ -2897,8 +2897,8 @@
                 "word": "durchhalten",
                 "translation": "выдерживать",
                 "transcription": "[ДУРХ-халь-тен]",
-                "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Gemeinsam werden wir durchhalten.",
-                "sentenceTranslation": "На пустоши в бурю Кент поддерживает старого короля: Вместе мы выдержим.",
+                "sentence": "Am Rand des Moorfelds stützt Kent den taumelnden Herrscher. Ich umarme das Wort „durchhalten“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "На краю болотного поля Кент поддерживает качающегося правителя. Я обнимаю слово «выдерживать», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2922,8 +2922,8 @@
                 "word": "die Kälte",
                 "translation": "холод",
                 "transcription": "[ди КЕЛ-те]",
-                "sentence": "Auf der Heide im Sturm stützt Kent den alten König: Die Kälte dringt in unsere Knochen.",
-                "sentenceTranslation": "На пустоши в бурю Кент поддерживает старого короля: Холод проникает в наши кости.",
+                "sentence": "Unter dem peitschenden Regen spricht Kent ein leises Trostlied. Ich presse das Wort „die Kälte“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под хлещущим дождём Кент тихо напевает утешительную песнь. Я стискиваю слово «холод» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beistand",
@@ -2950,38 +2950,38 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "буря",
                     "сопровождать",
                     "утешать",
+                    "буря",
                     "поддержка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Beistand»?",
                 "choices": [
-                    "поддержка",
                     "буря",
+                    "поддержка",
                     "утешать",
                     "сопровождать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
                     "сопровождать",
-                    "выдерживать",
-                    "утешать",
-                    "холод"
+                    "буря",
+                    "холод",
+                    "убежище"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "убежище",
-                    "холод",
+                    "сопровождать",
+                    "выдерживать",
                     "утешать",
                     "поддержка"
                 ],
@@ -2990,30 +2990,30 @@
             {
                 "question": "Что означает немецкое слово «die Zuflucht»?",
                 "choices": [
-                    "сопровождать",
+                    "убежище",
                     "буря",
-                    "утешать",
-                    "убежище"
+                    "поддержка",
+                    "сопровождать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «durchhalten»?",
                 "choices": [
-                    "убежище",
                     "выдерживать",
-                    "утешать",
-                    "холод"
+                    "буря",
+                    "холод",
+                    "поддержка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "утешать",
-                    "холод",
                     "поддержка",
-                    "выдерживать"
+                    "холод",
+                    "убежище",
+                    "сопровождать"
                 ],
                 "correctIndex": 1
             }
@@ -3028,8 +3028,8 @@
                 "word": "der Tod",
                 "translation": "смерть",
                 "transcription": "[дер ТОД]",
-                "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Bis zum Tod bleibe ich an seiner Seite.",
-                "sentenceTranslation": "Перед телом Корделии в Дувре Кент отвергает корону: До смерти я остаюсь рядом с ним.",
+                "sentence": "Im stillen Sterbezimmer wacht Kent an Lears letztem Lager. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Tod“ gehört mir.",
+                "sentenceTranslation": "В тихой опочивальне смерти Кент стоит у последнего ложа Лира. Буря за окнами усиливает клятву: слово «смерть» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3055,8 +3055,8 @@
                 "word": "der Abschied",
                 "translation": "прощание",
                 "transcription": "[дер АБ-шид]",
-                "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Der Abschied von meinem König bricht mein Herz.",
-                "sentenceTranslation": "Перед телом Корделии в Дувре Кент отвергает корону: Прощание с моим королём разбивает моё сердце.",
+                "sentence": "Neben der verlöschenden Kerze streicht Kent über den zerrissenen Umhang. Wie ein stilles Gebet legt sich das Wort „der Abschied“ auf meine Lippen.",
+                "sentenceTranslation": "У догорающей свечи Кент гладит разорванный плащ. Как тихая молитва слово «прощание» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Abschied",
@@ -3090,8 +3090,8 @@
                 "word": "ewig",
                 "translation": "вечный",
                 "transcription": "[Э-виг]",
-                "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Meine Treue ist ewig, über den Tod hinaus.",
-                "sentenceTranslation": "Перед телом Корделии в Дувре Кент отвергает корону: Моя верность вечна, за пределами смерти.",
+                "sentence": "Vor den starren Wachen flüstert Kent ein letztes Versprechen. Mit fester Stimme schwöre ich mir: Das Wort „ewig“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед оцепеневшими стражами Кент шепчет последнее обещание. Твёрдым голосом я клянусь себе: слово «вечный» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Abschied",
@@ -3121,8 +3121,8 @@
                 "word": "weinen",
                 "translation": "плакать",
                 "transcription": "[ВАЙ-нен]",
-                "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Ich weine um meinen gefallenen König.",
-                "sentenceTranslation": "Перед телом Корделии в Дувре Кент отвергает корону: Я плачу о моём павшем короле.",
+                "sentence": "Auf dem leeren Thronstuhl legt Kent den eigenen Stab nieder. Mein Atem zeichnet das Wort „weinen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На пустом троне Кент кладёт свой посох. Моё дыхание рисует слово «плакать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3144,8 +3144,8 @@
                 "word": "die Erschöpfung",
                 "translation": "истощение",
                 "transcription": "[ди ер-ШЁП-фунг]",
-                "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Die Erschöpfung überwältigt meinen alten Körper.",
-                "sentenceTranslation": "Перед телом Корделии в Дувре Кент отвергает корону: Истощение одолевает моё старое тело.",
+                "sentence": "Zwischen verblassenden Wandmalereien schließt Kent kurz die Augen. Selbst wenn die Welt zerfällt, bleibt das Wort „die Erschöpfung“ mein Nordstern.",
+                "sentenceTranslation": "Среди блекнущих настенных росписей Кент на мгновение закрывает глаза. Даже если мир распадается, слово «истощение» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Abschied",
@@ -3168,8 +3168,8 @@
                 "word": "aufgeben",
                 "translation": "сдаваться",
                 "transcription": "[АУФ-ге-бен]",
-                "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Ich gebe auf, nachdem mein Herr gestorben ist.",
-                "sentenceTranslation": "Перед телом Корделии в Дувре Кент отвергает корону: Я сдаюсь после смерти моего господина.",
+                "sentence": "Am offenen Fenster lässt Kent den kalten Morgen herein. Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufgeben“ darf nicht vergehen.",
+                "sentenceTranslation": "У распахнутого окна Кент впускает холодное утро. Я шепчу стражам судьбы: слово «сдаваться» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Abschied",
@@ -3196,8 +3196,8 @@
                 "word": "die Trauer",
                 "translation": "скорбь",
                 "transcription": "[ди ТРАУ-ер]",
-                "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Die Trauer ist zu schwer zu ertragen.",
-                "sentenceTranslation": "Перед телом Корделии в Дувре Кент отвергает корону: Скорбь слишком тяжела, чтобы вынести.",
+                "sentence": "Im Schatten der Trauernden hält Kent Lears Hand bis zum letzten Schlag. Ich zeichne das Wort „die Trauer“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В тени скорбящих Кент держит руку Лира до последнего удара. Я вывожу слово «скорбь» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3222,8 +3222,8 @@
                 "word": "folgen",
                 "translation": "следовать",
                 "transcription": "[ФОЛЬ-ген]",
-                "sentence": "Vor Cordelias Leichnam in Dover verweigert Kent die Krone: Bald folge ich meinem König ins Jenseits.",
-                "sentenceTranslation": "Перед телом Корделии в Дувре Кент отвергает корону: Скоро я последую за королём в иной мир.",
+                "sentence": "Vor der stillen Hofkapelle beugt Kent das Knie für ein stummes Gebet. Ich halte das Wort „folgen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед молчаливой придворной часовней Кент преклоняет колено в безмолвной молитве. Я держу слово «следовать» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3247,8 +3247,8 @@
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
                     "смерть",
-                    "плакать",
                     "вечный",
+                    "плакать",
                     "прощание"
                 ],
                 "correctIndex": 0
@@ -3256,49 +3256,49 @@
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "прощание",
-                    "плакать",
                     "вечный",
-                    "смерть"
+                    "смерть",
+                    "плакать",
+                    "прощание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "скорбь",
-                    "вечный",
+                    "плакать",
                     "сдаваться",
-                    "плакать"
+                    "скорбь",
+                    "вечный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «weinen»?",
                 "choices": [
-                    "сдаваться",
-                    "плакать",
-                    "следовать",
-                    "смерть"
+                    "истощение",
+                    "вечный",
+                    "прощание",
+                    "плакать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Erschöpfung»?",
                 "choices": [
                     "скорбь",
-                    "сдаваться",
-                    "следовать",
-                    "истощение"
+                    "истощение",
+                    "вечный",
+                    "плакать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
+                    "вечный",
+                    "истощение",
                     "скорбь",
-                    "смерть",
-                    "плакать",
                     "сдаваться"
                 ],
                 "correctIndex": 3
@@ -3306,22 +3306,22 @@
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "истощение",
-                    "скорбь",
-                    "плакать",
-                    "сдаваться"
+                    "смерть",
+                    "вечный",
+                    "сдаваться",
+                    "скорбь"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «folgen»?",
                 "choices": [
-                    "истощение",
-                    "плакать",
+                    "смерть",
+                    "следовать",
                     "сдаваться",
-                    "следовать"
+                    "прощание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -3852,27 +3852,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/king_lear.html
+++ b/output/journeys/king_lear.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["власть", "королевство", "трон", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["трон", "власть", "править", "королевство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["трон", "власть", "провозглашать", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["церемония", "королевство", "великолепный", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["власть", "церемония", "провозглашать", "корона"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["трон", "корона", "провозглашать", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "трон", "провозглашать", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["церемония", "власть", "править", "великолепный"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "проклинать", "неблагодарность", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["неблагодарность", "проклинать", "унижать", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["изгонять", "неблагодарность", "унижать", "обида"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["обида", "сожалеть", "проклятие", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["проклинать", "изгонять", "унижать", "неблагодарность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["проклятие", "обида", "гнев", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["изгонять", "сожалеть", "проклинать", "неблагодарность"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["проклятие", "изгонять", "проклинать", "сожалеть"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["жестокость", "покидать", "отвергать", "отчаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["жестокость", "покидать", "отчаяние", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "слеза", "просить", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["просить", "отчаяние", "слеза", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["просить", "жестокость", "отвергать", "покидать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["одиночество", "нужда", "слеза", "просить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["просить", "одиночество", "слеза", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["отвергать", "жестокость", "одиночество", "нужда"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "безумие", "гром", "бушевать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["буря", "безумие", "бушевать", "гром"], "correct_index": 1}, {"question": "Что означает немецкое слово «toben»?", "choices": ["безумие", "голый", "бушевать", "хаос"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["безумие", "буря", "гром", "молния"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["кричать", "гром", "молния", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["гром", "кричать", "молния", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["хаос", "молния", "голый", "кричать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["хаос", "гром", "голый", "буря"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["мёрзнуть", "бедный", "нищий", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["нищета", "бедный", "нищий", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «arm»?", "choices": ["шут", "бедный", "хижина", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["нищета", "страдать", "мёрзнуть", "нищий"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["хижина", "нищий", "нищета", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["мёрзнуть", "страдать", "хижина", "познание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["хижина", "шут", "мёрзнуть", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["познание", "страдать", "нищий", "хижина"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "правда", "понимать", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["правда", "раскаяние", "понимать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "виновный", "раскаяние", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["мудрость", "раскаяние", "прощать", "узнавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["узнавать", "прощать", "мудрость", "прозрение"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["раскаяние", "правда", "мудрость", "прощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["прозрение", "мудрость", "понимать", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["узнавать", "понимать", "виновный", "правда"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["конец", "смерть", "прощать", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "смерть", "конец", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["смерть", "прощание", "умирать", "скорбь"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "умирать", "скорбь", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["сердце", "прощание", "прощать", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["конец", "скорбь", "сердце", "прощание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "прощать", "умирать", "вечный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["умирать", "скорбь", "прощать", "вечный"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["трон", "королевство", "править", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["власть", "править", "королевство", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "корона", "править", "церемония"], "correct_index": 0}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["власть", "великолепный", "трон", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["корона", "власть", "великолепный", "провозглашать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["власть", "править", "великолепный", "корона"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["власть", "трон", "королевство", "церемония"], "correct_index": 3}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["великолепный", "провозглашать", "корона", "королевство"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["неблагодарность", "унижать", "проклинать", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["унижать", "проклинать", "неблагодарность", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["унижать", "изгонять", "неблагодарность", "гнев"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["сожалеть", "проклинать", "изгонять", "проклятие"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["унижать", "изгонять", "проклятие", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["неблагодарность", "обида", "сожалеть", "проклятие"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["изгонять", "проклятие", "гнев", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["обида", "неблагодарность", "изгонять", "проклятие"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["отчаяние", "жестокость", "отвергать", "покидать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["жестокость", "отвергать", "покидать", "отчаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["покидать", "отчаяние", "жестокость", "одиночество"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "слеза", "отвергать", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["покидать", "одиночество", "нужда", "просить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["одиночество", "отчаяние", "жестокость", "слеза"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["одиночество", "отвергать", "слеза", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["нужда", "жестокость", "покидать", "слеза"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["бушевать", "гром", "буря", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["буря", "гром", "безумие", "бушевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «toben»?", "choices": ["буря", "бушевать", "безумие", "молния"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["гром", "безумие", "голый", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["бушевать", "кричать", "голый", "молния"], "correct_index": 3}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["буря", "голый", "хаос", "кричать"], "correct_index": 3}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["безумие", "хаос", "голый", "бушевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["буря", "гром", "хаос", "безумие"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищий", "мёрзнуть", "нищета", "бедный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["мёрзнуть", "нищий", "нищета", "бедный"], "correct_index": 1}, {"question": "Что означает немецкое слово «arm»?", "choices": ["бедный", "нищий", "шут", "познание"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["бедный", "нищета", "нищий", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["страдать", "шут", "нищий", "хижина"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "мёрзнуть", "бедный", "хижина"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "познание", "бедный", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["познание", "бедный", "хижина", "мёрзнуть"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["раскаяние", "правда", "узнавать", "понимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["узнавать", "раскаяние", "правда", "понимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "мудрость", "узнавать", "виновный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["понимать", "узнавать", "виновный", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "прощать", "понимать", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "раскаяние", "мудрость", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["узнавать", "правда", "прозрение", "виновный"], "correct_index": 2}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["узнавать", "правда", "мудрость", "виновный"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["умирать", "смерть", "прощать", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "умирать", "конец", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["прощание", "умирать", "скорбь", "вечный"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["скорбь", "сердце", "конец", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["сердце", "прощание", "прощать", "скорбь"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["конец", "смерть", "вечный", "скорбь"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["вечный", "прощание", "сердце", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "конец", "скорбь", "прощать"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,49 +465,49 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -517,11 +517,11 @@
                         <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">великолепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">великолепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">править</button>
                             
@@ -529,15 +529,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">корона</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">великолепный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">великолепный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
                             
@@ -545,49 +561,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «prächtig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">корона</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">великолепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,8 +600,24 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
@@ -616,15 +632,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Undankbarkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
@@ -632,33 +648,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Undankbarkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -668,13 +668,13 @@
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -684,45 +684,45 @@
                         <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклятие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Fluch»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,81 +735,81 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">просить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нужда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -821,11 +821,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нужда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слеза</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -835,29 +835,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Not»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нужда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слеза</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -870,15 +870,31 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
                             
@@ -886,47 +902,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «toben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «toben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хаос</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
                             
@@ -934,33 +918,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -970,29 +970,29 @@
                         <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хаос</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Chaos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1005,29 +1005,61 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «arm»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">познание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
@@ -1037,81 +1069,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «arm»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">познание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">познание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1123,11 +1123,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">познание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1140,33 +1140,33 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verstehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1178,73 +1178,57 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">виновный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">виновный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прозрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
                             
@@ -1252,17 +1236,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прозрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «schuldig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">виновный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1279,25 +1279,25 @@
                         <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
@@ -1307,31 +1307,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1349,55 +1349,55 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1424,8 +1424,8 @@
                 "word": "der Thron",
                 "translation": "трон",
                 "transcription": "[дер ТРОН]",
-                "sentence": "Im prunkvollen Thronsaal ruft König Lear: Vom Thron herab verkünde ich meinen Willen.",
-                "sentenceTranslation": "В роскошном тронном зале восклицает король Лир: С трона я провозглашаю свою волю.",
+                "sentence": "König Lear steht unter dem glühenden Kronleuchter des Thronsaals. Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Лир стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «трон» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1448,8 +1448,8 @@
                 "word": "das Königreich",
                 "translation": "королевство",
                 "transcription": "[дас КЁ-ниг-райх]",
-                "sentence": "Im prunkvollen Thronsaal ruft König Lear: Mein Königreich teile ich unter meinen Töchtern.",
-                "sentenceTranslation": "В роскошном тронном зале восклицает король Лир: Моё королевство я делю между дочерьми.",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich König Lear über Lears schweren Tisch. Das kalte Licht lässt das Wort „das Königreich“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "У развернутой карты королевства Лир склоняется над тяжёлым столом Лира. Холодный свет заставляет слово «королевство» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1472,8 +1472,8 @@
                 "word": "die Macht",
                 "translation": "власть",
                 "transcription": "[ди МАХТ]",
-                "sentence": "Im prunkvollen Thronsaal ruft König Lear: Die Macht gebe ich an jene, die mich am meisten liebt.",
-                "sentenceTranslation": "В роскошном тронном зале восклицает король Лир: Власть я отдаю той, кто любит меня больше всех.",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt König Lear die Hände hinter dem Rücken. Mein Atem zeichnet das Wort „die Macht“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед каменными статуями предков Лир сцепляет руки за спиной. Моё дыхание рисует слово «власть» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1498,8 +1498,8 @@
                 "word": "herrschen",
                 "translation": "править",
                 "transcription": "[ХЕР-шен]",
-                "sentence": "Im prunkvollen Thronsaal ruft König Lear: Ich habe lange genug geherrscht.",
-                "sentenceTranslation": "В роскошном тронном зале восклицает король Лир: Я правил достаточно долго.",
+                "sentence": "Zwischen flüsternden Höflingen gleitet König Lear über den kalten Marmorboden. Mein Atem zeichnet das Wort „herrschen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Между шепчущимися придворными Лир скользит по холодному мраморному полу. Моё дыхание рисует слово «править» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1523,8 +1523,8 @@
                 "word": "verkünden",
                 "translation": "провозглашать",
                 "transcription": "[фер-КЮН-ден]",
-                "sentence": "Im prunkvollen Thronsaal ruft König Lear: Ich verkünde die Teilung meines Reiches.",
-                "sentenceTranslation": "В роскошном тронном зале восклицает король Лир: Я провозглашаю раздел моего королевства.",
+                "sentence": "Am Rand des purpurnen Teppichs wartet König Lear auf ein Zeichen des Königs. Ich zeichne das Wort „verkünden“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На краю пурпурного ковра Лир ждёт знака от короля. Я вывожу слово «провозглашать» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehrlichkeit",
@@ -1551,8 +1551,8 @@
                 "word": "die Krone",
                 "translation": "корона",
                 "transcription": "[ди КРО-не]",
-                "sentence": "Im prunkvollen Thronsaal ruft König Lear: Diese Krone ist schwer geworden für mein altes Haupt.",
-                "sentenceTranslation": "В роскошном тронном зале восклицает король Лир: Эта корона стала тяжела для моей старой головы.",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt König Lear kurz den Blick. Ich zeichne das Wort „die Krone“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Лир на миг опускает взгляд. Я вывожу слово «корона» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1574,8 +1574,8 @@
                 "word": "die Zeremonie",
                 "translation": "церемония",
                 "transcription": "[ди це-ре-мо-НИ]",
-                "sentence": "Im prunkvollen Thronsaal ruft König Lear: Die Zeremonie der Teilung beginnt jetzt.",
-                "sentenceTranslation": "В роскошном тронном зале восклицает король Лир: Церемония раздела начинается сейчас.",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet König Lear das gespannte Antlitz des Hofes. Mit fester Stimme schwöre ich mir: Das Wort „die Zeremonie“ wird heute nicht verraten.",
+                "sentenceTranslation": "За позолоченной балюстрадой Лир наблюдает за напряжёнными лицами двора. Твёрдым голосом я клянусь себе: слово «церемония» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ehrlichkeit",
@@ -1602,8 +1602,8 @@
                 "word": "prächtig",
                 "translation": "великолепный",
                 "transcription": "[ПРЕХ-тиг]",
-                "sentence": "Im prunkvollen Thronsaal ruft König Lear: Ein prächtiger Tag für eine verhängnisvolle Entscheidung.",
-                "sentenceTranslation": "В роскошном тронном зале восклицает король Лир: Великолепный день для рокового решения.",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt König Lear langsam die Stimme. Ich halte das Wort „prächtig“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В отблесках открытых жаровен Лир медленно поднимает голос. Я держу слово «великолепный» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "König",
@@ -1627,39 +1627,39 @@
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
-                    "власть",
-                    "королевство",
                     "трон",
-                    "править"
+                    "королевство",
+                    "править",
+                    "власть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
-                    "трон",
                     "власть",
                     "править",
-                    "королевство"
+                    "королевство",
+                    "трон"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "трон",
                     "власть",
-                    "провозглашать",
-                    "править"
+                    "корона",
+                    "править",
+                    "церемония"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
-                    "церемония",
-                    "королевство",
+                    "власть",
                     "великолепный",
+                    "трон",
                     "править"
                 ],
                 "correctIndex": 3
@@ -1667,42 +1667,42 @@
             {
                 "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
+                    "корона",
                     "власть",
-                    "церемония",
-                    "провозглашать",
-                    "корона"
+                    "великолепный",
+                    "провозглашать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Krone»?",
                 "choices": [
-                    "трон",
-                    "корона",
-                    "провозглашать",
-                    "власть"
+                    "власть",
+                    "править",
+                    "великолепный",
+                    "корона"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
-                    "церемония",
+                    "власть",
                     "трон",
-                    "провозглашать",
-                    "править"
+                    "королевство",
+                    "церемония"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «prächtig»?",
                 "choices": [
-                    "церемония",
-                    "власть",
-                    "править",
-                    "великолепный"
+                    "великолепный",
+                    "провозглашать",
+                    "корона",
+                    "королевство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -1715,8 +1715,8 @@
                 "word": "demütigen",
                 "translation": "унижать",
                 "transcription": "[де-МЮ-ти-ген]",
-                "sentence": "In Gonerils Palast fühlt Lear: Meine eigene Tochter will mich demütigen!",
-                "sentenceTranslation": "Во дворце Гонериль Лир ощущает: Моя собственная дочь хочет меня унизить!",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt König Lear zwischen gepackten Kisten. Ich halte das Wort „demütigen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Лир замирает среди нагруженных ящиков. Я держу слово «унижать» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Strafe",
@@ -1746,8 +1746,8 @@
                 "word": "der Zorn",
                 "translation": "гнев",
                 "transcription": "[дер ЦОРН]",
-                "sentence": "In Gonerils Palast fühlt Lear: Mein Zorn brennt wie Feuer in meiner Brust!",
-                "sentenceTranslation": "Во дворце Гонериль Лир ощущает: Мой гнев горит как огонь в моей груди!",
+                "sentence": "Auf der windigen Freitreppe blickt König Lear zum schweigenden Hof hinunter. Ich presse das Wort „der Zorn“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Лир смотрит вниз на молчаливый двор. Я стискиваю слово «гнев» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1772,8 +1772,8 @@
                 "word": "die Undankbarkeit",
                 "translation": "неблагодарность",
                 "transcription": "[ди УН-данк-бар-кайт]",
-                "sentence": "In Gonerils Palast fühlt Lear: Die Undankbarkeit ist schärfer als der Zahn einer Schlange!",
-                "sentenceTranslation": "Во дворце Гонериль Лир ощущает: Неблагодарность острее змеиного зуба!",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt König Lear den Reisemantel enger. Selbst wenn die Welt zerfällt, bleibt das Wort „die Undankbarkeit“ mein Nordstern.",
+                "sentenceTranslation": "Среди оставленных слуг Лир плотнее запахивает дорожный плащ. Даже если мир распадается, слово «неблагодарность» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Zorn",
@@ -1796,8 +1796,8 @@
                 "word": "verfluchen",
                 "translation": "проклинать",
                 "transcription": "[фер-ФЛУ-хен]",
-                "sentence": "In Gonerils Palast fühlt Lear: Ich verfluche dich bei allen Sternen!",
-                "sentenceTranslation": "Во дворце Гонериль Лир ощущает: Я проклинаю тебя всеми звёздами!",
+                "sentence": "Am dunklen Pferdestall streicht König Lear einem nervösen Tier über die Mähne. Ich flüstere den Wächtern des Schicksals zu: Das Wort „verfluchen“ darf nicht vergehen.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Лир гладит гриву нервного коня. Я шепчу стражам судьбы: слово «проклинать» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1823,8 +1823,8 @@
                 "word": "vertreiben",
                 "translation": "изгонять",
                 "transcription": "[фер-ТРАЙ-бен]",
-                "sentence": "In Gonerils Palast fühlt Lear: Aus meinem eigenen Haus will sie mich vertreiben!",
-                "sentenceTranslation": "Во дворце Гонериль Лир ощущает: Из моего собственного дома она хочет меня изгнать!",
+                "sentence": "Vor dem knarrenden Fallgatter tastet König Lear ein letztes Mal nach dem Haustor. Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Лир в последний раз касается родной двери. Твёрдым голосом я клянусь себе: слово «изгонять» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1851,8 +1851,8 @@
                 "word": "die Kränkung",
                 "translation": "обида",
                 "transcription": "[ди КРЭН-кунг]",
-                "sentence": "In Gonerils Palast fühlt Lear: Diese Kränkung werde ich nicht vergessen!",
-                "sentenceTranslation": "Во дворце Гонериль Лир ощущает: Эту обиду я не забуду!",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht König Lear den Ring an der Hand. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Kränkung“ bleibt lebendig.",
+                "sentenceTranslation": "Среди разбросанных свитков Лир вертит кольцо на пальце. Каждой клеткой тела я обещаю: слово «обида» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Zorn",
@@ -1875,8 +1875,8 @@
                 "word": "bereuen",
                 "translation": "сожалеть",
                 "transcription": "[бе-РОЙ-ен]",
-                "sentence": "In Gonerils Palast fühlt Lear: Sie wird ihre Grausamkeit bereuen!",
-                "sentenceTranslation": "Во дворце Гонериль Лир ощущает: Она пожалеет о своей жестокости!",
+                "sentence": "Am leeren Bankettisch zählt König Lear die verlöschenden Kerzen. Wie ein stilles Gebet legt sich das Wort „bereuen“ auf meine Lippen.",
+                "sentenceTranslation": "У пустого банкетного стола Лир пересчитывает гаснущие свечи. Как тихая молитва слово «сожалеть» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1901,8 +1901,8 @@
                 "word": "der Fluch",
                 "translation": "проклятие",
                 "transcription": "[дер ФЛУХ]",
-                "sentence": "In Gonerils Palast fühlt Lear: Mein Fluch soll über dich kommen!",
-                "sentenceTranslation": "Во дворце Гонериль Лир ощущает: Моё проклятие падёт на тебя!",
+                "sentence": "Zwischen schweigenden Wachen geht König Lear auf den kalten Hof hinaus. Ich zeichne das Wort „der Fluch“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Между молчаливыми стражниками Лир выходит на холодный двор. Я черчу слово «проклятие» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1925,19 +1925,19 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
+                    "неблагодарность",
                     "унижать",
                     "проклинать",
-                    "неблагодарность",
                     "гнев"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "неблагодарность",
-                    "проклинать",
                     "унижать",
+                    "проклинать",
+                    "неблагодарность",
                     "гнев"
                 ],
                 "correctIndex": 3
@@ -1945,40 +1945,40 @@
             {
                 "question": "Что означает немецкое слово «die Undankbarkeit»?",
                 "choices": [
+                    "унижать",
                     "изгонять",
                     "неблагодарность",
-                    "унижать",
-                    "обида"
+                    "гнев"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "обида",
                     "сожалеть",
-                    "проклятие",
-                    "проклинать"
+                    "проклинать",
+                    "изгонять",
+                    "проклятие"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "проклинать",
-                    "изгонять",
                     "унижать",
-                    "неблагодарность"
+                    "изгонять",
+                    "проклятие",
+                    "гнев"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Kränkung»?",
                 "choices": [
-                    "проклятие",
+                    "неблагодарность",
                     "обида",
-                    "гнев",
-                    "изгонять"
+                    "сожалеть",
+                    "проклятие"
                 ],
                 "correctIndex": 1
             },
@@ -1986,21 +1986,21 @@
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
                     "изгонять",
-                    "сожалеть",
-                    "проклинать",
-                    "неблагодарность"
+                    "проклятие",
+                    "гнев",
+                    "сожалеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Fluch»?",
                 "choices": [
-                    "проклятие",
+                    "обида",
+                    "неблагодарность",
                     "изгонять",
-                    "проклинать",
-                    "сожалеть"
+                    "проклятие"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2013,8 +2013,8 @@
                 "word": "verlassen",
                 "translation": "покидать",
                 "transcription": "[фер-ЛА-сен]",
-                "sentence": "Auf dem Hof von Regans Burg fleht Lear: Auch Regan will mich verlassen und verstoßen!",
-                "sentenceTranslation": "На дворе замка Реганы Лир умоляет: И Регана хочет меня покинуть и отвергнуть!",
+                "sentence": "Im zugigen Seitenflügel lauscht König Lear dem Heulen der Küstenwinde. Wie ein stilles Gebet legt sich das Wort „verlassen“ auf meine Lippen.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Лир слушает вой прибрежного ветра. Как тихая молитва слово «покидать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2037,8 +2037,8 @@
                 "word": "verstoßen",
                 "translation": "отвергать",
                 "transcription": "[фер-ШТО-сен]",
-                "sentence": "Auf dem Hof von Regans Burg fleht Lear: Meine Töchter verstoßen mich wie einen Bettler!",
-                "sentenceTranslation": "На дворе замка Реганы Лир умоляет: Мои дочери отвергают меня как нищего!",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet König Lear einen zerknitterten Brief. Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig.",
+                "sentenceTranslation": "Перед дымным камином замка Лир складывает измятый лист. Каждой клеткой тела я обещаю: слово «отвергать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2067,8 +2067,8 @@
                 "word": "die Grausamkeit",
                 "translation": "жестокость",
                 "transcription": "[ди ГРАУ-зам-кайт]",
-                "sentence": "Auf dem Hof von Regans Burg fleht Lear: Ihre Grausamkeit übertrifft die ihrer Schwester!",
-                "sentenceTranslation": "На дворе замка Реганы Лир умоляет: Её жестокость превосходит жестокость сестры!",
+                "sentence": "Unter farblosen Wandteppichen schreitet König Lear rastlos auf und ab. Wie ein stilles Gebet legt sich das Wort „die Grausamkeit“ auf meine Lippen.",
+                "sentenceTranslation": "Под выцветшими гобеленами Лир беспокойно меряет шагами зал. Как тихая молитва слово «жестокость» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bosheit",
@@ -2102,8 +2102,8 @@
                 "word": "die Verzweiflung",
                 "translation": "отчаяние",
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
-                "sentence": "Auf dem Hof von Regans Burg fleht Lear: Die Verzweiflung packt mein altes Herz!",
-                "sentenceTranslation": "На дворе замка Реганы Лир умоляет: Отчаяние охватывает моё старое сердце!",
+                "sentence": "An der schmalen Fensterluke zählt König Lear die Fackeln auf dem Hof. Ich zeichne das Wort „die Verzweiflung“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У узкой бойницы Лир считает факелы на дворе. Я черчу слово «отчаяние» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2128,8 +2128,8 @@
                 "word": "betteln",
                 "translation": "просить",
                 "transcription": "[БЕ-тельн]",
-                "sentence": "Auf dem Hof von Regans Burg fleht Lear: Muss ich um Unterkunft betteln bei meinen eigenen Kindern?",
-                "sentenceTranslation": "На дворе замка Реганы Лир умоляет: Должен ли я просить крова у собственных детей?",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht König Lear nach frischen Botschaften. Ich presse das Wort „betteln“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Лир ищет свежие вести. Я стискиваю слово «просить» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Feigheit",
@@ -2158,8 +2158,8 @@
                 "word": "die Einsamkeit",
                 "translation": "одиночество",
                 "transcription": "[ди АЙН-зам-кайт]",
-                "sentence": "Auf dem Hof von Regans Burg fleht Lear: Die Einsamkeit umgibt mich wie ein kalter Mantel.",
-                "sentenceTranslation": "На дворе замка Реганы Лир умоляет: Одиночество окружает меня как холодный плащ.",
+                "sentence": "Im stillen Kapellenraum kniet König Lear vor der kalten Steinfigur. Ich umarme das Wort „die Einsamkeit“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В тихой капелле Лир преклоняет колени перед холодной каменной фигурой. Я обнимаю слово «одиночество», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2182,8 +2182,8 @@
                 "word": "die Träne",
                 "translation": "слеза",
                 "transcription": "[ди ТРЭ-не]",
-                "sentence": "Auf dem Hof von Regans Burg fleht Lear: Keine Träne will ich für diese Undankbaren vergießen!",
-                "sentenceTranslation": "На дворе замка Реганы Лир умоляет: Ни одной слезы я не пролью за этих неблагодарных!",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält König Lear die Laterne fest. Selbst wenn die Welt zerfällt, bleibt das Wort „die Träne“ mein Nordstern.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Лир крепко держит фонарь. Даже если мир распадается, слово «слеза» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2205,8 +2205,8 @@
                 "word": "die Not",
                 "translation": "нужда",
                 "transcription": "[ди НОТ]",
-                "sentence": "Auf dem Hof von Regans Burg fleht Lear: In meiner Not erkennen sie mich nicht als Vater.",
-                "sentenceTranslation": "На дворе замка Реганы Лир умоляет: В моей нужде они не признают меня отцом.",
+                "sentence": "Im Schatten der hohen Burgmauern schreibt König Lear eine fiebrige Antwort. Mein Atem zeichnet das Wort „die Not“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тени высоких стен Лир пишет лихорадочный ответ. Моё дыхание рисует слово «нужда» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2229,82 +2229,82 @@
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
+                    "отчаяние",
                     "жестокость",
-                    "покидать",
                     "отвергать",
-                    "отчаяние"
+                    "покидать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
                     "жестокость",
+                    "отвергать",
                     "покидать",
-                    "отчаяние",
-                    "отвергать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Grausamkeit»?",
-                "choices": [
-                    "жестокость",
-                    "слеза",
-                    "просить",
                     "отчаяние"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Verzweiflung»?",
-                "choices": [
-                    "просить",
-                    "отчаяние",
-                    "слеза",
-                    "покидать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «betteln»?",
+                "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "просить",
+                    "покидать",
+                    "отчаяние",
                     "жестокость",
+                    "одиночество"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Verzweiflung»?",
+                "choices": [
+                    "отчаяние",
+                    "слеза",
                     "отвергать",
-                    "покидать"
+                    "жестокость"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «betteln»?",
+                "choices": [
+                    "покидать",
+                    "одиночество",
+                    "нужда",
+                    "просить"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
                     "одиночество",
-                    "нужда",
-                    "слеза",
-                    "просить"
+                    "отчаяние",
+                    "жестокость",
+                    "слеза"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Träne»?",
                 "choices": [
-                    "просить",
                     "одиночество",
+                    "отвергать",
                     "слеза",
-                    "покидать"
+                    "жестокость"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Not»?",
                 "choices": [
-                    "отвергать",
+                    "нужда",
                     "жестокость",
-                    "одиночество",
-                    "нужда"
+                    "покидать",
+                    "слеза"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2317,8 +2317,8 @@
                 "word": "der Sturm",
                 "translation": "буря",
                 "transcription": "[дер ШТУРМ]",
-                "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Der Sturm in meinem Kopf ist schlimmer als draußen!",
-                "sentenceTranslation": "На пустоши под хлещущим дождём Лир кричит: Буря в моей голове хуже, чем снаружи!",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich König Lear gegen den Wind. Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Лир упирается в ветер. Я обнимаю слово «буря», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2343,8 +2343,8 @@
                 "word": "der Wahnsinn",
                 "translation": "безумие",
                 "transcription": "[дер ВАН-зин]",
-                "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Der Wahnsinn ist gnädiger als die Vernunft!",
-                "sentenceTranslation": "На пустоши под хлещущим дождём Лир кричит: Безумие милосерднее разума!",
+                "sentence": "Unter einem zerrissenen Banner schützt König Lear die Augen vor den Blitzen. Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Под разорванным знаменем Лир прикрывает глаза от молний. Моё дыхание рисует слово «безумие» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2368,8 +2368,8 @@
                 "word": "toben",
                 "translation": "бушевать",
                 "transcription": "[ТО-бен]",
-                "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Lasst die Winde toben und die Blitze fallen!",
-                "sentenceTranslation": "На пустоши под хлещущим дождём Лир кричит: Пусть ветры бушуют и молнии падают!",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht König Lear Deckung vor dem Donner. Ich flüstere den Wächtern des Schicksals zu: Das Wort „toben“ darf nicht vergehen.",
+                "sentenceTranslation": "У поваленного дерева Лир ищет укрытия от грома. Я шепчу стражам судьбы: слово «бушевать» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2391,8 +2391,8 @@
                 "word": "der Donner",
                 "translation": "гром",
                 "transcription": "[дер ДО-нер]",
-                "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Der Donner ist die Stimme der Götter!",
-                "sentenceTranslation": "На пустоши под хлещущим дождём Лир кричит: Гром - это голос богов!",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert König Lear durch den Schlamm. Ich umarme das Wort „der Donner“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Между пенящимися лужами Лир пробирается через грязь. Я обнимаю слово «гром», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2415,8 +2415,8 @@
                 "word": "der Blitz",
                 "translation": "молния",
                 "transcription": "[дер БЛИЦ]",
-                "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Die Blitze sollen meine weißen Haare verbrennen!",
-                "sentenceTranslation": "На пустоши под хлещущим дождём Лир кричит: Пусть молнии сожгут мои седые волосы!",
+                "sentence": "Vor einem zuckenden Himmel hebt König Lear die Arme trotzig an. Ich atme tief ein und lasse nur das Wort „der Blitz“ wieder hinaus.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Лир упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «молния».",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2439,8 +2439,8 @@
                 "word": "schreien",
                 "translation": "кричать",
                 "transcription": "[ШРАЙ-ен]",
-                "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Ich schreie in den Wind meine Wut hinaus!",
-                "sentenceTranslation": "На пустоши под хлещущим дождём Лир кричит: Я кричу в ветер свою ярость!",
+                "sentence": "Unter dem durchtränkten Umhang presst König Lear den Atem gegen die Kälte. Ich zeichne das Wort „schreien“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под промокшим плащом Лир прижимает дыхание к груди, спасаясь от холода. Я вывожу слово «кричать» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "Folter",
@@ -2467,8 +2467,8 @@
                 "word": "nackt",
                 "translation": "голый",
                 "transcription": "[НАКТ]",
-                "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Nackt kam ich auf die Welt, nackt gehe ich!",
-                "sentenceTranslation": "На пустоши под хлещущим дождём Лир кричит: Голым я пришёл в мир, голым и уйду!",
+                "sentence": "Am kläglichen Feuerrest wärmt König Lear zitternde Finger. Ich zeichne das Wort „nackt“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У жалких огненных углей Лир греет дрожащие пальцы. Я черчу слово «голый» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Sturm",
@@ -2495,8 +2495,8 @@
                 "word": "das Chaos",
                 "translation": "хаос",
                 "transcription": "[дас ХА-ос]",
-                "sentence": "Auf der Heide unter peitschendem Regen schreit Lear: Das Chaos in der Natur spiegelt meine Seele!",
-                "sentenceTranslation": "На пустоши под хлещущим дождём Лир кричит: Хаос в природе отражает мою душу!",
+                "sentence": "Zwischen heulenden Hunden ruft König Lear gegen den tosenden Sturm an. Ich halte das Wort „das Chaos“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Среди воющих псов Лир перекрикивает беснующуюся бурю. Я держу слово «хаос» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2519,82 +2519,82 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "буря",
-                    "безумие",
+                    "бушевать",
                     "гром",
-                    "бушевать"
+                    "буря",
+                    "безумие"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
                     "буря",
+                    "гром",
                     "безумие",
-                    "бушевать",
-                    "гром"
+                    "бушевать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «toben»?",
                 "choices": [
-                    "безумие",
-                    "голый",
-                    "бушевать",
-                    "хаос"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Donner»?",
-                "choices": [
-                    "безумие",
                     "буря",
-                    "гром",
+                    "бушевать",
+                    "безумие",
                     "молния"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Blitz»?",
-                "choices": [
-                    "кричать",
-                    "гром",
-                    "молния",
-                    "безумие"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «schreien»?",
-                "choices": [
-                    "гром",
-                    "кричать",
-                    "молния",
-                    "безумие"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «der Donner»?",
+                "choices": [
+                    "гром",
+                    "безумие",
+                    "голый",
+                    "буря"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «der Blitz»?",
+                "choices": [
+                    "бушевать",
+                    "кричать",
+                    "голый",
+                    "молния"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «schreien»?",
+                "choices": [
+                    "буря",
+                    "голый",
+                    "хаос",
+                    "кричать"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
+                    "безумие",
                     "хаос",
-                    "молния",
                     "голый",
-                    "кричать"
+                    "бушевать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Chaos»?",
                 "choices": [
-                    "хаос",
+                    "буря",
                     "гром",
-                    "голый",
-                    "буря"
+                    "хаос",
+                    "безумие"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2607,8 +2607,8 @@
                 "word": "das Elend",
                 "translation": "нищета",
                 "transcription": "[дас Э-ленд]",
-                "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Im Elend erkenne ich die Wahrheit der Welt.",
-                "sentenceTranslation": "В полуразвалившейся хижине у Глостера Лир бредит: В нищете я познаю истину мира.",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt König Lear bei der flackernden Kerze. Selbst wenn die Welt zerfällt, bleibt das Wort „das Elend“ mein Nordstern.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Лир сидит у мерцающей свечи. Даже если мир распадается, слово «нищета» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2631,8 +2631,8 @@
                 "word": "der Bettler",
                 "translation": "нищий",
                 "transcription": "[дер БЕТ-лер]",
-                "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Dieser Bettler ist glücklicher als ich, der König!",
-                "sentenceTranslation": "В полуразвалившейся хижине у Глостера Лир бредит: Этот нищий счастливее меня, короля!",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht König Lear über ein altes Wappen. Mit fester Stimme schwöre ich mir: Das Wort „der Bettler“ wird heute nicht verraten.",
+                "sentenceTranslation": "Среди помятых доспехов Лир гладит старый герб. Твёрдым голосом я клянусь себе: слово «нищий» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Elend",
@@ -2658,8 +2658,8 @@
                 "word": "arm",
                 "translation": "бедный",
                 "transcription": "[АРМ]",
-                "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Die Armen leiden mehr als Könige jemals wissen.",
-                "sentenceTranslation": "В полуразвалившейся хижине у Глостера Лир бредит: Бедные страдают больше, чем короли когда-либо узнают.",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt König Lear fast den Kopf. Selbst wenn die Welt zerfällt, bleibt das Wort „arm“ mein Nordstern.",
+                "sentenceTranslation": "О низкую балку хижины Лир едва не ударяется головой. Даже если мир распадается, слово «бедный» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Elend",
@@ -2682,8 +2682,8 @@
                 "word": "frieren",
                 "translation": "мёрзнуть",
                 "transcription": "[ФРИ-рен]",
-                "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Wir alle frieren in dieser kalten Welt.",
-                "sentenceTranslation": "В полуразвалившейся хижине у Глостера Лир бредит: Мы все мёрзнем в этом холодном мире.",
+                "sentence": "Neben der schlafenden Wache flüstert König Lear in die schwere Nacht. Das kalte Licht lässt das Wort „frieren“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Рядом со спящим стражем Лир шепчет в тяжёлую ночь. Холодный свет заставляет слово «мёрзнуть» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Elend",
@@ -2713,8 +2713,8 @@
                 "word": "die Hütte",
                 "translation": "хижина",
                 "transcription": "[ди ХЮ-те]",
-                "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Diese Hütte ist ein Palast für die Verlassenen.",
-                "sentenceTranslation": "В полуразвалившейся хижине у Глостера Лир бредит: Эта хижина - дворец для покинутых.",
+                "sentence": "Vor dem einfachen Feldbett betrachtet König Lear die Narben vergangener Schlachten. Ich zeichne das Wort „die Hütte“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед грубой походной койкой Лир разглядывает шрамы прошлых битв. Я черчу слово «хижина» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Elend",
@@ -2741,8 +2741,8 @@
                 "word": "leiden",
                 "translation": "страдать",
                 "transcription": "[ЛАЙ-ден]",
-                "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Wer nicht gelitten hat, kennt das Leben nicht.",
-                "sentenceTranslation": "В полуразвалившейся хижине у Глостера Лир бредит: Кто не страдал, не знает жизни.",
+                "sentence": "Im Geruch von feuchtem Stroh legt König Lear den Mantel zur Seite. Mein Atem zeichnet das Wort „leiden“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В запахе влажной соломы Лир откладывает плащ в сторону. Моё дыхание рисует слово «страдать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2768,8 +2768,8 @@
                 "word": "der Narr",
                 "translation": "шут",
                 "transcription": "[дер НАР]",
-                "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Mein Narr ist weiser als ich je war.",
-                "sentenceTranslation": "В полуразвалившейся хижине у Глостера Лир бредит: Мой шут мудрее, чем я когда-либо был.",
+                "sentence": "Auf dem wackligen Holztisch ordnet König Lear zerlesene Briefe. Selbst wenn die Welt zerfällt, bleibt das Wort „der Narr“ mein Nordstern.",
+                "sentenceTranslation": "На шатком деревянном столе Лир раскладывает зачитанные письма. Даже если мир распадается, слово «шут» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2792,8 +2792,8 @@
                 "word": "die Erkenntnis",
                 "translation": "познание",
                 "transcription": "[ди ер-КЕНТ-нис]",
-                "sentence": "In der verfallenen Hütte bei Gloucester halluziniert Lear: Die Erkenntnis kommt durch Schmerz und Verlust.",
-                "sentenceTranslation": "В полуразвалившейся хижине у Глостера Лир бредит: Познание приходит через боль и утрату.",
+                "sentence": "Am Eingang der Hütte späht König Lear nach einem vertrauten Schatten. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Erkenntnis“ darf nicht vergehen.",
+                "sentenceTranslation": "У входа в хижину Лир высматривает знакомую тень. Я шепчу стражам судьбы: слово «познание» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2819,80 +2819,80 @@
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
-                    "мёрзнуть",
-                    "бедный",
                     "нищий",
-                    "нищета"
+                    "мёрзнуть",
+                    "нищета",
+                    "бедный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
-                    "нищета",
-                    "бедный",
+                    "мёрзнуть",
                     "нищий",
-                    "мёрзнуть"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «arm»?",
-                "choices": [
-                    "шут",
-                    "бедный",
-                    "хижина",
-                    "нищий"
+                    "нищета",
+                    "бедный"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «arm»?",
+                "choices": [
+                    "бедный",
+                    "нищий",
+                    "шут",
+                    "познание"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
+                    "бедный",
                     "нищета",
-                    "страдать",
-                    "мёрзнуть",
-                    "нищий"
+                    "нищий",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
-                    "хижина",
+                    "страдать",
+                    "шут",
                     "нищий",
-                    "нищета",
+                    "хижина"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «leiden»?",
+                "choices": [
+                    "страдать",
+                    "мёрзнуть",
+                    "бедный",
+                    "хижина"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «der Narr»?",
+                "choices": [
+                    "шут",
+                    "познание",
+                    "бедный",
                     "страдать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «leiden»?",
-                "choices": [
-                    "мёрзнуть",
-                    "страдать",
-                    "хижина",
-                    "познание"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Narr»?",
-                "choices": [
-                    "хижина",
-                    "шут",
-                    "мёрзнуть",
-                    "нищий"
-                ],
-                "correctIndex": 1
-            },
-            {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
                     "познание",
-                    "страдать",
-                    "нищий",
-                    "хижина"
+                    "бедный",
+                    "хижина",
+                    "мёрзнуть"
                 ],
                 "correctIndex": 0
             }
@@ -2907,8 +2907,8 @@
                 "word": "erkennen",
                 "translation": "узнавать",
                 "transcription": "[эр-КЕ-нен]",
-                "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Ich erkenne dich, meine treue Cordelia!",
-                "sentenceTranslation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Я узнаю тебя, моя верная Корделия!",
+                "sentence": "Auf den weißen Klippen von Dover blickt König Lear in den aufgewühlten Kanal. Ich halte das Wort „erkennen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На белых скалах Дувра Лир смотрит в вздыбленный пролив. Я держу слово «узнавать» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2936,8 +2936,8 @@
                 "word": "verstehen",
                 "translation": "понимать",
                 "transcription": "[фер-ШТЕ-ен]",
-                "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Jetzt verstehe ich, wer mich wirklich liebte.",
-                "sentenceTranslation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Теперь я понимаю, кто действительно меня любил.",
+                "sentence": "Zwischen flatternden Feldzeichen richtet König Lear den Helm. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verstehen“ gehört mir.",
+                "sentenceTranslation": "Среди хлопающих штандартов Лир поправляет шлем. Буря за окнами усиливает клятву: слово «понимать» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2960,8 +2960,8 @@
                 "word": "die Wahrheit",
                 "translation": "правда",
                 "transcription": "[ди ВАР-хайт]",
-                "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Die Wahrheit war immer in deinen Worten, Kind.",
-                "sentenceTranslation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Правда всегда была в твоих словах, дитя.",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet König Lear Marschrouten in den Sand. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Wahrheit“ gehört mir.",
+                "sentenceTranslation": "У французского костра Лир рисует в песке путь марша. Буря за окнами усиливает клятву: слово «правда» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2985,8 +2985,8 @@
                 "word": "die Reue",
                 "translation": "раскаяние",
                 "transcription": "[ди РОЙ-е]",
-                "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Die Reue brennt heißer als alle Feuer der Hölle.",
-                "sentenceTranslation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Раскаяние жжёт горячее всех адских огней.",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert König Lear das Siegel. Das Echo des Wortes „die Reue“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Лир проверяет печати. Эхо слова «раскаяние» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3010,8 +3010,8 @@
                 "word": "die Weisheit",
                 "translation": "мудрость",
                 "transcription": "[ди ВАЙС-хайт]",
-                "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Die Weisheit kommt zu spät zu mir.",
-                "sentenceTranslation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Мудрость приходит ко мне слишком поздно.",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht König Lear dem dumpfen Meer. Ich umarme das Wort „die Weisheit“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Лир слушает глухой шум моря. Я обнимаю слово «мудрость», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Erbe",
@@ -3044,8 +3044,8 @@
                 "word": "vergeben",
                 "translation": "прощать",
                 "transcription": "[фер-ГЕ-бен]",
-                "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Kannst du einem törichten alten Mann vergeben?",
-                "sentenceTranslation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Можешь ли ты простить глупого старика?",
+                "sentence": "Auf dem sandigen Trainingsplatz übt König Lear das Ziehen des Schwerts. Wie ein stilles Gebet legt sich das Wort „vergeben“ auf meine Lippen.",
+                "sentenceTranslation": "На песчаном плацу Лир отрабатывает выхват меча. Как тихая молитва слово «прощать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3069,8 +3069,8 @@
                 "word": "die Einsicht",
                 "translation": "прозрение",
                 "transcription": "[ди АЙН-зихт]",
-                "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Die Einsicht verbrennt meine Seele.",
-                "sentenceTranslation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Прозрение сжигает мою душу.",
+                "sentence": "Zwischen pochenden Trommeln hebt König Lear das Banner der Hoffnung. Mein Atem zeichnet das Wort „die Einsicht“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Под гул барабанов Лир поднимает знамя надежды. Моё дыхание рисует слово «прозрение» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Weisheit",
@@ -3093,8 +3093,8 @@
                 "word": "schuldig",
                 "translation": "виновный",
                 "transcription": "[ШУЛЬ-диг]",
-                "sentence": "Vor den Klippen von Dover bei Cordelias Truppen erkennt Lear: Ich bin schuldig vor meiner Tochter.",
-                "sentenceTranslation": "У утёсов Дувра рядом с войском Корделии Лир осознаёт: Я виновен перед своей дочерью.",
+                "sentence": "Am Morgennebel der Küste legt König Lear die Hand auf das pochende Herz. Selbst wenn die Welt zerfällt, bleibt das Wort „schuldig“ mein Nordstern.",
+                "sentenceTranslation": "В утреннем тумане побережья Лир кладёт ладонь на бьющееся сердце. Даже если мир распадается, слово «виновный» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Weisheit",
@@ -3118,82 +3118,82 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "узнавать",
+                    "раскаяние",
                     "правда",
-                    "понимать",
-                    "раскаяние"
+                    "узнавать",
+                    "понимать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verstehen»?",
                 "choices": [
-                    "правда",
+                    "узнавать",
                     "раскаяние",
-                    "понимать",
-                    "узнавать"
+                    "правда",
+                    "понимать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
                     "правда",
-                    "виновный",
-                    "раскаяние",
-                    "прощать"
+                    "мудрость",
+                    "узнавать",
+                    "виновный"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "мудрость",
-                    "раскаяние",
-                    "прощать",
-                    "узнавать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Weisheit»?",
-                "choices": [
+                    "понимать",
                     "узнавать",
-                    "прощать",
-                    "мудрость",
-                    "прозрение"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «vergeben»?",
-                "choices": [
-                    "раскаяние",
-                    "правда",
-                    "мудрость",
-                    "прощать"
+                    "виновный",
+                    "раскаяние"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Einsicht»?",
+                "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "прозрение",
                     "мудрость",
+                    "прощать",
                     "понимать",
+                    "раскаяние"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «vergeben»?",
+                "choices": [
+                    "прощать",
+                    "раскаяние",
+                    "мудрость",
                     "правда"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Einsicht»?",
+                "choices": [
+                    "узнавать",
+                    "правда",
+                    "прозрение",
+                    "виновный"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «schuldig»?",
                 "choices": [
                     "узнавать",
-                    "понимать",
-                    "виновный",
-                    "правда"
+                    "правда",
+                    "мудрость",
+                    "виновный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -3206,8 +3206,8 @@
                 "word": "verzeihen",
                 "translation": "прощать",
                 "transcription": "[фер-ЦАЙ-ен]",
-                "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Verzeih mir, ich bin nur ein törichter alter Mann.",
-                "sentenceTranslation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Прости меня, я всего лишь глупый старик.",
+                "sentence": "Im feuchten Kerker stützt König Lear sich an den tropfenden Stein. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verzeihen“ gehört mir.",
+                "sentenceTranslation": "В сыром подземелье Лир опирается на сочащийся камень. Буря за окнами усиливает клятву: слово «прощать» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3231,8 +3231,8 @@
                 "word": "der Tod",
                 "translation": "смерть",
                 "transcription": "[дер ТОД]",
-                "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Der Tod ist gnädiger als das Leben ohne dich.",
-                "sentenceTranslation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Смерть милосерднее жизни без тебя.",
+                "sentence": "Unter der trüben Laterne zählt König Lear die eisernen Ringe der Kette. Ich umarme das Wort „der Tod“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Под мутным фонарём Лир пересчитывает железные кольца цепи. Я обнимаю слово «смерть», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3258,8 +3258,8 @@
                 "word": "sterben",
                 "translation": "умирать",
                 "transcription": "[ШТЕР-бен]",
-                "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Lass mich an deiner Seite sterben, Cordelia.",
-                "sentenceTranslation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Позволь мне умереть рядом с тобой, Корделия.",
+                "sentence": "Neben der schweren Holztür horcht König Lear auf entferntes Schluchzen. Wie ein stilles Gebet legt sich das Wort „sterben“ auf meine Lippen.",
+                "sentenceTranslation": "У тяжёлой двери Лир прислушивается к далёким рыданиям. Как тихая молитва слово «умирать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3285,8 +3285,8 @@
                 "word": "das Ende",
                 "translation": "конец",
                 "transcription": "[дас ЕН-де]",
-                "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Das Ende kommt, aber mit dir bin ich nicht allein.",
-                "sentenceTranslation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Конец приходит, но с тобой я не одинок.",
+                "sentence": "Auf der kalten Steinbank zieht König Lear den Mantel enger um die Schultern. Ich presse das Wort „das Ende“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На холодной каменной скамье Лир плотнее кутается в плащ. Я стискиваю слово «конец» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3311,8 +3311,8 @@
                 "word": "das Herz",
                 "translation": "сердце",
                 "transcription": "[дас ХЕРЦ]",
-                "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Mein Herz bricht vor Schmerz und Liebe.",
-                "sentenceTranslation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Моё сердце разбивается от боли и любви.",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt König Lear das Gesicht zum Licht. Ich umarme das Wort „das Herz“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Между тенями решёток Лир поднимает лицо к свету. Я обнимаю слово «сердце», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3335,8 +3335,8 @@
                 "word": "die Trauer",
                 "translation": "скорбь",
                 "transcription": "[ди ТРАУ-ер]",
-                "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Die Trauer überwältigt meine Seele.",
-                "sentenceTranslation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Скорбь переполняет мою душу.",
+                "sentence": "Am rostigen Wassereimer spiegelt König Lear kurz die eigenen Augen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Trauer“ gehört mir.",
+                "sentenceTranslation": "У ржавого ведра с водой Лир на мгновение видит отражение глаз. Буря за окнами усиливает клятву: слово «скорбь» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3361,8 +3361,8 @@
                 "word": "der Abschied",
                 "translation": "прощание",
                 "transcription": "[дер АБ-шид]",
-                "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Das ist unser letzter Abschied, mein Kind.",
-                "sentenceTranslation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Это наше последнее прощание, дитя моё.",
+                "sentence": "Im dumpfen Hall der Schritte zählt König Lear den Rhythmus der Wachen. Ich presse das Wort „der Abschied“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В глухом эхе шагов Лир отсчитывает ритм часовых. Я стискиваю слово «прощание» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Abschied",
@@ -3396,8 +3396,8 @@
                 "word": "ewig",
                 "translation": "вечный",
                 "transcription": "[Э-виг]",
-                "sentence": "Im Kerker, den Edmund bewacht, flüstert Lear: Unsere Liebe wird ewig dauern, mein Kind.",
-                "sentenceTranslation": "В темнице, которую охраняет Эдмунд, Лир шепчет: Наша любовь будет вечной, дитя моё.",
+                "sentence": "Vor dem verriegelten Fenster zeichnet König Lear Kreise in den Staub. Ich flüstere den Wächtern des Schicksals zu: Das Wort „ewig“ darf nicht vergehen.",
+                "sentenceTranslation": "Перед заколоченным окном Лир чертит круги в пыли. Я шепчу стражам судьбы: слово «вечный» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Abschied",
@@ -3428,42 +3428,42 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "конец",
+                    "умирать",
                     "смерть",
                     "прощать",
-                    "умирать"
+                    "конец"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "умирать",
                     "смерть",
+                    "умирать",
                     "конец",
                     "прощать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "смерть",
                     "прощание",
                     "умирать",
-                    "скорбь"
+                    "скорбь",
+                    "вечный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "конец",
-                    "умирать",
                     "скорбь",
+                    "сердце",
+                    "конец",
                     "смерть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Herz»?",
@@ -3471,7 +3471,7 @@
                     "сердце",
                     "прощание",
                     "прощать",
-                    "умирать"
+                    "скорбь"
                 ],
                 "correctIndex": 0
             },
@@ -3479,31 +3479,31 @@
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
                     "конец",
-                    "скорбь",
-                    "сердце",
-                    "прощание"
+                    "смерть",
+                    "вечный",
+                    "скорбь"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
+                    "вечный",
                     "прощание",
-                    "прощать",
-                    "умирать",
-                    "вечный"
+                    "сердце",
+                    "умирать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "умирать",
+                    "вечный",
+                    "конец",
                     "скорбь",
-                    "прощать",
-                    "вечный"
+                    "прощать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -4034,27 +4034,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/oswald.html
+++ b/output/journeys/oswald.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["служить", "преданность", "слуга", "послушание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["преданность", "слуга", "служить", "послушание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["раболепный", "служить", "преданность", "покорный"], "correct_index": 2}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["преданность", "покорный", "служить", "управляющий"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["слуга", "покорный", "управляющий", "исполнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["покорный", "исполнять", "служить", "слуга"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["слуга", "покорный", "раболепный", "преданность"], "correct_index": 2}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["управляющий", "раболепный", "послушание", "исполнять"], "correct_index": 3}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["спешка", "передавать", "гонец", "поручение"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["поручение", "гонец", "передавать", "спешка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["поручение", "передавать", "торопиться", "спешка"], "correct_index": 3}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["передавать", "торопиться", "поручение", "послание"], "correct_index": 0}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["спешить", "поручение", "послание", "передавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["послание", "передавать", "спешка", "поручение"], "correct_index": 0}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["торопиться", "передавать", "спешка", "гонец"], "correct_index": 0}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["оскорблять", "трусость", "неуважение", "оскорбление"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорблять", "неуважение", "трусость", "оскорбление"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["неуважение", "пренебрегать", "трусость", "высмеивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["пренебрегать", "оскорбление", "трусливый", "оскорблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["высмеивать", "оскорблять", "трусливый", "оскорбление"], "correct_index": 0}, {"question": "Что означает немецкое слово «frech»?", "choices": ["оскорбление", "трусливый", "дерзкий", "пренебрегать"], "correct_index": 2}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["пренебрегать", "дерзкий", "оскорбление", "оскорблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «feige»?", "choices": ["трусливый", "трусость", "дерзкий", "пренебрегать"], "correct_index": 0}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["скрытность", "шпион", "шпионить", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["скрытность", "предательство", "шпионить", "шпион"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["вынюхивать", "скрытность", "выдавать", "шпионить"], "correct_index": 1}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["шпионить", "подслушивать", "вынюхивать", "предательство"], "correct_index": 0}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["выдавать", "подслушивать", "скрытность", "шпион"], "correct_index": 1}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["вынюхивать", "шпион", "подслушивать", "выдавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["вынюхивать", "шпион", "предательство", "выдавать"], "correct_index": 0}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["ковать", "план", "интрига", "коварство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["ковать", "план", "коварство", "интрига"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["хитрый", "ковать", "коварство", "план"], "correct_index": 2}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["коварный", "ковать", "интрига", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["план", "интрига", "коварный", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["интрига", "коварный", "ковать", "коварство"], "correct_index": 1}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["ловушка", "хитрый", "обманывать", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["план", "ловушка", "ковать", "коварство"], "correct_index": 1}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["преследование", "преследовать", "гнаться", "охота"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["гнаться", "преследовать", "преследование", "охота"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["охота", "добыча", "преследовать", "травить"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["добыча", "выслеживать", "преследовать", "гнаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["охота", "выслеживать", "добыча", "преследование"], "correct_index": 1}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["выслеживать", "преследовать", "добыча", "травить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["преследовать", "гнаться", "преследование", "добыча"], "correct_index": 3}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["падать", "трусость", "смерть", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["падать", "трусость", "поражение", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["смерть", "проигрывать", "хныкать", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["хныкать", "трусость", "смерть", "падать"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["смерть", "проигрывать", "жалкий", "хныкать"], "correct_index": 1}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["проигрывать", "поражение", "хныкать", "умолять"], "correct_index": 2}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["трусость", "проигрывать", "умолять", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["жалкий", "смерть", "трусость", "хныкать"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["слуга", "послушание", "преданность", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["послушание", "преданность", "служить", "слуга"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["управляющий", "покорный", "послушание", "преданность"], "correct_index": 3}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["преданность", "исполнять", "служить", "управляющий"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["раболепный", "покорный", "служить", "управляющий"], "correct_index": 3}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["преданность", "раболепный", "управляющий", "покорный"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["исполнять", "управляющий", "раболепный", "покорный"], "correct_index": 2}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["покорный", "преданность", "исполнять", "раболепный"], "correct_index": 2}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["передавать", "поручение", "спешка", "гонец"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["гонец", "спешка", "поручение", "передавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["спешка", "передавать", "поручение", "послание"], "correct_index": 0}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["передавать", "послание", "спешить", "спешка"], "correct_index": 0}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["спешить", "торопиться", "поручение", "гонец"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["гонец", "спешить", "передавать", "послание"], "correct_index": 3}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["передавать", "спешка", "гонец", "торопиться"], "correct_index": 3}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["трусость", "оскорбление", "оскорблять", "неуважение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорблять", "оскорбление", "трусость", "неуважение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["оскорблять", "пренебрегать", "трусость", "высмеивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["трусливый", "оскорблять", "дерзкий", "пренебрегать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["оскорблять", "пренебрегать", "дерзкий", "высмеивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «frech»?", "choices": ["трусость", "высмеивать", "дерзкий", "пренебрегать"], "correct_index": 2}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["неуважение", "оскорблять", "оскорбление", "пренебрегать"], "correct_index": 3}, {"question": "Что означает немецкое слово «feige»?", "choices": ["пренебрегать", "неуважение", "трусливый", "трусость"], "correct_index": 2}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["шпионить", "предательство", "скрытность", "шпион"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["предательство", "шпионить", "шпион", "скрытность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["шпион", "скрытность", "вынюхивать", "шпионить"], "correct_index": 1}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["шпион", "шпионить", "выдавать", "подслушивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["выдавать", "шпион", "скрытность", "подслушивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["вынюхивать", "скрытность", "подслушивать", "выдавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["подслушивать", "предательство", "шпионить", "вынюхивать"], "correct_index": 3}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "ковать", "план", "коварство"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["коварство", "план", "интрига", "ковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["коварство", "коварный", "интрига", "ковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["ковать", "интрига", "коварный", "хитрый"], "correct_index": 0}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["план", "коварство", "хитрый", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["коварный", "план", "коварство", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["обманывать", "интрига", "хитрый", "план"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["хитрый", "коварство", "ловушка", "обманывать"], "correct_index": 2}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["преследование", "охота", "гнаться", "преследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["преследовать", "преследование", "гнаться", "охота"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["гнаться", "травить", "преследовать", "преследование"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["выслеживать", "преследовать", "травить", "гнаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["травить", "выслеживать", "охота", "преследование"], "correct_index": 1}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["гнаться", "преследование", "охота", "травить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["преследование", "добыча", "преследовать", "охота"], "correct_index": 1}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["трусость", "поражение", "падать", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["падать", "трусость", "поражение", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["хныкать", "проигрывать", "поражение", "жалкий"], "correct_index": 2}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["смерть", "падать", "поражение", "трусость"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["проигрывать", "поражение", "смерть", "хныкать"], "correct_index": 0}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["падать", "хныкать", "умолять", "проигрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["умолять", "проигрывать", "падать", "трусость"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["смерть", "хныкать", "падать", "жалкий"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Управляющий</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,49 +465,49 @@
             <div class="quiz-phase-container active" data-phase="steward">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Gehorsam»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ergebenheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">преданность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">покорный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Gehorsam»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Ergebenheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">управляющий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -519,6 +519,22 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">исполнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
@@ -529,33 +545,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">исполнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">раболепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">покорный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -565,29 +565,29 @@
                         <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">раболепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">покорный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «befolgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">управляющий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раболепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">исполнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раболепный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,49 +600,49 @@
             <div class="quiz-phase-container" data-phase="messenger">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Bote»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Auftrag»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Eile»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Auftrag»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Eile»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">торопиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -654,11 +654,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">послание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -670,43 +670,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">послание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">послание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «eilen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">торопиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -719,33 +719,33 @@
             <div class="quiz-phase-container" data-phase="insult">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Beleidigung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Respektlosigkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неуважение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -755,7 +755,7 @@
                         <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">пренебрегать</button>
                             
@@ -767,33 +767,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «beleidigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусливый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">высмеивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пренебрегать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -803,9 +803,9 @@
                         <div class="quiz-question">Что означает немецкое слово «frech»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">высмеивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
                             
@@ -815,33 +815,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «feige»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">дерзкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">неуважение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трусливый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «feige»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,33 +854,33 @@
             <div class="quiz-phase-container" data-phase="spy">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Spion»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -890,11 +890,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вынюхивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
                             
@@ -902,33 +902,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «spionieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вынюхивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «lauschen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -940,7 +940,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">подслушивать</button>
                             
@@ -950,17 +950,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «schnüffeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подслушивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вынюхивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,15 +973,15 @@
             <div class="quiz-phase-container" data-phase="schemer">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
                             
@@ -993,45 +993,45 @@
                         <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">коварный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1043,9 +1043,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
@@ -1053,31 +1053,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «tückisch»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">коварный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verschlagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                             
@@ -1085,17 +1085,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1114,11 +1114,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">охота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1128,11 +1128,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Jagd»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
                             
@@ -1144,13 +1144,13 @@
                         <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1160,11 +1160,11 @@
                         <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выслеживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">травить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
                             
@@ -1176,11 +1176,11 @@
                         <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">травить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
                             
@@ -1192,11 +1192,11 @@
                         <div class="quiz-question">Что означает немецкое слово «hetzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выслеживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
                             
@@ -1204,17 +1204,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Beute»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">добыча</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,17 +1227,17 @@
             <div class="quiz-phase-container" data-phase="coward_death">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1259,97 +1259,97 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жалкий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умолять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хныкать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «erbärmlich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жалкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хныкать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жалкий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1376,8 +1376,8 @@
                 "word": "der Diener",
                 "translation": "слуга",
                 "transcription": "[дер ДИ-нер]",
-                "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Als Diener gehorche ich meiner Herrin blind.",
-                "sentenceTranslation": "В доме Гонериль Освальд распоряжается как управляющий: Как слуга я слепо подчиняюсь своей госпоже.",
+                "sentence": "Im Saal der Herrin richtet Oswald die silbernen Teller entlang der langen Tafel aus. Ich zeichne das Wort „der Diener“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В зале госпожи Освальд выравнивает серебряные блюда вдоль длинного стола. Я черчу слово «слуга» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1400,8 +1400,8 @@
                 "word": "der Gehorsam",
                 "translation": "послушание",
                 "transcription": "[дер ге-ХОР-зам]",
-                "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Mein Gehorsam kennt keine Fragen.",
-                "sentenceTranslation": "В доме Гонериль Освальд распоряжается как управляющий: Моё послушание не знает вопросов.",
+                "sentence": "Vor dem Spiegel prüft Oswald den makellosen Sitz des Dienerkleids. Ich halte das Wort „der Gehorsam“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед зеркалом Освальд проверяет безупречную посадку дворецкого наряда. Я держу слово «послушание» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Diener",
@@ -1424,8 +1424,8 @@
                 "word": "die Ergebenheit",
                 "translation": "преданность",
                 "transcription": "[ди ер-ГЕ-бен-хайт]",
-                "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Meine Ergebenheit gilt nur Lady Goneril.",
-                "sentenceTranslation": "В доме Гонериль Освальд распоряжается как управляющий: Моя преданность принадлежит только леди Гонерилье.",
+                "sentence": "Zwischen Rechnungsbüchern notiert Oswald jedes Fass Wein. Ich presse das Wort „die Ergebenheit“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди бухгалтерских книг Освальд записывает каждую бочку вина. Я стискиваю слово «преданность» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Diener",
@@ -1448,8 +1448,8 @@
                 "word": "dienen",
                 "translation": "служить",
                 "transcription": "[ДИ-нен]",
-                "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Ich diene ohne Gewissen oder Ehre.",
-                "sentenceTranslation": "В доме Гонериль Освальд распоряжается как управляющий: Я служу без совести и чести.",
+                "sentence": "Am Hofeingang begrüßt Oswald mit steifem Nicken die ankommenden Lords. Wie ein stilles Gebet legt sich das Wort „dienen“ auf meine Lippen.",
+                "sentenceTranslation": "У входа во двор Освальд сдержанно кивает прибывающим лордам. Как тихая молитва слово «служить» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1472,8 +1472,8 @@
                 "word": "der Verwalter",
                 "translation": "управляющий",
                 "transcription": "[дер фер-ВАЛЬ-тер]",
-                "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Als Verwalter kontrolliere ich den Haushalt.",
-                "sentenceTranslation": "В доме Гонериль Освальд распоряжается как управляющий: Как управляющий я контролирую дом.",
+                "sentence": "Unter den wachsamen Augen Gonerils verteilt Oswald die Tagesbefehle. Mit fester Stimme schwöre ich mir: Das Wort „der Verwalter“ wird heute nicht verraten.",
+                "sentenceTranslation": "Под внимательным взглядом Гонерильи Освальд раздаёт дневные распоряжения. Твёрдым голосом я клянусь себе: слово «управляющий» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Diener",
@@ -1496,8 +1496,8 @@
                 "word": "ergeben",
                 "translation": "покорный",
                 "transcription": "[ер-ГЕ-бен]",
-                "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Ergeben folge ich jedem Befehl.",
-                "sentenceTranslation": "В доме Гонериль Освальд распоряжается как управляющий: Покорно я следую каждому приказу.",
+                "sentence": "Auf der Küchenrampe kontrolliert Oswald die frischen Vorräte. Das Echo des Wortes „ergeben“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На кухонном пандусе Освальд проверяет свежие припасы. Эхо слова «покорный» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Diener",
@@ -1520,8 +1520,8 @@
                 "word": "unterwürfig",
                 "translation": "раболепный",
                 "transcription": "[УН-тер-вюр-фиг]",
-                "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Unterwürfig krieche ich vor meiner Herrin.",
-                "sentenceTranslation": "В доме Гонериль Освальд распоряжается как управляющий: Раболепно я пресмыкаюсь перед госпожой.",
+                "sentence": "Neben der Ahnengalerie wischt Oswald letzte Staubkörner fort. Ich umarme das Wort „unterwürfig“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Рядом с галереей предков Освальд смахивает последние пылинки. Я обнимаю слово «раболепный», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Diener",
@@ -1544,8 +1544,8 @@
                 "word": "befolgen",
                 "translation": "исполнять",
                 "transcription": "[бе-ФОЛЬ-ген]",
-                "sentence": "Im Haus der Goneril herrscht Oswald als Verwalter: Jeden Befehl befolge ich sofort.",
-                "sentenceTranslation": "В доме Гонериль Освальд распоряжается как управляющий: Каждый приказ я исполняю немедленно.",
+                "sentence": "Im Kontor versiegelt Oswald sorgsam die königliche Korrespondenz. Ich atme tief ein und lasse nur das Wort „befolgen“ wieder hinaus.",
+                "sentenceTranslation": "В конторе Освальд тщательно запечатывает королевскую корреспонденцию. Я глубоко вдыхаю и выпускаю только слово «исполнять».",
                 "visual_hint": "📚",
                 "themes": [
                     "Diener",
@@ -1570,38 +1570,38 @@
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
-                    "служить",
-                    "преданность",
                     "слуга",
-                    "послушание"
+                    "послушание",
+                    "преданность",
+                    "служить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Gehorsam»?",
                 "choices": [
+                    "послушание",
                     "преданность",
-                    "слуга",
                     "служить",
-                    "послушание"
+                    "слуга"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ergebenheit»?",
                 "choices": [
-                    "раболепный",
-                    "служить",
-                    "преданность",
-                    "покорный"
+                    "управляющий",
+                    "покорный",
+                    "послушание",
+                    "преданность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
                     "преданность",
-                    "покорный",
+                    "исполнять",
                     "служить",
                     "управляющий"
                 ],
@@ -1610,42 +1610,42 @@
             {
                 "question": "Что означает немецкое слово «der Verwalter»?",
                 "choices": [
-                    "слуга",
+                    "раболепный",
                     "покорный",
-                    "управляющий",
-                    "исполнять"
+                    "служить",
+                    "управляющий"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ergeben»?",
                 "choices": [
-                    "покорный",
-                    "исполнять",
-                    "служить",
-                    "слуга"
+                    "преданность",
+                    "раболепный",
+                    "управляющий",
+                    "покорный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «unterwürfig»?",
                 "choices": [
-                    "слуга",
-                    "покорный",
+                    "исполнять",
+                    "управляющий",
                     "раболепный",
-                    "преданность"
+                    "покорный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «befolgen»?",
                 "choices": [
-                    "управляющий",
-                    "раболепный",
-                    "послушание",
-                    "исполнять"
+                    "покорный",
+                    "преданность",
+                    "исполнять",
+                    "раболепный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -1658,8 +1658,8 @@
                 "word": "der Bote",
                 "translation": "гонец",
                 "transcription": "[дер БО-те]",
-                "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Als Bote überbringe ich böse Nachrichten.",
-                "sentenceTranslation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Как гонец я приношу дурные вести.",
+                "sentence": "Auf staubigen Straßen peitscht Oswald das Pferd zu größerer Eile. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Bote“ gehört mir.",
+                "sentenceTranslation": "На пыльных дорогах Освальд подгоняет коня к большей скорости. Буря за окнами усиливает клятву: слово «гонец» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1682,8 +1682,8 @@
                 "word": "der Auftrag",
                 "translation": "поручение",
                 "transcription": "[дер АУФ-траг]",
-                "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Jeden Auftrag erfülle ich gewissenhaft.",
-                "sentenceTranslation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Каждое поручение я выполняю добросовестно.",
+                "sentence": "Vor verschlossenen Toren zeigt Oswald das mit Wachs versiegelte Schreiben. Das kalte Licht lässt das Wort „der Auftrag“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Перед закрытыми воротами Освальд предъявляет письмо, запечатанное воском. Холодный свет заставляет слово «поручение» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Auftrag",
@@ -1706,8 +1706,8 @@
                 "word": "die Eile",
                 "translation": "спешка",
                 "transcription": "[ди АЙ-ле]",
-                "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: In großer Eile renne ich hin und her.",
-                "sentenceTranslation": "Между дворцом Гонериль и замком Реганы Освальд бегает: В большой спешке я бегаю туда-сюда.",
+                "sentence": "In der Nacht rast Oswald mit einer Laterne als einzigem Stern. Selbst wenn die Welt zerfällt, bleibt das Wort „die Eile“ mein Nordstern.",
+                "sentenceTranslation": "Ночью Освальд мчится, освещаемый одной лишь латерной. Даже если мир распадается, слово «спешка» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Auftrag",
@@ -1730,8 +1730,8 @@
                 "word": "überbringen",
                 "translation": "передавать",
                 "transcription": "[ю-бер-БРИН-ген]",
-                "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Ich überbringe Befehle an alle Diener.",
-                "sentenceTranslation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Я передаю приказы всем слугам.",
+                "sentence": "Am Grenzposten überreicht Oswald den Befehl mit überheblichem Lächeln. Das Echo des Wortes „überbringen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На пограничной заставе Освальд вручает приказ с высокомерной улыбкой. Эхо слова «передавать» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Auftrag",
@@ -1754,8 +1754,8 @@
                 "word": "hasten",
                 "translation": "спешить",
                 "transcription": "[ХАС-тен]",
-                "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Ich haste von einem Ort zum anderen.",
-                "sentenceTranslation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Я спешу с места на место.",
+                "sentence": "Zwischen zerrissenen Bannern schützt Oswald die Nachricht vor dem Regen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „hasten“ darf nicht vergehen.",
+                "sentenceTranslation": "Среди порванных знамён Освальд прикрывает письмо от дождя. Я шепчу стражам судьбы: слово «спешить» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Auftrag",
@@ -1778,8 +1778,8 @@
                 "word": "die Botschaft",
                 "translation": "послание",
                 "transcription": "[ди БОТ-шафт]",
-                "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Die Botschaft meiner Herrin ist grausam.",
-                "sentenceTranslation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Послание моей госпожи жестоко.",
+                "sentence": "Auf dem Hofe Lear erhebt Oswald die Stimme über den Tumult. Das Echo des Wortes „die Botschaft“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На дворе Лира Освальд возвышает голос над шумом. Эхо слова «послание» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Auftrag",
@@ -1802,8 +1802,8 @@
                 "word": "eilen",
                 "translation": "торопиться",
                 "transcription": "[АЙ-лен]",
-                "sentence": "Zwischen Gonerils Palast und Regans Burg rennt Oswald: Ich eile, um ihre Wünsche zu erfüllen.",
-                "sentenceTranslation": "Между дворцом Гонериль и замком Реганы Освальд бегает: Я тороплюсь исполнить её желания.",
+                "sentence": "Im Schatten der Stallungen tauscht Oswald heimlich versiegelte Rollen. Mit fester Stimme schwöre ich mir: Das Wort „eilen“ wird heute nicht verraten.",
+                "sentenceTranslation": "В тени конюшен Освальд тайно меняет запечатанные свитки. Твёрдым голосом я клянусь себе: слово «торопиться» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Auftrag",
@@ -1827,40 +1827,40 @@
             {
                 "question": "Что означает немецкое слово «der Bote»?",
                 "choices": [
-                    "спешка",
                     "передавать",
-                    "гонец",
-                    "поручение"
+                    "поручение",
+                    "спешка",
+                    "гонец"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Auftrag»?",
                 "choices": [
-                    "поручение",
                     "гонец",
-                    "передавать",
-                    "спешка"
+                    "спешка",
+                    "поручение",
+                    "передавать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Eile»?",
                 "choices": [
-                    "поручение",
+                    "спешка",
                     "передавать",
-                    "торопиться",
-                    "спешка"
+                    "поручение",
+                    "послание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «überbringen»?",
                 "choices": [
                     "передавать",
-                    "торопиться",
-                    "поручение",
-                    "послание"
+                    "послание",
+                    "спешить",
+                    "спешка"
                 ],
                 "correctIndex": 0
             },
@@ -1868,31 +1868,31 @@
                 "question": "Что означает немецкое слово «hasten»?",
                 "choices": [
                     "спешить",
+                    "торопиться",
                     "поручение",
-                    "послание",
-                    "передавать"
+                    "гонец"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Botschaft»?",
                 "choices": [
-                    "послание",
+                    "гонец",
+                    "спешить",
                     "передавать",
-                    "спешка",
-                    "поручение"
+                    "послание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «eilen»?",
                 "choices": [
-                    "торопиться",
                     "передавать",
                     "спешка",
-                    "гонец"
+                    "гонец",
+                    "торопиться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -1905,8 +1905,8 @@
                 "word": "die Beleidigung",
                 "translation": "оскорбление",
                 "transcription": "[ди бе-ЛАЙ-ди-гунг]",
-                "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Jede Beleidigung spreche ich mit Genuss aus.",
-                "sentenceTranslation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Каждое оскорбление я произношу с наслаждением.",
+                "sentence": "Vor dem gealterten König verneigt sich Oswald nur einen Hauch zu wenig. Das Echo des Wortes „die Beleidigung“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Перед постаревшим королём Освальд кланяется лишь на долю меньше. Эхо слова «оскорбление» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beleidigung",
@@ -1929,8 +1929,8 @@
                 "word": "die Respektlosigkeit",
                 "translation": "неуважение",
                 "transcription": "[ди рес-ПЕКТ-ло-зиг-кайт]",
-                "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Meine Respektlosigkeit kennt keine Grenzen.",
-                "sentenceTranslation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Моё неуважение не знает границ.",
+                "sentence": "Am Torbogen blockiert Oswald den Weg mit erhobenem Stab. Ich halte das Wort „die Respektlosigkeit“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В проёме ворот Освальд преграждает путь поднятым жезлом. Я держу слово «неуважение» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beleidigung",
@@ -1953,8 +1953,8 @@
                 "word": "die Feigheit",
                 "translation": "трусость",
                 "transcription": "[ди ФАЙГ-хайт]",
-                "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Aus Feigheit greife ich nur Schwache an.",
-                "sentenceTranslation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Из трусости я нападаю только на слабых.",
+                "sentence": "Zwischen entrüsteten Rittern rollt Oswald mit den Augen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Feigheit“ bleibt lebendig.",
+                "sentenceTranslation": "Среди возмущённых рыцарей Освальд закатывает глаза. Каждой клеткой тела я обещаю: слово «трусость» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beleidigung",
@@ -1980,8 +1980,8 @@
                 "word": "beleidigen",
                 "translation": "оскорблять",
                 "transcription": "[бе-ЛАЙ-ди-ген]",
-                "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Ich beleidige den alten König ohne Scham.",
-                "sentenceTranslation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Я оскорбляю старого короля без стыда.",
+                "sentence": "Auf der Treppe wischt Oswald imaginären Staub von Lears Mantel. Ich halte das Wort „beleidigen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На лестнице Освальд стряхивает воображаемую пыль с плаща Лира. Я держу слово «оскорблять» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2003,8 +2003,8 @@
                 "word": "verhöhnen",
                 "translation": "высмеивать",
                 "transcription": "[фер-ХЁ-нен]",
-                "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Ich verhöhne seine königliche Würde.",
-                "sentenceTranslation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Я высмеиваю его королевское достоинство.",
+                "sentence": "Neben Gonerils kühlen Blick flüstert Oswald eine spitze Bemerkung. Das kalte Licht lässt das Wort „verhöhnen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Рядом с холодным взглядом Гонерильи Освальд шепчет едкое замечание. Холодный свет заставляет слово «высмеивать» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beleidigung",
@@ -2033,8 +2033,8 @@
                 "word": "frech",
                 "translation": "дерзкий",
                 "transcription": "[ФРЕХ]",
-                "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Frech widerspreche ich dem alten Mann.",
-                "sentenceTranslation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Дерзко я возражаю старику.",
+                "sentence": "Auf dem Hof setzt Oswald sich mit verschränkten Armen gegen jede Bitte zur Wehr. Selbst wenn die Welt zerfällt, bleibt das Wort „frech“ mein Nordstern.",
+                "sentenceTranslation": "На дворе Освальд скрестив руки сопротивляется любой просьбе. Даже если мир распадается, слово «дерзкий» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beleidigung",
@@ -2057,8 +2057,8 @@
                 "word": "missachten",
                 "translation": "пренебрегать",
                 "transcription": "[МИС-ах-тен]",
-                "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Ich missachte seinen früheren Rang.",
-                "sentenceTranslation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Я пренебрегаю его прежним рангом.",
+                "sentence": "Im Flur stößt Oswald den alten König absichtlich zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „missachten“ bleibt lebendig.",
+                "sentenceTranslation": "В коридоре Освальд нарочно отталкивает старого короля в сторону. Каждой клеткой тела я обещаю: слово «пренебрегать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beleidigung",
@@ -2081,8 +2081,8 @@
                 "word": "feige",
                 "translation": "трусливый",
                 "transcription": "[ФАЙ-ге]",
-                "sentence": "Vor König Lear am Tor von Gonerils Schloss spottet Oswald: Feige verstecke ich mich hinter meiner Herrin.",
-                "sentenceTranslation": "Перед королём Лиром у ворот замка Гонериль Освальд издевается: Трусливо я прячусь за своей госпожой.",
+                "sentence": "Auf dem Balkon lacht Oswald laut über Lears Hilflosigkeit. Ich halte das Wort „feige“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На балконе Освальд громко смеётся над беспомощностью Лира. Я держу слово «трусливый» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beleidigung",
@@ -2106,27 +2106,27 @@
             {
                 "question": "Что означает немецкое слово «die Beleidigung»?",
                 "choices": [
-                    "оскорблять",
                     "трусость",
-                    "неуважение",
-                    "оскорбление"
+                    "оскорбление",
+                    "оскорблять",
+                    "неуважение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Respektlosigkeit»?",
                 "choices": [
                     "оскорблять",
-                    "неуважение",
+                    "оскорбление",
                     "трусость",
-                    "оскорбление"
+                    "неуважение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
-                    "неуважение",
+                    "оскорблять",
                     "пренебрегать",
                     "трусость",
                     "высмеивать"
@@ -2136,28 +2136,28 @@
             {
                 "question": "Что означает немецкое слово «beleidigen»?",
                 "choices": [
-                    "пренебрегать",
-                    "оскорбление",
                     "трусливый",
-                    "оскорблять"
+                    "оскорблять",
+                    "дерзкий",
+                    "пренебрегать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "высмеивать",
                     "оскорблять",
-                    "трусливый",
-                    "оскорбление"
+                    "пренебрегать",
+                    "дерзкий",
+                    "высмеивать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «frech»?",
                 "choices": [
-                    "оскорбление",
-                    "трусливый",
+                    "трусость",
+                    "высмеивать",
                     "дерзкий",
                     "пренебрегать"
                 ],
@@ -2166,22 +2166,22 @@
             {
                 "question": "Что означает немецкое слово «missachten»?",
                 "choices": [
-                    "пренебрегать",
-                    "дерзкий",
+                    "неуважение",
+                    "оскорблять",
                     "оскорбление",
-                    "оскорблять"
+                    "пренебрегать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «feige»?",
                 "choices": [
+                    "пренебрегать",
+                    "неуважение",
                     "трусливый",
-                    "трусость",
-                    "дерзкий",
-                    "пренебрегать"
+                    "трусость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2194,8 +2194,8 @@
                 "word": "der Spion",
                 "translation": "шпион",
                 "transcription": "[дер шпи-ОН]",
-                "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Als Spion lausche ich an jeder Tür.",
-                "sentenceTranslation": "В коридорах замка Олбани Освальд крадётся: Как шпион я подслушиваю у каждой двери.",
+                "sentence": "Im Dunkel des Treppenhauses hält Oswald den Atem an, um Gespräche zu belauschen. Wie ein stilles Gebet legt sich das Wort „der Spion“ auf meine Lippen.",
+                "sentenceTranslation": "В темноте лестницы Освальд задерживает дыхание, подслушивая разговоры. Как тихая молитва слово «шпион» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Heimlichkeit",
@@ -2218,8 +2218,8 @@
                 "word": "der Verrat",
                 "translation": "предательство",
                 "transcription": "[дер фер-РАТ]",
-                "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Der Verrat ist mein tägliches Geschäft.",
-                "sentenceTranslation": "В коридорах замка Олбани Освальд крадётся: Предательство - моё ежедневное дело.",
+                "sentence": "Hinter schweren Vorhängen notiert Oswald jedes geflüsterte Wort. Das kalte Licht lässt das Wort „der Verrat“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "За тяжёлыми портьерами Освальд записывает каждое прошептанное слово. Холодный свет заставляет слово «предательство» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2244,8 +2244,8 @@
                 "word": "die Heimlichkeit",
                 "translation": "скрытность",
                 "transcription": "[ди ХАЙМ-лих-кайт]",
-                "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: In Heimlichkeit sammle ich Informationen.",
-                "sentenceTranslation": "В коридорах замка Олбани Освальд крадётся: В скрытности я собираю информацию.",
+                "sentence": "Auf den Mauern späht Oswald nach Reitern am Horizont. Ich halte das Wort „die Heimlichkeit“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На стенах Освальд высматривает всадников на горизонте. Я держу слово «скрытность» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Heimlichkeit",
@@ -2268,8 +2268,8 @@
                 "word": "spionieren",
                 "translation": "шпионить",
                 "transcription": "[шпи-о-НИ-рен]",
-                "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Ich spioniere für meine böse Herrin.",
-                "sentenceTranslation": "В коридорах замка Олбани Освальд крадётся: Я шпионю для моей злой госпожи.",
+                "sentence": "Zwischen Küchenmägden tauscht Oswald Gerüchte gegen Kupferstücke. Ich halte das Wort „spionieren“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Среди кухонных служанок Освальд обменивает слухи на медяки. Я держу слово «шпионить» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Heimlichkeit",
@@ -2292,8 +2292,8 @@
                 "word": "lauschen",
                 "translation": "подслушивать",
                 "transcription": "[ЛАУ-шен]",
-                "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Heimlich lausche ich allen Gesprächen.",
-                "sentenceTranslation": "В коридорах замка Олбани Освальд крадётся: Тайно я подслушиваю все разговоры.",
+                "sentence": "Im Kerzenlicht zeichnet Oswald geheime Wege auf Pergament. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „lauschen“ gehört mir.",
+                "sentenceTranslation": "При свете свечи Освальд вычерчивает тайные пути на пергаменте. Буря за окнами усиливает клятву: слово «подслушивать» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Heimlichkeit",
@@ -2316,8 +2316,8 @@
                 "word": "verraten",
                 "translation": "выдавать",
                 "transcription": "[фер-РА-тен]",
-                "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Ich verrate jeden an meine Herrin.",
-                "sentenceTranslation": "В коридорах замка Олбани Освальд крадётся: Я выдаю каждого своей госпоже.",
+                "sentence": "Unter dem Fenster von Regan beugt Oswald sich tief in die Nacht hinaus. Ich zeichne das Wort „verraten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под окном Реганы Освальд глубоко склоняется в ночную тьму. Я вывожу слово «выдавать» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2344,8 +2344,8 @@
                 "word": "schnüffeln",
                 "translation": "вынюхивать",
                 "transcription": "[ШНЮФ-фельн]",
-                "sentence": "In den Korridoren von Albanys Burg schleicht Oswald: Überall schnüffle ich nach Geheimnissen.",
-                "sentenceTranslation": "В коридорах замка Олбани Освальд крадётся: Везде я вынюхиваю секреты.",
+                "sentence": "Vor Gonerils Gemach übergibt Oswald flüsternd die gesammelten Nachrichten. Ich zeichne das Wort „schnüffeln“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед покоями Гонерильи Освальд шёпотом передаёт собранные вести. Я черчу слово «вынюхивать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Heimlichkeit",
@@ -2369,29 +2369,29 @@
             {
                 "question": "Что означает немецкое слово «der Spion»?",
                 "choices": [
-                    "скрытность",
-                    "шпион",
                     "шпионить",
-                    "предательство"
+                    "предательство",
+                    "скрытность",
+                    "шпион"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "скрытность",
                     "предательство",
                     "шпионить",
-                    "шпион"
+                    "шпион",
+                    "скрытность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Heimlichkeit»?",
                 "choices": [
-                    "вынюхивать",
+                    "шпион",
                     "скрытность",
-                    "выдавать",
+                    "вынюхивать",
                     "шпионить"
                 ],
                 "correctIndex": 1
@@ -2399,28 +2399,28 @@
             {
                 "question": "Что означает немецкое слово «spionieren»?",
                 "choices": [
+                    "шпион",
                     "шпионить",
-                    "подслушивать",
-                    "вынюхивать",
-                    "предательство"
+                    "выдавать",
+                    "подслушивать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «lauschen»?",
                 "choices": [
                     "выдавать",
-                    "подслушивать",
+                    "шпион",
                     "скрытность",
-                    "шпион"
+                    "подслушивать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
                     "вынюхивать",
-                    "шпион",
+                    "скрытность",
                     "подслушивать",
                     "выдавать"
                 ],
@@ -2429,12 +2429,12 @@
             {
                 "question": "Что означает немецкое слово «schnüffeln»?",
                 "choices": [
-                    "вынюхивать",
-                    "шпион",
+                    "подслушивать",
                     "предательство",
-                    "выдавать"
+                    "шпионить",
+                    "вынюхивать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -2447,8 +2447,8 @@
                 "word": "die Intrige",
                 "translation": "интрига",
                 "transcription": "[ди ин-ТРИ-ге]",
-                "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Jede Intrige spinne ich mit Freude.",
-                "sentenceTranslation": "На ночных советах с Гонериль Освальд планирует: Каждую интригу я плету с радостью.",
+                "sentence": "In der Schreibstube entwirft Oswald ein Netz aus widersprüchlichen Botschaften. Ich presse das Wort „die Intrige“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В писчей комнате Освальд плетёт сеть противоречивых посланий. Я стискиваю слово «интрига» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2473,8 +2473,8 @@
                 "word": "der Plan",
                 "translation": "план",
                 "transcription": "[дер ПЛАН]",
-                "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Mein hinterhältiger Plan wird funktionieren.",
-                "sentenceTranslation": "На ночных советах с Гонериль Освальд планирует: Мой коварный план сработает.",
+                "sentence": "Neben Gonerils Lager zeichnet Oswald heimlich zwei Namen auf ein Pergament. Ich zeichne das Wort „der Plan“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Рядом с ложем Гонерильи Освальд тайком выводит два имени на пергаменте. Я черчу слово «план» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Hinterlist",
@@ -2501,8 +2501,8 @@
                 "word": "die Hinterlist",
                 "translation": "коварство",
                 "transcription": "[ди ХИН-тер-лист]",
-                "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Mit Hinterlist verfolge ich meine Ziele.",
-                "sentenceTranslation": "На ночных советах с Гонериль Освальд планирует: С коварством я преследую свои цели.",
+                "sentence": "Auf der Gartenterrasse verbrennt Oswald Beweise im bronzezeitigen Becken. Ich presse das Wort „die Hinterlist“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На садовой террасе Освальд сжигает улики в бронзовой чаше. Я стискиваю слово «коварство» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Hinterlist",
@@ -2525,8 +2525,8 @@
                 "word": "schmieden",
                 "translation": "ковать",
                 "transcription": "[ШМИ-ден]",
-                "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Ich schmiede Pläne gegen alle Feinde.",
-                "sentenceTranslation": "На ночных советах с Гонериль Освальд планирует: Я кую планы против всех врагов.",
+                "sentence": "Im Stall flüstert Oswald falsche Befehle in die Ohren der Reiter. Ich umarme das Wort „schmieden“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В конюшне Освальд шепчет ложные приказы в уши всадников. Я обнимаю слово «ковать», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Hinterlist",
@@ -2549,8 +2549,8 @@
                 "word": "hintergehen",
                 "translation": "обманывать",
                 "transcription": "[ХИН-тер-ге-ен]",
-                "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Ich hintergehe jeden, der mir traut.",
-                "sentenceTranslation": "На ночных советах с Гонериль Освальд планирует: Я обманываю каждого, кто мне доверяет.",
+                "sentence": "Vor Regans Dienern versteckt Oswald die Briefe im Futter der Pferde. Das Echo des Wortes „hintergehen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Перед слугами Реганы Освальд прячет письма в корме лошадей. Эхо слова «обманывать» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Hinterlist",
@@ -2575,8 +2575,8 @@
                 "word": "tückisch",
                 "translation": "коварный",
                 "transcription": "[ТЮ-киш]",
-                "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Tückisch plane ich meinen nächsten Schritt.",
-                "sentenceTranslation": "На ночных советах с Гонериль Освальд планирует: Коварно я планирую свой следующий шаг.",
+                "sentence": "Unter der Laube formt Oswald aus Wachs ein neues Siegel. Selbst wenn die Welt zerfällt, bleibt das Wort „tückisch“ mein Nordstern.",
+                "sentenceTranslation": "Под беседкой Освальд отливает из воска новую печать. Даже если мир распадается, слово «коварный» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Hinterlist",
@@ -2599,8 +2599,8 @@
                 "word": "verschlagen",
                 "translation": "хитрый",
                 "transcription": "[фер-ШЛАГ-ен]",
-                "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Verschlagen verberge ich meine wahren Absichten.",
-                "sentenceTranslation": "На ночных советах с Гонериль Освальд планирует: Хитро я скрываю свои истинные намерения.",
+                "sentence": "In der Mitternachtspause verteilt Oswald verschlüsselte Notizen. Das Echo des Wortes „verschlagen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В полночный перерыв Освальд раздаёт зашифрованные записки. Эхо слова «хитрый» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Hinterlist",
@@ -2623,8 +2623,8 @@
                 "word": "die Falle",
                 "translation": "ловушка",
                 "transcription": "[ди ФА-ле]",
-                "sentence": "Bei nächtlichen Beratungen mit Goneril plant Oswald: Ich stelle Fallen für die Ahnungslosen.",
-                "sentenceTranslation": "На ночных советах с Гонериль Освальд планирует: Я ставлю ловушки для ничего не подозревающих.",
+                "sentence": "Auf dem Kartentisch verschiebt Oswald Figuren, als wären es echte Menschen. Ich presse das Wort „die Falle“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На столе с картами Освальд переставляет фигурки, будто это живые люди. Я стискиваю слово «ловушка» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Brief",
@@ -2652,49 +2652,49 @@
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
+                    "интрига",
                     "ковать",
                     "план",
-                    "интрига",
                     "коварство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
-                    "ковать",
-                    "план",
                     "коварство",
-                    "интрига"
+                    "план",
+                    "интрига",
+                    "ковать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Hinterlist»?",
                 "choices": [
-                    "хитрый",
-                    "ковать",
                     "коварство",
-                    "план"
+                    "коварный",
+                    "интрига",
+                    "ковать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «schmieden»?",
                 "choices": [
-                    "коварный",
                     "ковать",
                     "интрига",
-                    "план"
+                    "коварный",
+                    "хитрый"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «hintergehen»?",
                 "choices": [
                     "план",
-                    "интрига",
-                    "коварный",
+                    "коварство",
+                    "хитрый",
                     "обманывать"
                 ],
                 "correctIndex": 3
@@ -2702,32 +2702,32 @@
             {
                 "question": "Что означает немецкое слово «tückisch»?",
                 "choices": [
-                    "интрига",
                     "коварный",
-                    "ковать",
-                    "коварство"
+                    "план",
+                    "коварство",
+                    "обманывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verschlagen»?",
                 "choices": [
-                    "ловушка",
-                    "хитрый",
                     "обманывать",
+                    "интрига",
+                    "хитрый",
                     "план"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
-                    "план",
+                    "хитрый",
+                    "коварство",
                     "ловушка",
-                    "ковать",
-                    "коварство"
+                    "обманывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2740,8 +2740,8 @@
                 "word": "die Verfolgung",
                 "translation": "преследование",
                 "transcription": "[ди фер-ФОЛЬ-гунг]",
-                "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Die Verfolgung des blinden Grafen beginnt.",
-                "sentenceTranslation": "На полях близ Дувра Освальд гонится за слепым Глостером: Преследование слепого графа начинается.",
+                "sentence": "Mit gespannter Armbrust durchstreift Oswald die nächtlichen Felder. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verfolgung“ bleibt lebendig.",
+                "sentenceTranslation": "С натянутым арбалетом Освальд прочёсывает ночные поля. Каждой клеткой тела я обещаю: слово «преследование» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gefahr",
@@ -2764,8 +2764,8 @@
                 "word": "die Jagd",
                 "translation": "охота",
                 "transcription": "[ди ЯГДТ]",
-                "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Die Jagd auf Gloucester macht mir Spaß.",
-                "sentenceTranslation": "На полях близ Дувра Освальд гонится за слепым Глостером: Охота на Глостера доставляет мне удовольствие.",
+                "sentence": "Auf dem Küstenpfad späht Oswald nach Spuren des fliehenden Grafen. Das Echo des Wortes „die Jagd“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На прибрежной тропе Освальд высматривает следы бегущего графа. Эхо слова «охота» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gefahr",
@@ -2788,8 +2788,8 @@
                 "word": "verfolgen",
                 "translation": "преследовать",
                 "transcription": "[фер-ФОЛЬ-ген]",
-                "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Gnadenlos verfolge ich den alten Mann.",
-                "sentenceTranslation": "На полях близ Дувра Освальд гонится за слепым Глостером: Безжалостно я преследую старика.",
+                "sentence": "Zwischen Dornenhecken zückt Oswald das versteckte Messer. Mein Atem zeichnet das Wort „verfolgen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Среди колючих кустов Освальд выхватывает спрятанный нож. Моё дыхание рисует слово «преследовать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2812,8 +2812,8 @@
                 "word": "jagen",
                 "translation": "гнаться",
                 "transcription": "[Я-ген]",
-                "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Wie ein Hund jage ich meine Beute.",
-                "sentenceTranslation": "На полях близ Дувра Освальд гонится за слепым Глостером: Как собака я гонюсь за добычей.",
+                "sentence": "Am Moorloch testet Oswald die Tiefe mit der Spitze der Lanze. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „jagen“ gehört mir.",
+                "sentenceTranslation": "У болотной ямы Освальд проверяет глубину наконечником копья. Буря за окнами усиливает клятву: слово «гнаться» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gefahr",
@@ -2841,8 +2841,8 @@
                 "word": "aufspüren",
                 "translation": "выслеживать",
                 "transcription": "[АУФ-шпю-рен]",
-                "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Ich spüre den Flüchtling überall auf.",
-                "sentenceTranslation": "На полях близ Дувра Освальд гонится за слепым Глостером: Я выслеживаю беглеца повсюду.",
+                "sentence": "Vor einem verlassenen Hof horcht Oswald auf das Schnaufen der Pferde. Wie ein stilles Gebet legt sich das Wort „aufspüren“ auf meine Lippen.",
+                "sentenceTranslation": "У заброшенного двора Освальд прислушивается к сопению коней. Как тихая молитва слово «выслеживать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gefahr",
@@ -2865,8 +2865,8 @@
                 "word": "hetzen",
                 "translation": "травить",
                 "transcription": "[ХЕ-цен]",
-                "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Ich hetze ihn bis zum Ende.",
-                "sentenceTranslation": "На полях близ Дувра Освальд гонится за слепым Глостером: Я травлю его до конца.",
+                "sentence": "Unter Regans Banner motiviert Oswald die Soldaten zu schnellerer Jagd. Ich halte das Wort „hetzen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Под знаменем Реганы Освальд подгоняет солдат к более быстрой охоте. Я держу слово «травить» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gefahr",
@@ -2889,8 +2889,8 @@
                 "word": "die Beute",
                 "translation": "добыча",
                 "transcription": "[ди БОЙ-те]",
-                "sentence": "Auf den Feldern nahe Dover jagt Oswald den blinden Gloucester: Der Graf ist meine leichte Beute.",
-                "sentenceTranslation": "На полях близ Дувра Освальд гонится за слепым Глостером: Граф - моя лёгкая добыча.",
+                "sentence": "Auf den Klippen über Dover späht Oswald in die graue Ferne. Mit fester Stimme schwöre ich mir: Das Wort „die Beute“ wird heute nicht verraten.",
+                "sentenceTranslation": "На скалах над Дувром Освальд вглядывается в серую даль. Твёрдым голосом я клянусь себе: слово «добыча» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Gefahr",
@@ -2915,18 +2915,18 @@
                 "question": "Что означает немецкое слово «die Verfolgung»?",
                 "choices": [
                     "преследование",
-                    "преследовать",
+                    "охота",
                     "гнаться",
-                    "охота"
+                    "преследовать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Jagd»?",
                 "choices": [
-                    "гнаться",
                     "преследовать",
                     "преследование",
+                    "гнаться",
                     "охота"
                 ],
                 "correctIndex": 3
@@ -2934,19 +2934,19 @@
             {
                 "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
-                    "охота",
-                    "добыча",
+                    "гнаться",
+                    "травить",
                     "преследовать",
-                    "травить"
+                    "преследование"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
-                    "добыча",
                     "выслеживать",
                     "преследовать",
+                    "травить",
                     "гнаться"
                 ],
                 "correctIndex": 3
@@ -2954,9 +2954,9 @@
             {
                 "question": "Что означает немецкое слово «aufspüren»?",
                 "choices": [
-                    "охота",
+                    "травить",
                     "выслеживать",
-                    "добыча",
+                    "охота",
                     "преследование"
                 ],
                 "correctIndex": 1
@@ -2964,9 +2964,9 @@
             {
                 "question": "Что означает немецкое слово «hetzen»?",
                 "choices": [
-                    "выслеживать",
-                    "преследовать",
-                    "добыча",
+                    "гнаться",
+                    "преследование",
+                    "охота",
                     "травить"
                 ],
                 "correctIndex": 3
@@ -2974,12 +2974,12 @@
             {
                 "question": "Что означает немецкое слово «die Beute»?",
                 "choices": [
-                    "преследовать",
-                    "гнаться",
                     "преследование",
-                    "добыча"
+                    "добыча",
+                    "преследовать",
+                    "охота"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {}
@@ -2992,8 +2992,8 @@
                 "word": "der Tod",
                 "translation": "смерть",
                 "transcription": "[дер ТОД]",
-                "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Der Tod ereilt mich durch Эдгars Hand.",
-                "sentenceTranslation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Смерть настигает меня от руки Эдгара.",
+                "sentence": "Im dunstigen Wald stürzt Oswald vor Edgars Klinge rückwärts. Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В туманном лесу Освальд падает навзничь перед клинком Эдгара. Моё дыхание рисует слово «смерть» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3019,8 +3019,8 @@
                 "word": "die Feigheit",
                 "translation": "трусость",
                 "transcription": "[ди ФАЙГ-хайт]",
-                "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Meine Feigheit führt zu meinem Ende.",
-                "sentenceTranslation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Моя трусость приводит к моему концу.",
+                "sentence": "Neben einem morschen Baum bittet Oswald mit erhobenen Händen um Gnade. Ich halte das Wort „die Feigheit“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У трухлявого дерева Освальд вздымает руки, умоляя о пощаде. Я держу слово «трусость» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beleidigung",
@@ -3046,8 +3046,8 @@
                 "word": "die Niederlage",
                 "translation": "поражение",
                 "transcription": "[ди НИ-дер-ла-ге]",
-                "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Die Niederlage ist mein letztes Schicksal.",
-                "sentenceTranslation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Поражение - моя последняя судьба.",
+                "sentence": "Am Boden liegend tastet Oswald vergeblich nach dem verlorenen Schwert. Ich halte das Wort „die Niederlage“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Лежа на земле, Освальд тщетно ищет потерянный меч. Я держу слово «поражение» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Duell",
@@ -3074,8 +3074,8 @@
                 "word": "fallen",
                 "translation": "падать",
                 "transcription": "[ФА-лен]",
-                "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Ich falle wie der Feigling, der ich bin.",
-                "sentenceTranslation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Я падаю как трус, которым являюсь.",
+                "sentence": "Vor Edgars ernster Miene rutscht Oswald im nassen Laub aus. Wie ein stilles Gebet legt sich das Wort „fallen“ auf meine Lippen.",
+                "sentenceTranslation": "Перед суровым взглядом Эдгара Освальд скользит на мокрой листве. Как тихая молитва слово «падать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3099,8 +3099,8 @@
                 "word": "unterliegen",
                 "translation": "проигрывать",
                 "transcription": "[ун-тер-ЛИ-ген]",
-                "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Ich unterliege dem edlen Edgar.",
-                "sentenceTranslation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Я проигрываю благородному Эдгару.",
+                "sentence": "Unter einem kalten Regen stammelt Oswald letzte Ausflüchte. Mein Atem zeichnet das Wort „unterliegen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Под холодным дождём Освальд лепечет последние оправдания. Моё дыхание рисует слово «проигрывать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Feigheit",
@@ -3124,8 +3124,8 @@
                 "word": "wimmern",
                 "translation": "хныкать",
                 "transcription": "[ВИМ-мерн]",
-                "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Wimmernd bitte ich um Gnade.",
-                "sentenceTranslation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Хныкая, я прошу о пощаде.",
+                "sentence": "Im Schatten der Bäume erkennt Oswald zu spät die gerechte Vergeltung. Ich umarme das Wort „wimmern“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В тени деревьев Освальд слишком поздно осознаёт справедливое возмездие. Я обнимаю слово «хныкать», будто это единственный союзник.",
                 "visual_hint": "📚",
                 "themes": [
                     "Feigheit",
@@ -3148,8 +3148,8 @@
                 "word": "betteln",
                 "translation": "умолять",
                 "transcription": "[БЕ-тельн]",
-                "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Um mein Leben bettle ich vergeblich.",
-                "sentenceTranslation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: О жизни я умоляю напрасно.",
+                "sentence": "Auf dem Waldboden erlischt Oswalds Atem ohne Ehrenwache. Ich zeichne das Wort „betteln“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На лесной земле дыхание Освальд гаснет без почётного караула. Я черчу слово «умолять» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Feigheit",
@@ -3178,8 +3178,8 @@
                 "word": "erbärmlich",
                 "translation": "жалкий",
                 "transcription": "[ер-БЕРМ-лих]",
-                "sentence": "Als Edgar ihn am Strand von Dover stellt, jammert Oswald: Erbärmlich ende ich wie ich gelebt habe.",
-                "sentenceTranslation": "Когда Эдгар настигает его на берегу Дувра, Освальд стонет: Жалко я заканчиваю, как и жил.",
+                "sentence": "Neben dem fallengelassenen Brief liegt Oswald reglos im Schlamm. Das kalte Licht lässt das Wort „erbärmlich“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Рядом с оброненным письмом Освальд неподвижно лежит в грязи. Холодный свет заставляет слово «жалкий» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Feigheit",
@@ -3203,12 +3203,12 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "падать",
                     "трусость",
-                    "смерть",
-                    "поражение"
+                    "поражение",
+                    "падать",
+                    "смерть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
@@ -3223,62 +3223,62 @@
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "смерть",
-                    "проигрывать",
                     "хныкать",
-                    "поражение"
+                    "проигрывать",
+                    "поражение",
+                    "жалкий"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
-                    "хныкать",
-                    "трусость",
                     "смерть",
-                    "падать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «unterliegen»?",
-                "choices": [
-                    "смерть",
-                    "проигрывать",
-                    "жалкий",
-                    "хныкать"
+                    "падать",
+                    "поражение",
+                    "трусость"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «wimmern»?",
+                "question": "Что означает немецкое слово «unterliegen»?",
                 "choices": [
                     "проигрывать",
                     "поражение",
-                    "хныкать",
-                    "умолять"
+                    "смерть",
+                    "хныкать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «wimmern»?",
+                "choices": [
+                    "падать",
+                    "хныкать",
+                    "умолять",
+                    "проигрывать"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «betteln»?",
                 "choices": [
-                    "трусость",
-                    "проигрывать",
                     "умолять",
-                    "поражение"
+                    "проигрывать",
+                    "падать",
+                    "трусость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erbärmlich»?",
                 "choices": [
-                    "жалкий",
                     "смерть",
-                    "трусость",
-                    "хныкать"
+                    "хныкать",
+                    "падать",
+                    "жалкий"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -3809,27 +3809,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);

--- a/output/journeys/regan.html
+++ b/output/journeys/regan.html
@@ -446,7 +446,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["притворяться", "превосходить", "фальшь", "состязаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["притворяться", "фальшь", "состязаться", "превосходить"], "correct_index": 3}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["притворяться", "фальшь", "разыгрывать", "состязаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["разыгрывать", "алчность", "фальшь", "превосходить"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["выманивать", "алчность", "разыгрывать", "превосходить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die List»?", "choices": ["состязаться", "притворяться", "хитрость", "выманивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["хитрость", "притворяться", "выманивать", "фальшь"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["алчность", "разыгрывать", "превосходить", "притворяться"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["союз", "заговорить", "планировать", "делить"], "correct_index": 0}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["союз", "планировать", "делить", "заговорить"], "correct_index": 2}, {"question": "Что означает немецкое слово «planen»?", "choices": ["делить", "сговор", "заговорить", "планировать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["заговорить", "договариваться", "союз", "планировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["договариваться", "союз", "сговор", "стратегия"], "correct_index": 2}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["договариваться", "сговор", "заговорить", "планировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["договариваться", "союз", "стратегия", "делить"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["злоба", "пытать", "насмехаться", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["злоба", "пытать", "насмехаться", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["жёсткость", "злоба", "жестоко обращаться", "насмехаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["отвергать", "насмехаться", "пытать", "злоба"], "correct_index": 3}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["унижать", "жестоко обращаться", "злоба", "отвергать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жестокость", "унижать", "жёсткость", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["пытать", "отвергать", "жёсткость", "насмехаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "унижать", "пытать", "злоба"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["садизм", "ослеплять", "выкалывать", "наслаждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["выкалывать", "садизм", "ослеплять", "наслаждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["пытка", "брутальность", "наслаждаться", "садизм"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["наслаждаться", "ослеплять", "выкалывать", "брутальность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["наслаждаться", "брутальность", "пытка", "садизм"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["растаптывать", "наслаждаться", "беспощадный", "брутальность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["садизм", "выкалывать", "брутальность", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["пытка", "растаптывать", "беспощадный", "брутальность"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вдова", "вожделение", "соблазнять", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["соблазнять", "вожделеть", "вдова", "вожделение"], "correct_index": 1}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["вожделеть", "вдова", "соблазнять", "добиваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["вдова", "соблазнять", "вожделение", "вожделеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «locken»?", "choices": ["заманивать", "вожделеть", "похоть", "вдова"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["вожделеть", "вожделение", "похоть", "добиваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «werben»?", "choices": ["соблазнять", "добиваться", "заманивать", "похоть"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["соревноваться", "соперничество", "угрожать", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["соревноваться", "ненавидеть", "соперничество", "угрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["соревноваться", "не доверять", "угрожать", "бороться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["угрожать", "ненавидеть", "соперничество", "не доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["бороться", "соревноваться", "подозревать", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["соревноваться", "соперничество", "бороться", "не доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["соперничество", "соревноваться", "подозревать", "угрожать"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["мучение", "издыхать", "страдать", "отравленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "отравленный", "мучение", "издыхать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["мучение", "издыхать", "проклятый", "проклинать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["мучение", "страдать", "расплачиваться", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["проклятый", "проклинать", "расплачиваться", "отравленный"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["мучение", "страдать", "проклинать", "рок"], "correct_index": 3}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["проклинать", "проклятый", "страдать", "расплачиваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["издыхать", "расплачиваться", "рок", "проклятый"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["притворяться", "фальшь", "превосходить", "состязаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["превосходить", "состязаться", "притворяться", "фальшь"], "correct_index": 0}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["состязаться", "превосходить", "разыгрывать", "выманивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["состязаться", "притворяться", "алчность", "фальшь"], "correct_index": 3}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["разыгрывать", "состязаться", "алчность", "превосходить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["выманивать", "хитрость", "алчность", "фальшь"], "correct_index": 1}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["хитрость", "выманивать", "превосходить", "фальшь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["состязаться", "выманивать", "фальшь", "алчность"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["планировать", "делить", "заговорить", "союз"], "correct_index": 3}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["заговорить", "делить", "союз", "планировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «planen»?", "choices": ["планировать", "делить", "договариваться", "стратегия"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["стратегия", "сговор", "планировать", "заговорить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["делить", "заговорить", "планировать", "сговор"], "correct_index": 3}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["договариваться", "стратегия", "союз", "делить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["стратегия", "делить", "планировать", "сговор"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["унижать", "злоба", "пытать", "насмехаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["пытать", "насмехаться", "унижать", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["жестоко обращаться", "насмехаться", "отвергать", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["унижать", "насмехаться", "злоба", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["пытать", "жестоко обращаться", "жестокость", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["пытать", "насмехаться", "злоба", "жёсткость"], "correct_index": 3}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["жёсткость", "жестокость", "унижать", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["унижать", "пытать", "жестокость", "жёсткость"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "садизм", "выкалывать", "наслаждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["садизм", "наслаждаться", "ослеплять", "выкалывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["растаптывать", "наслаждаться", "ослеплять", "садизм"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["ослеплять", "выкалывать", "растаптывать", "беспощадный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["ослеплять", "садизм", "беспощадный", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["беспощадный", "растаптывать", "брутальность", "наслаждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["садизм", "беспощадный", "брутальность", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["растаптывать", "брутальность", "пытка", "ослеплять"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вдова", "вожделеть", "вожделение", "соблазнять"], "correct_index": 0}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вожделение", "вдова", "вожделеть", "соблазнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["вдова", "соблазнять", "добиваться", "похоть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["добиваться", "заманивать", "вожделение", "соблазнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «locken»?", "choices": ["вожделеть", "заманивать", "соблазнять", "добиваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["похоть", "вожделение", "добиваться", "заманивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «werben»?", "choices": ["добиваться", "вожделение", "вожделеть", "вдова"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["соревноваться", "соперничество", "угрожать", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["угрожать", "соперничество", "ненавидеть", "соревноваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["угрожать", "ненавидеть", "соревноваться", "бороться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["угрожать", "соперничество", "не доверять", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["угрожать", "бороться", "соперничество", "не доверять"], "correct_index": 1}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["бороться", "не доверять", "угрожать", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["ненавидеть", "не доверять", "соперничество", "подозревать"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["отравленный", "страдать", "мучение", "издыхать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["отравленный", "издыхать", "мучение", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["страдать", "проклинать", "проклятый", "издыхать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["издыхать", "расплачиваться", "мучение", "отравленный"], "correct_index": 2}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["проклинать", "проклятый", "отравленный", "расплачиваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["издыхать", "расплачиваться", "рок", "отравленный"], "correct_index": 2}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["мучение", "расплачиваться", "издыхать", "проклинать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["проклятый", "страдать", "расплачиваться", "издыхать"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Притворная любовь</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -471,9 +471,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
                             
@@ -481,95 +481,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «übertreffen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «wetteifern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Falschheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">алчность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">алчность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «erschleichen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
                             
@@ -577,17 +497,97 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Habgier»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «wetteifern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">разыгрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Falschheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">алчность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">алчность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выманивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">алчность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erschleichen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выманивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Habgier»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выманивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">алчность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,61 +600,29 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «teilen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «planen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «teilen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                             
@@ -664,17 +632,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «planen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">договариваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сговор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -686,27 +686,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стратегия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Strategie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -719,47 +719,15 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестоко обращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
                             
@@ -767,17 +735,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -787,11 +787,43 @@
                         <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жестоко обращаться</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «abweisen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                             
@@ -799,49 +831,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «abweisen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,97 +854,97 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «genießen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">растаптывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">растаптывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -956,27 +956,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">растаптывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -995,43 +995,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1041,43 +1041,27 @@
                         <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">добиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «locken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
                             
@@ -1085,17 +1069,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">заманивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «werben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">добиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">заманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1124,31 +1124,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соревноваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «bedrohen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
                             
@@ -1156,13 +1156,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">не доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
                             
@@ -1172,15 +1188,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
@@ -1188,33 +1204,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">не доверять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «argwöhnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,29 +1227,13 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «vergiftet»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
                             
@@ -1259,47 +1243,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклятый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
                             
@@ -1307,31 +1291,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Verhängnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">проклятый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отравленный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">расплачиваться</button>
                             
@@ -1339,8 +1307,8 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verflucht»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Verhängnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
@@ -1349,7 +1317,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verflucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклятый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1376,8 +1376,8 @@
                 "word": "vortäuschen",
                 "translation": "притворяться",
                 "transcription": "[ФОР-той-шен]",
-                "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Ich täusche Liebe vor, die nie existierte.",
-                "sentenceTranslation": "В тронном зале Лира Регана соперничает с сестрой: Я притворяюсь в любви, которой никогда не было.",
+                "sentence": "Regan steht unter dem glühenden Kronleuchter des Thronsaals. Mein Atem zeichnet das Wort „vortäuschen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Регана стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «притворяться» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "vortäuschen",
@@ -1401,8 +1401,8 @@
                 "word": "übertreffen",
                 "translation": "превосходить",
                 "transcription": "[ю-бер-ТРЕ-фен]",
-                "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Ich will meine Schwester in der Lüge übertreffen.",
-                "sentenceTranslation": "В тронном зале Лира Регана соперничает с сестрой: Я хочу превзойти сестру во лжи.",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Regan über Lears schweren Tisch. Mit jeder Faser meines Körpers verspreche ich: Das Wort „übertreffen“ bleibt lebendig.",
+                "sentenceTranslation": "У развернутой карты королевства Регана склоняется над тяжёлым столом Лира. Каждой клеткой тела я обещаю: слово «превосходить» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "vortäuschen",
@@ -1425,8 +1425,8 @@
                 "word": "wetteifern",
                 "translation": "состязаться",
                 "transcription": "[ВЕТ-ай-ферн]",
-                "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Wir wetteifern um das größte Erbe.",
-                "sentenceTranslation": "В тронном зале Лира Регана соперничает с сестрой: Мы состязаемся за большее наследство.",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Regan die Hände hinter dem Rücken. Ich flüstere den Wächtern des Schicksals zu: Das Wort „wetteifern“ darf nicht vergehen.",
+                "sentenceTranslation": "Перед каменными статуями предков Регана сцепляет руки за спиной. Я шепчу стражам судьбы: слово «состязаться» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "vortäuschen",
@@ -1449,8 +1449,8 @@
                 "word": "die Falschheit",
                 "translation": "фальшь",
                 "transcription": "[ди ФАЛЬШ-хайт]",
-                "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Meine Falschheit kennt keine Grenzen.",
-                "sentenceTranslation": "В тронном зале Лира Регана соперничает с сестрой: Моя фальшь не знает границ.",
+                "sentence": "Zwischen flüsternden Höflingen gleitet Regan über den kalten Marmorboden. Mit fester Stimme schwöre ich mir: Das Wort „die Falschheit“ wird heute nicht verraten.",
+                "sentenceTranslation": "Между шепчущимися придворными Регана скользит по холодному мраморному полу. Твёрдым голосом я клянусь себе: слово «фальшь» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "vortäuschen",
@@ -1473,8 +1473,8 @@
                 "word": "vorspielen",
                 "translation": "разыгрывать",
                 "transcription": "[ФОР-шпи-лен]",
-                "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Ich spiele ihm Töchterliebe vor.",
-                "sentenceTranslation": "В тронном зале Лира Регана соперничает с сестрой: Я разыгрываю перед ним дочернюю любовь.",
+                "sentence": "Am Rand des purpurnen Teppichs wartet Regan auf ein Zeichen des Königs. Das Echo des Wortes „vorspielen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На краю пурпурного ковра Регана ждёт знака от короля. Эхо слова «разыгрывать» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "vortäuschen",
@@ -1497,8 +1497,8 @@
                 "word": "die List",
                 "translation": "хитрость",
                 "transcription": "[ди ЛИСТ]",
-                "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Mit List gewinne ich sein Vertrauen.",
-                "sentenceTranslation": "В тронном зале Лира Регана соперничает с сестрой: Хитростью я завоёвываю его доверие.",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Regan kurz den Blick. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die List“ darf nicht vergehen.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Регана на миг опускает взгляд. Я шепчу стражам судьбы: слово «хитрость» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Klippe",
@@ -1529,8 +1529,8 @@
                 "word": "erschleichen",
                 "translation": "выманивать",
                 "transcription": "[ер-ШЛАЙ-хен]",
-                "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Ich erschleiche mir sein Königreich.",
-                "sentenceTranslation": "В тронном зале Лира Регана соперничает с сестрой: Я выманиваю его королевство.",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Regan das gespannte Antlitz des Hofes. Wie ein stilles Gebet legt sich das Wort „erschleichen“ auf meine Lippen.",
+                "sentenceTranslation": "За позолоченной балюстрадой Регана наблюдает за напряжёнными лицами двора. Как тихая молитва слово «выманивать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "vortäuschen",
@@ -1553,8 +1553,8 @@
                 "word": "die Habgier",
                 "translation": "алчность",
                 "transcription": "[ди ХАБ-гир]",
-                "sentence": "Im Thronsaal von Lear wetteifert Regan mit ihrer Schwester: Die Habgier treibt meine süßen Worte.",
-                "sentenceTranslation": "В тронном зале Лира Регана соперничает с сестрой: Алчность движет моими сладкими словами.",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Regan langsam die Stimme. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Habgier“ gehört mir.",
+                "sentenceTranslation": "В отблесках открытых жаровен Регана медленно поднимает голос. Буря за окнами усиливает клятву: слово «алчность» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "vortäuschen",
@@ -1579,8 +1579,8 @@
                 "question": "Что означает немецкое слово «vortäuschen»?",
                 "choices": [
                     "притворяться",
-                    "превосходить",
                     "фальшь",
+                    "превосходить",
                     "состязаться"
                 ],
                 "correctIndex": 0
@@ -1588,72 +1588,72 @@
             {
                 "question": "Что означает немецкое слово «übertreffen»?",
                 "choices": [
-                    "притворяться",
-                    "фальшь",
+                    "превосходить",
                     "состязаться",
-                    "превосходить"
+                    "притворяться",
+                    "фальшь"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «wetteifern»?",
                 "choices": [
-                    "притворяться",
-                    "фальшь",
+                    "состязаться",
+                    "превосходить",
                     "разыгрывать",
-                    "состязаться"
+                    "выманивать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Falschheit»?",
                 "choices": [
-                    "разыгрывать",
+                    "состязаться",
+                    "притворяться",
                     "алчность",
-                    "фальшь",
-                    "превосходить"
+                    "фальшь"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vorspielen»?",
                 "choices": [
-                    "выманивать",
-                    "алчность",
                     "разыгрывать",
+                    "состязаться",
+                    "алчность",
                     "превосходить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "состязаться",
-                    "притворяться",
+                    "выманивать",
                     "хитрость",
-                    "выманивать"
+                    "алчность",
+                    "фальшь"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erschleichen»?",
                 "choices": [
                     "хитрость",
-                    "притворяться",
                     "выманивать",
+                    "превосходить",
                     "фальшь"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Habgier»?",
                 "choices": [
-                    "алчность",
-                    "разыгрывать",
-                    "превосходить",
-                    "притворяться"
+                    "состязаться",
+                    "выманивать",
+                    "фальшь",
+                    "алчность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -1666,8 +1666,8 @@
                 "word": "das Bündnis",
                 "translation": "союз",
                 "transcription": "[дас БЮНД-нис]",
-                "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Ein Bündnis mit Goneril gegen unseren Vater.",
-                "sentenceTranslation": "На тайном сговоре в покоях Гонериль Регана шепчет: Союз с Гонерильей против нашего отца.",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Regan zwischen gepackten Kisten. Mein Atem zeichnet das Wort „das Bündnis“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Регана замирает среди нагруженных ящиков. Моё дыхание рисует слово «союз» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bündnis",
@@ -1694,8 +1694,8 @@
                 "word": "teilen",
                 "translation": "делить",
                 "transcription": "[ТАЙ-лен]",
-                "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Wir teilen das Reich zwischen uns.",
-                "sentenceTranslation": "На тайном сговоре в покоях Гонериль Регана шепчет: Мы делим королевство между собой.",
+                "sentence": "Auf der windigen Freitreppe blickt Regan zum schweigenden Hof hinunter. Mit fester Stimme schwöre ich mir: Das Wort „teilen“ wird heute nicht verraten.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Регана смотрит вниз на молчаливый двор. Твёрдым голосом я клянусь себе: слово «делить» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1717,8 +1717,8 @@
                 "word": "planen",
                 "translation": "планировать",
                 "transcription": "[ПЛА-нен]",
-                "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Wir planen den Untergang des alten Königs.",
-                "sentenceTranslation": "На тайном сговоре в покоях Гонериль Регана шепчет: Мы планируем падение старого короля.",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Regan den Reisemantel enger. Mit jeder Faser meines Körpers verspreche ich: Das Wort „planen“ bleibt lebendig.",
+                "sentenceTranslation": "Среди оставленных слуг Регана плотнее запахивает дорожный плащ. Каждой клеткой тела я обещаю: слово «планировать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bündnis",
@@ -1741,8 +1741,8 @@
                 "word": "verschwören",
                 "translation": "заговорить",
                 "transcription": "[фер-ШВЁ-рен]",
-                "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Wir verschwören uns gegen ihn.",
-                "sentenceTranslation": "На тайном сговоре в покоях Гонериль Регана шепчет: Мы составляем заговор против него.",
+                "sentence": "Am dunklen Pferdestall streicht Regan einem nervösen Tier über die Mähne. Ich halte das Wort „verschwören“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Регана гладит гриву нервного коня. Я держу слово «заговорить» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -1764,8 +1764,8 @@
                 "word": "die Absprache",
                 "translation": "сговор",
                 "transcription": "[ди АБ-шпра-хе]",
-                "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Unsere Absprache ist perfekt.",
-                "sentenceTranslation": "На тайном сговоре в покоях Гонериль Регана шепчет: Наш сговор совершенен.",
+                "sentence": "Vor dem knarrenden Fallgatter tastet Regan ein letztes Mal nach dem Haustor. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Absprache“ darf nicht vergehen.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Регана в последний раз касается родной двери. Я шепчу стражам судьбы: слово «сговор» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bündnis",
@@ -1788,8 +1788,8 @@
                 "word": "vereinbaren",
                 "translation": "договариваться",
                 "transcription": "[фер-АЙН-ба-рен]",
-                "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Wir vereinbaren gemeinsame Grausamkeit.",
-                "sentenceTranslation": "На тайном сговоре в покоях Гонериль Регана шепчет: Мы договариваемся о совместной жестокости.",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Regan den Ring an der Hand. Mit jeder Faser meines Körpers verspreche ich: Das Wort „vereinbaren“ bleibt lebendig.",
+                "sentenceTranslation": "Среди разбросанных свитков Регана вертит кольцо на пальце. Каждой клеткой тела я обещаю: слово «договариваться» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bündnis",
@@ -1812,8 +1812,8 @@
                 "word": "die Strategie",
                 "translation": "стратегия",
                 "transcription": "[ди штра-те-ГИ]",
-                "sentence": "Beim geheimen Pakt in Gonerils Gemächern flüstert Regan: Unsere Strategie wird ihn brechen.",
-                "sentenceTranslation": "На тайном сговоре в покоях Гонериль Регана шепчет: Наша стратегия сломает его.",
+                "sentence": "Am leeren Bankettisch zählt Regan die verlöschenden Kerzen. Das Echo des Wortes „die Strategie“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У пустого банкетного стола Регана пересчитывает гаснущие свечи. Эхо слова «стратегия» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bündnis",
@@ -1837,72 +1837,72 @@
             {
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
-                    "союз",
-                    "заговорить",
-                    "планировать",
-                    "делить"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «teilen»?",
-                "choices": [
-                    "союз",
                     "планировать",
                     "делить",
-                    "заговорить"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «planen»?",
-                "choices": [
-                    "делить",
-                    "сговор",
                     "заговорить",
-                    "планировать"
+                    "союз"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «verschwören»?",
+                "question": "Что означает немецкое слово «teilen»?",
                 "choices": [
                     "заговорить",
-                    "договариваться",
+                    "делить",
                     "союз",
                     "планировать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «planen»?",
+                "choices": [
+                    "планировать",
+                    "делить",
+                    "договариваться",
+                    "стратегия"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «verschwören»?",
+                "choices": [
+                    "стратегия",
+                    "сговор",
+                    "планировать",
+                    "заговорить"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Absprache»?",
                 "choices": [
-                    "договариваться",
-                    "союз",
-                    "сговор",
-                    "стратегия"
+                    "делить",
+                    "заговорить",
+                    "планировать",
+                    "сговор"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vereinbaren»?",
                 "choices": [
                     "договариваться",
-                    "сговор",
-                    "заговорить",
-                    "планировать"
+                    "стратегия",
+                    "союз",
+                    "делить"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Strategie»?",
                 "choices": [
-                    "договариваться",
-                    "союз",
                     "стратегия",
-                    "делить"
+                    "делить",
+                    "планировать",
+                    "сговор"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -1915,8 +1915,8 @@
                 "word": "foltern",
                 "translation": "пытать",
                 "transcription": "[ФОЛЬ-терн]",
-                "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Ich foltere ihn mit kalten Worten.",
-                "sentenceTranslation": "В своём замке в Глостере Регана унижает короля: Я пытаю его холодными словами.",
+                "sentence": "Im zugigen Seitenflügel lauscht Regan dem Heulen der Küstenwinde. Mein Atem zeichnet das Wort „foltern“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Регана слушает вой прибрежного ветра. Моё дыхание рисует слово «пытать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -1943,8 +1943,8 @@
                 "word": "erniedrigen",
                 "translation": "унижать",
                 "transcription": "[ер-НИД-ри-ген]",
-                "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Ich erniedrige den einst mächtigen König.",
-                "sentenceTranslation": "В своём замке в Глостере Регана унижает короля: Я унижаю некогда могущественного короля.",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Regan einen zerknitterten Brief. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erniedrigen“ gehört mir.",
+                "sentenceTranslation": "Перед дымным камином замка Регана складывает измятый лист. Буря за окнами усиливает клятву: слово «унижать» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Strafe",
@@ -1972,8 +1972,8 @@
                 "word": "verhöhnen",
                 "translation": "насмехаться",
                 "transcription": "[фер-ХЁ-нен]",
-                "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Ich verhöhne seine väterliche Liebe.",
-                "sentenceTranslation": "В своём замке в Глостере Регана унижает короля: Я насмехаюсь над его отцовской любовью.",
+                "sentence": "Unter farblosen Wandteppichen schreitet Regan rastlos auf und ab. Ich halte das Wort „verhöhnen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Под выцветшими гобеленами Регана беспокойно меряет шагами зал. Я держу слово «насмехаться» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Beleidigung",
@@ -2002,8 +2002,8 @@
                 "word": "die Bosheit",
                 "translation": "злоба",
                 "transcription": "[ди БОС-хайт]",
-                "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Meine Bosheit kennt kein Erbarmen.",
-                "sentenceTranslation": "В своём замке в Глостере Регана унижает короля: Моя злоба не знает милосердия.",
+                "sentence": "An der schmalen Fensterluke zählt Regan die Fackeln auf dem Hof. Ich halte das Wort „die Bosheit“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У узкой бойницы Регана считает факелы на дворе. Я держу слово «злоба» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bosheit",
@@ -2030,8 +2030,8 @@
                 "word": "misshandeln",
                 "translation": "жестоко обращаться",
                 "transcription": "[МИС-хан-дельн]",
-                "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Ich misshandle den alten Mann.",
-                "sentenceTranslation": "В своём замке в Глостере Регана унижает короля: Я жестоко обращаюсь со стариком.",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Regan nach frischen Botschaften. Mit jeder Faser meines Körpers verspreche ich: Das Wort „misshandeln“ bleibt lebendig.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Регана ищет свежие вести. Каждой клеткой тела я обещаю: слово «жестоко обращаться» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "erniedrigen",
@@ -2055,8 +2055,8 @@
                 "word": "die Härte",
                 "translation": "жёсткость",
                 "transcription": "[ди ХЕР-те]",
-                "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Mit eiserner Härte stoße ich ihn fort.",
-                "sentenceTranslation": "В своём замке в Глостере Регана унижает короля: С железной жёсткостью я отталкиваю его.",
+                "sentence": "Im stillen Kapellenraum kniet Regan vor der kalten Steinfigur. Ich presse das Wort „die Härte“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В тихой капелле Регана преклоняет колени перед холодной каменной фигурой. Я стискиваю слово «жёсткость» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bosheit",
@@ -2084,8 +2084,8 @@
                 "word": "abweisen",
                 "translation": "отвергать",
                 "transcription": "[АБ-вай-зен]",
-                "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Ich weise alle seine Bitten ab.",
-                "sentenceTranslation": "В своём замке в Глостере Регана унижает короля: Я отвергаю все его просьбы.",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Regan die Laterne fest. Mein Atem zeichnet das Wort „abweisen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Регана крепко держит фонарь. Моё дыхание рисует слово «отвергать» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "erniedrigen",
@@ -2109,8 +2109,8 @@
                 "word": "die Grausamkeit",
                 "translation": "жестокость",
                 "transcription": "[ди ГРАУ-зам-кайт]",
-                "sentence": "In ihrem Schloss in Gloucester demütigt Regan den König: Meine Grausamkeit übertrifft die meiner Schwester.",
-                "sentenceTranslation": "В своём замке в Глостере Регана унижает короля: Моя жестокость превосходит жестокость сестры.",
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Regan eine fiebrige Antwort. Mein Atem zeichnet das Wort „die Grausamkeit“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тени высоких стен Регана пишет лихорадочный ответ. Моё дыхание рисует слово «жестокость» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Bosheit",
@@ -2145,82 +2145,82 @@
             {
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
+                    "унижать",
                     "злоба",
                     "пытать",
-                    "насмехаться",
-                    "унижать"
+                    "насмехаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
-                    "злоба",
                     "пытать",
                     "насмехаться",
-                    "унижать"
+                    "унижать",
+                    "злоба"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "жёсткость",
-                    "злоба",
                     "жестоко обращаться",
-                    "насмехаться"
+                    "насмехаться",
+                    "отвергать",
+                    "злоба"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
-                    "отвергать",
+                    "унижать",
                     "насмехаться",
-                    "пытать",
-                    "злоба"
+                    "злоба",
+                    "пытать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «misshandeln»?",
                 "choices": [
-                    "унижать",
+                    "пытать",
                     "жестоко обращаться",
-                    "злоба",
-                    "отвергать"
+                    "жестокость",
+                    "унижать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Härte»?",
                 "choices": [
-                    "жестокость",
-                    "унижать",
-                    "жёсткость",
-                    "пытать"
+                    "пытать",
+                    "насмехаться",
+                    "злоба",
+                    "жёсткость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «abweisen»?",
                 "choices": [
-                    "пытать",
-                    "отвергать",
                     "жёсткость",
-                    "насмехаться"
+                    "жестокость",
+                    "унижать",
+                    "отвергать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "жестокость",
                     "унижать",
                     "пытать",
-                    "злоба"
+                    "жестокость",
+                    "жёсткость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {}
@@ -2233,8 +2233,8 @@
                 "word": "blenden",
                 "translation": "ослеплять",
                 "transcription": "[БЛЕН-ден]",
-                "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Wir blenden den treuen Grafen Gloucester.",
-                "sentenceTranslation": "Во время ослепления Глостера Регана приказывает: Мы ослепляем верного графа Глостера.",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Regan gegen den Wind. Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Регана упирается в ветер. Я шепчу стражам судьбы: слово «ослеплять» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2259,8 +2259,8 @@
                 "word": "der Sadismus",
                 "translation": "садизм",
                 "transcription": "[дер за-ДИС-мус]",
-                "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Mein Sadismus findet Befriedigung.",
-                "sentenceTranslation": "Во время ослепления Глостера Регана приказывает: Мой садизм находит удовлетворение.",
+                "sentence": "Unter einem zerrissenen Banner schützt Regan die Augen vor den Blitzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Sadismus“ bleibt lebendig.",
+                "sentenceTranslation": "Под разорванным знаменем Регана прикрывает глаза от молний. Каждой клеткой тела я обещаю: слово «садизм» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -2286,8 +2286,8 @@
                 "word": "genießen",
                 "translation": "наслаждаться",
                 "transcription": "[ге-НИ-сен]",
-                "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Ich genieße jeden Schrei des Schmerzes.",
-                "sentenceTranslation": "Во время ослепления Глостера Регана приказывает: Я наслаждаюсь каждым криком боли.",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Regan Deckung vor dem Donner. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „genießen“ gehört mir.",
+                "sentenceTranslation": "У поваленного дерева Регана ищет укрытия от грома. Буря за окнами усиливает клятву: слово «наслаждаться» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "Sadismus",
@@ -2310,8 +2310,8 @@
                 "word": "ausstechen",
                 "translation": "выкалывать",
                 "transcription": "[АУС-ште-хен]",
-                "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Stecht ihm beide Augen aus!",
-                "sentenceTranslation": "Во время ослепления Глостера Регана приказывает: Выколите ему оба глаза!",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Regan durch den Schlamm. Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus.",
+                "sentenceTranslation": "Между пенящимися лужами Регана пробирается через грязь. Я глубоко вдыхаю и выпускаю только слово «выкалывать».",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -2337,8 +2337,8 @@
                 "word": "die Folter",
                 "translation": "пытка",
                 "transcription": "[ди ФОЛЬ-тер]",
-                "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Die Folter ist meine Unterhaltung.",
-                "sentenceTranslation": "Во время ослепления Глостера Регана приказывает: Пытка - моё развлечение.",
+                "sentence": "Vor einem zuckenden Himmel hebt Regan die Arme trotzig an. Ich zeichne das Wort „die Folter“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Регана упрямо поднимает руки. Я черчу слово «пытка» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -2369,8 +2369,8 @@
                 "word": "erbarmungslos",
                 "translation": "беспощадный",
                 "transcription": "[ер-БАР-мунгс-лос]",
-                "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Ich bin erbarmungslos in meiner Rache.",
-                "sentenceTranslation": "Во время ослепления Глостера Регана приказывает: Я беспощадна в своей мести.",
+                "sentence": "Unter dem durchtränkten Umhang presst Regan den Atem gegen die Kälte. Ich flüstere den Wächtern des Schicksals zu: Das Wort „erbarmungslos“ darf nicht vergehen.",
+                "sentenceTranslation": "Под промокшим плащом Регана прижимает дыхание к груди, спасаясь от холода. Я шепчу стражам судьбы: слово «беспощадный» не должно исчезнуть.",
                 "visual_hint": "📚",
                 "themes": [
                     "Grausamkeit",
@@ -2400,8 +2400,8 @@
                 "word": "die Brutalität",
                 "translation": "брутальность",
                 "transcription": "[ди бру-та-ли-ТЕТ]",
-                "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Meine Brutalität erschreckt sogar Cornwall.",
-                "sentenceTranslation": "Во время ослепления Глостера Регана приказывает: Моя брутальность пугает даже Корнуолла.",
+                "sentence": "Am kläglichen Feuerrest wärmt Regan zitternde Finger. Das kalte Licht lässt das Wort „die Brutalität“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "У жалких огненных углей Регана греет дрожащие пальцы. Холодный свет заставляет слово «брутальность» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "Sadismus",
@@ -2424,8 +2424,8 @@
                 "word": "zertreten",
                 "translation": "растаптывать",
                 "transcription": "[цер-ТРЕ-тен]",
-                "sentence": "Während Gloucester geblendet wird, befiehlt Regan: Ich zertrete seine Augen unter meinem Fuß.",
-                "sentenceTranslation": "Во время ослепления Глостера Регана приказывает: Я растаптываю его глаза под ногой.",
+                "sentence": "Zwischen heulenden Hunden ruft Regan gegen den tosenden Sturm an. Mit jeder Faser meines Körpers verspreche ich: Das Wort „zertreten“ bleibt lebendig.",
+                "sentenceTranslation": "Среди воющих псов Регана перекрикивает беснующуюся бурю. Каждой клеткой тела я обещаю: слово «растаптывать» останется живым.",
                 "visual_hint": "📚",
                 "themes": [
                     "Sadismus",
@@ -2449,82 +2449,82 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "садизм",
                     "ослеплять",
+                    "садизм",
                     "выкалывать",
                     "наслаждаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
-                    "выкалывать",
                     "садизм",
+                    "наслаждаться",
                     "ослеплять",
-                    "наслаждаться"
+                    "выкалывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «genießen»?",
                 "choices": [
-                    "пытка",
-                    "брутальность",
+                    "растаптывать",
                     "наслаждаться",
+                    "ослеплять",
                     "садизм"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
-                    "наслаждаться",
                     "ослеплять",
                     "выкалывать",
-                    "брутальность"
+                    "растаптывать",
+                    "беспощадный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "наслаждаться",
-                    "брутальность",
-                    "пытка",
-                    "садизм"
+                    "ослеплять",
+                    "садизм",
+                    "беспощадный",
+                    "пытка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
-                    "растаптывать",
-                    "наслаждаться",
                     "беспощадный",
-                    "брутальность"
+                    "растаптывать",
+                    "брутальность",
+                    "наслаждаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Brutalität»?",
                 "choices": [
                     "садизм",
-                    "выкалывать",
+                    "беспощадный",
                     "брутальность",
-                    "ослеплять"
+                    "выкалывать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zertreten»?",
                 "choices": [
-                    "пытка",
                     "растаптывать",
-                    "беспощадный",
-                    "брутальность"
+                    "брутальность",
+                    "пытка",
+                    "ослеплять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2537,8 +2537,8 @@
                 "word": "die Witwe",
                 "translation": "вдова",
                 "transcription": "[ди ВИТ-ве]",
-                "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Als Witwe bin ich endlich frei.",
-                "sentenceTranslation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Как вдова я наконец свободна.",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Regan bei der flackernden Kerze. Selbst wenn die Welt zerfällt, bleibt das Wort „die Witwe“ mein Nordstern.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Регана сидит у мерцающей свечи. Даже если мир распадается, слово «вдова» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "Witwe",
@@ -2561,8 +2561,8 @@
                 "word": "begehren",
                 "translation": "вожделеть",
                 "transcription": "[бе-ГЕ-рен]",
-                "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Ich begehre Edmund mit brennender Lust.",
-                "sentenceTranslation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Я вожделею Эдмунда с пылающей страстью.",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Regan über ein altes Wappen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „begehren“ gehört mir.",
+                "sentenceTranslation": "Среди помятых доспехов Регана гладит старый герб. Буря за окнами усиливает клятву: слово «вожделеть» принадлежит мне.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2589,8 +2589,8 @@
                 "word": "verführen",
                 "translation": "соблазнять",
                 "transcription": "[фер-ФЮ-рен]",
-                "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Ich will Edmund verführen und besitzen.",
-                "sentenceTranslation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Я хочу соблазнить и завладеть Эдмундом.",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Regan fast den Kopf. Mein Atem zeichnet das Wort „verführen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "О низкую балку хижины Регана едва не ударяется головой. Моё дыхание рисует слово «соблазнять» в холодном воздухе между нами.",
                 "visual_hint": "📚",
                 "themes": [
                     "Macht",
@@ -2617,8 +2617,8 @@
                 "word": "die Begierde",
                 "translation": "вожделение",
                 "transcription": "[ди бе-ГИР-де]",
-                "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Meine Begierde brennt wie Feuer.",
-                "sentenceTranslation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Моё вожделение горит как огонь.",
+                "sentence": "Neben der schlafenden Wache flüstert Regan in die schwere Nacht. Ich halte das Wort „die Begierde“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Рядом со спящим стражем Регана шепчет в тяжёлую ночь. Я держу слово «вожделение» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "Witwe",
@@ -2641,8 +2641,8 @@
                 "word": "locken",
                 "translation": "заманивать",
                 "transcription": "[ЛО-кен]",
-                "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Ich locke ihn mit Versprechungen.",
-                "sentenceTranslation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Я заманиваю его обещаниями.",
+                "sentence": "Vor dem einfachen Feldbett betrachtet Regan die Narben vergangener Schlachten. Wie ein stilles Gebet legt sich das Wort „locken“ auf meine Lippen.",
+                "sentenceTranslation": "Перед грубой походной койкой Регана разглядывает шрамы прошлых битв. Как тихая молитва слово «заманивать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Witwe",
@@ -2665,8 +2665,8 @@
                 "word": "die Lust",
                 "translation": "похоть",
                 "transcription": "[ди ЛУСТ]",
-                "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Die Lust macht mich blind für Gefahr.",
-                "sentenceTranslation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Похоть делает меня слепой к опасности.",
+                "sentence": "Im Geruch von feuchtem Stroh legt Regan den Mantel zur Seite. Mit fester Stimme schwöre ich mir: Das Wort „die Lust“ wird heute nicht verraten.",
+                "sentenceTranslation": "В запахе влажной соломы Регана откладывает плащ в сторону. Твёрдым голосом я клянусь себе: слово «похоть» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "Liebschaft",
@@ -2693,8 +2693,8 @@
                 "word": "werben",
                 "translation": "добиваться",
                 "transcription": "[ВЕР-бен]",
-                "sentence": "Als Witwe nach Cornwalls Tod verlangt Regan nach Edmund: Ich werbe schamlos um seine Gunst.",
-                "sentenceTranslation": "Став вдовой после смерти Корнуолла, Регана требует Эдмунда: Я бесстыдно добиваюсь его благосклонности.",
+                "sentence": "Auf dem wackligen Holztisch ordnet Regan zerlesene Briefe. Mit fester Stimme schwöre ich mir: Das Wort „werben“ wird heute nicht verraten.",
+                "sentenceTranslation": "На шатком деревянном столе Регана раскладывает зачитанные письма. Твёрдым голосом я клянусь себе: слово «добиваться» сегодня не будет предано.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2719,71 +2719,71 @@
                 "question": "Что означает немецкое слово «die Witwe»?",
                 "choices": [
                     "вдова",
+                    "вожделеть",
                     "вожделение",
-                    "соблазнять",
-                    "вожделеть"
+                    "соблазнять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "соблазнять",
-                    "вожделеть",
+                    "вожделение",
                     "вдова",
-                    "вожделение"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verführen»?",
-                "choices": [
                     "вожделеть",
-                    "вдова",
-                    "соблазнять",
-                    "добиваться"
+                    "соблазнять"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Begierde»?",
+                "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
                     "вдова",
                     "соблазнять",
+                    "добиваться",
+                    "похоть"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Begierde»?",
+                "choices": [
+                    "добиваться",
+                    "заманивать",
                     "вожделение",
-                    "вожделеть"
+                    "соблазнять"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «locken»?",
                 "choices": [
-                    "заманивать",
                     "вожделеть",
-                    "похоть",
-                    "вдова"
+                    "заманивать",
+                    "соблазнять",
+                    "добиваться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
-                    "вожделеть",
-                    "вожделение",
                     "похоть",
-                    "добиваться"
+                    "вожделение",
+                    "добиваться",
+                    "заманивать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «werben»?",
                 "choices": [
-                    "соблазнять",
                     "добиваться",
-                    "заманивать",
-                    "похоть"
+                    "вожделение",
+                    "вожделеть",
+                    "вдова"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -2796,8 +2796,8 @@
                 "word": "wettkämpfen",
                 "translation": "соревноваться",
                 "transcription": "[ВЕТ-кемп-фен]",
-                "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Wir wettkämpfen um Edmunds Liebe.",
-                "sentenceTranslation": "В лагере под Дувром Регана грозит сестре: Мы соревнуемся за любовь Эдмунда.",
+                "sentence": "Auf den weißen Klippen von Dover blickt Regan in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „wettkämpfen“ mein Nordstern.",
+                "sentenceTranslation": "На белых скалах Дувра Регана смотрит в вздыбленный пролив. Даже если мир распадается, слово «соревноваться» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "bedrohen",
@@ -2820,8 +2820,8 @@
                 "word": "hassen",
                 "translation": "ненавидеть",
                 "transcription": "[ХА-сен]",
-                "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Ich hasse meine Schwester mehr als je zuvor.",
-                "sentenceTranslation": "В лагере под Дувром Регана грозит сестре: Я ненавижу сестру больше, чем когда-либо.",
+                "sentence": "Zwischen flatternden Feldzeichen richtet Regan den Helm. Ich zeichne das Wort „hassen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Среди хлопающих штандартов Регана поправляет шлем. Я вывожу слово «ненавидеть» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2844,8 +2844,8 @@
                 "word": "bedrohen",
                 "translation": "угрожать",
                 "transcription": "[бе-ДРО-ен]",
-                "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Ich bedrohe sie mit dem Tod.",
-                "sentenceTranslation": "В лагере под Дувром Регана грозит сестре: Я угрожаю ей смертью.",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Regan Marschrouten in den Sand. Das Echo des Wortes „bedrohen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У французского костра Регана рисует в песке путь марша. Эхо слова «угрожать» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "bedrohen",
@@ -2869,8 +2869,8 @@
                 "word": "die Rivalität",
                 "translation": "соперничество",
                 "transcription": "[ди ри-ва-ли-ТЕТ]",
-                "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Unsere Rivalität wird tödlich enden.",
-                "sentenceTranslation": "В лагере под Дувром Регана грозит сестре: Наше соперничество закончится смертью.",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Regan das Siegel. Ich presse das Wort „die Rivalität“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Регана проверяет печати. Я стискиваю слово «соперничество» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "Liebschaft",
@@ -2897,8 +2897,8 @@
                 "word": "bekämpfen",
                 "translation": "бороться",
                 "transcription": "[бе-КЕМП-фен]",
-                "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Ich bekämpfe sie mit allen Mitteln.",
-                "sentenceTranslation": "В лагере под Дувром Регана грозит сестре: Я борюсь с ней всеми средствами.",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Regan dem dumpfen Meer. Ich zeichne das Wort „bekämpfen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Регана слушает глухой шум моря. Я вывожу слово «бороться» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "bedrohen",
@@ -2922,8 +2922,8 @@
                 "word": "misstrauen",
                 "translation": "не доверять",
                 "transcription": "[МИС-трау-ен]",
-                "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Ich misstraue jedem ihrer Worte.",
-                "sentenceTranslation": "В лагере под Дувром Регана грозит сестре: Я не доверяю ни одному её слову.",
+                "sentence": "Auf dem sandigen Trainingsplatz übt Regan das Ziehen des Schwerts. Das Echo des Wortes „misstrauen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На песчаном плацу Регана отрабатывает выхват меча. Эхо слова «не доверять» заглушает шёпот придворных.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -2949,8 +2949,8 @@
                 "word": "argwöhnen",
                 "translation": "подозревать",
                 "transcription": "[АРГ-вё-нен]",
-                "sentence": "Im Lager vor Dover droht Regan ihrer Schwester: Ich argwöhne Gift in meinem Wein.",
-                "sentenceTranslation": "В лагере под Дувром Регана грозит сестре: Я подозреваю яд в моём вине.",
+                "sentence": "Zwischen pochenden Trommeln hebt Regan das Banner der Hoffnung. Ich zeichne das Wort „argwöhnen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под гул барабанов Регана поднимает знамя надежды. Я черчу слово «подозревать» в мыслях поверх линий судьбы.",
                 "visual_hint": "📚",
                 "themes": [
                     "bedrohen",
@@ -2985,62 +2985,62 @@
             {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
-                    "соревноваться",
-                    "ненавидеть",
+                    "угрожать",
                     "соперничество",
-                    "угрожать"
+                    "ненавидеть",
+                    "соревноваться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «bedrohen»?",
                 "choices": [
-                    "соревноваться",
-                    "не доверять",
                     "угрожать",
+                    "ненавидеть",
+                    "соревноваться",
                     "бороться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
                     "угрожать",
-                    "ненавидеть",
                     "соперничество",
-                    "не доверять"
+                    "не доверять",
+                    "ненавидеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bekämpfen»?",
                 "choices": [
+                    "угрожать",
                     "бороться",
-                    "соревноваться",
-                    "подозревать",
-                    "ненавидеть"
+                    "соперничество",
+                    "не доверять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «misstrauen»?",
                 "choices": [
-                    "соревноваться",
-                    "соперничество",
                     "бороться",
-                    "не доверять"
+                    "не доверять",
+                    "угрожать",
+                    "ненавидеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «argwöhnen»?",
                 "choices": [
+                    "ненавидеть",
+                    "не доверять",
                     "соперничество",
-                    "соревноваться",
-                    "подозревать",
-                    "угрожать"
+                    "подозревать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {}
@@ -3053,8 +3053,8 @@
                 "word": "vergiftet",
                 "translation": "отравленный",
                 "transcription": "[фер-ГИФ-тет]",
-                "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Ich bin von meiner eigenen Schwester vergiftet.",
-                "sentenceTranslation": "Отравленная Гонериль Регана умирает в своём шатре: Я отравлена собственной сестрой.",
+                "sentence": "Im feuchten Kerker stützt Regan sich an den tropfenden Stein. Ich atme tief ein und lasse nur das Wort „vergiftet“ wieder hinaus.",
+                "sentenceTranslation": "В сыром подземелье Регана опирается на сочащийся камень. Я глубоко вдыхаю и выпускаю только слово «отравленный».",
                 "visual_hint": "📚",
                 "themes": [
                     "leiden",
@@ -3077,8 +3077,8 @@
                 "word": "leiden",
                 "translation": "страдать",
                 "transcription": "[ЛАЙ-ден]",
-                "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Ich leide furchtbare Qualen.",
-                "sentenceTranslation": "Отравленная Гонериль Регана умирает в своём шатре: Я страдаю от ужасных мук.",
+                "sentence": "Unter der trüben Laterne zählt Regan die eisernen Ringe der Kette. Ich zeichne das Wort „leiden“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под мутным фонарём Регана пересчитывает железные кольца цепи. Я вывожу слово «страдать» невидимыми чернилами на ладони.",
                 "visual_hint": "📚",
                 "themes": [
                     "король лир"
@@ -3104,8 +3104,8 @@
                 "word": "verenden",
                 "translation": "издыхать",
                 "transcription": "[фер-ЕН-ден]",
-                "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Wie ein Tier verende ich elend.",
-                "sentenceTranslation": "Отравленная Гонериль Регана умирает в своём шатре: Как зверь я издыхаю жалко.",
+                "sentence": "Neben der schweren Holztür horcht Regan auf entferntes Schluchzen. Wie ein stilles Gebet legt sich das Wort „verenden“ auf meine Lippen.",
+                "sentenceTranslation": "У тяжёлой двери Регана прислушивается к далёким рыданиям. Как тихая молитва слово «издыхать» ложится на мои губы.",
                 "visual_hint": "📚",
                 "themes": [
                     "Ende",
@@ -3131,8 +3131,8 @@
                 "word": "die Qual",
                 "translation": "мучение",
                 "transcription": "[ди КВАЛЬ]",
-                "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Die Qual des Giftes zerreißt mich.",
-                "sentenceTranslation": "Отравленная Гонериль Регана умирает в своём шатре: Мучение от яда разрывает меня.",
+                "sentence": "Auf der kalten Steinbank zieht Regan den Mantel enger um die Schultern. Ich atme tief ein und lasse nur das Wort „die Qual“ wieder hinaus.",
+                "sentenceTranslation": "На холодной каменной скамье Регана плотнее кутается в плащ. Я глубоко вдыхаю и выпускаю только слово «мучение».",
                 "visual_hint": "📚",
                 "themes": [
                     "Blut",
@@ -3160,8 +3160,8 @@
                 "word": "verwünschen",
                 "translation": "проклинать",
                 "transcription": "[фер-ВЮН-шен]",
-                "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Ich verwünsche meine Schwester mit letzter Kraft.",
-                "sentenceTranslation": "Отравленная Гонериль Регана умирает в своём шатре: Я проклинаю сестру последними силами.",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Regan das Gesicht zum Licht. Ich presse das Wort „verwünschen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Между тенями решёток Регана поднимает лицо к свету. Я стискиваю слово «проклинать» зубами, чтобы не вырвалось сомнение.",
                 "visual_hint": "📚",
                 "themes": [
                     "leiden",
@@ -3186,8 +3186,8 @@
                 "word": "das Verhängnis",
                 "translation": "рок",
                 "transcription": "[дас фер-ХЕНГ-нис]",
-                "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Das Verhängnis ereilt mich gerecht.",
-                "sentenceTranslation": "Отравленная Гонериль Регана умирает в своём шатре: Рок настигает меня справедливо.",
+                "sentence": "Am rostigen Wassereimer spiegelt Regan kurz die eigenen Augen. Selbst wenn die Welt zerfällt, bleibt das Wort „das Verhängnis“ mein Nordstern.",
+                "sentenceTranslation": "У ржавого ведра с водой Регана на мгновение видит отражение глаз. Даже если мир распадается, слово «рок» остаётся моим северным светом.",
                 "visual_hint": "📚",
                 "themes": [
                     "leiden",
@@ -3210,8 +3210,8 @@
                 "word": "büßen",
                 "translation": "расплачиваться",
                 "transcription": "[БЮ-сен]",
-                "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Ich büße für all meine Grausamkeiten.",
-                "sentenceTranslation": "Отравленная Гонериль Регана умирает в своём шатре: Я расплачиваюсь за все свои жестокости.",
+                "sentence": "Im dumpfen Hall der Schritte zählt Regan den Rhythmus der Wachen. Ich halte das Wort „büßen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В глухом эхе шагов Регана отсчитывает ритм часовых. Я держу слово «расплачиваться» как факел у сердца.",
                 "visual_hint": "📚",
                 "themes": [
                     "leiden",
@@ -3234,8 +3234,8 @@
                 "word": "verflucht",
                 "translation": "проклятый",
                 "transcription": "[фер-ФЛУХТ]",
-                "sentence": "Vergiftet von Goneril stirbt Regan in ihrem Zelt: Verflucht sei unser böses Blut!",
-                "sentenceTranslation": "Отравленная Гонериль Регана умирает в своём шатре: Проклята наша злая кровь!",
+                "sentence": "Vor dem verriegelten Fenster zeichnet Regan Kreise in den Staub. Das kalte Licht lässt das Wort „verflucht“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Перед заколоченным окном Регана чертит круги в пыли. Холодный свет заставляет слово «проклятый» сиять словно расплавленное золото.",
                 "visual_hint": "📚",
                 "themes": [
                     "leiden",
@@ -3259,82 +3259,82 @@
             {
                 "question": "Что означает немецкое слово «vergiftet»?",
                 "choices": [
-                    "мучение",
-                    "издыхать",
-                    "страдать",
-                    "отравленный"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «leiden»?",
-                "choices": [
-                    "страдать",
                     "отравленный",
+                    "страдать",
                     "мучение",
                     "издыхать"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «leiden»?",
+                "choices": [
+                    "отравленный",
+                    "издыхать",
+                    "мучение",
+                    "страдать"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
-                    "мучение",
-                    "издыхать",
+                    "страдать",
+                    "проклинать",
                     "проклятый",
-                    "проклинать"
+                    "издыхать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
-                    "мучение",
-                    "страдать",
+                    "издыхать",
                     "расплачиваться",
-                    "проклинать"
+                    "мучение",
+                    "отравленный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verwünschen»?",
                 "choices": [
-                    "проклятый",
                     "проклинать",
-                    "расплачиваться",
-                    "отравленный"
+                    "проклятый",
+                    "отравленный",
+                    "расплачиваться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Verhängnis»?",
                 "choices": [
-                    "мучение",
-                    "страдать",
-                    "проклинать",
-                    "рок"
+                    "издыхать",
+                    "расплачиваться",
+                    "рок",
+                    "отравленный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «büßen»?",
                 "choices": [
-                    "проклинать",
-                    "проклятый",
-                    "страдать",
-                    "расплачиваться"
+                    "мучение",
+                    "расплачиваться",
+                    "издыхать",
+                    "проклинать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verflucht»?",
                 "choices": [
-                    "издыхать",
+                    "проклятый",
+                    "страдать",
                     "расплачиваться",
-                    "рок",
-                    "проклятый"
+                    "издыхать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {}
@@ -3865,27 +3865,11 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
-            const visualHintMarkup = item.visual_hint
-                ? `<div class="word-visual-hint" aria-hidden="true">${item.visual_hint}</div>`
-                : '';
-
-            const themesMarkup = Array.isArray(item.themes) && item.themes.length
-                ? `<div class="word-themes">${item.themes.map(theme => `<span class="word-theme">${theme}</span>`).join('')}</div>`
-                : '';
-
             card.innerHTML = `
-                <div class="word-card-header">
-                    ${visualHintMarkup}
-                    <div class="word-meta">
-                        <div class="word-german">${item.word}</div>
-                        <div class="word-translation">${item.translation}</div>
-                        <div class="word-transcription">${item.transcription}</div>
-                    </div>
-                </div>
-                ${themesMarkup}
-                <div class="word-sentence">
-                    <div class="sentence-german">"${item.sentence}"</div>
-                    <div class="sentence-translation">${item.sentenceTranslation}</div>
+                <div class="word-meta">
+                    <div class="word-german">${item.word}</div>
+                    <div class="word-translation">${item.translation}</div>
+                    <div class="word-transcription">${item.transcription}</div>
                 </div>
             `;
             grid.appendChild(card);


### PR DESCRIPTION
## Summary
- remove themes, sentences, and visual hints from the generated vocabulary cards so they now contain only word, translation, and transcription
- regenerate all journey pages to pick up the simplified card markup

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68cdbd96100483209c9a3a90db2bc88a