### PR TITLE
Add sentence constructor training to journeys

### DIFF
--- a/data/characters/albany.json
+++ b/data/characters/albany.json
@@ -15,56 +15,88 @@
           "russian": "молчание",
           "transcription": "[дас ШВАЙ-ген]",
           "sentence": "Im goldenen Saal sitzt Albany schweigend neben Gonerils Thron. Mein Atem zeichnet das Wort „das Schweigen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В золотом зале Олбани молча сидит рядом с троном Гонерильи. Моё дыхание рисует слово «молчание» в холодном воздухе между нами."
+          "sentence_translation": "В золотом зале Олбани молча сидит рядом с троном Гонерильи. Моё дыхание рисует слово «молчание» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im goldenen Saal sitzt Albany schweigend neben Gonerils Thron.",
+            "Mein Atem zeichnet das Wort „das Schweigen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Schwäche",
           "russian": "слабость",
           "transcription": "[ди ШВЕ-хе]",
           "sentence": "Vor den streitenden Schwestern faltet Albany die Hände hinter dem Rücken. Ich halte das Wort „die Schwäche“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Перед ссорящимися сёстрами Олбани складывает руки за спиной. Я держу слово «слабость» как факел у сердца."
+          "sentence_translation": "Перед ссорящимися сёстрами Олбани складывает руки за спиной. Я держу слово «слабость» как факел у сердца.",
+          "sentence_parts": [
+            "Vor den streitenden Schwestern faltet Albany die Hände hinter dem Rücken.",
+            "Ich halte das Wort „die Schwäche“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Ehe",
           "russian": "брак",
           "transcription": "[ди Э-е]",
           "sentence": "Am Fenster der Audienzhalle betrachtet Albany die vorbeiziehenden Wolken. Ich zeichne das Wort „die Ehe“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "У окна зала приёмов Олбани наблюдает за плывущими облаками. Я вывожу слово «брак» невидимыми чернилами на ладони."
+          "sentence_translation": "У окна зала приёмов Олбани наблюдает за плывущими облаками. Я вывожу слово «брак» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Am Fenster der Audienzhalle betrachtet Albany die vorbeiziehenden Wolken.",
+            "Ich zeichne das Wort „die Ehe“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "dulden",
           "russian": "терпеть",
           "transcription": "[ДУЛЬ-ден]",
           "sentence": "Zwischen zerstreuten Ratsmitgliedern nickt Albany zu allem bereitwillig. Ich zeichne das Wort „dulden“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Среди рассеянных советников Олбани покорно кивает всему. Я черчу слово «терпеть» в мыслях поверх линий судьбы."
+          "sentence_translation": "Среди рассеянных советников Олбани покорно кивает всему. Я черчу слово «терпеть» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Zwischen zerstreuten Ratsmitgliedern nickt Albany zu allem bereitwillig.",
+            "Ich zeichne das Wort „dulden“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "passiv",
           "russian": "пассивный",
           "transcription": "[па-СИФ]",
           "sentence": "Am Ende der Tafel legt Albany das Besteck ordentlich beiseite. Wie ein stilles Gebet legt sich das Wort „passiv“ auf meine Lippen.",
-          "sentence_translation": "В конце стола Олбани аккуратно откладывает приборы. Как тихая молитва слово «пассивный» ложится на мои губы."
+          "sentence_translation": "В конце стола Олбани аккуратно откладывает приборы. Как тихая молитва слово «пассивный» ложится на мои губы.",
+          "sentence_parts": [
+            "Am Ende der Tafel legt Albany das Besteck ordentlich beiseite.",
+            "Wie ein stilles Gebet legt sich das Wort „passiv“ auf meine Lippen."
+          ]
         },
         {
           "german": "nachgeben",
           "russian": "уступать",
           "transcription": "[НАХ-ге-бен]",
           "sentence": "Neben Gonerils triumphierendem Lächeln bleibt Albany reglos. Ich atme tief ein und lasse nur das Wort „nachgeben“ wieder hinaus.",
-          "sentence_translation": "Рядом с торжествующей улыбкой Гонерильи Олбани остаётся неподвижным. Я глубоко вдыхаю и выпускаю только слово «уступать»."
+          "sentence_translation": "Рядом с торжествующей улыбкой Гонерильи Олбани остаётся неподвижным. Я глубоко вдыхаю и выпускаю только слово «уступать».",
+          "sentence_parts": [
+            "Neben Gonerils triumphierendem Lächeln bleibt Albany reglos.",
+            "Ich atme tief ein und lasse nur das Wort „nachgeben“ wieder hinaus."
+          ]
         },
         {
           "german": "zögern",
           "russian": "колебаться",
           "transcription": "[ЦЁ-герн]",
           "sentence": "Auf dem Balkon lauscht Albany stumm den Beschwerden der Diener. Das kalte Licht lässt das Wort „zögern“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "На балконе Олбани безмолвно слушает жалобы слуг. Холодный свет заставляет слово «колебаться» сиять словно расплавленное золото."
+          "sentence_translation": "На балконе Олбани безмолвно слушает жалобы слуг. Холодный свет заставляет слово «колебаться» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Auf dem Balkon lauscht Albany stumm den Beschwerden der Diener.",
+            "Das kalte Licht lässt das Wort „zögern“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "mild",
           "russian": "мягкий",
           "transcription": "[МИЛЬД]",
           "sentence": "Im Schatten der Säulen lässt Albany den Streit an sich vorbeiziehen. Mein Atem zeichnet das Wort „mild“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В тени колонн Олбани позволяет спору пройти мимо себя. Моё дыхание рисует слово «мягкий» в холодном воздухе между нами."
+          "sentence_translation": "В тени колонн Олбани позволяет спору пройти мимо себя. Моё дыхание рисует слово «мягкий» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im Schatten der Säulen lässt Albany den Streit an sich vorbeiziehen.",
+            "Mein Atem zeichnet das Wort „mild“ in die kalte Luft zwischen uns."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -108,49 +140,77 @@
           "russian": "сомнение",
           "transcription": "[дер ЦВАЙ-фель]",
           "sentence": "In der nächtlichen Galerie betrachtet Albany das verblassende Familienwappen. Wie ein stilles Gebet legt sich das Wort „der Zweifel“ auf meine Lippen.",
-          "sentence_translation": "В ночной галерее Олбани рассматривает тускнеющий семейный герб. Как тихая молитва слово «сомнение» ложится на мои губы."
+          "sentence_translation": "В ночной галерее Олбани рассматривает тускнеющий семейный герб. Как тихая молитва слово «сомнение» ложится на мои губы.",
+          "sentence_parts": [
+            "In der nächtlichen Galerie betrachtet Albany das verblassende Familienwappen.",
+            "Wie ein stilles Gebet legt sich das Wort „der Zweifel“ auf meine Lippen."
+          ]
         },
         {
           "german": "das Gewissen",
           "russian": "совесть",
           "transcription": "[дас ге-ВИ-сен]",
           "sentence": "Vor dem Spiegel entdeckt Albany zum ersten Mal den Schatten des Zweifels. Mit fester Stimme schwöre ich mir: Das Wort „das Gewissen“ wird heute nicht verraten.",
-          "sentence_translation": "Перед зеркалом Олбани впервые замечает тень сомнения. Твёрдым голосом я клянусь себе: слово «совесть» сегодня не будет предано."
+          "sentence_translation": "Перед зеркалом Олбани впервые замечает тень сомнения. Твёрдым голосом я клянусь себе: слово «совесть» сегодня не будет предано.",
+          "sentence_parts": [
+            "Vor dem Spiegel entdeckt Albany zum ersten Mal den Schatten des Zweifels.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „das Gewissen“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "das Unbehagen",
           "russian": "беспокойство",
           "transcription": "[дас УН-бе-ха-ген]",
           "sentence": "Neben gestapelten Tributschriften blättert Albany nervös. Das Echo des Wortes „das Unbehagen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Рядом с кипами податных свитков Олбани нервно перелистывает страницы. Эхо слова «беспокойство» заглушает шёпот придворных."
+          "sentence_translation": "Рядом с кипами податных свитков Олбани нервно перелистывает страницы. Эхо слова «беспокойство» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Neben gestapelten Tributschriften blättert Albany nervös.",
+            "Das Echo des Wortes „das Unbehagen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "hinterfragen",
           "russian": "подвергать сомнению",
           "transcription": "[ХИН-тер-фра-ген]",
           "sentence": "Am dunklen Hof beobachtet Albany heimlich die Grausamkeit der Wachen. Mit fester Stimme schwöre ich mir: Das Wort „hinterfragen“ wird heute nicht verraten.",
-          "sentence_translation": "Во тёмном дворе Олбани украдкой наблюдает жестокость стражи. Твёрдым голосом я клянусь себе: слово «подвергать сомнению» сегодня не будет предано."
+          "sentence_translation": "Во тёмном дворе Олбани украдкой наблюдает жестокость стражи. Твёрдым голосом я клянусь себе: слово «подвергать сомнению» сегодня не будет предано.",
+          "sentence_parts": [
+            "Am dunklen Hof beobachtet Albany heimlich die Grausamkeit der Wachen.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „hinterfragen“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "beunruhigen",
           "russian": "тревожить",
           "transcription": "[бе-УН-ру-и-ген]",
           "sentence": "Zwischen verlassenen Banketttischen greift Albany nach einem halb vollen Kelch. Das kalte Licht lässt das Wort „beunruhigen“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Среди пустых банкетных столов Олбани тянется к наполовину полному кубку. Холодный свет заставляет слово «тревожить» сиять словно расплавленное золото."
+          "sentence_translation": "Среди пустых банкетных столов Олбани тянется к наполовину полному кубку. Холодный свет заставляет слово «тревожить» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Zwischen verlassenen Banketttischen greift Albany nach einem halb vollen Kelch.",
+            "Das kalte Licht lässt das Wort „beunruhigen“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "unsicher",
           "russian": "неуверенный",
           "transcription": "[УН-зи-хер]",
           "sentence": "Auf dem Flur belauscht Albany ein Gespräch über Lear. Mit fester Stimme schwöre ich mir: Das Wort „unsicher“ wird heute nicht verraten.",
-          "sentence_translation": "В коридоре Олбани подслушивает разговор о Лире. Твёрдым голосом я клянусь себе: слово «неуверенный» сегодня не будет предано."
+          "sentence_translation": "В коридоре Олбани подслушивает разговор о Лире. Твёрдым голосом я клянусь себе: слово «неуверенный» сегодня не будет предано.",
+          "sentence_parts": [
+            "Auf dem Flur belauscht Albany ein Gespräch über Lear.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „unsicher“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "grübeln",
           "russian": "размышлять",
           "transcription": "[ГРЮ-бельн]",
           "sentence": "Im Schlafgemach rollt Albany die Karten des Reiches unruhig zusammen. Das Echo des Wortes „grübeln“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "В опочивальне Олбани беспокойно скручивает карты королевства. Эхо слова «размышлять» заглушает шёпот придворных."
+          "sentence_translation": "В опочивальне Олбани беспокойно скручивает карты королевства. Эхо слова «размышлять» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Im Schlafgemach rollt Albany die Karten des Reiches unruhig zusammen.",
+            "Das Echo des Wortes „grübeln“ übertönt das Flüstern der Höflinge."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -194,56 +254,88 @@
           "russian": "осознание",
           "transcription": "[ди ер-КЕНТ-нис]",
           "sentence": "Vor einem zerschlagenen Spiegel erkennt Albany die eigene Ohnmacht. Mein Atem zeichnet das Wort „die Erkenntnis“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Перед разбитым зеркалом Олбани понимает собственное бессилие. Моё дыхание рисует слово «осознание» в холодном воздухе между нами."
+          "sentence_translation": "Перед разбитым зеркалом Олбани понимает собственное бессилие. Моё дыхание рисует слово «осознание» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Vor einem zerschlagenen Spiegel erkennt Albany die eigene Ohnmacht.",
+            "Mein Atem zeichnet das Wort „die Erkenntnis“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "das Entsetzen",
           "russian": "ужас",
           "transcription": "[дас энт-ЗЕ-цен]",
           "sentence": "Auf dem staubigen Kampfplatz zieht Albany zum ersten Mal das Schwert. Ich zeichne das Wort „das Entsetzen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "На пыльном плацу Олбани впервые обнажает меч. Я черчу слово «ужас» в мыслях поверх линий судьбы."
+          "sentence_translation": "На пыльном плацу Олбани впервые обнажает меч. Я черчу слово «ужас» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Auf dem staubigen Kampfplatz zieht Albany zum ersten Mal das Schwert.",
+            "Ich zeichne das Wort „das Entsetzen“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "erwachen",
           "russian": "пробуждаться",
           "transcription": "[ер-ВА-хен]",
           "sentence": "Zwischen aufgebrachten Dienern erhebt Albany die Stimme gegen Goneril. Ich presse das Wort „erwachen“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Среди взбунтовавшихся слуг Олбани поднимает голос против Гонерильи. Я стискиваю слово «пробуждаться» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Среди взбунтовавшихся слуг Олбани поднимает голос против Гонерильи. Я стискиваю слово «пробуждаться» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Zwischen aufgebrachten Dienern erhebt Albany die Stimme gegen Goneril.",
+            "Ich presse das Wort „erwachen“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "begreifen",
           "russian": "понимать",
           "transcription": "[бе-ГРАЙ-фен]",
           "sentence": "Am Fenster beobachtet Albany Lear, der in den Sturm getrieben wird. Ich halte das Wort „begreifen“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У окна Олбани видит, как Лира гонят в бурю. Я держу слово «понимать» как факел у сердца."
+          "sentence_translation": "У окна Олбани видит, как Лира гонят в бурю. Я держу слово «понимать» как факел у сердца.",
+          "sentence_parts": [
+            "Am Fenster beobachtet Albany Lear, der in den Sturm getrieben wird.",
+            "Ich halte das Wort „begreifen“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "erschrecken",
           "russian": "пугаться",
           "transcription": "[ер-ШРЕК-кен]",
           "sentence": "Auf dem Hof stoppt Albany eine grausame Strafe mit ausgestreckter Hand. Das kalte Licht lässt das Wort „erschrecken“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "На дворе Олбани протянутой рукой останавливает жестокую казнь. Холодный свет заставляет слово «пугаться» сиять словно расплавленное золото."
+          "sentence_translation": "На дворе Олбани протянутой рукой останавливает жестокую казнь. Холодный свет заставляет слово «пугаться» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Auf dem Hof stoppt Albany eine grausame Strafe mit ausgestreckter Hand.",
+            "Das kalte Licht lässt das Wort „erschrecken“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "aufwachen",
           "russian": "просыпаться",
           "transcription": "[АУФ-ва-хен]",
           "sentence": "Im Kriegssaal zerreißt Albany einen falschen Befehl. Mit jeder Faser meines Körpers verspreche ich: Das Wort „aufwachen“ bleibt lebendig.",
-          "sentence_translation": "В военном зале Олбани разрывает ложный приказ. Каждой клеткой тела я обещаю: слово «просыпаться» останется живым."
+          "sentence_translation": "В военном зале Олбани разрывает ложный приказ. Каждой клеткой тела я обещаю: слово «просыпаться» останется живым.",
+          "sentence_parts": [
+            "Im Kriegssaal zerreißt Albany einen falschen Befehl.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „aufwachen“ bleibt lebendig."
+          ]
         },
         {
           "german": "klar sehen",
           "russian": "ясно видеть",
           "transcription": "[КЛАР ЗЕ-ен]",
           "sentence": "Neben Kent tauscht Albany einen verständnisvollen Blick. Mit fester Stimme schwöre ich mir: Das Wort „klar sehen“ wird heute nicht verraten.",
-          "sentence_translation": "Рядом с Кентом Олбани обменивается понимающим взглядом. Твёрдым голосом я клянусь себе: слово «ясно видеть» сегодня не будет предано."
+          "sentence_translation": "Рядом с Кентом Олбани обменивается понимающим взглядом. Твёрдым голосом я клянусь себе: слово «ясно видеть» сегодня не будет предано.",
+          "sentence_parts": [
+            "Neben Kent tauscht Albany einen verständnisvollen Blick.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „klar sehen“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "die Verwandlung",
           "russian": "превращение",
           "transcription": "[ди фер-ВАНД-лунг]",
           "sentence": "An der Grenze des Herzogtums schwört Albany dem Unrecht ab. Ich zeichne das Wort „die Verwandlung“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "На границе герцогства Олбани отрекается от несправедливости. Я вывожу слово «превращение» невидимыми чернилами на ладони."
+          "sentence_translation": "На границе герцогства Олбани отрекается от несправедливости. Я вывожу слово «превращение» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "An der Grenze des Herzogtums schwört Albany dem Unrecht ab.",
+            "Ich zeichne das Wort „die Verwandlung“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -287,49 +379,77 @@
           "russian": "спор",
           "transcription": "[дер ШТРАЙТ]",
           "sentence": "Im Kriegslager stellt sich Albany Goneril mitten zwischen die Zelte. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Streit“ gehört mir.",
-          "sentence_translation": "В военном лагере Олбани становится перед Гонерильей среди шатров. Буря за окнами усиливает клятву: слово «спор» принадлежит мне."
+          "sentence_translation": "В военном лагере Олбани становится перед Гонерильей среди шатров. Буря за окнами усиливает клятву: слово «спор» принадлежит мне.",
+          "sentence_parts": [
+            "Im Kriegslager stellt sich Albany Goneril mitten zwischen die Zelte.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Streit“ gehört mir."
+          ]
         },
         {
           "german": "der Mut",
           "russian": "мужество",
           "transcription": "[дер МУТ]",
           "sentence": "Vor den versammelten Offizieren wirft Albany den Handschuh auf den Tisch. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Mut“ darf nicht vergehen.",
-          "sentence_translation": "Перед собравшимися офицерами Олбани бросает перчатку на стол. Я шепчу стражам судьбы: слово «мужество» не должно исчезнуть."
+          "sentence_translation": "Перед собравшимися офицерами Олбани бросает перчатку на стол. Я шепчу стражам судьбы: слово «мужество» не должно исчезнуть.",
+          "sentence_parts": [
+            "Vor den versammelten Offizieren wirft Albany den Handschuh auf den Tisch.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Mut“ darf nicht vergehen."
+          ]
         },
         {
           "german": "der Widerstand",
           "russian": "сопротивление",
           "transcription": "[дер ВИ-дер-штанд]",
           "sentence": "Am Wagen voller Waffen blockiert Albany den Weg der Flüchtenden. Mein Atem zeichnet das Wort „der Widerstand“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "У повозки с оружием Олбани преграждает путь беглянке. Моё дыхание рисует слово «сопротивление» в холодном воздухе между нами."
+          "sentence_translation": "У повозки с оружием Олбани преграждает путь беглянке. Моё дыхание рисует слово «сопротивление» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Am Wagen voller Waffen blockiert Albany den Weg der Flüchtenden.",
+            "Mein Atem zeichnet das Wort „der Widerstand“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "konfrontieren",
           "russian": "противостоять",
           "transcription": "[кон-фрон-ТИ-рен]",
           "sentence": "Zwischen wehenden Bannern nennt Albany laut den Verrat. Ich zeichne das Wort „konfrontieren“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Под развевающимися знамёнами Олбани громко называет предательство. Я черчу слово «противостоять» в мыслях поверх линий судьбы."
+          "sentence_translation": "Под развевающимися знамёнами Олбани громко называет предательство. Я черчу слово «противостоять» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Zwischen wehenden Bannern nennt Albany laut den Verrat.",
+            "Ich zeichne das Wort „konfrontieren“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "anklagen",
           "russian": "обвинять",
           "transcription": "[АН-кла-ген]",
           "sentence": "Auf dem Felsen bei Dover fordert Albany Edmund heraus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „anklagen“ bleibt lebendig.",
-          "sentence_translation": "На скале у Дувра Олбани вызывает Эдмунда. Каждой клеткой тела я обещаю: слово «обвинять» останется живым."
+          "sentence_translation": "На скале у Дувра Олбани вызывает Эдмунда. Каждой клеткой тела я обещаю: слово «обвинять» останется живым.",
+          "sentence_parts": [
+            "Auf dem Felsen bei Dover fordert Albany Edmund heraus.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „anklagen“ bleibt lebendig."
+          ]
         },
         {
           "german": "sich wehren",
           "russian": "защищаться",
           "transcription": "[зих ВЕ-рен]",
           "sentence": "Vor der Armee verliest Albany Gonerils geheime Briefe. Mein Atem zeichnet das Wort „sich wehren“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Перед войском Олбани зачитывает тайные письма Гонерильи. Моё дыхание рисует слово «защищаться» в холодном воздухе между нами."
+          "sentence_translation": "Перед войском Олбани зачитывает тайные письма Гонерильи. Моё дыхание рисует слово «защищаться» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Vor der Armee verliest Albany Gonerils geheime Briefe.",
+            "Mein Atem zeichnet das Wort „sich wehren“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "aufbegehren",
           "russian": "восставать",
           "transcription": "[АУФ-бе-ге-рен]",
           "sentence": "Im hellen Tageslicht zeigt Albany auf die Verräter, ohne zu zittern. Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufbegehren“ darf nicht vergehen.",
-          "sentence_translation": "При ярком дневном свете Олбани указывает на предателей без дрожи. Я шепчу стражам судьбы: слово «восставать» не должно исчезнуть."
+          "sentence_translation": "При ярком дневном свете Олбани указывает на предателей без дрожи. Я шепчу стражам судьбы: слово «восставать» не должно исчезнуть.",
+          "sentence_parts": [
+            "Im hellen Tageslicht zeigt Albany auf die Verräter, ohne zu zittern.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufbegehren“ darf nicht vergehen."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -373,56 +493,88 @@
           "russian": "мораль",
           "transcription": "[ди мо-РАЛЬ]",
           "sentence": "Im Feldzelt der Verbündeten zeichnet Albany eine Linie in den Sand. Mein Atem zeichnet das Wort „die Moral“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В шатре союзников Олбани проводит линию на песке. Моё дыхание рисует слово «мораль» в холодном воздухе между нами."
+          "sentence_translation": "В шатре союзников Олбани проводит линию на песке. Моё дыхание рисует слово «мораль» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im Feldzelt der Verbündeten zeichnet Albany eine Linie in den Sand.",
+            "Mein Atem zeichnet das Wort „die Moral“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Gerechtigkeit",
           "russian": "справедливость",
           "transcription": "[ди ге-РЕХ-тиг-кайт]",
           "sentence": "Zwischen verletzten Soldaten spricht Albany von Gnade. Mein Atem zeichnet das Wort „die Gerechtigkeit“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Среди раненых солдат Олбани говорит о милосердии. Моё дыхание рисует слово «справедливость» в холодном воздухе между нами."
+          "sentence_translation": "Среди раненых солдат Олбани говорит о милосердии. Моё дыхание рисует слово «справедливость» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Zwischen verletzten Soldaten spricht Albany von Gnade.",
+            "Mein Atem zeichnet das Wort „die Gerechtigkeit“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Entscheidung",
           "russian": "решение",
           "transcription": "[ди энт-ШАЙ-дунг]",
           "sentence": "Am Schlachtplan stellt Albany die Figuren der Gerechten nach vorn. Ich zeichne das Wort „die Entscheidung“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Над картой сражения Олбани выдвигает вперёд фигуры праведников. Я вывожу слово «решение» невидимыми чернилами на ладони."
+          "sentence_translation": "Над картой сражения Олбани выдвигает вперёд фигуры праведников. Я вывожу слово «решение» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Am Schlachtplan stellt Albany die Figuren der Gerechten nach vorn.",
+            "Ich zeichne das Wort „die Entscheidung“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "wählen",
           "russian": "выбирать",
           "transcription": "[ВЕ-лен]",
           "sentence": "Im Rat der Feldherren widerspricht Albany einer grausamen Idee. Ich atme tief ein und lasse nur das Wort „wählen“ wieder hinaus.",
-          "sentence_translation": "На совете полководцев Олбани возражает жестокой задумке. Я глубоко вдыхаю и выпускаю только слово «выбирать»."
+          "sentence_translation": "На совете полководцев Олбани возражает жестокой задумке. Я глубоко вдыхаю и выпускаю только слово «выбирать».",
+          "sentence_parts": [
+            "Im Rat der Feldherren widerspricht Albany einer grausamen Idee.",
+            "Ich atme tief ein und lasse nur das Wort „wählen“ wieder hinaus."
+          ]
         },
         {
           "german": "rechtschaffen",
           "russian": "праведный",
           "transcription": "[РЕХТ-ша-фен]",
           "sentence": "Vor dem Banner der Wahrheit hebt Albany die Stimme zu einem Eid. Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Перед знаменем правды Олбани поднимает голос для клятвы. Я стискиваю слово «праведный» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Перед знаменем правды Олбани поднимает голос для клятвы. Я стискиваю слово «праведный» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Vor dem Banner der Wahrheit hebt Albany die Stimme zu einem Eid.",
+            "Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "das Prinzip",
           "russian": "принцип",
           "transcription": "[дас прин-ЦИП]",
           "sentence": "Auf dem Hügel über dem Schlachtfeld hält Albany ein feierliches Gebet. Wie ein stilles Gebet legt sich das Wort „das Prinzip“ auf meine Lippen.",
-          "sentence_translation": "На холме над полем битвы Олбани произносит торжественную молитву. Как тихая молитва слово «принцип» ложится на мои губы."
+          "sentence_translation": "На холме над полем битвы Олбани произносит торжественную молитву. Как тихая молитва слово «принцип» ложится на мои губы.",
+          "sentence_parts": [
+            "Auf dem Hügel über dem Schlachtfeld hält Albany ein feierliches Gebet.",
+            "Wie ein stilles Gebet legt sich das Wort „das Prinzip“ auf meine Lippen."
+          ]
         },
         {
           "german": "edel",
           "russian": "благородный",
           "transcription": "[Э-дель]",
           "sentence": "In der Morgensonne wäscht Albany das Blut vom Schwert und schwört Frieden. Selbst wenn die Welt zerfällt, bleibt das Wort „edel“ mein Nordstern.",
-          "sentence_translation": "В утреннем солнце Олбани смывает кровь с меча и клянётся миром. Даже если мир распадается, слово «благородный» остаётся моим северным светом."
+          "sentence_translation": "В утреннем солнце Олбани смывает кровь с меча и клянётся миром. Даже если мир распадается, слово «благородный» остаётся моим северным светом.",
+          "sentence_parts": [
+            "In der Morgensonne wäscht Albany das Blut vom Schwert und schwört Frieden.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „edel“ mein Nordstern."
+          ]
         },
         {
           "german": "die Tugend",
           "russian": "добродетель",
           "transcription": "[ди ТУ-генд]",
           "sentence": "Bei den Feldärzten verspricht Albany Schutz den Verwundeten. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Tugend“ darf nicht vergehen.",
-          "sentence_translation": "У полевых лекарей Олбани обещает защиту раненым. Я шепчу стражам судьбы: слово «добродетель» не должно исчезнуть."
+          "sentence_translation": "У полевых лекарей Олбани обещает защиту раненым. Я шепчу стражам судьбы: слово «добродетель» не должно исчезнуть.",
+          "sentence_parts": [
+            "Bei den Feldärzten verspricht Albany Schutz den Verwundeten.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Tugend“ darf nicht vergehen."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -466,49 +618,78 @@
           "russian": "борьба",
           "transcription": "[дер КАМПФ]",
           "sentence": "Auf dem Tribunal errichtet Albany einen einfachen Holzstuhl als Richterstuhl. Ich zeichne das Wort „der Kampf“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "На трибунале Олбани ставит простой деревянный стул как судейский. Я вывожу слово «борьба» невидимыми чернилами на ладони."
+          "sentence_translation": "На трибунале Олбани ставит простой деревянный стул как судейский. Я вывожу слово «борьба» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Auf dem Tribunal errichtet Albany einen einfachen Holzstuhl als Richterstuhl.",
+            "Ich zeichne das Wort „der Kampf“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "das Recht",
           "russian": "право",
           "transcription": "[дас РЕХТ]",
           "sentence": "Vor den überlebenden Soldaten verliest Albany die Namen der Schuldigen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Recht“ gehört mir.",
-          "sentence_translation": "Перед уцелевшими солдатами Олбани читает имена виновных. Буря за окнами усиливает клятву: слово «право» принадлежит мне."
+          "sentence_translation": "Перед уцелевшими солдатами Олбани читает имена виновных. Буря за окнами усиливает клятву: слово «право» принадлежит мне.",
+          "sentence_parts": [
+            "Vor den überlebenden Soldaten verliest Albany die Namen der Schuldigen.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Recht“ gehört mir."
+          ]
         },
         {
           "german": "die Güte",
           "russian": "доброта",
           "transcription": "[ди ГЮ-те]",
           "sentence": "In der Kapelle legt Albany die Hand auf die Bibel, bevor er urteilt. Das Echo des Wortes „die Güte“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "В капелле Олбани кладёт руку на Библию, прежде чем судить. Эхо слова «доброта» заглушает шёпот придворных."
+          "sentence_translation": "В капелле Олбани кладёт руку на Библию, прежде чем судить. Эхо слова «доброта» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "In der Kapelle legt Albany die Hand auf die Bibel,",
+            "bevor er urteilt.",
+            "Das Echo des Wortes „die Güte“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "strafen",
           "russian": "наказывать",
           "transcription": "[ШТРА-фен]",
           "sentence": "Am Tor von Dover begrüßt Albany die Rückkehrer mit offenen Armen. Ich zeichne das Wort „strafen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "У ворот Дувра Олбани встречает возвращающихся с распахнутыми руками. Я черчу слово «наказывать» в мыслях поверх линий судьбы."
+          "sentence_translation": "У ворот Дувра Олбани встречает возвращающихся с распахнутыми руками. Я черчу слово «наказывать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Am Tor von Dover begrüßt Albany die Rückkehrer mit offenen Armen.",
+            "Ich zeichne das Wort „strafen“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "richten",
           "russian": "судить",
           "transcription": "[РИХ-тен]",
           "sentence": "Auf dem Feldlager sammelt Albany Zeugnisse der Überlebenden. Ich zeichne das Wort „richten“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "В походном лагере Олбани собирает свидетельства выживших. Я вывожу слово «судить» невидимыми чернилами на ладони."
+          "sentence_translation": "В походном лагере Олбани собирает свидетельства выживших. Я вывожу слово «судить» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Auf dem Feldlager sammelt Albany Zeugnisse der Überlebenden.",
+            "Ich zeichne das Wort „richten“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "beschützen",
           "russian": "защищать",
           "transcription": "[бе-ШЮ-цен]",
           "sentence": "Zwischen verstummten Trommeln verliest Albany den Befehl zur Gerechtigkeit. Ich zeichne das Wort „beschützen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Среди смолкших барабанов Олбани зачитывает приказ о справедливости. Я черчу слово «защищать» в мыслях поверх линий судьбы."
+          "sentence_translation": "Среди смолкших барабанов Олбани зачитывает приказ о справедливости. Я черчу слово «защищать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Zwischen verstummten Trommeln verliest Albany den Befehl zur Gerechtigkeit.",
+            "Ich zeichne das Wort „beschützen“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "eingreifen",
           "russian": "вмешиваться",
           "transcription": "[АЙН-грай-фен]",
           "sentence": "Im Schatten des zerstörten Schlosses schwört Albany das Reich zu erneuern. Ich zeichne das Wort „eingreifen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "В тени разрушенного замка Олбани клянётся обновить королевство. Я черчу слово «вмешиваться» в мыслях поверх линий судьбы."
+          "sentence_translation": "В тени разрушенного замка Олбани клянётся обновить королевство. Я черчу слово «вмешиваться» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Im Schatten des zerstörten Schlosses schwört Albany das Reich zu erneuern.",
+            "Ich zeichne das Wort „eingreifen“ in Gedanken über die Linien des Schicksals."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -552,56 +733,88 @@
           "russian": "правление",
           "transcription": "[ди ХЕР-шафт]",
           "sentence": "Im Saal voller Verwundeter verteilt Albany sanfte Worte und Befehle zugleich. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Herrschaft“ darf nicht vergehen.",
-          "sentence_translation": "В зале, полном раненых, Олбани раздаёт мягкие слова и приказы одновременно. Я шепчу стражам судьбы: слово «правление» не должно исчезнуть."
+          "sentence_translation": "В зале, полном раненых, Олбани раздаёт мягкие слова и приказы одновременно. Я шепчу стражам судьбы: слово «правление» не должно исчезнуть.",
+          "sentence_parts": [
+            "Im Saal voller Verwundeter verteilt Albany sanfte Worte und Befehle zugleich.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Herrschaft“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
           "sentence": "Auf dem behelfsmäßigen Thron richtet Albany das Reich wieder auf. Das Echo des Wortes „die Weisheit“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "На временном троне Олбани вновь поднимает королевство. Эхо слова «мудрость» заглушает шёпот придворных."
+          "sentence_translation": "На временном троне Олбани вновь поднимает королевство. Эхо слова «мудрость» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Auf dem behelfsmäßigen Thron richtet Albany das Reich wieder auf.",
+            "Das Echo des Wortes „die Weisheit“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "der Neuanfang",
           "russian": "новое начало",
           "transcription": "[дер НОЙ-ан-фанг]",
           "sentence": "Zwischen vertrockneten Kränzen trägt Albany die neue Krone ohne Triumph. Ich umarme das Wort „der Neuanfang“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Среди засохших венков Олбани носит новую корону без торжества. Я обнимаю слово «новое начало», будто это единственный союзник."
+          "sentence_translation": "Среди засохших венков Олбани носит новую корону без торжества. Я обнимаю слово «новое начало», будто это единственный союзник.",
+          "sentence_parts": [
+            "Zwischen vertrockneten Kränzen trägt Albany die neue Krone ohne Triumph.",
+            "Ich umarme das Wort „der Neuanfang“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "lenken",
           "russian": "направлять",
           "transcription": "[ЛЕН-кен]",
           "sentence": "Vor dem Volk verspricht Albany Heilung für das verwundete Land. Das Echo des Wortes „lenken“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Перед народом Олбани обещает исцеление раненой земле. Эхо слова «направлять» заглушает шёпот придворных."
+          "sentence_translation": "Перед народом Олбани обещает исцеление раненой земле. Эхо слова «направлять» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Vor dem Volk verspricht Albany Heilung für das verwundete Land.",
+            "Das Echo des Wortes „lenken“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "aufbauen",
           "russian": "строить",
           "transcription": "[АУФ-бау-ен]",
           "sentence": "Auf den Stufen des Tempels hebt Albany die Gefallenen in Ehren hervor. Ich halte das Wort „aufbauen“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "На ступенях храма Олбани чтит павших. Я держу слово «строить» как факел у сердца."
+          "sentence_translation": "На ступенях храма Олбани чтит павших. Я держу слово «строить» как факел у сердца.",
+          "sentence_parts": [
+            "Auf den Stufen des Tempels hebt Albany die Gefallenen in Ehren hervor.",
+            "Ich halte das Wort „aufbauen“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "erneuern",
           "russian": "обновлять",
           "transcription": "[ер-НОЙ-ерн]",
           "sentence": "Unter wehenden Flaggen lässt Albany die Glocken der Hoffnung schlagen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erneuern“ gehört mir.",
-          "sentence_translation": "Под развевающимися флагами Олбани велит бить колоколам надежды. Буря за окнами усиливает клятву: слово «обновлять» принадлежит мне."
+          "sentence_translation": "Под развевающимися флагами Олбани велит бить колоколам надежды. Буря за окнами усиливает клятву: слово «обновлять» принадлежит мне.",
+          "sentence_parts": [
+            "Unter wehenden Flaggen lässt Albany die Glocken der Hoffnung schlagen.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erneuern“ gehört mir."
+          ]
         },
         {
           "german": "versöhnen",
           "russian": "примирять",
           "transcription": "[фер-ЗЁ-нен]",
           "sentence": "Im Rat der Überlebenden hört Albany jedem zu, bevor er entscheidet. Selbst wenn die Welt zerfällt, bleibt das Wort „versöhnen“ mein Nordstern.",
-          "sentence_translation": "На совете выживших Олбани выслушивает каждого, прежде чем решать. Даже если мир распадается, слово «примирять» остаётся моим северным светом."
+          "sentence_translation": "На совете выживших Олбани выслушивает каждого, прежде чем решать. Даже если мир распадается, слово «примирять» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Im Rat der Überlebenden hört Albany jedem zu, bevor er entscheidet.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „versöhnen“ mein Nordstern."
+          ]
         },
         {
           "german": "der Friede",
           "russian": "мир",
           "transcription": "[дер ФРИ-де]",
           "sentence": "An der Küste von Dover lässt Albany neue Schiffe zum Schutz auslaufen. Ich zeichne das Wort „der Friede“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "У берега Дувра Олбани отправляет в море новые корабли для защиты. Я черчу слово «мир» в мыслях поверх линий судьбы."
+          "sentence_translation": "У берега Дувра Олбани отправляет в море новые корабли для защиты. Я черчу слово «мир» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "An der Küste von Dover lässt Albany neue Schiffe zum Schutz auslaufen.",
+            "Ich zeichne das Wort „der Friede“ in Gedanken über die Linien des Schicksals."
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/cordelia.json
+++ b/data/characters/cordelia.json
@@ -21,56 +21,88 @@
           "russian": "правда",
           "transcription": "[ди ВАР-хайт]",
           "sentence": "Cordelia steht unter dem glühenden Kronleuchter des Thronsaals. Das kalte Licht lässt das Wort „die Wahrheit“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Корделия стоит под пылающей люстрой тронного зала. Холодный свет заставляет слово «правда» сиять словно расплавленное золото."
+          "sentence_translation": "Корделия стоит под пылающей люстрой тронного зала. Холодный свет заставляет слово «правда» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Cordelia steht unter dem glühenden Kronleuchter des Thronsaals.",
+            "Das kalte Licht lässt das Wort „die Wahrheit“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "die Zeremonie",
           "russian": "церемония",
           "transcription": "[ди це-ре-мо-НИ]",
           "sentence": "Neben der ausgerollten Reichskarte beugt sich Cordelia über Lears schweren Tisch. Ich atme tief ein und lasse nur das Wort „die Zeremonie“ wieder hinaus.",
-          "sentence_translation": "У развернутой карты королевства Корделия склоняется над тяжёлым столом Лира. Я глубоко вдыхаю и выпускаю только слово «церемония»."
+          "sentence_translation": "У развернутой карты королевства Корделия склоняется над тяжёлым столом Лира. Я глубоко вдыхаю и выпускаю только слово «церемония».",
+          "sentence_parts": [
+            "Neben der ausgerollten Reichskarte beugt sich Cordelia über Lears schweren Tisch.",
+            "Ich atme tief ein und lasse nur das Wort „die Zeremonie“ wieder hinaus."
+          ]
         },
         {
           "german": "verkünden",
           "russian": "провозглашать",
           "transcription": "[фер-КЮН-ден]",
           "sentence": "Vor den steinernen Ahnenstatuen verschränkt Cordelia die Hände hinter dem Rücken. Ich presse das Wort „verkünden“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Перед каменными статуями предков Корделия сцепляет руки за спиной. Я стискиваю слово «провозглашать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Перед каменными статуями предков Корделия сцепляет руки за спиной. Я стискиваю слово «провозглашать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Vor den steinernen Ahnenstatuen verschränkt Cordelia die Hände hinter dem Rücken.",
+            "Ich presse das Wort „verkünden“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Macht",
           "russian": "власть",
           "transcription": "[ди МАХТ]",
           "sentence": "Zwischen flüsternden Höflingen gleitet Cordelia über den kalten Marmorboden. Ich zeichne das Wort „die Macht“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Между шепчущимися придворными Корделия скользит по холодному мраморному полу. Я вывожу слово «власть» невидимыми чернилами на ладони."
+          "sentence_translation": "Между шепчущимися придворными Корделия скользит по холодному мраморному полу. Я вывожу слово «власть» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Zwischen flüsternden Höflingen gleitet Cordelia über den kalten Marmorboden.",
+            "Ich zeichne das Wort „die Macht“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "gehorchen",
           "russian": "повиноваться",
           "transcription": "[ге-ХОР-хен]",
           "sentence": "Am Rand des purpurnen Teppichs wartet Cordelia auf ein Zeichen des Königs. Mit jeder Faser meines Körpers verspreche ich: Das Wort „gehorchen“ bleibt lebendig.",
-          "sentence_translation": "На краю пурпурного ковра Корделия ждёт знака от короля. Каждой клеткой тела я обещаю: слово «повиноваться» останется живым."
+          "sentence_translation": "На краю пурпурного ковра Корделия ждёт знака от короля. Каждой клеткой тела я обещаю: слово «повиноваться» останется живым.",
+          "sentence_parts": [
+            "Am Rand des purpurnen Teppichs wartet Cordelia auf ein Zeichen des Königs.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „gehorchen“ bleibt lebendig."
+          ]
         },
         {
           "german": "die Pflicht",
           "russian": "долг",
           "transcription": "[ди ПФЛИХТ]",
           "sentence": "Unter wehenden Standarten der Schwestern senkt Cordelia kurz den Blick. Mit fester Stimme schwöre ich mir: Das Wort „die Pflicht“ wird heute nicht verraten.",
-          "sentence_translation": "Под развевающимися штандартами сестёр Корделия на миг опускает взгляд. Твёрдым голосом я клянусь себе: слово «долг» сегодня не будет предано."
+          "sentence_translation": "Под развевающимися штандартами сестёр Корделия на миг опускает взгляд. Твёрдым голосом я клянусь себе: слово «долг» сегодня не будет предано.",
+          "sentence_parts": [
+            "Unter wehenden Standarten der Schwestern senkt Cordelia kurz den Blick.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „die Pflicht“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "feierlich",
           "russian": "торжественный",
           "transcription": "[ФАЙ-ер-лих]",
           "sentence": "Hinter der vergoldeten Balustrade beobachtet Cordelia das gespannte Antlitz des Hofes. Ich presse das Wort „feierlich“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "За позолоченной балюстрадой Корделия наблюдает за напряжёнными лицами двора. Я стискиваю слово «торжественный» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "За позолоченной балюстрадой Корделия наблюдает за напряжёнными лицами двора. Я стискиваю слово «торжественный» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Hinter der vergoldeten Balustrade beobachtet Cordelia das gespannte Antlitz des Hofes.",
+            "Ich presse das Wort „feierlich“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Treue",
           "russian": "верность",
           "transcription": "[ди ТРОЙ-е]",
           "sentence": "Im Schein der offenen Feuerbecken erhebt Cordelia langsam die Stimme. Das Echo des Wortes „die Treue“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "В отблесках открытых жаровен Корделия медленно поднимает голос. Эхо слова «верность» заглушает шёпот придворных."
+          "sentence_translation": "В отблесках открытых жаровен Корделия медленно поднимает голос. Эхо слова «верность» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Im Schein der offenen Feuerbecken erhebt Cordelia langsam die Stimme.",
+            "Das Echo des Wortes „die Treue“ übertönt das Flüstern der Höflinge."
+          ]
         }
       ],
       "quizzes": [
@@ -114,56 +146,89 @@
           "russian": "изгонять",
           "transcription": "[фер-ШТО-сен]",
           "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Cordelia zwischen gepackten Kisten. Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig.",
-          "sentence_translation": "В гулком проёме ворот замка Гонерильи Корделия замирает среди нагруженных ящиков. Каждой клеткой тела я обещаю: слово «изгонять» останется живым."
+          "sentence_translation": "В гулком проёме ворот замка Гонерильи Корделия замирает среди нагруженных ящиков. Каждой клеткой тела я обещаю: слово «изгонять» останется живым.",
+          "sentence_parts": [
+            "Im hallenden Torbogen von Gonerils Burg verharrt Cordelia zwischen gepackten Kisten.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig."
+          ]
         },
         {
           "german": "verlassen",
           "russian": "покидать",
           "transcription": "[фер-ЛА-сен]",
           "sentence": "Auf der windigen Freitreppe blickt Cordelia zum schweigenden Hof hinunter. Ich atme tief ein und lasse nur das Wort „verlassen“ wieder hinaus.",
-          "sentence_translation": "На продуваемой ветром лестнице Корделия смотрит вниз на молчаливый двор. Я глубоко вдыхаю и выпускаю только слово «покидать»."
+          "sentence_translation": "На продуваемой ветром лестнице Корделия смотрит вниз на молчаливый двор. Я глубоко вдыхаю и выпускаю только слово «покидать».",
+          "sentence_parts": [
+            "Auf der windigen Freitreppe blickt Cordelia zum schweigenden Hof hinunter.",
+            "Ich atme tief ein und lasse nur das Wort „verlassen“ wieder hinaus."
+          ]
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
           "sentence": "Zwischen zurückgelassenen Dienern schließt Cordelia den Reisemantel enger. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Zorn“ bleibt lebendig.",
-          "sentence_translation": "Среди оставленных слуг Корделия плотнее запахивает дорожный плащ. Каждой клеткой тела я обещаю: слово «гнев» останется живым."
+          "sentence_translation": "Среди оставленных слуг Корделия плотнее запахивает дорожный плащ. Каждой клеткой тела я обещаю: слово «гнев» останется живым.",
+          "sentence_parts": [
+            "Zwischen zurückgelassenen Dienern schließt Cordelia den Reisemantel enger.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Zorn“ bleibt lebendig."
+          ]
         },
         {
           "german": "die Strafe",
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
           "sentence": "Am dunklen Pferdestall streicht Cordelia einem nervösen Tier über die Mähne. Ich presse das Wort „die Strafe“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "У тёмного конюшенного ряда Корделия гладит гриву нервного коня. Я стискиваю слово «наказание» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "У тёмного конюшенного ряда Корделия гладит гриву нервного коня. Я стискиваю слово «наказание» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Am dunklen Pferdestall streicht Cordelia einem nervösen Tier über die Mähne.",
+            "Ich presse das Wort „die Strafe“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "fremd",
           "russian": "чужой",
           "transcription": "[ФРЕМД]",
           "sentence": "Vor dem knarrenden Fallgatter tastet Cordelia ein letztes Mal nach dem Haustor. Mein Atem zeichnet das Wort „fremd“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Перед скрипящим подъёмным мостом Корделия в последний раз касается родной двери. Моё дыхание рисует слово «чужой» в холодном воздухе между нами."
+          "sentence_translation": "Перед скрипящим подъёмным мостом Корделия в последний раз касается родной двери. Моё дыхание рисует слово «чужой» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Vor dem knarrenden Fallgatter tastet Cordelia ein letztes Mal nach dem Haustor.",
+            "Mein Atem zeichnet das Wort „fremd“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Mitgift",
           "russian": "приданое",
           "transcription": "[ди МИТ-гифт]",
           "sentence": "Zwischen verstreuten Schriftrollen dreht Cordelia den Ring an der Hand. Ich zeichne das Wort „die Mitgift“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Среди разбросанных свитков Корделия вертит кольцо на пальце. Я черчу слово «приданое» в мыслях поверх линий судьбы."
+          "sentence_translation": "Среди разбросанных свитков Корделия вертит кольцо на пальце. Я черчу слово «приданое» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Zwischen verstreuten Schriftrollen dreht Cordelia den Ring an der Hand.",
+            "Ich zeichne das Wort „die Mitgift“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "aufnehmen",
           "russian": "принимать",
           "transcription": "[АУФ-не-мен]",
           "sentence": "Am leeren Bankettisch zählt Cordelia die verlöschenden Kerzen. Mein Atem zeichnet das Wort „aufnehmen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "У пустого банкетного стола Корделия пересчитывает гаснущие свечи. Моё дыхание рисует слово «принимать» в холодном воздухе между нами."
+          "sentence_translation": "У пустого банкетного стола Корделия пересчитывает гаснущие свечи. Моё дыхание рисует слово «принимать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Am leeren Bankettisch zählt Cordelia die verlöschenden Kerzen.",
+            "Mein Atem zeichnet das Wort „aufnehmen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Hoffnung",
           "russian": "надежда",
           "transcription": "[ди ХОФ-нунг]",
           "sentence": "Zwischen schweigenden Wachen geht Cordelia auf den kalten Hof hinaus. Ich atme tief ein und lasse nur das Wort „die Hoffnung“ wieder hinaus.",
-          "sentence_translation": "Между молчаливыми стражниками Корделия выходит на холодный двор. Я глубоко вдыхаю и выпускаю только слово «надежда»."
+          "sentence_translation": "Между молчаливыми стражниками Корделия выходит на холодный двор. Я глубоко вдыхаю и выпускаю только слово «надежда».",
+          "sentence_parts": [
+            "Zwischen schweigenden Wachen geht Cordelia auf den kalten Hof hinaus.",
+            "Ich atme tief ein und lasse nur das Wort „die Hoffnung“ wieder hinaus."
+          ]
         }
       ],
       "quizzes": [
@@ -207,56 +272,88 @@
           "russian": "забота",
           "transcription": "[ди ЗОР-ге]",
           "sentence": "Im zugigen Seitenflügel lauscht Cordelia dem Heulen der Küstenwinde. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Sorge“ bleibt lebendig.",
-          "sentence_translation": "В продуваемом ветром боковом крыле Корделия слушает вой прибрежного ветра. Каждой клеткой тела я обещаю: слово «забота» останется живым."
+          "sentence_translation": "В продуваемом ветром боковом крыле Корделия слушает вой прибрежного ветра. Каждой клеткой тела я обещаю: слово «забота» останется живым.",
+          "sentence_parts": [
+            "Im zugigen Seitenflügel lauscht Cordelia dem Heulen der Küstenwinde.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Sorge“ bleibt lebendig."
+          ]
         },
         {
           "german": "die Einsamkeit",
           "russian": "одиночество",
           "transcription": "[ди АЙН-зам-кайт]",
           "sentence": "Vor dem rauchigen Kamin der Burg faltet Cordelia einen zerknitterten Brief. Mein Atem zeichnet das Wort „die Einsamkeit“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Перед дымным камином замка Корделия складывает измятый лист. Моё дыхание рисует слово «одиночество» в холодном воздухе между нами."
+          "sentence_translation": "Перед дымным камином замка Корделия складывает измятый лист. Моё дыхание рисует слово «одиночество» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Vor dem rauchigen Kamin der Burg faltet Cordelia einen zerknitterten Brief.",
+            "Mein Atem zeichnet das Wort „die Einsamkeit“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Nachricht",
           "russian": "известие",
           "transcription": "[ди НАХ-рихт]",
           "sentence": "Unter farblosen Wandteppichen schreitet Cordelia rastlos auf und ab. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Nachricht“ gehört mir.",
-          "sentence_translation": "Под выцветшими гобеленами Корделия беспокойно меряет шагами зал. Буря за окнами усиливает клятву: слово «известие» принадлежит мне."
+          "sentence_translation": "Под выцветшими гобеленами Корделия беспокойно меряет шагами зал. Буря за окнами усиливает клятву: слово «известие» принадлежит мне.",
+          "sentence_parts": [
+            "Unter farblosen Wandteppichen schreitet Cordelia rastlos auf und ab.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Nachricht“ gehört mir."
+          ]
         },
         {
           "german": "die Angst",
           "russian": "страх",
           "transcription": "[ди АНГСТ]",
           "sentence": "An der schmalen Fensterluke zählt Cordelia die Fackeln auf dem Hof. Ich halte das Wort „die Angst“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У узкой бойницы Корделия считает факелы на дворе. Я держу слово «страх» как факел у сердца."
+          "sentence_translation": "У узкой бойницы Корделия считает факелы на дворе. Я держу слово «страх» как факел у сердца.",
+          "sentence_parts": [
+            "An der schmalen Fensterluke zählt Cordelia die Fackeln auf dem Hof.",
+            "Ich halte das Wort „die Angst“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
           "sentence": "Zwischen Reisekoffern der Gesandten sucht Cordelia nach frischen Botschaften. Das Echo des Wortes „leiden“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Среди дорожных сундуков послов Корделия ищет свежие вести. Эхо слова «страдать» заглушает шёпот придворных."
+          "sentence_translation": "Среди дорожных сундуков послов Корделия ищет свежие вести. Эхо слова «страдать» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Zwischen Reisekoffern der Gesandten sucht Cordelia nach frischen Botschaften.",
+            "Das Echo des Wortes „leiden“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "beschützen",
           "russian": "защищать",
           "transcription": "[бе-ШЮ-цен]",
           "sentence": "Im stillen Kapellenraum kniet Cordelia vor der kalten Steinfigur. Ich atme tief ein und lasse nur das Wort „beschützen“ wieder hinaus.",
-          "sentence_translation": "В тихой капелле Корделия преклоняет колени перед холодной каменной фигурой. Я глубоко вдыхаю и выпускаю только слово «защищать»."
+          "sentence_translation": "В тихой капелле Корделия преклоняет колени перед холодной каменной фигурой. Я глубоко вдыхаю и выпускаю только слово «защищать».",
+          "sentence_parts": [
+            "Im stillen Kapellenraum kniet Cordelia vor der kalten Steinfigur.",
+            "Ich atme tief ein und lasse nur das Wort „beschützen“ wieder hinaus."
+          ]
         },
         {
           "german": "die Sehnsucht",
           "russian": "тоска",
           "transcription": "[ди ЗЕН-зухт]",
           "sentence": "Auf dem Balkon, den das Meer besprüht, hält Cordelia die Laterne fest. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Sehnsucht“ gehört mir.",
-          "sentence_translation": "На балконе, омываемом морскими брызгами, Корделия крепко держит фонарь. Буря за окнами усиливает клятву: слово «тоска» принадлежит мне."
+          "sentence_translation": "На балконе, омываемом морскими брызгами, Корделия крепко держит фонарь. Буря за окнами усиливает клятву: слово «тоска» принадлежит мне.",
+          "sentence_parts": [
+            "Auf dem Balkon, den das Meer besprüht, hält Cordelia die Laterne fest.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Sehnsucht“ gehört mir."
+          ]
         },
         {
           "german": "beten",
           "russian": "молиться",
           "transcription": "[БЕ-тен]",
           "sentence": "Im Schatten der hohen Burgmauern schreibt Cordelia eine fiebrige Antwort. Selbst wenn die Welt zerfällt, bleibt das Wort „beten“ mein Nordstern.",
-          "sentence_translation": "В тени высоких стен Корделия пишет лихорадочный ответ. Даже если мир распадается, слово «молиться» остаётся моим северным светом."
+          "sentence_translation": "В тени высоких стен Корделия пишет лихорадочный ответ. Даже если мир распадается, слово «молиться» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Im Schatten der hohen Burgmauern schreibt Cordelia eine fiebrige Antwort.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „beten“ mein Nordstern."
+          ]
         }
       ],
       "quizzes": [
@@ -300,56 +397,88 @@
           "russian": "возвращаться",
           "transcription": "[цу-РЮК-ке-рен]",
           "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Cordelia gegen den Wind. Das kalte Licht lässt das Wort „zurückkehren“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Посреди хлещущей дождём пустоши Корделия упирается в ветер. Холодный свет заставляет слово «возвращаться» сиять словно расплавленное золото."
+          "sentence_translation": "Посреди хлещущей дождём пустоши Корделия упирается в ветер. Холодный свет заставляет слово «возвращаться» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Mitten auf der vom Regen gepeitschten Heide stemmt sich Cordelia gegen den Wind.",
+            "Das kalte Licht lässt das Wort „zurückkehren“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "der Kampf",
           "russian": "борьба",
           "transcription": "[дер КАМПФ]",
           "sentence": "Unter einem zerrissenen Banner schützt Cordelia die Augen vor den Blitzen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Kampf“ darf nicht vergehen.",
-          "sentence_translation": "Под разорванным знаменем Корделия прикрывает глаза от молний. Я шепчу стражам судьбы: слово «борьба» не должно исчезнуть."
+          "sentence_translation": "Под разорванным знаменем Корделия прикрывает глаза от молний. Я шепчу стражам судьбы: слово «борьба» не должно исчезнуть.",
+          "sentence_parts": [
+            "Unter einem zerrissenen Banner schützt Cordelia die Augen vor den Blitzen.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Kampf“ darf nicht vergehen."
+          ]
         },
         {
           "german": "retten",
           "russian": "спасать",
           "transcription": "[РЕ-тен]",
           "sentence": "Am Rand eines umgestürzten Baumes sucht Cordelia Deckung vor dem Donner. Ich flüstere den Wächtern des Schicksals zu: Das Wort „retten“ darf nicht vergehen.",
-          "sentence_translation": "У поваленного дерева Корделия ищет укрытия от грома. Я шепчу стражам судьбы: слово «спасать» не должно исчезнуть."
+          "sentence_translation": "У поваленного дерева Корделия ищет укрытия от грома. Я шепчу стражам судьбы: слово «спасать» не должно исчезнуть.",
+          "sentence_parts": [
+            "Am Rand eines umgestürzten Baumes sucht Cordelia Deckung vor dem Donner.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „retten“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Schlacht",
           "russian": "битва",
           "transcription": "[ди ШЛАХТ]",
           "sentence": "Zwischen schäumenden Wassergräben stolpert Cordelia durch den Schlamm. Mit fester Stimme schwöre ich mir: Das Wort „die Schlacht“ wird heute nicht verraten.",
-          "sentence_translation": "Между пенящимися лужами Корделия пробирается через грязь. Твёрдым голосом я клянусь себе: слово «битва» сегодня не будет предано."
+          "sentence_translation": "Между пенящимися лужами Корделия пробирается через грязь. Твёрдым голосом я клянусь себе: слово «битва» сегодня не будет предано.",
+          "sentence_parts": [
+            "Zwischen schäumenden Wassergräben stolpert Cordelia durch den Schlamm.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „die Schlacht“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "mutig",
           "russian": "храбрый",
           "transcription": "[МУ-тиг]",
           "sentence": "Vor einem zuckenden Himmel hebt Cordelia die Arme trotzig an. Ich atme tief ein und lasse nur das Wort „mutig“ wieder hinaus.",
-          "sentence_translation": "На фоне вспыхивающего неба Корделия упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «храбрый»."
+          "sentence_translation": "На фоне вспыхивающего неба Корделия упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «храбрый».",
+          "sentence_parts": [
+            "Vor einem zuckenden Himmel hebt Cordelia die Arme trotzig an.",
+            "Ich atme tief ein und lasse nur das Wort „mutig“ wieder hinaus."
+          ]
         },
         {
           "german": "die Gerechtigkeit",
           "russian": "справедливость",
           "transcription": "[ди ге-РЕХ-тиг-кайт]",
           "sentence": "Unter dem durchtränkten Umhang presst Cordelia den Atem gegen die Kälte. Selbst wenn die Welt zerfällt, bleibt das Wort „die Gerechtigkeit“ mein Nordstern.",
-          "sentence_translation": "Под промокшим плащом Корделия прижимает дыхание к груди, спасаясь от холода. Даже если мир распадается, слово «справедливость» остаётся моим северным светом."
+          "sentence_translation": "Под промокшим плащом Корделия прижимает дыхание к груди, спасаясь от холода. Даже если мир распадается, слово «справедливость» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Unter dem durchtränkten Umhang presst Cordelia den Atem gegen die Kälte.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Gerechtigkeit“ mein Nordstern."
+          ]
         },
         {
           "german": "siegen",
           "russian": "побеждать",
           "transcription": "[ЗИ-ген]",
           "sentence": "Am kläglichen Feuerrest wärmt Cordelia zitternde Finger. Wie ein stilles Gebet legt sich das Wort „siegen“ auf meine Lippen.",
-          "sentence_translation": "У жалких огненных углей Корделия греет дрожащие пальцы. Как тихая молитва слово «побеждать» ложится на мои губы."
+          "sentence_translation": "У жалких огненных углей Корделия греет дрожащие пальцы. Как тихая молитва слово «побеждать» ложится на мои губы.",
+          "sentence_parts": [
+            "Am kläglichen Feuerrest wärmt Cordelia zitternde Finger.",
+            "Wie ein stilles Gebet legt sich das Wort „siegen“ auf meine Lippen."
+          ]
         },
         {
           "german": "die Armee",
           "russian": "армия",
           "transcription": "[ди ар-МЭ]",
           "sentence": "Zwischen heulenden Hunden ruft Cordelia gegen den tosenden Sturm an. Ich zeichne das Wort „die Armee“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Среди воющих псов Корделия перекрикивает беснующуюся бурю. Я черчу слово «армия» в мыслях поверх линий судьбы."
+          "sentence_translation": "Среди воющих псов Корделия перекрикивает беснующуюся бурю. Я черчу слово «армия» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Zwischen heulenden Hunden ruft Cordelia gegen den tosenden Sturm an.",
+            "Ich zeichne das Wort „die Armee“ in Gedanken über die Linien des Schicksals."
+          ]
         }
       ],
       "quizzes": [
@@ -393,56 +522,88 @@
           "russian": "прощать",
           "transcription": "[фер-ЦАЙ-ен]",
           "sentence": "Im dunklen Zelt der Feldärzte sitzt Cordelia bei der flackernden Kerze. Wie ein stilles Gebet legt sich das Wort „verzeihen“ auf meine Lippen.",
-          "sentence_translation": "В тёмном шатре полевых лекарей Корделия сидит у мерцающей свечи. Как тихая молитва слово «прощать» ложится на мои губы."
+          "sentence_translation": "В тёмном шатре полевых лекарей Корделия сидит у мерцающей свечи. Как тихая молитва слово «прощать» ложится на мои губы.",
+          "sentence_parts": [
+            "Im dunklen Zelt der Feldärzte sitzt Cordelia bei der flackernden Kerze.",
+            "Wie ein stilles Gebet legt sich das Wort „verzeihen“ auf meine Lippen."
+          ]
         },
         {
           "german": "die Tränen",
           "russian": "слёзы",
           "transcription": "[ди ТРЕ-нен]",
           "sentence": "Zwischen zerbeulten Rüstungen streicht Cordelia über ein altes Wappen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Tränen“ gehört mir.",
-          "sentence_translation": "Среди помятых доспехов Корделия гладит старый герб. Буря за окнами усиливает клятву: слово «слёзы» принадлежит мне."
+          "sentence_translation": "Среди помятых доспехов Корделия гладит старый герб. Буря за окнами усиливает клятву: слово «слёзы» принадлежит мне.",
+          "sentence_parts": [
+            "Zwischen zerbeulten Rüstungen streicht Cordelia über ein altes Wappen.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Tränen“ gehört mir."
+          ]
         },
         {
           "german": "umarmen",
           "russian": "обнимать",
           "transcription": "[ум-АР-мен]",
           "sentence": "Am niedrigen Dachbalken der Hütte stößt Cordelia fast den Kopf. Ich presse das Wort „umarmen“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "О низкую балку хижины Корделия едва не ударяется головой. Я стискиваю слово «обнимать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "О низкую балку хижины Корделия едва не ударяется головой. Я стискиваю слово «обнимать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Am niedrigen Dachbalken der Hütte stößt Cordelia fast den Kopf.",
+            "Ich presse das Wort „umarmen“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "erkennen",
           "russian": "узнавать",
           "transcription": "[ер-КЕН-нен]",
           "sentence": "Neben der schlafenden Wache flüstert Cordelia in die schwere Nacht. Ich zeichne das Wort „erkennen“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Рядом со спящим стражем Корделия шепчет в тяжёлую ночь. Я вывожу слово «узнавать» невидимыми чернилами на ладони."
+          "sentence_translation": "Рядом со спящим стражем Корделия шепчет в тяжёлую ночь. Я вывожу слово «узнавать» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Neben der schlafenden Wache flüstert Cordelia in die schwere Nacht.",
+            "Ich zeichne das Wort „erkennen“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "heilen",
           "russian": "исцелять",
           "transcription": "[ХАЙ-лен]",
           "sentence": "Vor dem einfachen Feldbett betrachtet Cordelia die Narben vergangener Schlachten. Ich umarme das Wort „heilen“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Перед грубой походной койкой Корделия разглядывает шрамы прошлых битв. Я обнимаю слово «исцелять», будто это единственный союзник."
+          "sentence_translation": "Перед грубой походной койкой Корделия разглядывает шрамы прошлых битв. Я обнимаю слово «исцелять», будто это единственный союзник.",
+          "sentence_parts": [
+            "Vor dem einfachen Feldbett betrachtet Cordelia die Narben vergangener Schlachten.",
+            "Ich umarme das Wort „heilen“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Reue",
           "russian": "раскаяние",
           "transcription": "[ди РОЙ-е]",
           "sentence": "Im Geruch von feuchtem Stroh legt Cordelia den Mantel zur Seite. Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "В запахе влажной соломы Корделия откладывает плащ в сторону. Я черчу слово «раскаяние» в мыслях поверх линий судьбы."
+          "sentence_translation": "В запахе влажной соломы Корделия откладывает плащ в сторону. Я черчу слово «раскаяние» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Im Geruch von feuchtem Stroh legt Cordelia den Mantel zur Seite.",
+            "Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "sanft",
           "russian": "нежный",
           "transcription": "[ЗАНФТ]",
           "sentence": "Auf dem wackligen Holztisch ordnet Cordelia zerlesene Briefe. Ich zeichne das Wort „sanft“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "На шатком деревянном столе Корделия раскладывает зачитанные письма. Я черчу слово «нежный» в мыслях поверх линий судьбы."
+          "sentence_translation": "На шатком деревянном столе Корделия раскладывает зачитанные письма. Я черчу слово «нежный» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Auf dem wackligen Holztisch ordnet Cordelia zerlesene Briefe.",
+            "Ich zeichne das Wort „sanft“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "die Vergebung",
           "russian": "прощение",
           "transcription": "[ди фер-ГЕ-бунг]",
           "sentence": "Am Eingang der Hütte späht Cordelia nach einem vertrauten Schatten. Ich zeichne das Wort „die Vergebung“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "У входа в хижину Корделия высматривает знакомую тень. Я черчу слово «прощение» в мыслях поверх линий судьбы."
+          "sentence_translation": "У входа в хижину Корделия высматривает знакомую тень. Я черчу слово «прощение» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Am Eingang der Hütte späht Cordelia nach einem vertrauten Schatten.",
+            "Ich zeichne das Wort „die Vergebung“ in Gedanken über die Linien des Schicksals."
+          ]
         }
       ],
       "quizzes": [
@@ -486,56 +647,89 @@
           "russian": "пленный",
           "transcription": "[ге-ФАН-ген]",
           "sentence": "Auf den weißen Klippen von Dover blickt Cordelia in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „gefangen“ mein Nordstern.",
-          "sentence_translation": "На белых скалах Дувра Корделия смотрит в вздыбленный пролив. Даже если мир распадается, слово «пленный» остаётся моим северным светом."
+          "sentence_translation": "На белых скалах Дувра Корделия смотрит в вздыбленный пролив. Даже если мир распадается, слово «пленный» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Auf den weißen Klippen von Dover blickt Cordelia in den aufgewühlten Kanal.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „gefangen“ mein Nordstern."
+          ]
         },
         {
           "german": "das Gefängnis",
           "russian": "тюрьма",
           "transcription": "[дас ге-ФЭНГ-нис]",
           "sentence": "Zwischen flatternden Feldzeichen richtet Cordelia den Helm. Ich umarme das Wort „das Gefängnis“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Среди хлопающих штандартов Корделия поправляет шлем. Я обнимаю слово «тюрьма», будто это единственный союзник."
+          "sentence_translation": "Среди хлопающих штандартов Корделия поправляет шлем. Я обнимаю слово «тюрьма», будто это единственный союзник.",
+          "sentence_parts": [
+            "Zwischen flatternden Feldzeichen richtet Cordelia den Helm.",
+            "Ich umarme das Wort „das Gefängnis“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Würde",
           "russian": "достоинство",
           "transcription": "[ди ВЮР-де]",
           "sentence": "Am Lagerfeuer der Franzosen zeichnet Cordelia Marschrouten in den Sand. Selbst wenn die Welt zerfällt, bleibt das Wort „die Würde“ mein Nordstern.",
-          "sentence_translation": "У французского костра Корделия рисует в песке путь марша. Даже если мир распадается, слово «достоинство» остаётся моим северным светом."
+          "sentence_translation": "У французского костра Корделия рисует в песке путь марша. Даже если мир распадается, слово «достоинство» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Am Lagerfeuer der Franzosen zeichnet Cordelia Marschrouten in den Sand.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Würde“ mein Nordstern."
+          ]
         },
         {
           "german": "trösten",
           "russian": "утешать",
           "transcription": "[ТРЁС-тен]",
           "sentence": "Neben verschnürten Versorgungskisten kontrolliert Cordelia das Siegel. Ich halte das Wort „trösten“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У перевязанных провиантных ящиков Корделия проверяет печати. Я держу слово «утешать» как факел у сердца."
+          "sentence_translation": "У перевязанных провиантных ящиков Корделия проверяет печати. Я держу слово «утешать» как факел у сердца.",
+          "sentence_parts": [
+            "Neben verschnürten Versorgungskisten kontrolliert Cordelia das Siegel.",
+            "Ich halte das Wort „trösten“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "tapfer",
           "russian": "отважный",
           "transcription": "[ТАП-фер]",
           "sentence": "Vor dem Seidenzelt der Heerführer lauscht Cordelia dem dumpfen Meer. Ich umarme das Wort „tapfer“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Перед шёлковым шатром полководцев Корделия слушает глухой шум моря. Я обнимаю слово «отважный», будто это единственный союзник."
+          "sentence_translation": "Перед шёлковым шатром полководцев Корделия слушает глухой шум моря. Я обнимаю слово «отважный», будто это единственный союзник.",
+          "sentence_parts": [
+            "Vor dem Seidenzelt der Heerführer lauscht Cordelia dem dumpfen Meer.",
+            "Ich umarme das Wort „tapfer“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Demut",
           "russian": "смирение",
           "transcription": "[ди ДЕ-мут]",
           "sentence": "Auf dem sandigen Trainingsplatz übt Cordelia das Ziehen des Schwerts. Das kalte Licht lässt das Wort „die Demut“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "На песчаном плацу Корделия отрабатывает выхват меча. Холодный свет заставляет слово «смирение» сиять словно расплавленное золото."
+          "sentence_translation": "На песчаном плацу Корделия отрабатывает выхват меча. Холодный свет заставляет слово «смирение» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Auf dem sandigen Trainingsplatz übt Cordelia das Ziehen des Schwerts.",
+            "Das kalte Licht lässt das Wort „die Demut“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "das Schicksal",
           "russian": "судьба",
           "transcription": "[дас ШИК-заль]",
           "sentence": "Zwischen pochenden Trommeln hebt Cordelia das Banner der Hoffnung. Ich presse das Wort „das Schicksal“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Под гул барабанов Корделия поднимает знамя надежды. Я стискиваю слово «судьба» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Под гул барабанов Корделия поднимает знамя надежды. Я стискиваю слово «судьба» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Zwischen pochenden Trommeln hebt Cordelia das Banner der Hoffnung.",
+            "Ich presse das Wort „das Schicksal“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Ehre",
           "russian": "честь",
           "transcription": "[ди Э-ре]",
           "sentence": "Am Morgennebel der Küste legt Cordelia die Hand auf das pochende Herz. Selbst wenn die Welt zerfällt, bleibt das Wort „die Ehre“ mein Nordstern.",
-          "sentence_translation": "В утреннем тумане побережья Корделия кладёт ладонь на бьющееся сердце. Даже если мир распадается, слово «честь» остаётся моим северным светом."
+          "sentence_translation": "В утреннем тумане побережья Корделия кладёт ладонь на бьющееся сердце. Даже если мир распадается, слово «честь» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Am Morgennebel der Küste legt Cordelia die Hand auf das pochende Herz.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Ehre“ mein Nordstern."
+          ]
         }
       ],
       "quizzes": [
@@ -579,56 +773,88 @@
           "russian": "смерть",
           "transcription": "[дер ТОД]",
           "sentence": "Im feuchten Kerker stützt Cordelia sich an den tropfenden Stein. Ich atme tief ein und lasse nur das Wort „der Tod“ wieder hinaus.",
-          "sentence_translation": "В сыром подземелье Корделия опирается на сочащийся камень. Я глубоко вдыхаю и выпускаю только слово «смерть»."
+          "sentence_translation": "В сыром подземелье Корделия опирается на сочащийся камень. Я глубоко вдыхаю и выпускаю только слово «смерть».",
+          "sentence_parts": [
+            "Im feuchten Kerker stützt Cordelia sich an den tropfenden Stein.",
+            "Ich atme tief ein und lasse nur das Wort „der Tod“ wieder hinaus."
+          ]
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
           "sentence": "Unter der trüben Laterne zählt Cordelia die eisernen Ringe der Kette. Ich flüstere den Wächtern des Schicksals zu: Das Wort „sterben“ darf nicht vergehen.",
-          "sentence_translation": "Под мутным фонарём Корделия пересчитывает железные кольца цепи. Я шепчу стражам судьбы: слово «умирать» не должно исчезнуть."
+          "sentence_translation": "Под мутным фонарём Корделия пересчитывает железные кольца цепи. Я шепчу стражам судьбы: слово «умирать» не должно исчезнуть.",
+          "sentence_parts": [
+            "Unter der trüben Laterne zählt Cordelia die eisernen Ringe der Kette.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „sterben“ darf nicht vergehen."
+          ]
         },
         {
           "german": "das Opfer",
           "russian": "жертва",
           "transcription": "[дас ОП-фер]",
           "sentence": "Neben der schweren Holztür horcht Cordelia auf entferntes Schluchzen. Ich halte das Wort „das Opfer“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У тяжёлой двери Корделия прислушивается к далёким рыданиям. Я держу слово «жертва» как факел у сердца."
+          "sentence_translation": "У тяжёлой двери Корделия прислушивается к далёким рыданиям. Я держу слово «жертва» как факел у сердца.",
+          "sentence_parts": [
+            "Neben der schweren Holztür horcht Cordelia auf entferntes Schluchzen.",
+            "Ich halte das Wort „das Opfer“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Seele",
           "russian": "душа",
           "transcription": "[ди ЗЕ-ле]",
           "sentence": "Auf der kalten Steinbank zieht Cordelia den Mantel enger um die Schultern. Wie ein stilles Gebet legt sich das Wort „die Seele“ auf meine Lippen.",
-          "sentence_translation": "На холодной каменной скамье Корделия плотнее кутается в плащ. Как тихая молитва слово «душа» ложится на мои губы."
+          "sentence_translation": "На холодной каменной скамье Корделия плотнее кутается в плащ. Как тихая молитва слово «душа» ложится на мои губы.",
+          "sentence_parts": [
+            "Auf der kalten Steinbank zieht Cordelia den Mantel enger um die Schultern.",
+            "Wie ein stilles Gebet legt sich das Wort „die Seele“ auf meine Lippen."
+          ]
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЕН-де]",
           "sentence": "Zwischen Schatten der Gitterstäbe hebt Cordelia das Gesicht zum Licht. Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Между тенями решёток Корделия поднимает лицо к свету. Я держу слово «конец» как факел у сердца."
+          "sentence_translation": "Между тенями решёток Корделия поднимает лицо к свету. Я держу слово «конец» как факел у сердца.",
+          "sentence_parts": [
+            "Zwischen Schatten der Gitterstäbe hebt Cordelia das Gesicht zum Licht.",
+            "Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "ewig",
           "russian": "вечный",
           "transcription": "[Э-виг]",
           "sentence": "Am rostigen Wassereimer spiegelt Cordelia kurz die eigenen Augen. Das Echo des Wortes „ewig“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "У ржавого ведра с водой Корделия на мгновение видит отражение глаз. Эхо слова «вечный» заглушает шёпот придворных."
+          "sentence_translation": "У ржавого ведра с водой Корделия на мгновение видит отражение глаз. Эхо слова «вечный» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Am rostigen Wassereimer spiegelt Cordelia kurz die eigenen Augen.",
+            "Das Echo des Wortes „ewig“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
           "sentence": "Im dumpfen Hall der Schritte zählt Cordelia den Rhythmus der Wachen. Das Echo des Wortes „der Abschied“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "В глухом эхе шагов Корделия отсчитывает ритм часовых. Эхо слова «прощание» заглушает шёпот придворных."
+          "sentence_translation": "В глухом эхе шагов Корделия отсчитывает ритм часовых. Эхо слова «прощание» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Im dumpfen Hall der Schritte zählt Cordelia den Rhythmus der Wachen.",
+            "Das Echo des Wortes „der Abschied“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Erlösung",
           "russian": "спасение",
           "transcription": "[ди ер-ЛЁ-зунг]",
           "sentence": "Vor dem verriegelten Fenster zeichnet Cordelia Kreise in den Staub. Ich halte das Wort „die Erlösung“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Перед заколоченным окном Корделия чертит круги в пыли. Я держу слово «спасение» как факел у сердца."
+          "sentence_translation": "Перед заколоченным окном Корделия чертит круги в пыли. Я держу слово «спасение» как факел у сердца.",
+          "sentence_parts": [
+            "Vor dem verriegelten Fenster zeichnet Cordelia Kreise in den Staub.",
+            "Ich halte das Wort „die Erlösung“ wie eine Fackel vor meinem Herzen."
+          ]
         }
       ],
       "quizzes": [

--- a/data/characters/cornwall.json
+++ b/data/characters/cornwall.json
@@ -15,56 +15,88 @@
           "russian": "честолюбие",
           "transcription": "[дер ЭР-гайц]",
           "sentence": "In der Waffenkammer betrachtet Cornwall gierig die ausgestellten Kronjuwelen. Das Echo des Wortes „der Ehrgeiz“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "В оружейной Корнуолл жадно рассматривает выставленные коронные драгоценности. Эхо слова «честолюбие» заглушает шёпот придворных."
+          "sentence_translation": "В оружейной Корнуолл жадно рассматривает выставленные коронные драгоценности. Эхо слова «честолюбие» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "In der Waffenkammer betrachtet Cornwall gierig die ausgestellten Kronjuwelen.",
+            "Das Echo des Wortes „der Ehrgeiz“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Gier",
           "russian": "жадность",
           "transcription": "[ди ГИР]",
           "sentence": "Vor der Karte Englands fährt Cornwall mit dem Dolch über neue Grenzen. Mein Atem zeichnet das Wort „die Gier“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Перед картой Англии Корнуолл проводит кинжалом новые границы. Моё дыхание рисует слово «жадность» в холодном воздухе между нами."
+          "sentence_translation": "Перед картой Англии Корнуолл проводит кинжалом новые границы. Моё дыхание рисует слово «жадность» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Vor der Karte Englands fährt Cornwall mit dem Dolch über neue Grenzen.",
+            "Mein Atem zeichnet das Wort „die Gier“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "streben",
           "russian": "стремиться",
           "transcription": "[ШТРЕ-бен]",
           "sentence": "Zwischen knienden Vasallen lässt Cornwall die Finger über den Thronsessel gleiten. Ich presse das Wort „streben“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Среди преклонивших колено вассалов Корнуолл проводит пальцами по тронному креслу. Я стискиваю слово «стремиться» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Среди преклонивших колено вассалов Корнуолл проводит пальцами по тронному креслу. Я стискиваю слово «стремиться» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Zwischen knienden Vasallen lässt Cornwall die Finger über den Thronsessel gleiten.",
+            "Ich presse das Wort „streben“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "verlangen",
           "russian": "желать",
           "transcription": "[фер-ЛАН-ген]",
           "sentence": "Am hohen Fenster misst Cornwall den Abstand zur Hauptstadt. Mein Atem zeichnet das Wort „verlangen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "У высокого окна Корнуолл вымеряет расстояние до столицы. Моё дыхание рисует слово «желать» в холодном воздухе между нами."
+          "sentence_translation": "У высокого окна Корнуолл вымеряет расстояние до столицы. Моё дыхание рисует слово «желать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Am hohen Fenster misst Cornwall den Abstand zur Hauptstadt.",
+            "Mein Atem zeichnet das Wort „verlangen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "begehren",
           "russian": "вожделеть",
           "transcription": "[бе-ГЕ-рен]",
           "sentence": "Neben dem schwelenden Kamin testet Cornwall das Gewicht eines Schwertes. Ich flüstere den Wächtern des Schicksals zu: Das Wort „begehren“ darf nicht vergehen.",
-          "sentence_translation": "У тлеющего камина Корнуолл взвешивает на руке меч. Я шепчу стражам судьбы: слово «вожделеть» не должно исчезнуть."
+          "sentence_translation": "У тлеющего камина Корнуолл взвешивает на руке меч. Я шепчу стражам судьбы: слово «вожделеть» не должно исчезнуть.",
+          "sentence_parts": [
+            "Neben dem schwelenden Kamin testet Cornwall das Gewicht eines Schwertes.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „begehren“ darf nicht vergehen."
+          ]
         },
         {
           "german": "gierig",
           "russian": "жадный",
           "transcription": "[ГИ-риг]",
           "sentence": "Auf dem Turnierplatz lässt Cornwall seine Reiter zu später Stunde antreten. Selbst wenn die Welt zerfällt, bleibt das Wort „gierig“ mein Nordstern.",
-          "sentence_translation": "На турнирной площадке Корнуолл строит всадников поздним вечером. Даже если мир распадается, слово «жадный» остаётся моим северным светом."
+          "sentence_translation": "На турнирной площадке Корнуолл строит всадников поздним вечером. Даже если мир распадается, слово «жадный» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Auf dem Turnierplatz lässt Cornwall seine Reiter zu später Stunde antreten.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „gierig“ mein Nordstern."
+          ]
         },
         {
           "german": "die Herrschsucht",
           "russian": "властолюбие",
           "transcription": "[ди ХЕР-зухт]",
           "sentence": "Zwischen Pergamentrollen überdenkt Cornwall geheime Bündnisse. Wie ein stilles Gebet legt sich das Wort „die Herrschsucht“ auf meine Lippen.",
-          "sentence_translation": "Среди свитков пергамента Корнуолл обдумывает тайные союзы. Как тихая молитва слово «властолюбие» ложится на мои губы."
+          "sentence_translation": "Среди свитков пергамента Корнуолл обдумывает тайные союзы. Как тихая молитва слово «властолюбие» ложится на мои губы.",
+          "sentence_parts": [
+            "Zwischen Pergamentrollen überdenkt Cornwall geheime Bündnisse.",
+            "Wie ein stilles Gebet legt sich das Wort „die Herrschsucht“ auf meine Lippen."
+          ]
         },
         {
           "german": "ergreifen",
           "russian": "захватывать",
           "transcription": "[ер-ГРАЙ-фен]",
           "sentence": "Im Spiegel der Audienzhalle probt Cornwall das Lächeln eines Herrschers. Ich umarme das Wort „ergreifen“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В зеркале аудиенц-зала Корнуолл репетирует улыбку правителя. Я обнимаю слово «захватывать», будто это единственный союзник."
+          "sentence_translation": "В зеркале аудиенц-зала Корнуолл репетирует улыбку правителя. Я обнимаю слово «захватывать», будто это единственный союзник.",
+          "sentence_parts": [
+            "Im Spiegel der Audienzhalle probt Cornwall das Lächeln eines Herrschers.",
+            "Ich umarme das Wort „ergreifen“, als wäre es mein einziger Verbündeter."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -108,49 +140,77 @@
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
           "sentence": "Neben Regans vergiftetem Lächeln hebt Cornwall den Kelch zum Spott. Ich umarme das Wort „die Grausamkeit“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Рядом с ядовитой улыбкой Реганы Корнуолл поднимает кубок насмешки. Я обнимаю слово «жестокость», будто это единственный союзник."
+          "sentence_translation": "Рядом с ядовитой улыбкой Реганы Корнуолл поднимает кубок насмешки. Я обнимаю слово «жестокость», будто это единственный союзник.",
+          "sentence_parts": [
+            "Neben Regans vergiftetem Lächeln hebt Cornwall den Kelch zum Spott.",
+            "Ich umarme das Wort „die Grausamkeit“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Bosheit",
           "russian": "злоба",
           "transcription": "[ди БОС-хайт]",
           "sentence": "Auf der Galerie des Schlosses applaudiert Cornwall den Demütigungen des Königs. Ich umarme das Wort „die Bosheit“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "На галерее замка Корнуолл аплодирует унижениям короля. Я обнимаю слово «злоба», будто это единственный союзник."
+          "sentence_translation": "На галерее замка Корнуолл аплодирует унижениям короля. Я обнимаю слово «злоба», будто это единственный союзник.",
+          "sentence_parts": [
+            "Auf der Galerie des Schlosses applaudiert Cornwall den Demütigungen des Königs.",
+            "Ich umarme das Wort „die Bosheit“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "billigen",
           "russian": "одобрять",
           "transcription": "[БИ-ли-ген]",
           "sentence": "Zwischen eingeschüchterten Dienern greift Cornwall nach der Peitsche. Das kalte Licht lässt das Wort „billigen“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Среди запуганных слуг Корнуолл тянется к плётке. Холодный свет заставляет слово «одобрять» сиять словно расплавленное золото."
+          "sentence_translation": "Среди запуганных слуг Корнуолл тянется к плётке. Холодный свет заставляет слово «одобрять» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Zwischen eingeschüchterten Dienern greift Cornwall nach der Peitsche.",
+            "Das kalte Licht lässt das Wort „billigen“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "unterstützen",
           "russian": "поддерживать",
           "transcription": "[ун-тер-ШТЮ-цен]",
           "sentence": "Am hohen Lehnsessel sitzt Cornwall mit kalter Zufriedenheit. Ich zeichne das Wort „unterstützen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "В высоком кресле-ленном Корнуолл сидит с холодным довольством. Я черчу слово «поддерживать» в мыслях поверх линий судьбы."
+          "sentence_translation": "В высоком кресле-ленном Корнуолл сидит с холодным довольством. Я черчу слово «поддерживать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Am hohen Lehnsessel sitzt Cornwall mit kalter Zufriedenheit.",
+            "Ich zeichne das Wort „unterstützen“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "anstacheln",
           "russian": "подстрекать",
           "transcription": "[АН-шта-хельн]",
           "sentence": "Vor dem Bannerschrank zerreißt Cornwall einen höflichen Bittbrief. Selbst wenn die Welt zerfällt, bleibt das Wort „anstacheln“ mein Nordstern.",
-          "sentence_translation": "Перед шкафом со штандартами Корнуолл разрывает вежливое прошение. Даже если мир распадается, слово «подстрекать» остаётся моим северным светом."
+          "sentence_translation": "Перед шкафом со штандартами Корнуолл разрывает вежливое прошение. Даже если мир распадается, слово «подстрекать» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Vor dem Bannerschrank zerreißt Cornwall einen höflichen Bittbrief.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „anstacheln“ mein Nordstern."
+          ]
         },
         {
           "german": "ermutigen",
           "russian": "поощрять",
           "transcription": "[ер-МУ-ти-ген]",
           "sentence": "Unter stürmischen Trommeln befiehlt Cornwall den Wachen näherzukommen. Das Echo des Wortes „ermutigen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Под грохот барабанов Корнуолл приказывает стражам подойти ближе. Эхо слова «поощрять» заглушает шёпот придворных."
+          "sentence_translation": "Под грохот барабанов Корнуолл приказывает стражам подойти ближе. Эхо слова «поощрять» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Unter stürmischen Trommeln befiehlt Cornwall den Wachen näherzukommen.",
+            "Das Echo des Wortes „ermutigen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Härte",
           "russian": "суровость",
           "transcription": "[ди ХЕР-те]",
           "sentence": "Im Schatten der Folterkammer tauscht Cornwall mit Regan heimliche Blicke. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Härte“ darf nicht vergehen.",
-          "sentence_translation": "В тени пыточной Корнуолл обменивается с Реганой тайными взглядами. Я шепчу стражам судьбы: слово «суровость» не должно исчезнуть."
+          "sentence_translation": "В тени пыточной Корнуолл обменивается с Реганой тайными взглядами. Я шепчу стражам судьбы: слово «суровость» не должно исчезнуть.",
+          "sentence_parts": [
+            "Im Schatten der Folterkammer tauscht Cornwall mit Regan heimliche Blicke.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Härte“ darf nicht vergehen."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -194,56 +254,88 @@
           "russian": "тирания",
           "transcription": "[ди тю-ра-НАЙ]",
           "sentence": "Auf dem Burghof verteilt Cornwall neue, erbarmungslose Dekrete. Ich zeichne das Wort „die Tyrannei“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "На замковом дворе Корнуолл раздаёт новые беспощадные указы. Я вывожу слово «тирания» невидимыми чернилами на ладони."
+          "sentence_translation": "На замковом дворе Корнуолл раздаёт новые беспощадные указы. Я вывожу слово «тирания» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Auf dem Burghof verteilt Cornwall neue, erbarmungslose Dekrete.",
+            "Ich zeichne das Wort „die Tyrannei“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "die Unterdrückung",
           "russian": "угнетение",
           "transcription": "[ди ун-тер-ДРЮ-кунг]",
           "sentence": "Vor gefesselten Gefangenen lässt Cornwall die Streitkolben prüfen. Mein Atem zeichnet das Wort „die Unterdrückung“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Перед связанными пленниками Корнуолл приказывает проверить боевые булавы. Моё дыхание рисует слово «угнетение» в холодном воздухе между нами."
+          "sentence_translation": "Перед связанными пленниками Корнуолл приказывает проверить боевые булавы. Моё дыхание рисует слово «угнетение» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Vor gefesselten Gefangenen lässt Cornwall die Streitkolben prüfen.",
+            "Mein Atem zeichnet das Wort „die Unterdrückung“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Furcht",
           "russian": "страх",
           "transcription": "[ди ФУРХТ]",
           "sentence": "Zwischen klirrenden Ketten schreitet Cornwall mit schwerem Schritt. Ich halte das Wort „die Furcht“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Среди звенящих цепей Корнуолл идёт тяжёлым шагом. Я держу слово «страх» как факел у сердца."
+          "sentence_translation": "Среди звенящих цепей Корнуолл идёт тяжёлым шагом. Я держу слово «страх» как факел у сердца.",
+          "sentence_parts": [
+            "Zwischen klirrenden Ketten schreitet Cornwall mit schwerem Schritt.",
+            "Ich halte das Wort „die Furcht“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "unterdrücken",
           "russian": "подавлять",
           "transcription": "[ун-тер-ДРЮ-кен]",
           "sentence": "Am schwarzen Banner der Macht schwört Cornwall sich ewige Herrschaft. Mein Atem zeichnet das Wort „unterdrücken“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "У чёрного знамени власти Корнуолл клянётся вечным господством. Моё дыхание рисует слово «подавлять» в холодном воздухе между нами."
+          "sentence_translation": "У чёрного знамени власти Корнуолл клянётся вечным господством. Моё дыхание рисует слово «подавлять» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Am schwarzen Banner der Macht schwört Cornwall sich ewige Herrschaft.",
+            "Mein Atem zeichnet das Wort „unterdrücken“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "knechten",
           "russian": "порабощать",
           "transcription": "[КНЕХ-тен]",
           "sentence": "Auf dem Gerichtspodest stützt Cornwall sich auf den Stab aus Eisen. Ich presse das Wort „knechten“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "На судейском помосте Корнуолл опирается на железный посох. Я стискиваю слово «порабощать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "На судейском помосте Корнуолл опирается на железный посох. Я стискиваю слово «порабощать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Auf dem Gerichtspodest stützt Cornwall sich auf den Stab aus Eisen.",
+            "Ich presse das Wort „knechten“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "zwingen",
           "russian": "принуждать",
           "transcription": "[ЦВИН-ген]",
           "sentence": "Unter den Blicken eingeschüchterter Edelleute reißt Cornwall das Urteil an sich. Ich zeichne das Wort „zwingen“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Под взглядами запуганных дворян Корнуолл присваивает себе право суда. Я вывожу слово «принуждать» невидимыми чернилами на ладони."
+          "sentence_translation": "Под взглядами запуганных дворян Корнуолл присваивает себе право суда. Я вывожу слово «принуждать» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Unter den Blicken eingeschüchterter Edelleute reißt Cornwall das Urteil an sich.",
+            "Ich zeichne das Wort „zwingen“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "die Willkür",
           "russian": "произвол",
           "transcription": "[ди ВИЛЬ-кюр]",
           "sentence": "An der Treppe zum Kerker verteilt Cornwall grausame Befehle. Ich umarme das Wort „die Willkür“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "У лестницы в темницу Корнуолл раздаёт жестокие приказы. Я обнимаю слово «произвол», будто это единственный союзник."
+          "sentence_translation": "У лестницы в темницу Корнуолл раздаёт жестокие приказы. Я обнимаю слово «произвол», будто это единственный союзник.",
+          "sentence_parts": [
+            "An der Treppe zum Kerker verteilt Cornwall grausame Befehle.",
+            "Ich umarme das Wort „die Willkür“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "brutal",
           "russian": "брутальный",
           "transcription": "[бру-ТАЛЬ]",
           "sentence": "Im düsteren Thronsaal schlägt Cornwall mit der Faust auf die Armlehne. Ich halte das Wort „brutal“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "В мрачном тронном зале Корнуолл бьёт кулаком по подлокотнику. Я держу слово «брутальный» как факел у сердца."
+          "sentence_translation": "В мрачном тронном зале Корнуолл бьёт кулаком по подлокотнику. Я держу слово «брутальный» как факел у сердца.",
+          "sentence_parts": [
+            "Im düsteren Thronsaal schlägt Cornwall mit der Faust auf die Armlehne.",
+            "Ich halte das Wort „brutal“ wie eine Fackel vor meinem Herzen."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -287,49 +379,77 @@
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
           "sentence": "Vor den geschockten Höflingen deutet Cornwall auf die leeren Holzkolben. Wie ein stilles Gebet legt sich das Wort „die Strafe“ auf meine Lippen.",
-          "sentence_translation": "Перед потрясёнными придворными Корнуолл указывает на пустые колодки. Как тихая молитва слово «наказание» ложится на мои губы."
+          "sentence_translation": "Перед потрясёнными придворными Корнуолл указывает на пустые колодки. Как тихая молитва слово «наказание» ложится на мои губы.",
+          "sentence_parts": [
+            "Vor den geschockten Höflingen deutet Cornwall auf die leeren Holzkolben.",
+            "Wie ein stilles Gebet legt sich das Wort „die Strafe“ auf meine Lippen."
+          ]
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
           "sentence": "Auf dem nassen Hof befiehlt Cornwall die Fesselung des Widerspenstigen. Mit fester Stimme schwöre ich mir: Das Wort „der Zorn“ wird heute nicht verraten.",
-          "sentence_translation": "На мокром дворе Корнуолл приказывает заковать непокорного. Твёрдым голосом я клянусь себе: слово «гнев» сегодня не будет предано."
+          "sentence_translation": "На мокром дворе Корнуолл приказывает заковать непокорного. Твёрдым голосом я клянусь себе: слово «гнев» сегодня не будет предано.",
+          "sentence_parts": [
+            "Auf dem nassen Hof befiehlt Cornwall die Fesselung des Widerspenstigen.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „der Zorn“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "bestrafen",
           "russian": "карать",
           "transcription": "[бе-ШТРА-фен]",
           "sentence": "Neben Regans spöttischem Blick wirft Cornwall das Urteil in die Luft. Ich flüstere den Wächtern des Schicksals zu: Das Wort „bestrafen“ darf nicht vergehen.",
-          "sentence_translation": "Рядом с насмешливым взглядом Реганы Корнуолл бросает приговор в воздух. Я шепчу стражам судьбы: слово «карать» не должно исчезнуть."
+          "sentence_translation": "Рядом с насмешливым взглядом Реганы Корнуолл бросает приговор в воздух. Я шепчу стражам судьбы: слово «карать» не должно исчезнуть.",
+          "sentence_parts": [
+            "Neben Regans spöttischem Blick wirft Cornwall das Urteil in die Luft.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „bestrafen“ darf nicht vergehen."
+          ]
         },
         {
           "german": "züchtigen",
           "russian": "наказывать",
           "transcription": "[ЦЮХ-ти-ген]",
           "sentence": "Am Werkzeugtisch der Garde prüft Cornwall die scharfen Nägel. Ich presse das Wort „züchtigen“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "У верстака стражи Корнуолл проверяет острые гвозди. Я стискиваю слово «наказывать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "У верстака стражи Корнуолл проверяет острые гвозди. Я стискиваю слово «наказывать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Am Werkzeugtisch der Garde prüft Cornwall die scharfen Nägel.",
+            "Ich presse das Wort „züchtigen“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "demütigen",
           "russian": "унижать",
           "transcription": "[де-МЮ-ти-ген]",
           "sentence": "Vor den verschreckten Dienern lächelt Cornwall über das Flehen um Gnade. Ich flüstere den Wächtern des Schicksals zu: Das Wort „demütigen“ darf nicht vergehen.",
-          "sentence_translation": "Перед перепуганными слугами Корнуолл улыбается мольбам о пощаде. Я шепчу стражам судьбы: слово «унижать» не должно исчезнуть."
+          "sentence_translation": "Перед перепуганными слугами Корнуолл улыбается мольбам о пощаде. Я шепчу стражам судьбы: слово «унижать» не должно исчезнуть.",
+          "sentence_parts": [
+            "Vor den verschreckten Dienern lächelt Cornwall über das Flehen um Gnade.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „demütigen“ darf nicht vergehen."
+          ]
         },
         {
           "german": "erniedrigen",
           "russian": "унижать",
           "transcription": "[ер-НИД-ри-ген]",
           "sentence": "Unter Donnerhall befiehlt Cornwall das Opfer in den Regen zu stellen. Selbst wenn die Welt zerfällt, bleibt das Wort „erniedrigen“ mein Nordstern.",
-          "sentence_translation": "Под раскаты грома Корнуолл приказывает поставить жертву под дождь. Даже если мир распадается, слово «унижать» остаётся моим северным светом."
+          "sentence_translation": "Под раскаты грома Корнуолл приказывает поставить жертву под дождь. Даже если мир распадается, слово «унижать» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Unter Donnerhall befiehlt Cornwall das Opfer in den Regen zu stellen.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „erniedrigen“ mein Nordstern."
+          ]
         },
         {
           "german": "quälen",
           "russian": "мучить",
           "transcription": "[КВЕ-лен]",
           "sentence": "Auf dem Steinboden hinterlässt Cornwall Spuren von Blut und Wasser. Ich halte das Wort „quälen“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "На каменном полу Корнуолл оставляет следы крови и воды. Я держу слово «мучить» как факел у сердца."
+          "sentence_translation": "На каменном полу Корнуолл оставляет следы крови и воды. Я держу слово «мучить» как факел у сердца.",
+          "sentence_parts": [
+            "Auf dem Steinboden hinterlässt Cornwall Spuren von Blut und Wasser.",
+            "Ich halte das Wort „quälen“ wie eine Fackel vor meinem Herzen."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -373,56 +493,88 @@
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
           "sentence": "Im düsteren Saal bindet Cornwall den Grafen an den eichenen Stuhl. Mit fester Stimme schwöre ich mir: Das Wort „die Folter“ wird heute nicht verraten.",
-          "sentence_translation": "В мрачном зале Корнуолл приковывает графа к дубовому креслу. Твёрдым голосом я клянусь себе: слово «пытка» сегодня не будет предано."
+          "sentence_translation": "В мрачном зале Корнуолл приковывает графа к дубовому креслу. Твёрдым голосом я клянусь себе: слово «пытка» сегодня не будет предано.",
+          "sentence_parts": [
+            "Im düsteren Saal bindet Cornwall den Grafen an den eichenen Stuhl.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „die Folter“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "der Sadismus",
           "russian": "садизм",
           "transcription": "[дер за-ДИС-мус]",
           "sentence": "Neben knirschenden Seilen entfachen Regans Diener das Feuer, während Cornwall zuschaut. Ich zeichne das Wort „der Sadismus“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Под скрип канатов слуги Реганы раздувают огонь, пока Корнуолл наблюдает. Я черчу слово «садизм» в мыслях поверх линий судьбы."
+          "sentence_translation": "Под скрип канатов слуги Реганы раздувают огонь, пока Корнуолл наблюдает. Я черчу слово «садизм» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Neben knirschenden Seilen entfachen Regans Diener das Feuer, während Cornwall zuschaut.",
+            "Ich zeichne das Wort „der Sadismus“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "das Blut",
           "russian": "кровь",
           "transcription": "[дас БЛУТ]",
           "sentence": "Vor der versammelten Ritterschaft lässt Cornwall die Dolche bereitlegen. Ich zeichne das Wort „das Blut“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Перед собравшимся рыцарством Корнуолл велит приготовить кинжалы. Я черчу слово «кровь» в мыслях поверх линий судьбы."
+          "sentence_translation": "Перед собравшимся рыцарством Корнуолл велит приготовить кинжалы. Я черчу слово «кровь» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Vor der versammelten Ritterschaft lässt Cornwall die Dolche bereitlegen.",
+            "Ich zeichne das Wort „das Blut“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "foltern",
           "russian": "пытать",
           "transcription": "[ФОЛЬ-терн]",
           "sentence": "Am blutbefleckten Boden tritt Cornwall das Geständnis aus dem Gefangenen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „foltern“ bleibt lebendig.",
-          "sentence_translation": "На забрызганном кровью полу Корнуолл выбивает признание из пленника. Каждой клеткой тела я обещаю: слово «пытать» останется живым."
+          "sentence_translation": "На забрызганном кровью полу Корнуолл выбивает признание из пленника. Каждой клеткой тела я обещаю: слово «пытать» останется живым.",
+          "sentence_parts": [
+            "Am blutbefleckten Boden tritt Cornwall das Geständnis aus dem Gefangenen.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „foltern“ bleibt lebendig."
+          ]
         },
         {
           "german": "verstümmeln",
           "russian": "калечить",
           "transcription": "[фер-ШТЮМ-мельн]",
           "sentence": "Zwischen aufschreienden Dienern bleibt Cornwall eiskalt und unbewegt. Selbst wenn die Welt zerfällt, bleibt das Wort „verstümmeln“ mein Nordstern.",
-          "sentence_translation": "Среди вскрикивающих слуг Корнуолл остаётся ледяным и неподвижным. Даже если мир распадается, слово «калечить» остаётся моим северным светом."
+          "sentence_translation": "Среди вскрикивающих слуг Корнуолл остаётся ледяным и неподвижным. Даже если мир распадается, слово «калечить» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Zwischen aufschreienden Dienern bleibt Cornwall eiskalt und unbewegt.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „verstümmeln“ mein Nordstern."
+          ]
         },
         {
           "german": "blenden",
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
           "sentence": "Unter Regans Jubel reißt Cornwall das grausame Werk zu Ende. Mein Atem zeichnet das Wort „blenden“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Под ликование Реганы Корнуолл довершает жестокую работу. Моё дыхание рисует слово «ослеплять» в холодном воздухе между нами."
+          "sentence_translation": "Под ликование Реганы Корнуолл довершает жестокую работу. Моё дыхание рисует слово «ослеплять» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Unter Regans Jubel reißt Cornwall das grausame Werk zu Ende.",
+            "Mein Atem zeichnet das Wort „blenden“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "ausstechen",
           "russian": "выкалывать",
           "transcription": "[АУС-ште-хен]",
           "sentence": "Vor den entsetzten Augen des Hofes wischt Cornwall das Blut vom Stiefel. Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus.",
-          "sentence_translation": "Перед ужаснувшимися придворными Корнуолл стирает кровь с сапога. Я глубоко вдыхаю и выпускаю только слово «выкалывать»."
+          "sentence_translation": "Перед ужаснувшимися придворными Корнуолл стирает кровь с сапога. Я глубоко вдыхаю и выпускаю только слово «выкалывать».",
+          "sentence_parts": [
+            "Vor den entsetzten Augen des Hofes wischt Cornwall das Blut vom Stiefel.",
+            "Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus."
+          ]
         },
         {
           "german": "die Qual",
           "russian": "мука",
           "transcription": "[ди КВАЛЬ]",
           "sentence": "Im Nachhall der Schreie richtet Cornwall den Mantel und wendet sich zur Tür. Ich umarme das Wort „die Qual“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В отзвуках криков Корнуолл поправляет плащ и разворачивается к двери. Я обнимаю слово «мука», будто это единственный союзник."
+          "sentence_translation": "В отзвуках криков Корнуолл поправляет плащ и разворачивается к двери. Я обнимаю слово «мука», будто это единственный союзник.",
+          "sentence_parts": [
+            "Im Nachhall der Schreie richtet Cornwall den Mantel und wendet sich zur Tür.",
+            "Ich umarme das Wort „die Qual“, als wäre es mein einziger Verbündeter."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -466,49 +618,77 @@
           "russian": "рана",
           "transcription": "[ди ВУН-де]",
           "sentence": "Im dunklen Korridor presst Cornwall die Hand gegen die frische Wunde. Ich atme tief ein und lasse nur das Wort „die Wunde“ wieder hinaus.",
-          "sentence_translation": "В тёмном коридоре Корнуолл прижимает руку к свежей ране. Я глубоко вдыхаю и выпускаю только слово «рана»."
+          "sentence_translation": "В тёмном коридоре Корнуолл прижимает руку к свежей ране. Я глубоко вдыхаю и выпускаю только слово «рана».",
+          "sentence_parts": [
+            "Im dunklen Korridor presst Cornwall die Hand gegen die frische Wunde.",
+            "Ich atme tief ein und lasse nur das Wort „die Wunde“ wieder hinaus."
+          ]
         },
         {
           "german": "der Schmerz",
           "russian": "боль",
           "transcription": "[дер ШМЕРЦ]",
           "sentence": "Auf der Treppe taumelt Cornwall, während das Blut den Stein färbt. Das kalte Licht lässt das Wort „der Schmerz“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "На лестнице Корнуолл пошатывается, окрашивая камень кровью. Холодный свет заставляет слово «боль» сиять словно расплавленное золото."
+          "sentence_translation": "На лестнице Корнуолл пошатывается, окрашивая камень кровью. Холодный свет заставляет слово «боль» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Auf der Treppe taumelt Cornwall, während das Blut den Stein färbt.",
+            "Das kalte Licht lässt das Wort „der Schmerz“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "die Überraschung",
           "russian": "удивление",
           "transcription": "[ди ю-бер-РА-шунг]",
           "sentence": "Neben Regans erschrockener Stimme sucht Cornwall Halt am Geländer. Ich zeichne das Wort „die Überraschung“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Рядом с испуганным голосом Реганы Корнуолл ищет опоры в перилах. Я вывожу слово «удивление» невидимыми чернилами на ладони."
+          "sentence_translation": "Рядом с испуганным голосом Реганы Корнуолл ищет опоры в перилах. Я вывожу слово «удивление» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Neben Regans erschrockener Stimme sucht Cornwall Halt am Geländer.",
+            "Ich zeichne das Wort „die Überraschung“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "bluten",
           "russian": "кровоточить",
           "transcription": "[БЛУ-тен]",
           "sentence": "Im Stall greift Cornwall nach einem Sattel, doch die Kräfte schwinden. Ich umarme das Wort „bluten“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В конюшне Корнуолл тянется к седлу, но силы уходят. Я обнимаю слово «кровоточить», будто это единственный союзник."
+          "sentence_translation": "В конюшне Корнуолл тянется к седлу, но силы уходят. Я обнимаю слово «кровоточить», будто это единственный союзник.",
+          "sentence_parts": [
+            "Im Stall greift Cornwall nach einem Sattel, doch die Kräfte schwinden.",
+            "Ich umarme das Wort „bluten“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "verwundet",
           "russian": "раненый",
           "transcription": "[фер-ВУН-дет]",
           "sentence": "Vor dem Tor der Burg hinterlässt Cornwall eine Spur aus rotem Staub. Selbst wenn die Welt zerfällt, bleibt das Wort „verwundet“ mein Nordstern.",
-          "sentence_translation": "Перед воротами замка Корнуолл оставляет след из красной пыли. Даже если мир распадается, слово «раненый» остаётся моим северным светом."
+          "sentence_translation": "Перед воротами замка Корнуолл оставляет след из красной пыли. Даже если мир распадается, слово «раненый» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Vor dem Tor der Burg hinterlässt Cornwall eine Spur aus rotem Staub.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „verwundet“ mein Nordstern."
+          ]
         },
         {
           "german": "schwächen",
           "russian": "ослаблять",
           "transcription": "[ШВЕ-хен]",
           "sentence": "Auf dem Hof sinkt Cornwall zwischen erschrockenen Wachen zusammen. Wie ein stilles Gebet legt sich das Wort „schwächen“ auf meine Lippen.",
-          "sentence_translation": "На дворе Корнуолл падает среди испуганных стражников. Как тихая молитва слово «ослаблять» ложится на мои губы."
+          "sentence_translation": "На дворе Корнуолл падает среди испуганных стражников. Как тихая молитва слово «ослаблять» ложится на мои губы.",
+          "sentence_parts": [
+            "Auf dem Hof sinkt Cornwall zwischen erschrockenen Wachen zusammen.",
+            "Wie ein stilles Gebet legt sich das Wort „schwächen“ auf meine Lippen."
+          ]
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
           "sentence": "Unter dem bleiernen Himmel schwört Cornwall Rache mit letzter Kraft. Das kalte Licht lässt das Wort „leiden“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Под свинцовым небом Корнуолл клянётся в мести из последних сил. Холодный свет заставляет слово «страдать» сиять словно расплавленное золото."
+          "sentence_translation": "Под свинцовым небом Корнуолл клянётся в мести из последних сил. Холодный свет заставляет слово «страдать» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Unter dem bleiernen Himmel schwört Cornwall Rache mit letzter Kraft.",
+            "Das kalte Licht lässt das Wort „leiden“ wie geschmolzenes Gold erscheinen."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -552,56 +732,89 @@
           "russian": "смерть",
           "transcription": "[дер ТОД]",
           "sentence": "Im Treppenhaus der Burg bricht Cornwall auf das kalte Steinpodest. Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "На лестнице замка Корнуолл рушится на холодную площадку. Моё дыхание рисует слово «смерть» в холодном воздухе между нами."
+          "sentence_translation": "На лестнице замка Корнуолл рушится на холодную площадку. Моё дыхание рисует слово «смерть» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im Treppenhaus der Burg bricht Cornwall auf das kalte Steinpodest.",
+            "Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Vergeltung",
           "russian": "возмездие",
           "transcription": "[ди фер-ГЕЛЬ-тунг]",
           "sentence": "Zwischen zerbrochenen Waffen liegt Cornwall und ringt nach Atem. Das kalte Licht lässt das Wort „die Vergeltung“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Среди разбитого оружия Корнуолл лежит, хватая воздух. Холодный свет заставляет слово «возмездие» сиять словно расплавленное золото."
+          "sentence_translation": "Среди разбитого оружия Корнуолл лежит, хватая воздух. Холодный свет заставляет слово «возмездие» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Zwischen zerbrochenen Waffen liegt Cornwall und ringt nach Atem.",
+            "Das kalte Licht lässt das Wort „die Vergeltung“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЕН-де]",
           "sentence": "Vor Regans entsetztem Blick verliert Cornwall den Griff um das eigene Blut. Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Перед ужаснувшимся взглядом Реганы Корнуолл теряет хватку на собственной ране. Я держу слово «конец» как факел у сердца."
+          "sentence_translation": "Перед ужаснувшимся взглядом Реганы Корнуолл теряет хватку на собственной ране. Я держу слово «конец» как факел у сердца.",
+          "sentence_parts": [
+            "Vor Regans entsetztem Blick verliert Cornwall den Griff um das eigene Blut.",
+            "Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
           "sentence": "Am Fuß der Treppe murmelt Cornwall die letzten Befehle. Ich umarme das Wort „sterben“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "У подножия лестницы Корнуолл бормочет последние приказы. Я обнимаю слово «умирать», будто это единственный союзник."
+          "sentence_translation": "У подножия лестницы Корнуолл бормочет последние приказы. Я обнимаю слово «умирать», будто это единственный союзник.",
+          "sentence_parts": [
+            "Am Fuß der Treppe murmelt Cornwall die letzten Befehle.",
+            "Ich umarme das Wort „sterben“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "verenden",
           "russian": "издыхать",
           "transcription": "[фер-ЕН-ден]",
           "sentence": "Auf der kalten Flaggenkiste sinkt Cornwall schwer zusammen. Mein Atem zeichnet das Wort „verenden“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "На холодном сундуке со знамёнами Корнуолл тяжело оседает. Моё дыхание рисует слово «издыхать» в холодном воздухе между нами."
+          "sentence_translation": "На холодном сундуке со знамёнами Корнуолл тяжело оседает. Моё дыхание рисует слово «издыхать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Auf der kalten Flaggenkiste sinkt Cornwall schwer zusammen.",
+            "Mein Atem zeichnet das Wort „verenden“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "verfluchen",
           "russian": "проклинать",
           "transcription": "[фер-ФЛУ-хен]",
           "sentence": "Neben zerborstenen Fenstern haucht Cornwall den letzten Fluch aus. Mit fester Stimme schwöre ich mir: Das Wort „verfluchen“ wird heute nicht verraten.",
-          "sentence_translation": "У разбитых окон Корнуолл выдыхает последний проклятый звук. Твёрдым голосом я клянусь себе: слово «проклинать» сегодня не будет предано."
+          "sentence_translation": "У разбитых окон Корнуолл выдыхает последний проклятый звук. Твёрдым голосом я клянусь себе: слово «проклинать» сегодня не будет предано.",
+          "sentence_parts": [
+            "Neben zerborstenen Fenstern haucht Cornwall den letzten Fluch aus.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „verfluchen“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "röcheln",
           "russian": "хрипеть",
           "transcription": "[РЁ-хельн]",
           "sentence": "Unter dem prasselnden Regen verglimmt Cornwalls Leben rasch. Ich halte das Wort „röcheln“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Под проливным дождём жизнь Корнуолл быстро гаснет. Я держу слово «хрипеть» как факел у сердца."
+          "sentence_translation": "Под проливным дождём жизнь Корнуолл быстро гаснет. Я держу слово «хрипеть» как факел у сердца.",
+          "sentence_parts": [
+            "Unter dem prasselnden Regen verglimmt Cornwalls Leben rasch.",
+            "Ich halte das Wort „röcheln“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Strafe",
           "russian": "кара",
           "transcription": "[ди ШТРА-фе]",
           "sentence": "Im Staub des Hofes starrt Cornwall zum grauen Himmel, bevor die Augen erlöschen. Ich atme tief ein und lasse nur das Wort „die Strafe“ wieder hinaus.",
-          "sentence_translation": "В пыли двора Корнуолл смотрит в серое небо, прежде чем глаза угасают. Я глубоко вдыхаю и выпускаю только слово «кара»."
+          "sentence_translation": "В пыли двора Корнуолл смотрит в серое небо, прежде чем глаза угасают. Я глубоко вдыхаю и выпускаю только слово «кара».",
+          "sentence_parts": [
+            "Im Staub des Hofes starrt Cornwall zum grauen Himmel,",
+            "bevor die Augen erlöschen.",
+            "Ich atme tief ein und lasse nur das Wort „die Strafe“ wieder hinaus."
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/edgar.json
+++ b/data/characters/edgar.json
@@ -21,56 +21,88 @@
           "russian": "знать",
           "transcription": "[дер А-дель]",
           "sentence": "Edgar steht unter dem glühenden Kronleuchter des Thronsaals. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Adel“ bleibt lebendig.",
-          "sentence_translation": "Эдгар стоит под пылающей люстрой тронного зала. Каждой клеткой тела я обещаю: слово «знать» останется живым."
+          "sentence_translation": "Эдгар стоит под пылающей люстрой тронного зала. Каждой клеткой тела я обещаю: слово «знать» останется живым.",
+          "sentence_parts": [
+            "Edgar steht unter dem glühenden Kronleuchter des Thronsaals.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Adel“ bleibt lebendig."
+          ]
         },
         {
           "german": "der Erbe",
           "russian": "наследник",
           "transcription": "[дер ЕР-бе]",
           "sentence": "Neben der ausgerollten Reichskarte beugt sich Edgar über Lears schweren Tisch. Mein Atem zeichnet das Wort „der Erbe“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "У развернутой карты королевства Эдгар склоняется над тяжёлым столом Лира. Моё дыхание рисует слово «наследник» в холодном воздухе между нами."
+          "sentence_translation": "У развернутой карты королевства Эдгар склоняется над тяжёлым столом Лира. Моё дыхание рисует слово «наследник» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Neben der ausgerollten Reichskarte beugt sich Edgar über Lears schweren Tisch.",
+            "Mein Atem zeichnet das Wort „der Erbe“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "das Königreich",
           "russian": "королевство",
           "transcription": "[дас КЁ-ниг-райх]",
           "sentence": "Vor den steinernen Ahnenstatuen verschränkt Edgar die Hände hinter dem Rücken. Wie ein stilles Gebet legt sich das Wort „das Königreich“ auf meine Lippen.",
-          "sentence_translation": "Перед каменными статуями предков Эдгар сцепляет руки за спиной. Как тихая молитва слово «королевство» ложится на мои губы."
+          "sentence_translation": "Перед каменными статуями предков Эдгар сцепляет руки за спиной. Как тихая молитва слово «королевство» ложится на мои губы.",
+          "sentence_parts": [
+            "Vor den steinernen Ahnenstatuen verschränkt Edgar die Hände hinter dem Rücken.",
+            "Wie ein stilles Gebet legt sich das Wort „das Königreich“ auf meine Lippen."
+          ]
         },
         {
           "german": "vertrauen",
           "russian": "доверять",
           "transcription": "[фер-ТРАУ-ен]",
           "sentence": "Zwischen flüsternden Höflingen gleitet Edgar über den kalten Marmorboden. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vertrauen“ gehört mir.",
-          "sentence_translation": "Между шепчущимися придворными Эдгар скользит по холодному мраморному полу. Буря за окнами усиливает клятву: слово «доверять» принадлежит мне."
+          "sentence_translation": "Между шепчущимися придворными Эдгар скользит по холодному мраморному полу. Буря за окнами усиливает клятву: слово «доверять» принадлежит мне.",
+          "sentence_parts": [
+            "Zwischen flüsternden Höflingen gleitet Edgar über den kalten Marmorboden.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vertrauen“ gehört mir."
+          ]
         },
         {
           "german": "die Ehre",
           "russian": "честь",
           "transcription": "[ди Э-ре]",
           "sentence": "Am Rand des purpurnen Teppichs wartet Edgar auf ein Zeichen des Königs. Wie ein stilles Gebet legt sich das Wort „die Ehre“ auf meine Lippen.",
-          "sentence_translation": "На краю пурпурного ковра Эдгар ждёт знака от короля. Как тихая молитва слово «честь» ложится на мои губы."
+          "sentence_translation": "На краю пурпурного ковра Эдгар ждёт знака от короля. Как тихая молитва слово «честь» ложится на мои губы.",
+          "sentence_parts": [
+            "Am Rand des purpurnen Teppichs wartet Edgar auf ein Zeichen des Königs.",
+            "Wie ein stilles Gebet legt sich das Wort „die Ehre“ auf meine Lippen."
+          ]
         },
         {
           "german": "legitim",
           "russian": "законный",
           "transcription": "[ле-ги-ТИМ]",
           "sentence": "Unter wehenden Standarten der Schwestern senkt Edgar kurz den Blick. Mit jeder Faser meines Körpers verspreche ich: Das Wort „legitim“ bleibt lebendig.",
-          "sentence_translation": "Под развевающимися штандартами сестёр Эдгар на миг опускает взгляд. Каждой клеткой тела я обещаю: слово «законный» останется живым."
+          "sentence_translation": "Под развевающимися штандартами сестёр Эдгар на миг опускает взгляд. Каждой клеткой тела я обещаю: слово «законный» останется живым.",
+          "sentence_parts": [
+            "Unter wehenden Standarten der Schwestern senkt Edgar kurz den Blick.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „legitim“ bleibt lebendig."
+          ]
         },
         {
           "german": "der Graf",
           "russian": "граф",
           "transcription": "[дер ГРАФ]",
           "sentence": "Hinter der vergoldeten Balustrade beobachtet Edgar das gespannte Antlitz des Hofes. Das kalte Licht lässt das Wort „der Graf“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "За позолоченной балюстрадой Эдгар наблюдает за напряжёнными лицами двора. Холодный свет заставляет слово «граф» сиять словно расплавленное золото."
+          "sentence_translation": "За позолоченной балюстрадой Эдгар наблюдает за напряжёнными лицами двора. Холодный свет заставляет слово «граф» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Hinter der vergoldeten Balustrade beobachtet Edgar das gespannte Antlitz des Hofes.",
+            "Das kalte Licht lässt das Wort „der Graf“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "ahnungslos",
           "russian": "ничего не подозревающий",
           "transcription": "[А-нунгс-лос]",
           "sentence": "Im Schein der offenen Feuerbecken erhebt Edgar langsam die Stimme. Ich presse das Wort „ahnungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "В отблесках открытых жаровен Эдгар медленно поднимает голос. Я стискиваю слово «ничего не подозревающий» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "В отблесках открытых жаровен Эдгар медленно поднимает голос. Я стискиваю слово «ничего не подозревающий» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Im Schein der offenen Feuerbecken erhebt Edgar langsam die Stimme.",
+            "Ich presse das Wort „ahnungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         }
       ],
       "quizzes": [
@@ -114,56 +146,88 @@
           "russian": "бежать",
           "transcription": "[ФЛИ-ен]",
           "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Edgar zwischen gepackten Kisten. Selbst wenn die Welt zerfällt, bleibt das Wort „fliehen“ mein Nordstern.",
-          "sentence_translation": "В гулком проёме ворот замка Гонерильи Эдгар замирает среди нагруженных ящиков. Даже если мир распадается, слово «бежать» остаётся моим северным светом."
+          "sentence_translation": "В гулком проёме ворот замка Гонерильи Эдгар замирает среди нагруженных ящиков. Даже если мир распадается, слово «бежать» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Im hallenden Torbogen von Gonerils Burg verharrt Edgar zwischen gepackten Kisten.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „fliehen“ mein Nordstern."
+          ]
         },
         {
           "german": "der Verrat",
           "russian": "предательство",
           "transcription": "[дер фер-РАТ]",
           "sentence": "Auf der windigen Freitreppe blickt Edgar zum schweigenden Hof hinunter. Ich umarme das Wort „der Verrat“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "На продуваемой ветром лестнице Эдгар смотрит вниз на молчаливый двор. Я обнимаю слово «предательство», будто это единственный союзник."
+          "sentence_translation": "На продуваемой ветром лестнице Эдгар смотрит вниз на молчаливый двор. Я обнимаю слово «предательство», будто это единственный союзник.",
+          "sentence_parts": [
+            "Auf der windigen Freitreppe blickt Edgar zum schweigenden Hof hinunter.",
+            "Ich umarme das Wort „der Verrat“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Gefahr",
           "russian": "опасность",
           "transcription": "[ди ге-ФАР]",
           "sentence": "Zwischen zurückgelassenen Dienern schließt Edgar den Reisemantel enger. Ich zeichne das Wort „die Gefahr“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Среди оставленных слуг Эдгар плотнее запахивает дорожный плащ. Я вывожу слово «опасность» невидимыми чернилами на ладони."
+          "sentence_translation": "Среди оставленных слуг Эдгар плотнее запахивает дорожный плащ. Я вывожу слово «опасность» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Zwischen zurückgelassenen Dienern schließt Edgar den Reisemantel enger.",
+            "Ich zeichne das Wort „die Gefahr“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "verfolgen",
           "russian": "преследовать",
           "transcription": "[фер-ФОЛЬ-ген]",
           "sentence": "Am dunklen Pferdestall streicht Edgar einem nervösen Tier über die Mähne. Ich zeichne das Wort „verfolgen“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "У тёмного конюшенного ряда Эдгар гладит гриву нервного коня. Я вывожу слово «преследовать» невидимыми чернилами на ладони."
+          "sentence_translation": "У тёмного конюшенного ряда Эдгар гладит гриву нервного коня. Я вывожу слово «преследовать» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Am dunklen Pferdestall streicht Edgar einem nervösen Tier über die Mähne.",
+            "Ich zeichne das Wort „verfolgen“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "verstecken",
           "russian": "прятаться",
           "transcription": "[фер-ШТЕ-кен]",
           "sentence": "Vor dem knarrenden Fallgatter tastet Edgar ein letztes Mal nach dem Haustor. Das kalte Licht lässt das Wort „verstecken“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Перед скрипящим подъёмным мостом Эдгар в последний раз касается родной двери. Холодный свет заставляет слово «прятаться» сиять словно расплавленное золото."
+          "sentence_translation": "Перед скрипящим подъёмным мостом Эдгар в последний раз касается родной двери. Холодный свет заставляет слово «прятаться» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Vor dem knarrenden Fallgatter tastet Edgar ein letztes Mal nach dem Haustor.",
+            "Das kalte Licht lässt das Wort „verstecken“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "die Intrige",
           "russian": "интрига",
           "transcription": "[ди ин-ТРИ-ге]",
           "sentence": "Zwischen verstreuten Schriftrollen dreht Edgar den Ring an der Hand. Mein Atem zeichnet das Wort „die Intrige“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Среди разбросанных свитков Эдгар вертит кольцо на пальце. Моё дыхание рисует слово «интрига» в холодном воздухе между нами."
+          "sentence_translation": "Среди разбросанных свитков Эдгар вертит кольцо на пальце. Моё дыхание рисует слово «интрига» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Zwischen verstreuten Schriftrollen dreht Edgar den Ring an der Hand.",
+            "Mein Atem zeichnet das Wort „die Intrige“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "der Betrug",
           "russian": "обман",
           "transcription": "[дер бе-ТРУГ]",
           "sentence": "Am leeren Bankettisch zählt Edgar die verlöschenden Kerzen. Wie ein stilles Gebet legt sich das Wort „der Betrug“ auf meine Lippen.",
-          "sentence_translation": "У пустого банкетного стола Эдгар пересчитывает гаснущие свечи. Как тихая молитва слово «обман» ложится на мои губы."
+          "sentence_translation": "У пустого банкетного стола Эдгар пересчитывает гаснущие свечи. Как тихая молитва слово «обман» ложится на мои губы.",
+          "sentence_parts": [
+            "Am leeren Bankettisch zählt Edgar die verlöschenden Kerzen.",
+            "Wie ein stilles Gebet legt sich das Wort „der Betrug“ auf meine Lippen."
+          ]
         },
         {
           "german": "verbannen",
           "russian": "изгнать",
           "transcription": "[фер-БАН-нен]",
           "sentence": "Zwischen schweigenden Wachen geht Edgar auf den kalten Hof hinaus. Ich atme tief ein und lasse nur das Wort „verbannen“ wieder hinaus.",
-          "sentence_translation": "Между молчаливыми стражниками Эдгар выходит на холодный двор. Я глубоко вдыхаю и выпускаю только слово «изгнать»."
+          "sentence_translation": "Между молчаливыми стражниками Эдгар выходит на холодный двор. Я глубоко вдыхаю и выпускаю только слово «изгнать».",
+          "sentence_parts": [
+            "Zwischen schweigenden Wachen geht Edgar auf den kalten Hof hinaus.",
+            "Ich atme tief ein und lasse nur das Wort „verbannen“ wieder hinaus."
+          ]
         }
       ],
       "quizzes": [
@@ -207,56 +271,89 @@
           "russian": "безумие",
           "transcription": "[дер ВАН-зин]",
           "sentence": "Im zugigen Seitenflügel lauscht Edgar dem Heulen der Küstenwinde. Mit fester Stimme schwöre ich mir: Das Wort „der Wahnsinn“ wird heute nicht verraten.",
-          "sentence_translation": "В продуваемом ветром боковом крыле Эдгар слушает вой прибрежного ветра. Твёрдым голосом я клянусь себе: слово «безумие» сегодня не будет предано."
+          "sentence_translation": "В продуваемом ветром боковом крыле Эдгар слушает вой прибрежного ветра. Твёрдым голосом я клянусь себе: слово «безумие» сегодня не будет предано.",
+          "sentence_parts": [
+            "Im zugigen Seitenflügel lauscht Edgar dem Heulen der Küstenwinde.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „der Wahnsinn“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "der Bettler",
           "russian": "нищий",
           "transcription": "[дер БЕТ-лер]",
           "sentence": "Vor dem rauchigen Kamin der Burg faltet Edgar einen zerknitterten Brief. Ich halte das Wort „der Bettler“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Перед дымным камином замка Эдгар складывает измятый лист. Я держу слово «нищий» как факел у сердца."
+          "sentence_translation": "Перед дымным камином замка Эдгар складывает измятый лист. Я держу слово «нищий» как факел у сердца.",
+          "sentence_parts": [
+            "Vor dem rauchigen Kamin der Burg faltet Edgar einen zerknitterten Brief.",
+            "Ich halte das Wort „der Bettler“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Verkleidung",
           "russian": "маскировка",
           "transcription": "[ди фер-КЛАЙ-дунг]",
           "sentence": "Unter farblosen Wandteppichen schreitet Edgar rastlos auf und ab. Mit fester Stimme schwöre ich mir: Das Wort „die Verkleidung“ wird heute nicht verraten.",
-          "sentence_translation": "Под выцветшими гобеленами Эдгар беспокойно меряет шагами зал. Твёрдым голосом я клянусь себе: слово «маскировка» сегодня не будет предано."
+          "sentence_translation": "Под выцветшими гобеленами Эдгар беспокойно меряет шагами зал. Твёрдым голосом я клянусь себе: слово «маскировка» сегодня не будет предано.",
+          "sentence_parts": [
+            "Unter farblosen Wandteppichen schreitet Edgar rastlos auf und ab.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „die Verkleidung“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "nackt",
           "russian": "голый",
           "transcription": "[НАКТ]",
           "sentence": "An der schmalen Fensterluke zählt Edgar die Fackeln auf dem Hof. Ich presse das Wort „nackt“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "У узкой бойницы Эдгар считает факелы на дворе. Я стискиваю слово «голый» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "У узкой бойницы Эдгар считает факелы на дворе. Я стискиваю слово «голый» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "An der schmalen Fensterluke zählt Edgar die Fackeln auf dem Hof.",
+            "Ich presse das Wort „nackt“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "murmeln",
           "russian": "бормотать",
           "transcription": "[МУР-мельн]",
           "sentence": "Zwischen Reisekoffern der Gesandten sucht Edgar nach frischen Botschaften. Ich halte das Wort „murmeln“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Среди дорожных сундуков послов Эдгар ищет свежие вести. Я держу слово «бормотать» как факел у сердца."
+          "sentence_translation": "Среди дорожных сундуков послов Эдгар ищет свежие вести. Я держу слово «бормотать» как факел у сердца.",
+          "sentence_parts": [
+            "Zwischen Reisekoffern der Gesandten sucht Edgar nach frischen Botschaften.",
+            "Ich halte das Wort „murmeln“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "zittern",
           "russian": "дрожать",
           "transcription": "[ЦИ-терн]",
           "sentence": "Im stillen Kapellenraum kniet Edgar vor der kalten Steinfigur. Ich presse das Wort „zittern“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "В тихой капелле Эдгар преклоняет колени перед холодной каменной фигурой. Я стискиваю слово «дрожать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "В тихой капелле Эдгар преклоняет колени перед холодной каменной фигурой. Я стискиваю слово «дрожать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Im stillen Kapellenraum kniet Edgar vor der kalten Steinfigur.",
+            "Ich presse das Wort „zittern“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "das Elend",
           "russian": "нищета",
           "transcription": "[дас Э-ленд]",
           "sentence": "Auf dem Balkon, den das Meer besprüht, hält Edgar die Laterne fest. Ich presse das Wort „das Elend“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "На балконе, омываемом морскими брызгами, Эдгар крепко держит фонарь. Я стискиваю слово «нищета» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "На балконе, омываемом морскими брызгами, Эдгар крепко держит фонарь. Я стискиваю слово «нищета» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Auf dem Balkon, den das Meer besprüht, hält Edgar die Laterne fest.",
+            "Ich presse das Wort „das Elend“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "wahnsinnig",
           "russian": "безумный",
           "transcription": "[ВАН-зи-ниг]",
           "sentence": "Im Schatten der hohen Burgmauern schreibt Edgar eine fiebrige Antwort. Mit jeder Faser meines Körpers verspreche ich: Das Wort „wahnsinnig“ bleibt lebendig.",
-          "sentence_translation": "В тени высоких стен Эдгар пишет лихорадочный ответ. Каждой клеткой тела я обещаю: слово «безумный» останется живым."
+          "sentence_translation": "В тени высоких стен Эдгар пишет лихорадочный ответ. Каждой клеткой тела я обещаю: слово «безумный» останется живым.",
+          "sentence_parts": [
+            "Im Schatten der hohen Burgmauern schreibt Edgar eine fiebrige Antwort.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „wahnsinnig“ bleibt lebendig."
+          ]
         }
       ],
       "quizzes": [
@@ -300,56 +397,88 @@
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
           "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edgar gegen den Wind. Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen.",
-          "sentence_translation": "Посреди хлещущей дождём пустоши Эдгар упирается в ветер. Как тихая молитва слово «буря» ложится на мои губы."
+          "sentence_translation": "Посреди хлещущей дождём пустоши Эдгар упирается в ветер. Как тихая молитва слово «буря» ложится на мои губы.",
+          "sentence_parts": [
+            "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edgar gegen den Wind.",
+            "Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen."
+          ]
         },
         {
           "german": "frieren",
           "russian": "мёрзнуть",
           "transcription": "[ФРИ-рен]",
           "sentence": "Unter einem zerrissenen Banner schützt Edgar die Augen vor den Blitzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „frieren“ bleibt lebendig.",
-          "sentence_translation": "Под разорванным знаменем Эдгар прикрывает глаза от молний. Каждой клеткой тела я обещаю: слово «мёрзнуть» останется живым."
+          "sentence_translation": "Под разорванным знаменем Эдгар прикрывает глаза от молний. Каждой клеткой тела я обещаю: слово «мёрзнуть» останется живым.",
+          "sentence_parts": [
+            "Unter einem zerrissenen Banner schützt Edgar die Augen vor den Blitzen.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „frieren“ bleibt lebendig."
+          ]
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
           "sentence": "Am Rand eines umgestürzten Baumes sucht Edgar Deckung vor dem Donner. Ich atme tief ein und lasse nur das Wort „leiden“ wieder hinaus.",
-          "sentence_translation": "У поваленного дерева Эдгар ищет укрытия от грома. Я глубоко вдыхаю и выпускаю только слово «страдать»."
+          "sentence_translation": "У поваленного дерева Эдгар ищет укрытия от грома. Я глубоко вдыхаю и выпускаю только слово «страдать».",
+          "sentence_parts": [
+            "Am Rand eines umgestürzten Baumes sucht Edgar Deckung vor dem Donner.",
+            "Ich atme tief ein und lasse nur das Wort „leiden“ wieder hinaus."
+          ]
         },
         {
           "german": "die Hütte",
           "russian": "хижина",
           "transcription": "[ди ХЮ-те]",
           "sentence": "Zwischen schäumenden Wassergräben stolpert Edgar durch den Schlamm. Ich umarme das Wort „die Hütte“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Между пенящимися лужами Эдгар пробирается через грязь. Я обнимаю слово «хижина», будто это единственный союзник."
+          "sentence_translation": "Между пенящимися лужами Эдгар пробирается через грязь. Я обнимаю слово «хижина», будто это единственный союзник.",
+          "sentence_parts": [
+            "Zwischen schäumenden Wassergräben stolpert Edgar durch den Schlamm.",
+            "Ich umarme das Wort „die Hütte“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "beschützen",
           "russian": "защищать",
           "transcription": "[бе-ШЮ-цен]",
           "sentence": "Vor einem zuckenden Himmel hebt Edgar die Arme trotzig an. Mit jeder Faser meines Körpers verspreche ich: Das Wort „beschützen“ bleibt lebendig.",
-          "sentence_translation": "На фоне вспыхивающего неба Эдгар упрямо поднимает руки. Каждой клеткой тела я обещаю: слово «защищать» останется живым."
+          "sentence_translation": "На фоне вспыхивающего неба Эдгар упрямо поднимает руки. Каждой клеткой тела я обещаю: слово «защищать» останется живым.",
+          "sentence_parts": [
+            "Vor einem zuckenden Himmel hebt Edgar die Arme trotzig an.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „beschützen“ bleibt lebendig."
+          ]
         },
         {
           "german": "begleiten",
           "russian": "сопровождать",
           "transcription": "[бе-ГЛАЙ-тен]",
           "sentence": "Unter dem durchtränkten Umhang presst Edgar den Atem gegen die Kälte. Mit jeder Faser meines Körpers verspreche ich: Das Wort „begleiten“ bleibt lebendig.",
-          "sentence_translation": "Под промокшим плащом Эдгар прижимает дыхание к груди, спасаясь от холода. Каждой клеткой тела я обещаю: слово «сопровождать» останется живым."
+          "sentence_translation": "Под промокшим плащом Эдгар прижимает дыхание к груди, спасаясь от холода. Каждой клеткой тела я обещаю: слово «сопровождать» останется живым.",
+          "sentence_parts": [
+            "Unter dem durchtränkten Umhang presst Edgar den Atem gegen die Kälte.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „begleiten“ bleibt lebendig."
+          ]
         },
         {
           "german": "der Donner",
           "russian": "гром",
           "transcription": "[дер ДО-нер]",
           "sentence": "Am kläglichen Feuerrest wärmt Edgar zitternde Finger. Ich zeichne das Wort „der Donner“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "У жалких огненных углей Эдгар греет дрожащие пальцы. Я черчу слово «гром» в мыслях поверх линий судьбы."
+          "sentence_translation": "У жалких огненных углей Эдгар греет дрожащие пальцы. Я черчу слово «гром» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Am kläglichen Feuerrest wärmt Edgar zitternde Finger.",
+            "Ich zeichne das Wort „der Donner“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "der Blitz",
           "russian": "молния",
           "transcription": "[дер БЛИЦ]",
           "sentence": "Zwischen heulenden Hunden ruft Edgar gegen den tosenden Sturm an. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Blitz“ darf nicht vergehen.",
-          "sentence_translation": "Среди воющих псов Эдгар перекрикивает беснующуюся бурю. Я шепчу стражам судьбы: слово «молния» не должно исчезнуть."
+          "sentence_translation": "Среди воющих псов Эдгар перекрикивает беснующуюся бурю. Я шепчу стражам судьбы: слово «молния» не должно исчезнуть.",
+          "sentence_parts": [
+            "Zwischen heulenden Hunden ruft Edgar gegen den tosenden Sturm an.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Blitz“ darf nicht vergehen."
+          ]
         }
       ],
       "quizzes": [
@@ -393,56 +522,88 @@
           "russian": "слепой",
           "transcription": "[БЛИНД]",
           "sentence": "Im dunklen Zelt der Feldärzte sitzt Edgar bei der flackernden Kerze. Ich atme tief ein und lasse nur das Wort „blind“ wieder hinaus.",
-          "sentence_translation": "В тёмном шатре полевых лекарей Эдгар сидит у мерцающей свечи. Я глубоко вдыхаю и выпускаю только слово «слепой»."
+          "sentence_translation": "В тёмном шатре полевых лекарей Эдгар сидит у мерцающей свечи. Я глубоко вдыхаю и выпускаю только слово «слепой».",
+          "sentence_parts": [
+            "Im dunklen Zelt der Feldärzte sitzt Edgar bei der flackernden Kerze.",
+            "Ich atme tief ein und lasse nur das Wort „blind“ wieder hinaus."
+          ]
         },
         {
           "german": "führen",
           "russian": "вести",
           "transcription": "[ФЮ-рен]",
           "sentence": "Zwischen zerbeulten Rüstungen streicht Edgar über ein altes Wappen. Ich atme tief ein und lasse nur das Wort „führen“ wieder hinaus.",
-          "sentence_translation": "Среди помятых доспехов Эдгар гладит старый герб. Я глубоко вдыхаю и выпускаю только слово «вести»."
+          "sentence_translation": "Среди помятых доспехов Эдгар гладит старый герб. Я глубоко вдыхаю и выпускаю только слово «вести».",
+          "sentence_parts": [
+            "Zwischen zerbeulten Rüstungen streicht Edgar über ein altes Wappen.",
+            "Ich atme tief ein und lasse nur das Wort „führen“ wieder hinaus."
+          ]
         },
         {
           "german": "die Klippe",
           "russian": "утёс",
           "transcription": "[ди КЛИ-пе]",
           "sentence": "Am niedrigen Dachbalken der Hütte stößt Edgar fast den Kopf. Ich halte das Wort „die Klippe“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "О низкую балку хижины Эдгар едва не ударяется головой. Я держу слово «утёс» как факел у сердца."
+          "sentence_translation": "О низкую балку хижины Эдгар едва не ударяется головой. Я держу слово «утёс» как факел у сердца.",
+          "sentence_parts": [
+            "Am niedrigen Dachbalken der Hütte stößt Edgar fast den Kopf.",
+            "Ich halte das Wort „die Klippe“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "täuschen",
           "russian": "обманывать",
           "transcription": "[ТОЙ-шен]",
           "sentence": "Neben der schlafenden Wache flüstert Edgar in die schwere Nacht. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir.",
-          "sentence_translation": "Рядом со спящим стражем Эдгар шепчет в тяжёлую ночь. Буря за окнами усиливает клятву: слово «обманывать» принадлежит мне."
+          "sentence_translation": "Рядом со спящим стражем Эдгар шепчет в тяжёлую ночь. Буря за окнами усиливает клятву: слово «обманывать» принадлежит мне.",
+          "sentence_parts": [
+            "Neben der schlafenden Wache flüstert Edgar in die schwere Nacht.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir."
+          ]
         },
         {
           "german": "retten",
           "russian": "спасать",
           "transcription": "[РЕ-тен]",
           "sentence": "Vor dem einfachen Feldbett betrachtet Edgar die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „retten“ wird heute nicht verraten.",
-          "sentence_translation": "Перед грубой походной койкой Эдгар разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «спасать» сегодня не будет предано."
+          "sentence_translation": "Перед грубой походной койкой Эдгар разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «спасать» сегодня не будет предано.",
+          "sentence_parts": [
+            "Vor dem einfachen Feldbett betrachtet Edgar die Narben vergangener Schlachten.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „retten“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "die List",
           "russian": "хитрость",
           "transcription": "[ди ЛИСТ]",
           "sentence": "Im Geruch von feuchtem Stroh legt Edgar den Mantel zur Seite. Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern.",
-          "sentence_translation": "В запахе влажной соломы Эдгар откладывает плащ в сторону. Даже если мир распадается, слово «хитрость» остаётся моим северным светом."
+          "sentence_translation": "В запахе влажной соломы Эдгар откладывает плащ в сторону. Даже если мир распадается, слово «хитрость» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Im Geruch von feuchtem Stroh legt Edgar den Mantel zur Seite.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern."
+          ]
         },
         {
           "german": "trösten",
           "russian": "утешать",
           "transcription": "[ТРЁС-тен]",
           "sentence": "Auf dem wackligen Holztisch ordnet Edgar zerlesene Briefe. Ich flüstere den Wächtern des Schicksals zu: Das Wort „trösten“ darf nicht vergehen.",
-          "sentence_translation": "На шатком деревянном столе Эдгар раскладывает зачитанные письма. Я шепчу стражам судьбы: слово «утешать» не должно исчезнуть."
+          "sentence_translation": "На шатком деревянном столе Эдгар раскладывает зачитанные письма. Я шепчу стражам судьбы: слово «утешать» не должно исчезнуть.",
+          "sentence_parts": [
+            "Auf dem wackligen Holztisch ordnet Edgar zerlesene Briefe.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „trösten“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Verzweiflung",
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
           "sentence": "Am Eingang der Hütte späht Edgar nach einem vertrauten Schatten. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Verzweiflung“ gehört mir.",
-          "sentence_translation": "У входа в хижину Эдгар высматривает знакомую тень. Буря за окнами усиливает клятву: слово «отчаяние» принадлежит мне."
+          "sentence_translation": "У входа в хижину Эдгар высматривает знакомую тень. Буря за окнами усиливает клятву: слово «отчаяние» принадлежит мне.",
+          "sentence_parts": [
+            "Am Eingang der Hütte späht Edgar nach einem vertrauten Schatten.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Verzweiflung“ gehört mir."
+          ]
         }
       ],
       "quizzes": [
@@ -486,56 +647,89 @@
           "russian": "бой",
           "transcription": "[дер КАМПФ]",
           "sentence": "Auf den weißen Klippen von Dover blickt Edgar in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „der Kampf“ mein Nordstern.",
-          "sentence_translation": "На белых скалах Дувра Эдгар смотрит в вздыбленный пролив. Даже если мир распадается, слово «бой» остаётся моим северным светом."
+          "sentence_translation": "На белых скалах Дувра Эдгар смотрит в вздыбленный пролив. Даже если мир распадается, слово «бой» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Auf den weißen Klippen von Dover blickt Edgar in den aufgewühlten Kanal.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „der Kampf“ mein Nordstern."
+          ]
         },
         {
           "german": "das Duell",
           "russian": "дуэль",
           "transcription": "[дас ду-ЭЛЬ]",
           "sentence": "Zwischen flatternden Feldzeichen richtet Edgar den Helm. Ich atme tief ein und lasse nur das Wort „das Duell“ wieder hinaus.",
-          "sentence_translation": "Среди хлопающих штандартов Эдгар поправляет шлем. Я глубоко вдыхаю и выпускаю только слово «дуэль»."
+          "sentence_translation": "Среди хлопающих штандартов Эдгар поправляет шлем. Я глубоко вдыхаю и выпускаю только слово «дуэль».",
+          "sentence_parts": [
+            "Zwischen flatternden Feldzeichen richtet Edgar den Helm.",
+            "Ich atme tief ein und lasse nur das Wort „das Duell“ wieder hinaus."
+          ]
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
           "sentence": "Am Lagerfeuer der Franzosen zeichnet Edgar Marschrouten in den Sand. Ich presse das Wort „die Rache“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "У французского костра Эдгар рисует в песке путь марша. Я стискиваю слово «месть» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "У французского костра Эдгар рисует в песке путь марша. Я стискиваю слово «месть» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Am Lagerfeuer der Franzosen zeichnet Edgar Marschrouten in den Sand.",
+            "Ich presse das Wort „die Rache“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "enthüllen",
           "russian": "разоблачать",
           "transcription": "[энт-ХЮ-лен]",
           "sentence": "Neben verschnürten Versorgungskisten kontrolliert Edgar das Siegel. Ich halte das Wort „enthüllen“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У перевязанных провиантных ящиков Эдгар проверяет печати. Я держу слово «разоблачать» как факел у сердца."
+          "sentence_translation": "У перевязанных провиантных ящиков Эдгар проверяет печати. Я держу слово «разоблачать» как факел у сердца.",
+          "sentence_parts": [
+            "Neben verschnürten Versorgungskisten kontrolliert Edgar das Siegel.",
+            "Ich halte das Wort „enthüllen“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "siegen",
           "russian": "побеждать",
           "transcription": "[ЗИ-ген]",
           "sentence": "Vor dem Seidenzelt der Heerführer lauscht Edgar dem dumpfen Meer. Mein Atem zeichnet das Wort „siegen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Перед шёлковым шатром полководцев Эдгар слушает глухой шум моря. Моё дыхание рисует слово «побеждать» в холодном воздухе между нами."
+          "sentence_translation": "Перед шёлковым шатром полководцев Эдгар слушает глухой шум моря. Моё дыхание рисует слово «побеждать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Vor dem Seidenzelt der Heerführer lauscht Edgar dem dumpfen Meer.",
+            "Mein Atem zeichnet das Wort „siegen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Gerechtigkeit",
           "russian": "справедливость",
           "transcription": "[ди ге-РЕХ-тиг-кайт]",
           "sentence": "Auf dem sandigen Trainingsplatz übt Edgar das Ziehen des Schwerts. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Gerechtigkeit“ darf nicht vergehen.",
-          "sentence_translation": "На песчаном плацу Эдгар отрабатывает выхват меча. Я шепчу стражам судьбы: слово «справедливость» не должно исчезнуть."
+          "sentence_translation": "На песчаном плацу Эдгар отрабатывает выхват меча. Я шепчу стражам судьбы: слово «справедливость» не должно исчезнуть.",
+          "sentence_parts": [
+            "Auf dem sandigen Trainingsplatz übt Edgar das Ziehen des Schwerts.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Gerechtigkeit“ darf nicht vergehen."
+          ]
         },
         {
           "german": "das Schwert",
           "russian": "меч",
           "transcription": "[дас ШВЕРТ]",
           "sentence": "Zwischen pochenden Trommeln hebt Edgar das Banner der Hoffnung. Ich zeichne das Wort „das Schwert“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Под гул барабанов Эдгар поднимает знамя надежды. Я вывожу слово «меч» невидимыми чернилами на ладони."
+          "sentence_translation": "Под гул барабанов Эдгар поднимает знамя надежды. Я вывожу слово «меч» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Zwischen pochenden Trommeln hebt Edgar das Banner der Hoffnung.",
+            "Ich zeichne das Wort „das Schwert“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "der Bruder",
           "russian": "брат",
           "transcription": "[дер БРУ-дер]",
           "sentence": "Am Morgennebel der Küste legt Edgar die Hand auf das pochende Herz. Wie ein stilles Gebet legt sich das Wort „der Bruder“ auf meine Lippen.",
-          "sentence_translation": "В утреннем тумане побережья Эдгар кладёт ладонь на бьющееся сердце. Как тихая молитва слово «брат» ложится на мои губы."
+          "sentence_translation": "В утреннем тумане побережья Эдгар кладёт ладонь на бьющееся сердце. Как тихая молитва слово «брат» ложится на мои губы.",
+          "sentence_parts": [
+            "Am Morgennebel der Küste legt Edgar die Hand auf das pochende Herz.",
+            "Wie ein stilles Gebet legt sich das Wort „der Bruder“ auf meine Lippen."
+          ]
         }
       ],
       "quizzes": [
@@ -579,56 +773,88 @@
           "russian": "выживать",
           "transcription": "[ю-бер-ЛЕ-бен]",
           "sentence": "Im feuchten Kerker stützt Edgar sich an den tropfenden Stein. Ich halte das Wort „überleben“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "В сыром подземелье Эдгар опирается на сочащийся камень. Я держу слово «выживать» как факел у сердца."
+          "sentence_translation": "В сыром подземелье Эдгар опирается на сочащийся камень. Я держу слово «выживать» как факел у сердца.",
+          "sentence_parts": [
+            "Im feuchten Kerker stützt Edgar sich an den tropfenden Stein.",
+            "Ich halte das Wort „überleben“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "erben",
           "russian": "наследовать",
           "transcription": "[ЭР-бен]",
           "sentence": "Unter der trüben Laterne zählt Edgar die eisernen Ringe der Kette. Mit fester Stimme schwöre ich mir: Das Wort „erben“ wird heute nicht verraten.",
-          "sentence_translation": "Под мутным фонарём Эдгар пересчитывает железные кольца цепи. Твёрдым голосом я клянусь себе: слово «наследовать» сегодня не будет предано."
+          "sentence_translation": "Под мутным фонарём Эдгар пересчитывает железные кольца цепи. Твёрдым голосом я клянусь себе: слово «наследовать» сегодня не будет предано.",
+          "sentence_parts": [
+            "Unter der trüben Laterne zählt Edgar die eisernen Ringe der Kette.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „erben“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "die Zukunft",
           "russian": "будущее",
           "transcription": "[ди ЦУ-кунфт]",
           "sentence": "Neben der schweren Holztür horcht Edgar auf entferntes Schluchzen. Das Echo des Wortes „die Zukunft“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "У тяжёлой двери Эдгар прислушивается к далёким рыданиям. Эхо слова «будущее» заглушает шёпот придворных."
+          "sentence_translation": "У тяжёлой двери Эдгар прислушивается к далёким рыданиям. Эхо слова «будущее» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Neben der schweren Holztür horcht Edgar auf entferntes Schluchzen.",
+            "Das Echo des Wortes „die Zukunft“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "regieren",
           "russian": "править",
           "transcription": "[ре-ГИ-рен]",
           "sentence": "Auf der kalten Steinbank zieht Edgar den Mantel enger um die Schultern. Ich atme tief ein und lasse nur das Wort „regieren“ wieder hinaus.",
-          "sentence_translation": "На холодной каменной скамье Эдгар плотнее кутается в плащ. Я глубоко вдыхаю и выпускаю только слово «править»."
+          "sentence_translation": "На холодной каменной скамье Эдгар плотнее кутается в плащ. Я глубоко вдыхаю и выпускаю только слово «править».",
+          "sentence_parts": [
+            "Auf der kalten Steinbank zieht Edgar den Mantel enger um die Schultern.",
+            "Ich atme tief ein und lasse nur das Wort „regieren“ wieder hinaus."
+          ]
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
           "sentence": "Zwischen Schatten der Gitterstäbe hebt Edgar das Gesicht zum Licht. Ich halte das Wort „die Weisheit“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Между тенями решёток Эдгар поднимает лицо к свету. Я держу слово «мудрость» как факел у сердца."
+          "sentence_translation": "Между тенями решёток Эдгар поднимает лицо к свету. Я держу слово «мудрость» как факел у сердца.",
+          "sentence_parts": [
+            "Zwischen Schatten der Gitterstäbe hebt Edgar das Gesicht zum Licht.",
+            "Ich halte das Wort „die Weisheit“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Ordnung",
           "russian": "порядок",
           "transcription": "[ди ОРД-нунг]",
           "sentence": "Am rostigen Wassereimer spiegelt Edgar kurz die eigenen Augen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ordnung“ bleibt lebendig.",
-          "sentence_translation": "У ржавого ведра с водой Эдгар на мгновение видит отражение глаз. Каждой клеткой тела я обещаю: слово «порядок» останется живым."
+          "sentence_translation": "У ржавого ведра с водой Эдгар на мгновение видит отражение глаз. Каждой клеткой тела я обещаю: слово «порядок» останется живым.",
+          "sentence_parts": [
+            "Am rostigen Wassereimer spiegelt Edgar kurz die eigenen Augen.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ordnung“ bleibt lebendig."
+          ]
         },
         {
           "german": "die Verantwortung",
           "russian": "ответственность",
           "transcription": "[ди фер-АНТ-вор-тунг]",
           "sentence": "Im dumpfen Hall der Schritte zählt Edgar den Rhythmus der Wachen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Verantwortung“ darf nicht vergehen.",
-          "sentence_translation": "В глухом эхе шагов Эдгар отсчитывает ритм часовых. Я шепчу стражам судьбы: слово «ответственность» не должно исчезнуть."
+          "sentence_translation": "В глухом эхе шагов Эдгар отсчитывает ритм часовых. Я шепчу стражам судьбы: слово «ответственность» не должно исчезнуть.",
+          "sentence_parts": [
+            "Im dumpfen Hall der Schritte zählt Edgar den Rhythmus der Wachen.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Verantwortung“ darf nicht vergehen."
+          ]
         },
         {
           "german": "neu",
           "russian": "новый",
           "transcription": "[НОЙ]",
           "sentence": "Vor dem verriegelten Fenster zeichnet Edgar Kreise in den Staub. Mit fester Stimme schwöre ich mir: Das Wort „neu“ wird heute nicht verraten.",
-          "sentence_translation": "Перед заколоченным окном Эдгар чертит круги в пыли. Твёрдым голосом я клянусь себе: слово «новый» сегодня не будет предано."
+          "sentence_translation": "Перед заколоченным окном Эдгар чертит круги в пыли. Твёрдым голосом я клянусь себе: слово «новый» сегодня не будет предано.",
+          "sentence_parts": [
+            "Vor dem verriegelten Fenster zeichnet Edgar Kreise in den Staub.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „neu“ wird heute nicht verraten."
+          ]
         }
       ],
       "quizzes": [

--- a/data/characters/edmund.json
+++ b/data/characters/edmund.json
@@ -21,56 +21,88 @@
           "russian": "бастард",
           "transcription": "[дер БАС-тард]",
           "sentence": "Edmund steht unter dem glühenden Kronleuchter des Thronsaals. Mein Atem zeichnet das Wort „der Bastard“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Эдмунд стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «бастард» в холодном воздухе между нами."
+          "sentence_translation": "Эдмунд стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «бастард» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Edmund steht unter dem glühenden Kronleuchter des Thronsaals.",
+            "Mein Atem zeichnet das Wort „der Bastard“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "der Neid",
           "russian": "зависть",
           "transcription": "[дер НАЙД]",
           "sentence": "Neben der ausgerollten Reichskarte beugt sich Edmund über Lears schweren Tisch. Ich umarme das Wort „der Neid“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "У развернутой карты королевства Эдмунд склоняется над тяжёлым столом Лира. Я обнимаю слово «зависть», будто это единственный союзник."
+          "sentence_translation": "У развернутой карты королевства Эдмунд склоняется над тяжёлым столом Лира. Я обнимаю слово «зависть», будто это единственный союзник.",
+          "sentence_parts": [
+            "Neben der ausgerollten Reichskarte beugt sich Edmund über Lears schweren Tisch.",
+            "Ich umarme das Wort „der Neid“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Ambition",
           "russian": "амбиция",
           "transcription": "[ди ам-би-ЦИ-он]",
           "sentence": "Vor den steinernen Ahnenstatuen verschränkt Edmund die Hände hinter dem Rücken. Das Echo des Wortes „die Ambition“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Перед каменными статуями предков Эдмунд сцепляет руки за спиной. Эхо слова «амбиция» заглушает шёпот придворных."
+          "sentence_translation": "Перед каменными статуями предков Эдмунд сцепляет руки за спиной. Эхо слова «амбиция» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Vor den steinernen Ahnenstatuen verschränkt Edmund die Hände hinter dem Rücken.",
+            "Das Echo des Wortes „die Ambition“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "benachteiligt",
           "russian": "обделённый",
           "transcription": "[бе-НАХ-тай-лигт]",
           "sentence": "Zwischen flüsternden Höflingen gleitet Edmund über den kalten Marmorboden. Ich zeichne das Wort „benachteiligt“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Между шепчущимися придворными Эдмунд скользит по холодному мраморному полу. Я черчу слово «обделённый» в мыслях поверх линий судьбы."
+          "sentence_translation": "Между шепчущимися придворными Эдмунд скользит по холодному мраморному полу. Я черчу слово «обделённый» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Zwischen flüsternden Höflingen gleitet Edmund über den kalten Marmorboden.",
+            "Ich zeichne das Wort „benachteiligt“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
           "sentence": "Am Rand des purpurnen Teppichs wartet Edmund auf ein Zeichen des Königs. Mein Atem zeichnet das Wort „die Rache“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "На краю пурпурного ковра Эдмунд ждёт знака от короля. Моё дыхание рисует слово «месть» в холодном воздухе между нами."
+          "sentence_translation": "На краю пурпурного ковра Эдмунд ждёт знака от короля. Моё дыхание рисует слово «месть» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Am Rand des purpurnen Teppichs wartet Edmund auf ein Zeichen des Königs.",
+            "Mein Atem zeichnet das Wort „die Rache“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "aufsteigen",
           "russian": "возвышаться",
           "transcription": "[АУФ-штай-ген]",
           "sentence": "Unter wehenden Standarten der Schwestern senkt Edmund kurz den Blick. Ich zeichne das Wort „aufsteigen“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Под развевающимися штандартами сестёр Эдмунд на миг опускает взгляд. Я вывожу слово «возвышаться» невидимыми чернилами на ладони."
+          "sentence_translation": "Под развевающимися штандартами сестёр Эдмунд на миг опускает взгляд. Я вывожу слово «возвышаться» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Unter wehenden Standarten der Schwestern senkt Edmund kurz den Blick.",
+            "Ich zeichne das Wort „aufsteigen“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "unehelich",
           "russian": "внебрачный",
           "transcription": "[УН-э-е-лих]",
           "sentence": "Hinter der vergoldeten Balustrade beobachtet Edmund das gespannte Antlitz des Hofes. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unehelich“ gehört mir.",
-          "sentence_translation": "За позолоченной балюстрадой Эдмунд наблюдает за напряжёнными лицами двора. Буря за окнами усиливает клятву: слово «внебрачный» принадлежит мне."
+          "sentence_translation": "За позолоченной балюстрадой Эдмунд наблюдает за напряжёнными лицами двора. Буря за окнами усиливает клятву: слово «внебрачный» принадлежит мне.",
+          "sentence_parts": [
+            "Hinter der vergoldeten Balustrade beobachtet Edmund das gespannte Antlitz des Hofes.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unehelich“ gehört mir."
+          ]
         },
         {
           "german": "die Natur",
           "russian": "природа",
           "transcription": "[ди на-ТУР]",
           "sentence": "Im Schein der offenen Feuerbecken erhebt Edmund langsam die Stimme. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Natur“ darf nicht vergehen.",
-          "sentence_translation": "В отблесках открытых жаровен Эдмунд медленно поднимает голос. Я шепчу стражам судьбы: слово «природа» не должно исчезнуть."
+          "sentence_translation": "В отблесках открытых жаровен Эдмунд медленно поднимает голос. Я шепчу стражам судьбы: слово «природа» не должно исчезнуть.",
+          "sentence_parts": [
+            "Im Schein der offenen Feuerbecken erhebt Edmund langsam die Stimme.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Natur“ darf nicht vergehen."
+          ]
         }
       ],
       "quizzes": [
@@ -114,56 +146,89 @@
           "russian": "подделывать",
           "transcription": "[ФЕЛЬ-шен]",
           "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Edmund zwischen gepackten Kisten. Mit fester Stimme schwöre ich mir: Das Wort „fälschen“ wird heute nicht verraten.",
-          "sentence_translation": "В гулком проёме ворот замка Гонерильи Эдмунд замирает среди нагруженных ящиков. Твёрдым голосом я клянусь себе: слово «подделывать» сегодня не будет предано."
+          "sentence_translation": "В гулком проёме ворот замка Гонерильи Эдмунд замирает среди нагруженных ящиков. Твёрдым голосом я клянусь себе: слово «подделывать» сегодня не будет предано.",
+          "sentence_parts": [
+            "Im hallenden Torbogen von Gonerils Burg verharrt Edmund zwischen gepackten Kisten.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „fälschen“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "intrigieren",
           "russian": "интриговать",
           "transcription": "[ин-три-ГИ-рен]",
           "sentence": "Auf der windigen Freitreppe blickt Edmund zum schweigenden Hof hinunter. Ich zeichne das Wort „intrigieren“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "На продуваемой ветром лестнице Эдмунд смотрит вниз на молчаливый двор. Я вывожу слово «интриговать» невидимыми чернилами на ладони."
+          "sentence_translation": "На продуваемой ветром лестнице Эдмунд смотрит вниз на молчаливый двор. Я вывожу слово «интриговать» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Auf der windigen Freitreppe blickt Edmund zum schweigenden Hof hinunter.",
+            "Ich zeichne das Wort „intrigieren“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "beschuldigen",
           "russian": "обвинять",
           "transcription": "[бе-ШУЛЬ-ди-ген]",
           "sentence": "Zwischen zurückgelassenen Dienern schließt Edmund den Reisemantel enger. Ich flüstere den Wächtern des Schicksals zu: Das Wort „beschuldigen“ darf nicht vergehen.",
-          "sentence_translation": "Среди оставленных слуг Эдмунд плотнее запахивает дорожный плащ. Я шепчу стражам судьбы: слово «обвинять» не должно исчезнуть."
+          "sentence_translation": "Среди оставленных слуг Эдмунд плотнее запахивает дорожный плащ. Я шепчу стражам судьбы: слово «обвинять» не должно исчезнуть.",
+          "sentence_parts": [
+            "Zwischen zurückgelassenen Dienern schließt Edmund den Reisemantel enger.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „beschuldigen“ darf nicht vergehen."
+          ]
         },
         {
           "german": "der Plan",
           "russian": "план",
           "transcription": "[дер ПЛАН]",
           "sentence": "Am dunklen Pferdestall streicht Edmund einem nervösen Tier über die Mähne. Ich presse das Wort „der Plan“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "У тёмного конюшенного ряда Эдмунд гладит гриву нервного коня. Я стискиваю слово «план» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "У тёмного конюшенного ряда Эдмунд гладит гриву нервного коня. Я стискиваю слово «план» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Am dunklen Pferdestall streicht Edmund einem nervösen Tier über die Mähne.",
+            "Ich presse das Wort „der Plan“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "manipulieren",
           "russian": "манипулировать",
           "transcription": "[ма-ни-пу-ЛИ-рен]",
           "sentence": "Vor dem knarrenden Fallgatter tastet Edmund ein letztes Mal nach dem Haustor. Mit fester Stimme schwöre ich mir: Das Wort „manipulieren“ wird heute nicht verraten.",
-          "sentence_translation": "Перед скрипящим подъёмным мостом Эдмунд в последний раз касается родной двери. Твёрдым голосом я клянусь себе: слово «манипулировать» сегодня не будет предано."
+          "sentence_translation": "Перед скрипящим подъёмным мостом Эдмунд в последний раз касается родной двери. Твёрдым голосом я клянусь себе: слово «манипулировать» сегодня не будет предано.",
+          "sentence_parts": [
+            "Vor dem knarrenden Fallgatter tastet Edmund ein letztes Mal nach dem Haustor.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „manipulieren“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "der Brief",
           "russian": "письмо",
           "transcription": "[дер БРИФ]",
           "sentence": "Zwischen verstreuten Schriftrollen dreht Edmund den Ring an der Hand. Ich umarme das Wort „der Brief“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Среди разбросанных свитков Эдмунд вертит кольцо на пальце. Я обнимаю слово «письмо», будто это единственный союзник."
+          "sentence_translation": "Среди разбросанных свитков Эдмунд вертит кольцо на пальце. Я обнимаю слово «письмо», будто это единственный союзник.",
+          "sentence_parts": [
+            "Zwischen verstreuten Schriftrollen dreht Edmund den Ring an der Hand.",
+            "Ich umarme das Wort „der Brief“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "lügen",
           "russian": "лгать",
           "transcription": "[ЛЮ-ген]",
           "sentence": "Am leeren Bankettisch zählt Edmund die verlöschenden Kerzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „lügen“ bleibt lebendig.",
-          "sentence_translation": "У пустого банкетного стола Эдмунд пересчитывает гаснущие свечи. Каждой клеткой тела я обещаю: слово «лгать» останется живым."
+          "sentence_translation": "У пустого банкетного стола Эдмунд пересчитывает гаснущие свечи. Каждой клеткой тела я обещаю: слово «лгать» останется живым.",
+          "sentence_parts": [
+            "Am leeren Bankettisch zählt Edmund die verlöschenden Kerzen.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „lügen“ bleibt lebendig."
+          ]
         },
         {
           "german": "die Täuschung",
           "russian": "обман",
           "transcription": "[ди ТОЙ-шунг]",
           "sentence": "Zwischen schweigenden Wachen geht Edmund auf den kalten Hof hinaus. Das Echo des Wortes „die Täuschung“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Между молчаливыми стражниками Эдмунд выходит на холодный двор. Эхо слова «обман» заглушает шёпот придворных."
+          "sentence_translation": "Между молчаливыми стражниками Эдмунд выходит на холодный двор. Эхо слова «обман» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Zwischen schweigenden Wachen geht Edmund auf den kalten Hof hinaus.",
+            "Das Echo des Wortes „die Täuschung“ übertönt das Flüstern der Höflinge."
+          ]
         }
       ],
       "quizzes": [
@@ -207,56 +272,88 @@
           "russian": "изгонять",
           "transcription": "[фер-ТРАЙ-бен]",
           "sentence": "Im zugigen Seitenflügel lauscht Edmund dem Heulen der Küstenwinde. Das Echo des Wortes „vertreiben“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "В продуваемом ветром боковом крыле Эдмунд слушает вой прибрежного ветра. Эхо слова «изгонять» заглушает шёпот придворных."
+          "sentence_translation": "В продуваемом ветром боковом крыле Эдмунд слушает вой прибрежного ветра. Эхо слова «изгонять» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Im zugigen Seitenflügel lauscht Edmund dem Heulen der Küstenwinde.",
+            "Das Echo des Wortes „vertreiben“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "triumphieren",
           "russian": "торжествовать",
           "transcription": "[три-ум-ФИ-рен]",
           "sentence": "Vor dem rauchigen Kamin der Burg faltet Edmund einen zerknitterten Brief. Ich halte das Wort „triumphieren“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Перед дымным камином замка Эдмунд складывает измятый лист. Я держу слово «торжествовать» как факел у сердца."
+          "sentence_translation": "Перед дымным камином замка Эдмунд складывает измятый лист. Я держу слово «торжествовать» как факел у сердца.",
+          "sentence_parts": [
+            "Vor dem rauchigen Kamin der Burg faltet Edmund einen zerknitterten Brief.",
+            "Ich halte das Wort „triumphieren“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "erben",
           "russian": "наследовать",
           "transcription": "[ЭР-бен]",
           "sentence": "Unter farblosen Wandteppichen schreitet Edmund rastlos auf und ab. Ich zeichne das Wort „erben“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Под выцветшими гобеленами Эдмунд беспокойно меряет шагами зал. Я черчу слово «наследовать» в мыслях поверх линий судьбы."
+          "sentence_translation": "Под выцветшими гобеленами Эдмунд беспокойно меряет шагами зал. Я черчу слово «наследовать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Unter farblosen Wandteppichen schreitet Edmund rastlos auf und ab.",
+            "Ich zeichne das Wort „erben“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "der Erfolg",
           "russian": "успех",
           "transcription": "[дер эр-ФОЛЬГ]",
           "sentence": "An der schmalen Fensterluke zählt Edmund die Fackeln auf dem Hof. Wie ein stilles Gebet legt sich das Wort „der Erfolg“ auf meine Lippen.",
-          "sentence_translation": "У узкой бойницы Эдмунд считает факелы на дворе. Как тихая молитва слово «успех» ложится на мои губы."
+          "sentence_translation": "У узкой бойницы Эдмунд считает факелы на дворе. Как тихая молитва слово «успех» ложится на мои губы.",
+          "sentence_parts": [
+            "An der schmalen Fensterluke zählt Edmund die Fackeln auf dem Hof.",
+            "Wie ein stilles Gebet legt sich das Wort „der Erfolg“ auf meine Lippen."
+          ]
         },
         {
           "german": "gewinnen",
           "russian": "выигрывать",
           "transcription": "[ге-ВИН-нен]",
           "sentence": "Zwischen Reisekoffern der Gesandten sucht Edmund nach frischen Botschaften. Ich umarme das Wort „gewinnen“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Среди дорожных сундуков послов Эдмунд ищет свежие вести. Я обнимаю слово «выигрывать», будто это единственный союзник."
+          "sentence_translation": "Среди дорожных сундуков послов Эдмунд ищет свежие вести. Я обнимаю слово «выигрывать», будто это единственный союзник.",
+          "sentence_parts": [
+            "Zwischen Reisekoffern der Gesandten sucht Edmund nach frischen Botschaften.",
+            "Ich umarme das Wort „gewinnen“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Belohnung",
           "russian": "награда",
           "transcription": "[ди бе-ЛО-нунг]",
           "sentence": "Im stillen Kapellenraum kniet Edmund vor der kalten Steinfigur. Ich zeichne das Wort „die Belohnung“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "В тихой капелле Эдмунд преклоняет колени перед холодной каменной фигурой. Я вывожу слово «награда» невидимыми чернилами на ладони."
+          "sentence_translation": "В тихой капелле Эдмунд преклоняет колени перед холодной каменной фигурой. Я вывожу слово «награда» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Im stillen Kapellenraum kniet Edmund vor der kalten Steinfigur.",
+            "Ich zeichne das Wort „die Belohnung“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "verdrängen",
           "russian": "вытеснять",
           "transcription": "[фер-ДРЕН-ген]",
           "sentence": "Auf dem Balkon, den das Meer besprüht, hält Edmund die Laterne fest. Das kalte Licht lässt das Wort „verdrängen“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "На балконе, омываемом морскими брызгами, Эдмунд крепко держит фонарь. Холодный свет заставляет слово «вытеснять» сиять словно расплавленное золото."
+          "sentence_translation": "На балконе, омываемом морскими брызгами, Эдмунд крепко держит фонарь. Холодный свет заставляет слово «вытеснять» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Auf dem Balkon, den das Meer besprüht, hält Edmund die Laterne fest.",
+            "Das kalte Licht lässt das Wort „verdrängen“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "der Sieg",
           "russian": "победа",
           "transcription": "[дер ЗИГ]",
           "sentence": "Im Schatten der hohen Burgmauern schreibt Edmund eine fiebrige Antwort. Ich zeichne das Wort „der Sieg“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "В тени высоких стен Эдмунд пишет лихорадочный ответ. Я вывожу слово «победа» невидимыми чернилами на ладони."
+          "sentence_translation": "В тени высоких стен Эдмунд пишет лихорадочный ответ. Я вывожу слово «победа» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Im Schatten der hohen Burgmauern schreibt Edmund eine fiebrige Antwort.",
+            "Ich zeichne das Wort „der Sieg“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         }
       ],
       "quizzes": [
@@ -300,56 +397,89 @@
           "russian": "объединяться",
           "transcription": "[фер-БЮН-ден]",
           "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edmund gegen den Wind. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbünden“ gehört mir.",
-          "sentence_translation": "Посреди хлещущей дождём пустоши Эдмунд упирается в ветер. Буря за окнами усиливает клятву: слово «объединяться» принадлежит мне."
+          "sentence_translation": "Посреди хлещущей дождём пустоши Эдмунд упирается в ветер. Буря за окнами усиливает клятву: слово «объединяться» принадлежит мне.",
+          "sentence_parts": [
+            "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edmund gegen den Wind.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbünden“ gehört mir."
+          ]
         },
         {
           "german": "die Macht",
           "russian": "власть",
           "transcription": "[ди МАХТ]",
           "sentence": "Unter einem zerrissenen Banner schützt Edmund die Augen vor den Blitzen. Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Под разорванным знаменем Эдмунд прикрывает глаза от молний. Я обнимаю слово «власть», будто это единственный союзник."
+          "sentence_translation": "Под разорванным знаменем Эдмунд прикрывает глаза от молний. Я обнимаю слово «власть», будто это единственный союзник.",
+          "sentence_parts": [
+            "Unter einem zerrissenen Banner schützt Edmund die Augen vor den Blitzen.",
+            "Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "erobern",
           "russian": "завоёвывать",
           "transcription": "[эр-О-берн]",
           "sentence": "Am Rand eines umgestürzten Baumes sucht Edmund Deckung vor dem Donner. Das kalte Licht lässt das Wort „erobern“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "У поваленного дерева Эдмунд ищет укрытия от грома. Холодный свет заставляет слово «завоёвывать» сиять словно расплавленное золото."
+          "sentence_translation": "У поваленного дерева Эдмунд ищет укрытия от грома. Холодный свет заставляет слово «завоёвывать» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Am Rand eines umgestürzten Baumes sucht Edmund Deckung vor dem Donner.",
+            "Das kalte Licht lässt das Wort „erobern“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "das Bündnis",
           "russian": "союз",
           "transcription": "[дас БЮНД-нис]",
           "sentence": "Zwischen schäumenden Wassergräben stolpert Edmund durch den Schlamm. Das kalte Licht lässt das Wort „das Bündnis“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Между пенящимися лужами Эдмунд пробирается через грязь. Холодный свет заставляет слово «союз» сиять словно расплавленное золото."
+          "sentence_translation": "Между пенящимися лужами Эдмунд пробирается через грязь. Холодный свет заставляет слово «союз» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Zwischen schäumenden Wassergräben stolpert Edmund durch den Schlamm.",
+            "Das kalte Licht lässt das Wort „das Bündnis“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "verführen",
           "russian": "соблазнять",
           "transcription": "[фер-ФЮ-рен]",
           "sentence": "Vor einem zuckenden Himmel hebt Edmund die Arme trotzig an. Ich umarme das Wort „verführen“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "На фоне вспыхивающего неба Эдмунд упрямо поднимает руки. Я обнимаю слово «соблазнять», будто это единственный союзник."
+          "sentence_translation": "На фоне вспыхивающего неба Эдмунд упрямо поднимает руки. Я обнимаю слово «соблазнять», будто это единственный союзник.",
+          "sentence_parts": [
+            "Vor einem zuckenden Himmel hebt Edmund die Arme trotzig an.",
+            "Ich umarme das Wort „verführen“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Eroberung",
           "russian": "завоевание",
           "transcription": "[ди эр-О-бе-рунг]",
           "sentence": "Unter dem durchtränkten Umhang presst Edmund den Atem gegen die Kälte. Ich halte das Wort „die Eroberung“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Под промокшим плащом Эдмунд прижимает дыхание к груди, спасаясь от холода. Я держу слово «завоевание» как факел у сердца."
+          "sentence_translation": "Под промокшим плащом Эдмунд прижимает дыхание к груди, спасаясь от холода. Я держу слово «завоевание» как факел у сердца.",
+          "sentence_parts": [
+            "Unter dem durchtränkten Umhang presst Edmund den Atem gegen die Kälte.",
+            "Ich halte das Wort „die Eroberung“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "beherrschen",
           "russian": "господствовать",
           "transcription": "[бе-ХЕР-шен]",
           "sentence": "Am kläglichen Feuerrest wärmt Edmund zitternde Finger. Ich presse das Wort „beherrschen“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "У жалких огненных углей Эдмунд греет дрожащие пальцы. Я стискиваю слово «господствовать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "У жалких огненных углей Эдмунд греет дрожащие пальцы. Я стискиваю слово «господствовать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Am kläglichen Feuerrest wärmt Edmund zitternde Finger.",
+            "Ich presse das Wort „beherrschen“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Allianz",
           "russian": "альянс",
           "transcription": "[ди а-ли-АНЦС]",
           "sentence": "Zwischen heulenden Hunden ruft Edmund gegen den tosenden Sturm an. Ich presse das Wort „die Allianz“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Среди воющих псов Эдмунд перекрикивает беснующуюся бурю. Я стискиваю слово «альянс» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Среди воющих псов Эдмунд перекрикивает беснующуюся бурю. Я стискиваю слово «альянс» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Zwischen heulenden Hunden ruft Edmund gegen den tosenden Sturm an.",
+            "Ich presse das Wort „die Allianz“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         }
       ],
       "quizzes": [
@@ -393,56 +523,88 @@
           "russian": "предавать",
           "transcription": "[фер-РА-тен]",
           "sentence": "Im dunklen Zelt der Feldärzte sitzt Edmund bei der flackernden Kerze. Mein Atem zeichnet das Wort „verraten“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В тёмном шатре полевых лекарей Эдмунд сидит у мерцающей свечи. Моё дыхание рисует слово «предавать» в холодном воздухе между нами."
+          "sentence_translation": "В тёмном шатре полевых лекарей Эдмунд сидит у мерцающей свечи. Моё дыхание рисует слово «предавать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im dunklen Zelt der Feldärzte sitzt Edmund bei der flackernden Kerze.",
+            "Mein Atem zeichnet das Wort „verraten“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "blenden",
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
           "sentence": "Zwischen zerbeulten Rüstungen streicht Edmund über ein altes Wappen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen.",
-          "sentence_translation": "Среди помятых доспехов Эдмунд гладит старый герб. Я шепчу стражам судьбы: слово «ослеплять» не должно исчезнуть."
+          "sentence_translation": "Среди помятых доспехов Эдмунд гладит старый герб. Я шепчу стражам судьбы: слово «ослеплять» не должно исчезнуть.",
+          "sentence_parts": [
+            "Zwischen zerbeulten Rüstungen streicht Edmund über ein altes Wappen.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Grausamkeit",
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
           "sentence": "Am niedrigen Dachbalken der Hütte stößt Edmund fast den Kopf. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Grausamkeit“ gehört mir.",
-          "sentence_translation": "О низкую балку хижины Эдмунд едва не ударяется головой. Буря за окнами усиливает клятву: слово «жестокость» принадлежит мне."
+          "sentence_translation": "О низкую балку хижины Эдмунд едва не ударяется головой. Буря за окнами усиливает клятву: слово «жестокость» принадлежит мне.",
+          "sentence_parts": [
+            "Am niedrigen Dachbalken der Hütte stößt Edmund fast den Kopf.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Grausamkeit“ gehört mir."
+          ]
         },
         {
           "german": "denunzieren",
           "russian": "доносить",
           "transcription": "[де-нун-ЦИ-рен]",
           "sentence": "Neben der schlafenden Wache flüstert Edmund in die schwere Nacht. Ich presse das Wort „denunzieren“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Рядом со спящим стражем Эдмунд шепчет в тяжёлую ночь. Я стискиваю слово «доносить» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Рядом со спящим стражем Эдмунд шепчет в тяжёлую ночь. Я стискиваю слово «доносить» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Neben der schlafenden Wache flüstert Edmund in die schwere Nacht.",
+            "Ich presse das Wort „denunzieren“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "ausliefern",
           "russian": "выдавать",
           "transcription": "[АУС-ли-ферн]",
           "sentence": "Vor dem einfachen Feldbett betrachtet Edmund die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „ausliefern“ wird heute nicht verraten.",
-          "sentence_translation": "Перед грубой походной койкой Эдмунд разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «выдавать» сегодня не будет предано."
+          "sentence_translation": "Перед грубой походной койкой Эдмунд разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «выдавать» сегодня не будет предано.",
+          "sentence_parts": [
+            "Vor dem einfachen Feldbett betrachtet Edmund die Narben vergangener Schlachten.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „ausliefern“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "die Folter",
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
           "sentence": "Im Geruch von feuchtem Stroh legt Edmund den Mantel zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Folter“ bleibt lebendig.",
-          "sentence_translation": "В запахе влажной соломы Эдмунд откладывает плащ в сторону. Каждой клеткой тела я обещаю: слово «пытка» останется живым."
+          "sentence_translation": "В запахе влажной соломы Эдмунд откладывает плащ в сторону. Каждой клеткой тела я обещаю: слово «пытка» останется живым.",
+          "sentence_parts": [
+            "Im Geruch von feuchtem Stroh legt Edmund den Mantel zur Seite.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Folter“ bleibt lebendig."
+          ]
         },
         {
           "german": "opfern",
           "russian": "жертвовать",
           "transcription": "[ОП-ферн]",
           "sentence": "Auf dem wackligen Holztisch ordnet Edmund zerlesene Briefe. Das kalte Licht lässt das Wort „opfern“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "На шатком деревянном столе Эдмунд раскладывает зачитанные письма. Холодный свет заставляет слово «жертвовать» сиять словно расплавленное золото."
+          "sentence_translation": "На шатком деревянном столе Эдмунд раскладывает зачитанные письма. Холодный свет заставляет слово «жертвовать» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Auf dem wackligen Holztisch ordnet Edmund zerlesene Briefe.",
+            "Das kalte Licht lässt das Wort „opfern“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "erbarmungslos",
           "russian": "беспощадный",
           "transcription": "[эр-БАР-мунгс-лос]",
           "sentence": "Am Eingang der Hütte späht Edmund nach einem vertrauten Schatten. Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "У входа в хижину Эдмунд высматривает знакомую тень. Я стискиваю слово «беспощадный» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "У входа в хижину Эдмунд высматривает знакомую тень. Я стискиваю слово «беспощадный» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Am Eingang der Hütte späht Edmund nach einem vertrauten Schatten.",
+            "Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         }
       ],
       "quizzes": [
@@ -486,56 +648,89 @@
           "russian": "любовная связь",
           "transcription": "[ди ЛИБ-шафт]",
           "sentence": "Auf den weißen Klippen von Dover blickt Edmund in den aufgewühlten Kanal. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Liebschaft“ gehört mir.",
-          "sentence_translation": "На белых скалах Дувра Эдмунд смотрит в вздыбленный пролив. Буря за окнами усиливает клятву: слово «любовная связь» принадлежит мне."
+          "sentence_translation": "На белых скалах Дувра Эдмунд смотрит в вздыбленный пролив. Буря за окнами усиливает клятву: слово «любовная связь» принадлежит мне.",
+          "sentence_parts": [
+            "Auf den weißen Klippen von Dover blickt Edmund in den aufgewühlten Kanal.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Liebschaft“ gehört mir."
+          ]
         },
         {
           "german": "die Rivalität",
           "russian": "соперничество",
           "transcription": "[ди ри-ва-ли-ТЕТ]",
           "sentence": "Zwischen flatternden Feldzeichen richtet Edmund den Helm. Ich halte das Wort „die Rivalität“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Среди хлопающих штандартов Эдмунд поправляет шлем. Я держу слово «соперничество» как факел у сердца."
+          "sentence_translation": "Среди хлопающих штандартов Эдмунд поправляет шлем. Я держу слово «соперничество» как факел у сердца.",
+          "sentence_parts": [
+            "Zwischen flatternden Feldzeichen richtet Edmund den Helm.",
+            "Ich halte das Wort „die Rivalität“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "spielen",
           "russian": "играть",
           "transcription": "[ШПИ-лен]",
           "sentence": "Am Lagerfeuer der Franzosen zeichnet Edmund Marschrouten in den Sand. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „spielen“ gehört mir.",
-          "sentence_translation": "У французского костра Эдмунд рисует в песке путь марша. Буря за окнами усиливает клятву: слово «играть» принадлежит мне."
+          "sentence_translation": "У французского костра Эдмунд рисует в песке путь марша. Буря за окнами усиливает клятву: слово «играть» принадлежит мне.",
+          "sentence_parts": [
+            "Am Lagerfeuer der Franzosen zeichnet Edmund Marschrouten in den Sand.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „spielen“ gehört mir."
+          ]
         },
         {
           "german": "verlocken",
           "russian": "завлекать",
           "transcription": "[фер-ЛО-кен]",
           "sentence": "Neben verschnürten Versorgungskisten kontrolliert Edmund das Siegel. Ich flüstere den Wächtern des Schicksals zu: Das Wort „verlocken“ darf nicht vergehen.",
-          "sentence_translation": "У перевязанных провиантных ящиков Эдмунд проверяет печати. Я шепчу стражам судьбы: слово «завлекать» не должно исчезнуть."
+          "sentence_translation": "У перевязанных провиантных ящиков Эдмунд проверяет печати. Я шепчу стражам судьбы: слово «завлекать» не должно исчезнуть.",
+          "sentence_parts": [
+            "Neben verschnürten Versorgungskisten kontrolliert Edmund das Siegel.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „verlocken“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Lust",
           "russian": "похоть",
           "transcription": "[ди ЛУСТ]",
           "sentence": "Vor dem Seidenzelt der Heerführer lauscht Edmund dem dumpfen Meer. Ich presse das Wort „die Lust“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Перед шёлковым шатром полководцев Эдмунд слушает глухой шум моря. Я стискиваю слово «похоть» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Перед шёлковым шатром полководцев Эдмунд слушает глухой шум моря. Я стискиваю слово «похоть» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Vor dem Seidenzelt der Heerführer lauscht Edmund dem dumpfen Meer.",
+            "Ich presse das Wort „die Lust“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "ausnutzen",
           "russian": "использовать",
           "transcription": "[АУС-нут-цен]",
           "sentence": "Auf dem sandigen Trainingsplatz übt Edmund das Ziehen des Schwerts. Ich atme tief ein und lasse nur das Wort „ausnutzen“ wieder hinaus.",
-          "sentence_translation": "На песчаном плацу Эдмунд отрабатывает выхват меча. Я глубоко вдыхаю и выпускаю только слово «использовать»."
+          "sentence_translation": "На песчаном плацу Эдмунд отрабатывает выхват меча. Я глубоко вдыхаю и выпускаю только слово «использовать».",
+          "sentence_parts": [
+            "Auf dem sandigen Trainingsplatz übt Edmund das Ziehen des Schwerts.",
+            "Ich atme tief ein und lasse nur das Wort „ausnutzen“ wieder hinaus."
+          ]
         },
         {
           "german": "jonglieren",
           "russian": "жонглировать",
           "transcription": "[жон-ГЛИ-рен]",
           "sentence": "Zwischen pochenden Trommeln hebt Edmund das Banner der Hoffnung. Das kalte Licht lässt das Wort „jonglieren“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Под гул барабанов Эдмунд поднимает знамя надежды. Холодный свет заставляет слово «жонглировать» сиять словно расплавленное золото."
+          "sentence_translation": "Под гул барабанов Эдмунд поднимает знамя надежды. Холодный свет заставляет слово «жонглировать» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Zwischen pochenden Trommeln hebt Edmund das Banner der Hoffnung.",
+            "Das kalte Licht lässt das Wort „jonglieren“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "die Affäre",
           "russian": "интрига",
           "transcription": "[ди а-ФЕ-ре]",
           "sentence": "Am Morgennebel der Küste legt Edmund die Hand auf das pochende Herz. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Affäre“ darf nicht vergehen.",
-          "sentence_translation": "В утреннем тумане побережья Эдмунд кладёт ладонь на бьющееся сердце. Я шепчу стражам судьбы: слово «интрига» не должно исчезнуть."
+          "sentence_translation": "В утреннем тумане побережья Эдмунд кладёт ладонь на бьющееся сердце. Я шепчу стражам судьбы: слово «интрига» не должно исчезнуть.",
+          "sentence_parts": [
+            "Am Morgennebel der Küste legt Edmund die Hand auf das pochende Herz.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Affäre“ darf nicht vergehen."
+          ]
         }
       ],
       "quizzes": [
@@ -579,56 +774,88 @@
           "russian": "дуэль",
           "transcription": "[дас ду-ЭЛЬ]",
           "sentence": "Im feuchten Kerker stützt Edmund sich an den tropfenden Stein. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Duell“ gehört mir.",
-          "sentence_translation": "В сыром подземелье Эдмунд опирается на сочащийся камень. Буря за окнами усиливает клятву: слово «дуэль» принадлежит мне."
+          "sentence_translation": "В сыром подземелье Эдмунд опирается на сочащийся камень. Буря за окнами усиливает клятву: слово «дуэль» принадлежит мне.",
+          "sentence_parts": [
+            "Im feuchten Kerker stützt Edmund sich an den tropfenden Stein.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Duell“ gehört mir."
+          ]
         },
         {
           "german": "fallen",
           "russian": "падать",
           "transcription": "[ФАЛ-лен]",
           "sentence": "Unter der trüben Laterne zählt Edmund die eisernen Ringe der Kette. Ich zeichne das Wort „fallen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Под мутным фонарём Эдмунд пересчитывает железные кольца цепи. Я черчу слово «падать» в мыслях поверх линий судьбы."
+          "sentence_translation": "Под мутным фонарём Эдмунд пересчитывает железные кольца цепи. Я черчу слово «падать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Unter der trüben Laterne zählt Edmund die eisernen Ringe der Kette.",
+            "Ich zeichne das Wort „fallen“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
           "sentence": "Neben der schweren Holztür horcht Edmund auf entferntes Schluchzen. Das Echo des Wortes „bereuen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "У тяжёлой двери Эдмунд прислушивается к далёким рыданиям. Эхо слова «сожалеть» заглушает шёпот придворных."
+          "sentence_translation": "У тяжёлой двери Эдмунд прислушивается к далёким рыданиям. Эхо слова «сожалеть» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Neben der schweren Holztür horcht Edmund auf entferntes Schluchzen.",
+            "Das Echo des Wortes „bereuen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Niederlage",
           "russian": "поражение",
           "transcription": "[ди НИ-дер-ла-ге]",
           "sentence": "Auf der kalten Steinbank zieht Edmund den Mantel enger um die Schultern. Ich zeichne das Wort „die Niederlage“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "На холодной каменной скамье Эдмунд плотнее кутается в плащ. Я черчу слово «поражение» в мыслях поверх линий судьбы."
+          "sentence_translation": "На холодной каменной скамье Эдмунд плотнее кутается в плащ. Я черчу слово «поражение» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Auf der kalten Steinbank zieht Edmund den Mantel enger um die Schultern.",
+            "Ich zeichne das Wort „die Niederlage“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "verlieren",
           "russian": "проигрывать",
           "transcription": "[фер-ЛИ-рен]",
           "sentence": "Zwischen Schatten der Gitterstäbe hebt Edmund das Gesicht zum Licht. Mit fester Stimme schwöre ich mir: Das Wort „verlieren“ wird heute nicht verraten.",
-          "sentence_translation": "Между тенями решёток Эдмунд поднимает лицо к свету. Твёрдым голосом я клянусь себе: слово «проигрывать» сегодня не будет предано."
+          "sentence_translation": "Между тенями решёток Эдмунд поднимает лицо к свету. Твёрдым голосом я клянусь себе: слово «проигрывать» сегодня не будет предано.",
+          "sentence_parts": [
+            "Zwischen Schatten der Gitterstäbe hebt Edmund das Gesicht zum Licht.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „verlieren“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "der Untergang",
           "russian": "падение",
           "transcription": "[дер УН-тер-ганг]",
           "sentence": "Am rostigen Wassereimer spiegelt Edmund kurz die eigenen Augen. Ich halte das Wort „der Untergang“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У ржавого ведра с водой Эдмунд на мгновение видит отражение глаз. Я держу слово «падение» как факел у сердца."
+          "sentence_translation": "У ржавого ведра с водой Эдмунд на мгновение видит отражение глаз. Я держу слово «падение» как факел у сердца.",
+          "sentence_parts": [
+            "Am rostigen Wassereimer spiegelt Edmund kurz die eigenen Augen.",
+            "Ich halte das Wort „der Untergang“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "gestehen",
           "russian": "признаваться",
           "transcription": "[ге-ШТЕ-ен]",
           "sentence": "Im dumpfen Hall der Schritte zählt Edmund den Rhythmus der Wachen. Das Echo des Wortes „gestehen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "В глухом эхе шагов Эдмунд отсчитывает ритм часовых. Эхо слова «признаваться» заглушает шёпот придворных."
+          "sentence_translation": "В глухом эхе шагов Эдмунд отсчитывает ритм часовых. Эхо слова «признаваться» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Im dumpfen Hall der Schritte zählt Edmund den Rhythmus der Wachen.",
+            "Das Echo des Wortes „gestehen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЭН-де]",
           "sentence": "Vor dem verriegelten Fenster zeichnet Edmund Kreise in den Staub. Ich atme tief ein und lasse nur das Wort „das Ende“ wieder hinaus.",
-          "sentence_translation": "Перед заколоченным окном Эдмунд чертит круги в пыли. Я глубоко вдыхаю и выпускаю только слово «конец»."
+          "sentence_translation": "Перед заколоченным окном Эдмунд чертит круги в пыли. Я глубоко вдыхаю и выпускаю только слово «конец».",
+          "sentence_parts": [
+            "Vor dem verriegelten Fenster zeichnet Edmund Kreise in den Staub.",
+            "Ich atme tief ein und lasse nur das Wort „das Ende“ wieder hinaus."
+          ]
         }
       ],
       "quizzes": [

--- a/data/characters/fool.json
+++ b/data/characters/fool.json
@@ -15,56 +15,89 @@
           "russian": "шут",
           "transcription": "[дер НАР]",
           "sentence": "Im grellen Licht des Thronsaals schlägt Fool die Laute an. Ich presse das Wort „der Narr“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "В ярком свете тронного зала Шут ударяет по струнам лютни. Я стискиваю слово «шут» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "В ярком свете тронного зала Шут ударяет по струнам лютни. Я стискиваю слово «шут» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Im grellen Licht des Thronsaals schlägt Fool die Laute an.",
+            "Ich presse das Wort „der Narr“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
           "sentence": "Neben Lears Krone balanciert Fool auf einem Fuß. Ich atme tief ein und lasse nur das Wort „die Weisheit“ wieder hinaus.",
-          "sentence_translation": "Рядом с короной Лира Шут балансирует на одной ноге. Я глубоко вдыхаю и выпускаю только слово «мудрость»."
+          "sentence_translation": "Рядом с короной Лира Шут балансирует на одной ноге. Я глубоко вдыхаю и выпускаю только слово «мудрость».",
+          "sentence_parts": [
+            "Neben Lears Krone balanciert Fool auf einem Fuß.",
+            "Ich atme tief ein und lasse nur das Wort „die Weisheit“ wieder hinaus."
+          ]
         },
         {
           "german": "die Trauer",
           "russian": "печаль",
           "transcription": "[ди ТРАУ-ер]",
           "sentence": "Zwischen Hofdamen und Rittern wirbelt Fool mit flatterndem Schellenkleid. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Trauer“ bleibt lebendig.",
-          "sentence_translation": "Между дамами двора и рыцарями Шут кружится в звенящем костюме. Каждой клеткой тела я обещаю: слово «печаль» останется живым."
+          "sentence_translation": "Между дамами двора и рыцарями Шут кружится в звенящем костюме. Каждой клеткой тела я обещаю: слово «печаль» останется живым.",
+          "sentence_parts": [
+            "Zwischen Hofdamen und Rittern wirbelt Fool mit flatterndem Schellenkleid.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Trauer“ bleibt lebendig."
+          ]
         },
         {
           "german": "scherzen",
           "russian": "шутить",
           "transcription": "[ШЕР-цен]",
           "sentence": "Vor dem königlichen Podest verzieht Fool die Maske zum Spott. Ich zeichne das Wort „scherzen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Перед королевским помостом Шут кривит маску насмешки. Я черчу слово «шутить» в мыслях поверх линий судьбы."
+          "sentence_translation": "Перед королевским помостом Шут кривит маску насмешки. Я черчу слово «шутить» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Vor dem königlichen Podest verzieht Fool die Maske zum Spott.",
+            "Ich zeichne das Wort „scherzen“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "der Spaß",
           "russian": "забава",
           "transcription": "[дер ШПАС]",
           "sentence": "Am Bankettisch jongliert Fool mit goldenen Pokalen. Selbst wenn die Welt zerfällt, bleibt das Wort „der Spaß“ mein Nordstern.",
-          "sentence_translation": "У банкетного стола Шут жонглирует золотыми кубками. Даже если мир распадается, слово «забава» остаётся моим северным светом."
+          "sentence_translation": "У банкетного стола Шут жонглирует золотыми кубками. Даже если мир распадается, слово «забава» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Am Bankettisch jongliert Fool mit goldenen Pokalen.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „der Spaß“ mein Nordstern."
+          ]
         },
         {
           "german": "klug",
           "russian": "умный",
           "transcription": "[КЛУГ]",
           "sentence": "Zwischen Lachern und Seufzern zeichnet Fool Grimassen in die Luft. Das kalte Licht lässt das Wort „klug“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Среди смеха и вздохов Шут рисует в воздухе гримасы. Холодный свет заставляет слово «умный» сиять словно расплавленное золото."
+          "sentence_translation": "Среди смеха и вздохов Шут рисует в воздухе гримасы. Холодный свет заставляет слово «умный» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Zwischen Lachern und Seufzern zeichnet Fool Grimassen in die Luft.",
+            "Das kalte Licht lässt das Wort „klug“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "vermissen",
           "russian": "скучать",
           "transcription": "[фер-МИ-сен]",
           "sentence": "Im Schatten der Säulen lauscht Fool den leisen Worten Cordelias. Mein Atem zeichnet das Wort „vermissen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В тени колонн Шут прислушивается к тихим словам Корделии. Моё дыхание рисует слово «скучать» в холодном воздухе между нами."
+          "sentence_translation": "В тени колонн Шут прислушивается к тихим словам Корделии. Моё дыхание рисует слово «скучать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im Schatten der Säulen lauscht Fool den leisen Worten Cordelias.",
+            "Mein Atem zeichnet das Wort „vermissen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "der Witz",
           "russian": "остроумие",
           "transcription": "[дер ВИТЦ]",
           "sentence": "Auf der Marmorstufe lässt Fool ein Glöckchen über den Boden tanzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Witz“ bleibt lebendig.",
-          "sentence_translation": "На мраморной ступени Шут пускает колокольчик плясать по полу. Каждой клеткой тела я обещаю: слово «остроумие» останется живым."
+          "sentence_translation": "На мраморной ступени Шут пускает колокольчик плясать по полу. Каждой клеткой тела я обещаю: слово «остроумие» останется живым.",
+          "sentence_parts": [
+            "Auf der Marmorstufe lässt Fool ein Glöckchen über den Boden tanzen.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Witz“ bleibt lebendig."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -108,49 +141,78 @@
           "russian": "правда",
           "transcription": "[ди ВАР-хайт]",
           "sentence": "Vor Lears Ohr flüstert Fool mit funkelndem Blick die spöttische Wahrheit. Mit fester Stimme schwöre ich mir: Das Wort „die Wahrheit“ wird heute nicht verraten.",
-          "sentence_translation": "У самого уха Лира Шут с блеском в глазах шепчет язвительную правду. Твёрдым голосом я клянусь себе: слово «правда» сегодня не будет предано."
+          "sentence_translation": "У самого уха Лира Шут с блеском в глазах шепчет язвительную правду. Твёрдым голосом я клянусь себе: слово «правда» сегодня не будет предано.",
+          "sentence_parts": [
+            "Vor Lears Ohr flüstert Fool mit funkelndem Blick die spöttische Wahrheit.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „die Wahrheit“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "der Scherz",
           "russian": "шутка",
           "transcription": "[дер ШЕРЦ]",
           "sentence": "Auf dem Hofbalkon zeigt Fool mit der Laute auf die heuchlerischen Schwestern. Ich presse das Wort „der Scherz“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "На дворцовом балконе Шут указывает лютней на лицемерных сестёр. Я стискиваю слово «шутка» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "На дворцовом балконе Шут указывает лютней на лицемерных сестёр. Я стискиваю слово «шутка» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Auf dem Hofbalkon zeigt Fool mit der Laute auf die heuchlerischen Schwestern.",
+            "Ich presse das Wort „der Scherz“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Warnung",
           "russian": "предупреждение",
           "transcription": "[ди ВАР-нунг]",
           "sentence": "Zwischen umgestoßenen Bechern sammelt Fool die Lügen wie Perlen auf. Ich zeichne das Wort „die Warnung“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Среди опрокинутых кубков Шут собирает ложь словно жемчуг. Я черчу слово «предупреждение» в мыслях поверх линий судьбы."
+          "sentence_translation": "Среди опрокинутых кубков Шут собирает ложь словно жемчуг. Я черчу слово «предупреждение» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Zwischen umgestoßenen Bechern sammelt Fool die Lügen wie Perlen auf.",
+            "Ich zeichne das Wort „die Warnung“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "bitter",
           "russian": "горький",
           "transcription": "[БИ-тер]",
           "sentence": "An Lears Seite zeichnet Fool mit Kreide eine Krone auf den Boden. Wie ein stilles Gebet legt sich das Wort „bitter“ auf meine Lippen.",
-          "sentence_translation": "Рядом с Лиром Шут мелом рисует корону на полу. Как тихая молитва слово «горький» ложится на мои губы."
+          "sentence_translation": "Рядом с Лиром Шут мелом рисует корону на полу. Как тихая молитва слово «горький» ложится на мои губы.",
+          "sentence_parts": [
+            "An Lears Seite zeichnet Fool mit Kreide eine Krone auf den Boden.",
+            "Wie ein stilles Gebet legt sich das Wort „bitter“ auf meine Lippen."
+          ]
         },
         {
           "german": "spotten",
           "russian": "насмехаться",
           "transcription": "[ШПО-тен]",
           "sentence": "Im Gedränge der Höflinge spielt Fool eine schrille Warnmelodie. Mit fester Stimme schwöre ich mir: Das Wort „spotten“ wird heute nicht verraten.",
-          "sentence_translation": "В толчее придворных Шут играет пронзительную мелодию предупреждения. Твёрдым голосом я клянусь себе: слово «насмехаться» сегодня не будет предано."
+          "sentence_translation": "В толчее придворных Шут играет пронзительную мелодию предупреждения. Твёрдым голосом я клянусь себе: слово «насмехаться» сегодня не будет предано.",
+          "sentence_parts": [
+            "Im Gedränge der Höflinge spielt Fool eine schrille Warnmelodie.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „spotten“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "necken",
           "russian": "дразнить",
           "transcription": "[НЕ-кен]",
           "sentence": "Auf den Stufen zum Thron zieht Fool die Stirn in tiefe Falten. Ich presse das Wort „necken“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "На ступенях, ведущих к трону, Шут морщит лоб глубокими складками. Я стискиваю слово «дразнить» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "На ступенях, ведущих к трону, Шут морщит лоб глубокими складками. Я стискиваю слово «дразнить» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Auf den Stufen zum Thron zieht Fool die Stirn in tiefe Falten.",
+            "Ich presse das Wort „necken“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "enthüllen",
           "russian": "раскрывать",
           "transcription": "[энт-ХЮ-лен]",
           "sentence": "Neben dem Tränenstrom des Königs wischt Fool die Schminke vom Gesicht. Ich zeichne das Wort „enthüllen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Рядом с потоками слёз короля Шут стирает грим с лица. Я черчу слово «раскрывать» в мыслях поверх линий судьбы."
+          "sentence_translation": "Рядом с потоками слёз короля Шут стирает грим с лица. Я черчу слово «раскрывать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Neben dem Tränenstrom des Königs wischt Fool die Schminke vom Gesicht.",
+            "Ich zeichne das Wort „enthüllen“ in Gedanken über die Linien des Schicksals."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -194,56 +256,88 @@
           "russian": "пророчество",
           "transcription": "[ди про-фе-ЦАЙ-унг]",
           "sentence": "Unter dem Sternenzelt deutet Fool mit dem Stab die funkelnden Zeichen. Das kalte Licht lässt das Wort „die Prophezeiung“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Под звёздным шатром Шут посохом указывает на мерцающие знаки. Холодный свет заставляет слово «пророчество» сиять словно расплавленное золото."
+          "sentence_translation": "Под звёздным шатром Шут посохом указывает на мерцающие знаки. Холодный свет заставляет слово «пророчество» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Unter dem Sternenzelt deutet Fool mit dem Stab die funkelnden Zeichen.",
+            "Das kalte Licht lässt das Wort „die Prophezeiung“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "das Rätsel",
           "russian": "загадка",
           "transcription": "[дас РЕТ-зель]",
           "sentence": "Auf den Mauern des Schlosses rezitiert Fool Verse von kommenden Stürmen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Rätsel“ darf nicht vergehen.",
-          "sentence_translation": "На стенах замка Шут декламирует стихи о грядущих бурях. Я шепчу стражам судьбы: слово «загадка» не должно исчезнуть."
+          "sentence_translation": "На стенах замка Шут декламирует стихи о грядущих бурях. Я шепчу стражам судьбы: слово «загадка» не должно исчезнуть.",
+          "sentence_parts": [
+            "Auf den Mauern des Schlosses rezitiert Fool Verse von kommenden Stürmen.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Rätsel“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Vorahnung",
           "russian": "предчувствие",
           "transcription": "[ди ФОР-а-нунг]",
           "sentence": "Zwischen Rauch und Kerzenduft schleudert Fool rätselhafte Reime. Mit fester Stimme schwöre ich mir: Das Wort „die Vorahnung“ wird heute nicht verraten.",
-          "sentence_translation": "Среди дыма и аромата свечей Шут бросает загадочные рифмы. Твёрдым голосом я клянусь себе: слово «предчувствие» сегодня не будет предано."
+          "sentence_translation": "Среди дыма и аромата свечей Шут бросает загадочные рифмы. Твёрдым голосом я клянусь себе: слово «предчувствие» сегодня не будет предано.",
+          "sentence_parts": [
+            "Zwischen Rauch und Kerzenduft schleudert Fool rätselhafte Reime.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „die Vorahnung“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "vorhersagen",
           "russian": "предсказывать",
           "transcription": "[ФОР-хер-за-ген]",
           "sentence": "Am Brunnen des Hofes wirft Fool Kiesel, um die Zukunft zu spiegeln. Ich atme tief ein und lasse nur das Wort „vorhersagen“ wieder hinaus.",
-          "sentence_translation": "У дворцового фонтана Шут бросает гальку, чтобы отразить будущее. Я глубоко вдыхаю и выпускаю только слово «предсказывать»."
+          "sentence_translation": "У дворцового фонтана Шут бросает гальку, чтобы отразить будущее. Я глубоко вдыхаю и выпускаю только слово «предсказывать».",
+          "sentence_parts": [
+            "Am Brunnen des Hofes wirft Fool Kiesel, um die Zukunft zu spiegeln.",
+            "Ich atme tief ein und lasse nur das Wort „vorhersagen“ wieder hinaus."
+          ]
         },
         {
           "german": "deuten",
           "russian": "толковать",
           "transcription": "[ДОЙ-тен]",
           "sentence": "Vor erstaunten Dienern zeichnet Fool Kreise in den Staub. Ich presse das Wort „deuten“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Перед поражёнными слугами Шут чертит круги в пыли. Я стискиваю слово «толковать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Перед поражёнными слугами Шут чертит круги в пыли. Я стискиваю слово «толковать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Vor erstaunten Dienern zeichnet Fool Kreise in den Staub.",
+            "Ich presse das Wort „deuten“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "ahnen",
           "russian": "предчувствовать",
           "transcription": "[А-нен]",
           "sentence": "Auf der Markttreppe singt Fool von Königen, die zu Bettlern werden. Mit fester Stimme schwöre ich mir: Das Wort „ahnen“ wird heute nicht verraten.",
-          "sentence_translation": "На рыночной лестнице Шут поёт о королях, становящихся нищими. Твёрдым голосом я клянусь себе: слово «предчувствовать» сегодня не будет предано."
+          "sentence_translation": "На рыночной лестнице Шут поёт о королях, становящихся нищими. Твёрдым голосом я клянусь себе: слово «предчувствовать» сегодня не будет предано.",
+          "sentence_parts": [
+            "Auf der Markttreppe singt Fool von Königen, die zu Bettlern werden.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „ahnen“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "das Omen",
           "russian": "знамение",
           "transcription": "[дас О-мен]",
           "sentence": "Neben einem reisenden Pilger deutet Fool in den flammenden Himmel. Mit fester Stimme schwöre ich mir: Das Wort „das Omen“ wird heute nicht verraten.",
-          "sentence_translation": "Рядом со странствующим пилигримом Шут указывает на пылающее небо. Твёрдым голосом я клянусь себе: слово «знамение» сегодня не будет предано."
+          "sentence_translation": "Рядом со странствующим пилигримом Шут указывает на пылающее небо. Твёрдым голосом я клянусь себе: слово «знамение» сегодня не будет предано.",
+          "sentence_parts": [
+            "Neben einem reisenden Pilger deutet Fool in den flammenden Himmel.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „das Omen“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "rätselhaft",
           "russian": "загадочный",
           "transcription": "[РЕТ-зель-хафт]",
           "sentence": "Im Gewitterlicht zählt Fool die Schläge, die die Zukunft ankündigen. Ich zeichne das Wort „rätselhaft“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "В свете грозы Шут отсчитывает удары, возвещающие будущее. Я черчу слово «загадочный» в мыслях поверх линий судьбы."
+          "sentence_translation": "В свете грозы Шут отсчитывает удары, возвещающие будущее. Я черчу слово «загадочный» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Im Gewitterlicht zählt Fool die Schläge, die die Zukunft ankündigen.",
+            "Ich zeichne das Wort „rätselhaft“ in Gedanken über die Linien des Schicksals."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -287,49 +381,77 @@
           "russian": "безумие",
           "transcription": "[дер ВАН-зин]",
           "sentence": "In der sturmgepeitschten Heide drückt Fool Lear die klammen Hände. Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "На залитой бурей пустоши Шут сжимает озябшие руки Лира. Моё дыхание рисует слово «безумие» в холодном воздухе между нами."
+          "sentence_translation": "На залитой бурей пустоши Шут сжимает озябшие руки Лира. Моё дыхание рисует слово «безумие» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "In der sturmgepeitschten Heide drückt Fool Lear die klammen Hände.",
+            "Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Freundschaft",
           "russian": "дружба",
           "transcription": "[ди ФРОЙНД-шафт]",
           "sentence": "Zwischen zerrissenen Zelten singt Fool ein trostloses Wiegenlied. Ich umarme das Wort „die Freundschaft“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Среди разорванных шатров Шут поёт безутешную колыбельную. Я обнимаю слово «дружба», будто это единственный союзник."
+          "sentence_translation": "Среди разорванных шатров Шут поёт безутешную колыбельную. Я обнимаю слово «дружба», будто это единственный союзник.",
+          "sentence_parts": [
+            "Zwischen zerrissenen Zelten singt Fool ein trostloses Wiegenlied.",
+            "Ich umarme das Wort „die Freundschaft“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "begleiten",
           "russian": "сопровождать",
           "transcription": "[бе-ГЛАЙ-тен]",
           "sentence": "Am umgestürzten Wagen schirmt Fool den König vor der Peitsche des Regens. Ich presse das Wort „begleiten“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "У перевёрнутой повозки Шут заслоняет короля от кнута дождя. Я стискиваю слово «сопровождать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "У перевёрнутой повозки Шут заслоняет короля от кнута дождя. Я стискиваю слово «сопровождать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Am umgestürzten Wagen schirmt Fool den König vor der Peitsche des Regens.",
+            "Ich presse das Wort „begleiten“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "frieren",
           "russian": "мёрзнуть",
           "transcription": "[ФРИ-рен]",
           "sentence": "Unter dem knarzenden Dach der Hütte sitzt Fool dicht an Lear gedrängt. Ich flüstere den Wächtern des Schicksals zu: Das Wort „frieren“ darf nicht vergehen.",
-          "sentence_translation": "Под скрипучей крышей хижины Шут сидит вплотную к Лиру. Я шепчу стражам судьбы: слово «мёрзнуть» не должно исчезнуть."
+          "sentence_translation": "Под скрипучей крышей хижины Шут сидит вплотную к Лиру. Я шепчу стражам судьбы: слово «мёрзнуть» не должно исчезнуть.",
+          "sentence_parts": [
+            "Unter dem knarzenden Dach der Hütte sitzt Fool dicht an Lear gedrängt.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „frieren“ darf nicht vergehen."
+          ]
         },
         {
           "german": "singen",
           "russian": "петь",
           "transcription": "[ЗИН-ген]",
           "sentence": "Vor der tobenden Nacht schreit Fool seine Possen gegen den Wind. Ich zeichne das Wort „singen“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Перед бушующей ночью Шут выкрикивает свои шутки наперекор ветру. Я вывожу слово «петь» невидимыми чернилами на ладони."
+          "sentence_translation": "Перед бушующей ночью Шут выкрикивает свои шутки наперекор ветру. Я вывожу слово «петь» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Vor der tobenden Nacht schreit Fool seine Possen gegen den Wind.",
+            "Ich zeichne das Wort „singen“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "zittern",
           "russian": "дрожать",
           "transcription": "[ЦИ-терн]",
           "sentence": "Am aufgeweichten Boden zeichnet Fool mit Stock und Witz ein Schutzschild. Ich atme tief ein und lasse nur das Wort „zittern“ wieder hinaus.",
-          "sentence_translation": "На размокшей земле Шут рисует палкой и шутками защитный круг. Я глубоко вдыхаю и выпускаю только слово «дрожать»."
+          "sentence_translation": "На размокшей земле Шут рисует палкой и шутками защитный круг. Я глубоко вдыхаю и выпускаю только слово «дрожать».",
+          "sentence_parts": [
+            "Am aufgeweichten Boden zeichnet Fool mit Stock und Witz ein Schutzschild.",
+            "Ich atme tief ein und lasse nur das Wort „zittern“ wieder hinaus."
+          ]
         },
         {
           "german": "treu",
           "russian": "верный",
           "transcription": "[ТРОЙ]",
           "sentence": "In der Finsternis des Waldes zündet Fool einen letzten Funken Mut an. Ich umarme das Wort „treu“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В темноте леса Шут зажигает последний огонёк мужества. Я обнимаю слово «верный», будто это единственный союзник."
+          "sentence_translation": "В темноте леса Шут зажигает последний огонёк мужества. Я обнимаю слово «верный», будто это единственный союзник.",
+          "sentence_parts": [
+            "In der Finsternis des Waldes zündet Fool einen letzten Funken Mut an.",
+            "Ich umarme das Wort „treu“, als wäre es mein einziger Verbündeter."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -373,56 +495,88 @@
           "russian": "песня",
           "transcription": "[дас ЛИД]",
           "sentence": "Im warmen Schein der Hütte summt Fool eine Melodie über verlorene Kronen. Mein Atem zeichnet das Wort „das Lied“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В тёплом свете хижины Шут напевает мелодию о потерянных коронах. Моё дыхание рисует слово «песня» в холодном воздухе между нами."
+          "sentence_translation": "В тёплом свете хижины Шут напевает мелодию о потерянных коронах. Моё дыхание рисует слово «песня» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im warmen Schein der Hütte summt Fool eine Melodie über verlorene Kronen.",
+            "Mein Atem zeichnet das Wort „das Lied“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "der Trost",
           "russian": "утешение",
           "transcription": "[дер ТРОСТ]",
           "sentence": "Neben Lear legt Fool den Kopf auf die Knie und schaukelt im Takt. Ich zeichne das Wort „der Trost“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Рядом с Лиром Шут кладёт голову на колени и покачивается в такт. Я черчу слово «утешение» в мыслях поверх линий судьбы."
+          "sentence_translation": "Рядом с Лиром Шут кладёт голову на колени и покачивается в такт. Я черчу слово «утешение» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Neben Lear legt Fool den Kopf auf die Knie und schaukelt im Takt.",
+            "Ich zeichne das Wort „der Trost“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "die Ironie",
           "russian": "ирония",
           "transcription": "[ди и-ро-НИ]",
           "sentence": "Vor der knisternden Feuerstelle klatscht Fool den Rhythmus in die Hände. Ich atme tief ein und lasse nur das Wort „die Ironie“ wieder hinaus.",
-          "sentence_translation": "Перед потрескивающим огнём Шут отбивает ритм ладонями. Я глубоко вдыхаю и выпускаю только слово «ирония»."
+          "sentence_translation": "Перед потрескивающим огнём Шут отбивает ритм ладонями. Я глубоко вдыхаю и выпускаю только слово «ирония».",
+          "sentence_parts": [
+            "Vor der knisternden Feuerstelle klatscht Fool den Rhythmus in die Hände.",
+            "Ich atme tief ein und lasse nur das Wort „die Ironie“ wieder hinaus."
+          ]
         },
         {
           "german": "summen",
           "russian": "напевать",
           "transcription": "[ЗУ-мен]",
           "sentence": "Auf dem Holzbalken sitzt Fool und schwingt die Beine zur Melodie. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „summen“ gehört mir.",
-          "sentence_translation": "На деревянной балке Шут сидит и качает ногами в такт песне. Буря за окнами усиливает клятву: слово «напевать» принадлежит мне."
+          "sentence_translation": "На деревянной балке Шут сидит и качает ногами в такт песне. Буря за окнами усиливает клятву: слово «напевать» принадлежит мне.",
+          "sentence_parts": [
+            "Auf dem Holzbalken sitzt Fool und schwingt die Beine zur Melodie.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „summen“ gehört mir."
+          ]
         },
         {
           "german": "die Melodie",
           "russian": "мелодия",
           "transcription": "[ди ме-ло-ДИ]",
           "sentence": "Zwischen Schlafenden senkt Fool die Stimme zu einem flüsternden Refrain. Wie ein stilles Gebet legt sich das Wort „die Melodie“ auf meine Lippen.",
-          "sentence_translation": "Среди спящих Шут понижает голос до шёпотного припева. Как тихая молитва слово «мелодия» ложится на мои губы."
+          "sentence_translation": "Среди спящих Шут понижает голос до шёпотного припева. Как тихая молитва слово «мелодия» ложится на мои губы.",
+          "sentence_parts": [
+            "Zwischen Schlafenden senkt Fool die Stimme zu einem flüsternden Refrain.",
+            "Wie ein stilles Gebet legt sich das Wort „die Melodie“ auf meine Lippen."
+          ]
         },
         {
           "german": "pfeifen",
           "russian": "свистеть",
           "transcription": "[ПФАЙ-фен]",
           "sentence": "Am offenen Feld singt Fool gegen das Heulen der Nacht. Ich umarme das Wort „pfeifen“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "На открытом поле Шут поёт наперекор вою ночи. Я обнимаю слово «свистеть», будто это единственный союзник."
+          "sentence_translation": "На открытом поле Шут поёт наперекор вою ночи. Я обнимаю слово «свистеть», будто это единственный союзник.",
+          "sentence_parts": [
+            "Am offenen Feld singt Fool gegen das Heulen der Nacht.",
+            "Ich umarme das Wort „pfeifen“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "der Reim",
           "russian": "рифма",
           "transcription": "[дер РАЙМ]",
           "sentence": "In der Morgendämmerung stimmt Fool ein hoffnungsvolles Lied an. Selbst wenn die Welt zerfällt, bleibt das Wort „der Reim“ mein Nordstern.",
-          "sentence_translation": "На рассвете Шут заводит песню надежды. Даже если мир распадается, слово «рифма» остаётся моим северным светом."
+          "sentence_translation": "На рассвете Шут заводит песню надежды. Даже если мир распадается, слово «рифма» остаётся моим северным светом.",
+          "sentence_parts": [
+            "In der Morgendämmerung stimmt Fool ein hoffnungsvolles Lied an.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „der Reim“ mein Nordstern."
+          ]
         },
         {
           "german": "klingen",
           "russian": "звучать",
           "transcription": "[КЛИН-ген]",
           "sentence": "Über Lear gebeugt beendet Fool das Lied mit einem sanften Kuss auf die Stirn. Ich presse das Wort „klingen“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Наклонившись над Лиром, Шут завершает песню мягким поцелуем в лоб. Я стискиваю слово «звучать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Наклонившись над Лиром, Шут завершает песню мягким поцелуем в лоб. Я стискиваю слово «звучать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Über Lear gebeugt beendet Fool das Lied mit einem sanften Kuss auf die Stirn.",
+            "Ich presse das Wort „klingen“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -466,49 +620,77 @@
           "russian": "философия",
           "transcription": "[ди фи-ло-зо-ФИ]",
           "sentence": "Im verlassenen Hof sitzt Fool auf einem leeren Fass und denkt laut nach. Selbst wenn die Welt zerfällt, bleibt das Wort „die Philosophie“ mein Nordstern.",
-          "sentence_translation": "На пустынном дворе Шут сидит на пустой бочке и размышляет вслух. Даже если мир распадается, слово «философия» остаётся моим северным светом."
+          "sentence_translation": "На пустынном дворе Шут сидит на пустой бочке и размышляет вслух. Даже если мир распадается, слово «философия» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Im verlassenen Hof sitzt Fool auf einem leeren Fass und denkt laut nach.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Philosophie“ mein Nordstern."
+          ]
         },
         {
           "german": "das Schicksal",
           "russian": "судьба",
           "transcription": "[дас ШИК-заль]",
           "sentence": "Unter einer nackten Eiche zählt Fool die Fehler der Mächtigen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Schicksal“ darf nicht vergehen.",
-          "sentence_translation": "Под обнажённым дубом Шут пересчитывает ошибки власть имущих. Я шепчу стражам судьбы: слово «судьба» не должно исчезнуть."
+          "sentence_translation": "Под обнажённым дубом Шут пересчитывает ошибки власть имущих. Я шепчу стражам судьбы: слово «судьба» не должно исчезнуть.",
+          "sentence_parts": [
+            "Unter einer nackten Eiche zählt Fool die Fehler der Mächtigen.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Schicksal“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Vergänglichkeit",
           "russian": "бренность",
           "transcription": "[ди фер-ГЕНГ-лих-кайт]",
           "sentence": "Am stillen Bachlauf wirft Fool Steine, um die Zeit zu messen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Vergänglichkeit“ gehört mir.",
-          "sentence_translation": "У тихого ручья Шут бросает камни, чтобы измерить время. Буря за окнами усиливает клятву: слово «бренность» принадлежит мне."
+          "sentence_translation": "У тихого ручья Шут бросает камни, чтобы измерить время. Буря за окнами усиливает клятву: слово «бренность» принадлежит мне.",
+          "sentence_parts": [
+            "Am stillen Bachlauf wirft Fool Steine, um die Zeit zu messen.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Vergänglichkeit“ gehört mir."
+          ]
         },
         {
           "german": "nachdenken",
           "russian": "размышлять",
           "transcription": "[НАХ-ден-кен]",
           "sentence": "Neben einer verlassenen Bühne probt Fool Zeilen über Narrheit und Macht. Das kalte Licht lässt das Wort „nachdenken“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "У заброшенной сцены Шут репетирует строки о глупости и власти. Холодный свет заставляет слово «размышлять» сиять словно расплавленное золото."
+          "sentence_translation": "У заброшенной сцены Шут репетирует строки о глупости и власти. Холодный свет заставляет слово «размышлять» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Neben einer verlassenen Bühne probt Fool Zeilen über Narrheit und Macht.",
+            "Das kalte Licht lässt das Wort „nachdenken“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "erkennen",
           "russian": "познавать",
           "transcription": "[ер-КЕН-нен]",
           "sentence": "Auf dem Dachboden der Burg sortiert Fool Erinnerungen wie alte Kostüme. Ich atme tief ein und lasse nur das Wort „erkennen“ wieder hinaus.",
-          "sentence_translation": "На чердаке замка Шут раскладывает воспоминания как старые костюмы. Я глубоко вдыхаю и выпускаю только слово «познавать»."
+          "sentence_translation": "На чердаке замка Шут раскладывает воспоминания как старые костюмы. Я глубоко вдыхаю и выпускаю только слово «познавать».",
+          "sentence_parts": [
+            "Auf dem Dachboden der Burg sortiert Fool Erinnerungen wie alte Kostüme.",
+            "Ich atme tief ein und lasse nur das Wort „erkennen“ wieder hinaus."
+          ]
         },
         {
           "german": "der Sinn",
           "russian": "смысл",
           "transcription": "[дер ЗИН]",
           "sentence": "Vor einem Spiegel ohne Glas betrachtet Fool das eigene müde Gesicht. Selbst wenn die Welt zerfällt, bleibt das Wort „der Sinn“ mein Nordstern.",
-          "sentence_translation": "Перед зеркалом без стекла Шут разглядывает собственное усталое лицо. Даже если мир распадается, слово «смысл» остаётся моим северным светом."
+          "sentence_translation": "Перед зеркалом без стекла Шут разглядывает собственное усталое лицо. Даже если мир распадается, слово «смысл» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Vor einem Spiegel ohne Glas betrachtet Fool das eigene müde Gesicht.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „der Sinn“ mein Nordstern."
+          ]
         },
         {
           "german": "vergänglich",
           "russian": "преходящий",
           "transcription": "[фер-ГЕНГ-лих]",
           "sentence": "Im ersten Morgenlicht schreibt Fool letzte Sprüche auf Pergament. Ich atme tief ein und lasse nur das Wort „vergänglich“ wieder hinaus.",
-          "sentence_translation": "В первом утреннем свете Шут записывает последние остроты на пергамент. Я глубоко вдыхаю и выпускаю только слово «преходящий»."
+          "sentence_translation": "В первом утреннем свете Шут записывает последние остроты на пергамент. Я глубоко вдыхаю и выпускаю только слово «преходящий».",
+          "sentence_parts": [
+            "Im ersten Morgenlicht schreibt Fool letzte Sprüche auf Pergament.",
+            "Ich atme tief ein und lasse nur das Wort „vergänglich“ wieder hinaus."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -552,56 +734,89 @@
           "russian": "исчезать",
           "transcription": "[фер-ШВИН-ден]",
           "sentence": "Im Nebel des Morgens löst sich Fool zwischen den Zelten der Armee auf. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verschwinden“ gehört mir.",
-          "sentence_translation": "В утреннем тумане Шут растворяется между шатрами армии. Буря за окнами усиливает клятву: слово «исчезать» принадлежит мне."
+          "sentence_translation": "В утреннем тумане Шут растворяется между шатрами армии. Буря за окнами усиливает клятву: слово «исчезать» принадлежит мне.",
+          "sentence_parts": [
+            "Im Nebel des Morgens löst sich Fool zwischen den Zelten der Armee auf.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verschwinden“ gehört mir."
+          ]
         },
         {
           "german": "das Geheimnis",
           "russian": "тайна",
           "transcription": "[дас ге-ХАЙМ-нис]",
           "sentence": "Auf dem verlassenen Pfad lässt Fool nur ein Glöckchen zurück. Ich presse das Wort „das Geheimnis“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "На пустой тропе Шут оставляет лишь один колокольчик. Я стискиваю слово «тайна» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "На пустой тропе Шут оставляет лишь один колокольчик. Я стискиваю слово «тайна» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Auf dem verlassenen Pfad lässt Fool nur ein Glöckchen zurück.",
+            "Ich presse das Wort „das Geheimnis“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Leere",
           "russian": "пустота",
           "transcription": "[ди ЛЕ-ре]",
           "sentence": "Zwischen verstreuten Karten verschwindet Fool hinter einem Wandteppich. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leere“ bleibt lebendig.",
-          "sentence_translation": "Среди разбросанных карт Шут исчезает за гобеленом. Каждой клеткой тела я обещаю: слово «пустота» останется живым."
+          "sentence_translation": "Среди разбросанных карт Шут исчезает за гобеленом. Каждой клеткой тела я обещаю: слово «пустота» останется живым.",
+          "sentence_parts": [
+            "Zwischen verstreuten Karten verschwindet Fool hinter einem Wandteppich.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leere“ bleibt lebendig."
+          ]
         },
         {
           "german": "sich auflösen",
           "russian": "растворяться",
           "transcription": "[зих АУФ-лё-зен]",
           "sentence": "Am Rand des Schlachtfelds weht Fools bunter Schal davon. Ich zeichne das Wort „sich auflösen“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "На краю поля битвы уносит пёстрый шарф Шут. Я вывожу слово «растворяться» невидимыми чернилами на ладони."
+          "sentence_translation": "На краю поля битвы уносит пёстрый шарф Шут. Я вывожу слово «растворяться» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Am Rand des Schlachtfelds weht Fools bunter Schal davon.",
+            "Ich zeichne das Wort „sich auflösen“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "spurlos",
           "russian": "бесследно",
           "transcription": "[ШПУР-лос]",
           "sentence": "Unter den Blicken der Soldaten verbeugt sich Fool und geht ohne Abschied. Ich umarme das Wort „spurlos“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Под взглядами солдат Шут кланяется и уходит без прощания. Я обнимаю слово «бесследно», будто это единственный союзник."
+          "sentence_translation": "Под взглядами солдат Шут кланяется и уходит без прощания. Я обнимаю слово «бесследно», будто это единственный союзник.",
+          "sentence_parts": [
+            "Unter den Blicken der Soldaten verbeugt sich Fool und geht ohne Abschied.",
+            "Ich umarme das Wort „spurlos“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "der Nebel",
           "russian": "туман",
           "transcription": "[дер НЕ-бель]",
           "sentence": "Auf der Treppe der Burg bleibt Fools Schellenstab einsam liegen. Ich atme tief ein und lasse nur das Wort „der Nebel“ wieder hinaus.",
-          "sentence_translation": "На лестнице замка одиноко остаётся жезл с бубенчиками Шут. Я глубоко вдыхаю и выпускаю только слово «туман»."
+          "sentence_translation": "На лестнице замка одиноко остаётся жезл с бубенчиками Шут. Я глубоко вдыхаю и выпускаю только слово «туман».",
+          "sentence_parts": [
+            "Auf der Treppe der Burg bleibt Fools Schellenstab einsam liegen.",
+            "Ich atme tief ein und lasse nur das Wort „der Nebel“ wieder hinaus."
+          ]
         },
         {
           "german": "rätselhaft",
           "russian": "загадочный",
           "transcription": "[РЕТ-зель-хафт]",
           "sentence": "Im Rauschen des Meeres verliert sich Fools Stimme wie ein ferner Traum. Ich umarme das Wort „rätselhaft“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В шуме моря голос Шут растворяется как далёкий сон. Я обнимаю слово «загадочный», будто это единственный союзник."
+          "sentence_translation": "В шуме моря голос Шут растворяется как далёкий сон. Я обнимаю слово «загадочный», будто это единственный союзник.",
+          "sentence_parts": [
+            "Im Rauschen des Meeres verliert sich Fools Stimme wie ein ferner Traum.",
+            "Ich umarme das Wort „rätselhaft“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "fortgehen",
           "russian": "уходить",
           "transcription": "[ФОРТ-ге-ен]",
           "sentence": "Vor der aufgehenden Sonne wirft Fool einen letzten Schatten und verblasst. Ich zeichne das Wort „fortgehen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Перед восходящим солнцем Шут бросает последнюю тень и растворяется. Я черчу слово «уходить» в мыслях поверх линий судьбы."
+          "sentence_translation": "Перед восходящим солнцем Шут бросает последнюю тень и растворяется. Я черчу слово «уходить» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Vor der aufgehenden Sonne wirft Fool einen letzten Schatten und verblasst.",
+            "Ich zeichne das Wort „fortgehen“ in Gedanken über die Linien des Schicksals."
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/gloucester.json
+++ b/data/characters/gloucester.json
@@ -15,56 +15,88 @@
           "russian": "знать",
           "transcription": "[дер А-дель]",
           "sentence": "Gloucester steht unter dem glühenden Kronleuchter des Thronsaals. Selbst wenn die Welt zerfällt, bleibt das Wort „der Adel“ mein Nordstern.",
-          "sentence_translation": "Глостер стоит под пылающей люстрой тронного зала. Даже если мир распадается, слово «знать» остаётся моим северным светом."
+          "sentence_translation": "Глостер стоит под пылающей люстрой тронного зала. Даже если мир распадается, слово «знать» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Gloucester steht unter dem glühenden Kronleuchter des Thronsaals.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „der Adel“ mein Nordstern."
+          ]
         },
         {
           "german": "dienen",
           "russian": "служить",
           "transcription": "[ДИ-нен]",
           "sentence": "Neben der ausgerollten Reichskarte beugt sich Gloucester über Lears schweren Tisch. Mit fester Stimme schwöre ich mir: Das Wort „dienen“ wird heute nicht verraten.",
-          "sentence_translation": "У развернутой карты королевства Глостер склоняется над тяжёлым столом Лира. Твёрдым голосом я клянусь себе: слово «служить» сегодня не будет предано."
+          "sentence_translation": "У развернутой карты королевства Глостер склоняется над тяжёлым столом Лира. Твёрдым голосом я клянусь себе: слово «служить» сегодня не будет предано.",
+          "sentence_parts": [
+            "Neben der ausgerollten Reichskarte beugt sich Gloucester über Lears schweren Tisch.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „dienen“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "vertrauen",
           "russian": "доверять",
           "transcription": "[фер-ТРАУ-ен]",
           "sentence": "Vor den steinernen Ahnenstatuen verschränkt Gloucester die Hände hinter dem Rücken. Ich atme tief ein und lasse nur das Wort „vertrauen“ wieder hinaus.",
-          "sentence_translation": "Перед каменными статуями предков Глостер сцепляет руки за спиной. Я глубоко вдыхаю и выпускаю только слово «доверять»."
+          "sentence_translation": "Перед каменными статуями предков Глостер сцепляет руки за спиной. Я глубоко вдыхаю и выпускаю только слово «доверять».",
+          "sentence_parts": [
+            "Vor den steinernen Ahnenstatuen verschränkt Gloucester die Hände hinter dem Rücken.",
+            "Ich atme tief ein und lasse nur das Wort „vertrauen“ wieder hinaus."
+          ]
         },
         {
           "german": "der Graf",
           "russian": "граф",
           "transcription": "[дер ГРАФ]",
           "sentence": "Zwischen flüsternden Höflingen gleitet Gloucester über den kalten Marmorboden. Ich zeichne das Wort „der Graf“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Между шепчущимися придворными Глостер скользит по холодному мраморному полу. Я вывожу слово «граф» невидимыми чернилами на ладони."
+          "sentence_translation": "Между шепчущимися придворными Глостер скользит по холодному мраморному полу. Я вывожу слово «граф» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Zwischen flüsternden Höflingen gleitet Gloucester über den kalten Marmorboden.",
+            "Ich zeichne das Wort „der Graf“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "die Ehre",
           "russian": "честь",
           "transcription": "[ди Э-ре]",
           "sentence": "Am Rand des purpurnen Teppichs wartet Gloucester auf ein Zeichen des Königs. Ich zeichne das Wort „die Ehre“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "На краю пурпурного ковра Глостер ждёт знака от короля. Я вывожу слово «честь» невидимыми чернилами на ладони."
+          "sentence_translation": "На краю пурпурного ковра Глостер ждёт знака от короля. Я вывожу слово «честь» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Am Rand des purpurnen Teppichs wartet Gloucester auf ein Zeichen des Königs.",
+            "Ich zeichne das Wort „die Ehre“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "rechtschaffen",
           "russian": "праведный",
           "transcription": "[РЕХТ-ша-фен]",
           "sentence": "Unter wehenden Standarten der Schwestern senkt Gloucester kurz den Blick. Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Под развевающимися штандартами сестёр Глостер на миг опускает взгляд. Я стискиваю слово «праведный» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Под развевающимися штандартами сестёр Глостер на миг опускает взгляд. Я стискиваю слово «праведный» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Unter wehenden Standarten der Schwestern senkt Gloucester kurz den Blick.",
+            "Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Pflicht",
           "russian": "долг",
           "transcription": "[ди ПФЛИХТ]",
           "sentence": "Hinter der vergoldeten Balustrade beobachtet Gloucester das gespannte Antlitz des Hofes. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Pflicht“ gehört mir.",
-          "sentence_translation": "За позолоченной балюстрадой Глостер наблюдает за напряжёнными лицами двора. Буря за окнами усиливает клятву: слово «долг» принадлежит мне."
+          "sentence_translation": "За позолоченной балюстрадой Глостер наблюдает за напряжёнными лицами двора. Буря за окнами усиливает клятву: слово «долг» принадлежит мне.",
+          "sentence_parts": [
+            "Hinter der vergoldeten Balustrade beobachtet Gloucester das gespannte Antlitz des Hofes.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Pflicht“ gehört mir."
+          ]
         },
         {
           "german": "achten",
           "russian": "уважать",
           "transcription": "[АХ-тен]",
           "sentence": "Im Schein der offenen Feuerbecken erhebt Gloucester langsam die Stimme. Ich zeichne das Wort „achten“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "В отблесках открытых жаровен Глостер медленно поднимает голос. Я вывожу слово «уважать» невидимыми чернилами на ладони."
+          "sentence_translation": "В отблесках открытых жаровен Глостер медленно поднимает голос. Я вывожу слово «уважать» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Im Schein der offenen Feuerbecken erhebt Gloucester langsam die Stimme.",
+            "Ich zeichne das Wort „achten“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -108,56 +140,89 @@
           "russian": "письмо",
           "transcription": "[дер БРИФ]",
           "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Gloucester zwischen gepackten Kisten. Das kalte Licht lässt das Wort „der Brief“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "В гулком проёме ворот замка Гонерильи Глостер замирает среди нагруженных ящиков. Холодный свет заставляет слово «письмо» сиять словно расплавленное золото."
+          "sentence_translation": "В гулком проёме ворот замка Гонерильи Глостер замирает среди нагруженных ящиков. Холодный свет заставляет слово «письмо» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Im hallenden Torbogen von Gonerils Burg verharrt Gloucester zwischen gepackten Kisten.",
+            "Das kalte Licht lässt das Wort „der Brief“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "glauben",
           "russian": "верить",
           "transcription": "[ГЛАУ-бен]",
           "sentence": "Auf der windigen Freitreppe blickt Gloucester zum schweigenden Hof hinunter. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „glauben“ gehört mir.",
-          "sentence_translation": "На продуваемой ветром лестнице Глостер смотрит вниз на молчаливый двор. Буря за окнами усиливает клятву: слово «верить» принадлежит мне."
+          "sentence_translation": "На продуваемой ветром лестнице Глостер смотрит вниз на молчаливый двор. Буря за окнами усиливает клятву: слово «верить» принадлежит мне.",
+          "sentence_parts": [
+            "Auf der windigen Freitreppe blickt Gloucester zum schweigenden Hof hinunter.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „glauben“ gehört mir."
+          ]
         },
         {
           "german": "täuschen",
           "russian": "обманывать",
           "transcription": "[ТОЙ-шен]",
           "sentence": "Zwischen zurückgelassenen Dienern schließt Gloucester den Reisemantel enger. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir.",
-          "sentence_translation": "Среди оставленных слуг Глостер плотнее запахивает дорожный плащ. Буря за окнами усиливает клятву: слово «обманывать» принадлежит мне."
+          "sentence_translation": "Среди оставленных слуг Глостер плотнее запахивает дорожный плащ. Буря за окнами усиливает клятву: слово «обманывать» принадлежит мне.",
+          "sentence_parts": [
+            "Zwischen zurückgelassenen Dienern schließt Gloucester den Reisemantel enger.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir."
+          ]
         },
         {
           "german": "der Betrug",
           "russian": "обман",
           "transcription": "[дер бе-ТРУГ]",
           "sentence": "Am dunklen Pferdestall streicht Gloucester einem nervösen Tier über die Mähne. Ich zeichne das Wort „der Betrug“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "У тёмного конюшенного ряда Глостер гладит гриву нервного коня. Я черчу слово «обман» в мыслях поверх линий судьбы."
+          "sentence_translation": "У тёмного конюшенного ряда Глостер гладит гриву нервного коня. Я черчу слово «обман» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Am dunklen Pferdestall streicht Gloucester einem nervösen Tier über die Mähne.",
+            "Ich zeichne das Wort „der Betrug“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "arglos",
           "russian": "простодушный",
           "transcription": "[АРГ-лос]",
           "sentence": "Vor dem knarrenden Fallgatter tastet Gloucester ein letztes Mal nach dem Haustor. Ich zeichne das Wort „arglos“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Перед скрипящим подъёмным мостом Глостер в последний раз касается родной двери. Я вывожу слово «простодушный» невидимыми чернилами на ладони."
+          "sentence_translation": "Перед скрипящим подъёмным мостом Глостер в последний раз касается родной двери. Я вывожу слово «простодушный» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Vor dem knarrenden Fallgatter tastet Gloucester ein letztes Mal nach dem Haustor.",
+            "Ich zeichne das Wort „arglos“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "verdächtigen",
           "russian": "подозревать",
           "transcription": "[фер-ДЕХ-ти-ген]",
           "sentence": "Zwischen verstreuten Schriftrollen dreht Gloucester den Ring an der Hand. Selbst wenn die Welt zerfällt, bleibt das Wort „verdächtigen“ mein Nordstern.",
-          "sentence_translation": "Среди разбросанных свитков Глостер вертит кольцо на пальце. Даже если мир распадается, слово «подозревать» остаётся моим северным светом."
+          "sentence_translation": "Среди разбросанных свитков Глостер вертит кольцо на пальце. Даже если мир распадается, слово «подозревать» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Zwischen verstreuten Schriftrollen dreht Gloucester den Ring an der Hand.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „verdächtigen“ mein Nordstern."
+          ]
         },
         {
           "german": "leichtgläubig",
           "russian": "легковерный",
           "transcription": "[ЛАЙХТ-глой-биг]",
           "sentence": "Am leeren Bankettisch zählt Gloucester die verlöschenden Kerzen. Mein Atem zeichnet das Wort „leichtgläubig“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "У пустого банкетного стола Глостер пересчитывает гаснущие свечи. Моё дыхание рисует слово «легковерный» в холодном воздухе между нами."
+          "sentence_translation": "У пустого банкетного стола Глостер пересчитывает гаснущие свечи. Моё дыхание рисует слово «легковерный» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Am leeren Bankettisch zählt Gloucester die verlöschenden Kerzen.",
+            "Mein Atem zeichnet das Wort „leichtgläubig“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Falle",
           "russian": "ловушка",
           "transcription": "[ди ФА-ле]",
           "sentence": "Zwischen schweigenden Wachen geht Gloucester auf den kalten Hof hinaus. Ich presse das Wort „die Falle“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Между молчаливыми стражниками Глостер выходит на холодный двор. Я стискиваю слово «ловушка» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Между молчаливыми стражниками Глостер выходит на холодный двор. Я стискиваю слово «ловушка» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Zwischen schweigenden Wachen geht Gloucester auf den kalten Hof hinaus.",
+            "Ich presse das Wort „die Falle“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -201,49 +266,77 @@
           "russian": "изгонять",
           "transcription": "[фер-ШТО-сен]",
           "sentence": "Im zugigen Seitenflügel lauscht Gloucester dem Heulen der Küstenwinde. Ich umarme das Wort „verstoßen“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В продуваемом ветром боковом крыле Глостер слушает вой прибрежного ветра. Я обнимаю слово «изгонять», будто это единственный союзник."
+          "sentence_translation": "В продуваемом ветром боковом крыле Глостер слушает вой прибрежного ветра. Я обнимаю слово «изгонять», будто это единственный союзник.",
+          "sentence_parts": [
+            "Im zugigen Seitenflügel lauscht Gloucester dem Heulen der Küstenwinde.",
+            "Ich umarme das Wort „verstoßen“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "verfluchen",
           "russian": "проклинать",
           "transcription": "[фер-ФЛУ-хен]",
           "sentence": "Vor dem rauchigen Kamin der Burg faltet Gloucester einen zerknitterten Brief. Ich zeichne das Wort „verfluchen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Перед дымным камином замка Глостер складывает измятый лист. Я черчу слово «проклинать» в мыслях поверх линий судьбы."
+          "sentence_translation": "Перед дымным камином замка Глостер складывает измятый лист. Я черчу слово «проклинать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Vor dem rauchigen Kamin der Burg faltet Gloucester einen zerknitterten Brief.",
+            "Ich zeichne das Wort „verfluchen“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
           "sentence": "Unter farblosen Wandteppichen schreitet Gloucester rastlos auf und ab. Das kalte Licht lässt das Wort „bereuen“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Под выцветшими гобеленами Глостер беспокойно меряет шагами зал. Холодный свет заставляет слово «сожалеть» сиять словно расплавленное золото."
+          "sentence_translation": "Под выцветшими гобеленами Глостер беспокойно меряет шагами зал. Холодный свет заставляет слово «сожалеть» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Unter farblosen Wandteppichen schreitet Gloucester rastlos auf und ab.",
+            "Das kalte Licht lässt das Wort „bereuen“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "der Irrtum",
           "russian": "заблуждение",
           "transcription": "[дер ИР-тум]",
           "sentence": "An der schmalen Fensterluke zählt Gloucester die Fackeln auf dem Hof. Ich halte das Wort „der Irrtum“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У узкой бойницы Глостер считает факелы на дворе. Я держу слово «заблуждение» как факел у сердца."
+          "sentence_translation": "У узкой бойницы Глостер считает факелы на дворе. Я держу слово «заблуждение» как факел у сердца.",
+          "sentence_parts": [
+            "An der schmalen Fensterluke zählt Gloucester die Fackeln auf dem Hof.",
+            "Ich halte das Wort „der Irrtum“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "blind",
           "russian": "слепой",
           "transcription": "[БЛИНД]",
           "sentence": "Zwischen Reisekoffern der Gesandten sucht Gloucester nach frischen Botschaften. Wie ein stilles Gebet legt sich das Wort „blind“ auf meine Lippen.",
-          "sentence_translation": "Среди дорожных сундуков послов Глостер ищет свежие вести. Как тихая молитва слово «слепой» ложится на мои губы."
+          "sentence_translation": "Среди дорожных сундуков послов Глостер ищет свежие вести. Как тихая молитва слово «слепой» ложится на мои губы.",
+          "sentence_parts": [
+            "Zwischen Reisekoffern der Gesandten sucht Gloucester nach frischen Botschaften.",
+            "Wie ein stilles Gebet legt sich das Wort „blind“ auf meine Lippen."
+          ]
         },
         {
           "german": "jagen",
           "russian": "гнать",
           "transcription": "[Я-ген]",
           "sentence": "Im stillen Kapellenraum kniet Gloucester vor der kalten Steinfigur. Mit jeder Faser meines Körpers verspreche ich: Das Wort „jagen“ bleibt lebendig.",
-          "sentence_translation": "В тихой капелле Глостер преклоняет колени перед холодной каменной фигурой. Каждой клеткой тела я обещаю: слово «гнать» останется живым."
+          "sentence_translation": "В тихой капелле Глостер преклоняет колени перед холодной каменной фигурой. Каждой клеткой тела я обещаю: слово «гнать» останется живым.",
+          "sentence_parts": [
+            "Im stillen Kapellenraum kniet Gloucester vor der kalten Steinfigur.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „jagen“ bleibt lebendig."
+          ]
         },
         {
           "german": "die Ungerechtigkeit",
           "russian": "несправедливость",
           "transcription": "[ди УН-ге-рех-тиг-кайт]",
           "sentence": "Auf dem Balkon, den das Meer besprüht, hält Gloucester die Laterne fest. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ungerechtigkeit“ bleibt lebendig.",
-          "sentence_translation": "На балконе, омываемом морскими брызгами, Глостер крепко держит фонарь. Каждой клеткой тела я обещаю: слово «несправедливость» останется живым."
+          "sentence_translation": "На балконе, омываемом морскими брызгами, Глостер крепко держит фонарь. Каждой клеткой тела я обещаю: слово «несправедливость» останется живым.",
+          "sentence_parts": [
+            "Auf dem Balkon, den das Meer besprüht, hält Gloucester die Laterne fest.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ungerechtigkeit“ bleibt lebendig."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -287,56 +380,88 @@
           "russian": "помогать",
           "transcription": "[ХЕЛЬ-фен]",
           "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Gloucester gegen den Wind. Das Echo des Wortes „helfen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Посреди хлещущей дождём пустоши Глостер упирается в ветер. Эхо слова «помогать» заглушает шёпот придворных."
+          "sentence_translation": "Посреди хлещущей дождём пустоши Глостер упирается в ветер. Эхо слова «помогать» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Mitten auf der vom Regen gepeitschten Heide stemmt sich Gloucester gegen den Wind.",
+            "Das Echo des Wortes „helfen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "das Mitleid",
           "russian": "сострадание",
           "transcription": "[дас МИТ-лайд]",
           "sentence": "Unter einem zerrissenen Banner schützt Gloucester die Augen vor den Blitzen. Selbst wenn die Welt zerfällt, bleibt das Wort „das Mitleid“ mein Nordstern.",
-          "sentence_translation": "Под разорванным знаменем Глостер прикрывает глаза от молний. Даже если мир распадается, слово «сострадание» остаётся моим северным светом."
+          "sentence_translation": "Под разорванным знаменем Глостер прикрывает глаза от молний. Даже если мир распадается, слово «сострадание» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Unter einem zerrissenen Banner schützt Gloucester die Augen vor den Blitzen.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „das Mitleid“ mein Nordstern."
+          ]
         },
         {
           "german": "riskieren",
           "russian": "рисковать",
           "transcription": "[рис-КИ-рен]",
           "sentence": "Am Rand eines umgestürzten Baumes sucht Gloucester Deckung vor dem Donner. Selbst wenn die Welt zerfällt, bleibt das Wort „riskieren“ mein Nordstern.",
-          "sentence_translation": "У поваленного дерева Глостер ищет укрытия от грома. Даже если мир распадается, слово «рисковать» остаётся моим северным светом."
+          "sentence_translation": "У поваленного дерева Глостер ищет укрытия от грома. Даже если мир распадается, слово «рисковать» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Am Rand eines umgestürzten Baumes sucht Gloucester Deckung vor dem Donner.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „riskieren“ mein Nordstern."
+          ]
         },
         {
           "german": "die Gefahr",
           "russian": "опасность",
           "transcription": "[ди ге-ФАР]",
           "sentence": "Zwischen schäumenden Wassergräben stolpert Gloucester durch den Schlamm. Das kalte Licht lässt das Wort „die Gefahr“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Между пенящимися лужами Глостер пробирается через грязь. Холодный свет заставляет слово «опасность» сиять словно расплавленное золото."
+          "sentence_translation": "Между пенящимися лужами Глостер пробирается через грязь. Холодный свет заставляет слово «опасность» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Zwischen schäumenden Wassergräben stolpert Gloucester durch den Schlamm.",
+            "Das kalte Licht lässt das Wort „die Gefahr“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "heimlich",
           "russian": "тайно",
           "transcription": "[ХАЙМ-лих]",
           "sentence": "Vor einem zuckenden Himmel hebt Gloucester die Arme trotzig an. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „heimlich“ gehört mir.",
-          "sentence_translation": "На фоне вспыхивающего неба Глостер упрямо поднимает руки. Буря за окнами усиливает клятву: слово «тайно» принадлежит мне."
+          "sentence_translation": "На фоне вспыхивающего неба Глостер упрямо поднимает руки. Буря за окнами усиливает клятву: слово «тайно» принадлежит мне.",
+          "sentence_parts": [
+            "Vor einem zuckenden Himmel hebt Gloucester die Arme trotzig an.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „heimlich“ gehört mir."
+          ]
         },
         {
           "german": "schützen",
           "russian": "защищать",
           "transcription": "[ШЮ-цен]",
           "sentence": "Unter dem durchtränkten Umhang presst Gloucester den Atem gegen die Kälte. Mit jeder Faser meines Körpers verspreche ich: Das Wort „schützen“ bleibt lebendig.",
-          "sentence_translation": "Под промокшим плащом Глостер прижимает дыхание к груди, спасаясь от холода. Каждой клеткой тела я обещаю: слово «защищать» останется живым."
+          "sentence_translation": "Под промокшим плащом Глостер прижимает дыхание к груди, спасаясь от холода. Каждой клеткой тела я обещаю: слово «защищать» останется живым.",
+          "sentence_parts": [
+            "Unter dem durchtränkten Umhang presst Gloucester den Atem gegen die Kälte.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „schützen“ bleibt lebendig."
+          ]
         },
         {
           "german": "der Verrat",
           "russian": "измена",
           "transcription": "[дер фер-РАТ]",
           "sentence": "Am kläglichen Feuerrest wärmt Gloucester zitternde Finger. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Verrat“ gehört mir.",
-          "sentence_translation": "У жалких огненных углей Глостер греет дрожащие пальцы. Буря за окнами усиливает клятву: слово «измена» принадлежит мне."
+          "sentence_translation": "У жалких огненных углей Глостер греет дрожащие пальцы. Буря за окнами усиливает клятву: слово «измена» принадлежит мне.",
+          "sentence_parts": [
+            "Am kläglichen Feuerrest wärmt Gloucester zitternde Finger.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Verrat“ gehört mir."
+          ]
         },
         {
           "german": "wagen",
           "russian": "осмеливаться",
           "transcription": "[ВА-ген]",
           "sentence": "Zwischen heulenden Hunden ruft Gloucester gegen den tosenden Sturm an. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „wagen“ gehört mir.",
-          "sentence_translation": "Среди воющих псов Глостер перекрикивает беснующуюся бурю. Буря за окнами усиливает клятву: слово «осмеливаться» принадлежит мне."
+          "sentence_translation": "Среди воющих псов Глостер перекрикивает беснующуюся бурю. Буря за окнами усиливает клятву: слово «осмеливаться» принадлежит мне.",
+          "sentence_parts": [
+            "Zwischen heulenden Hunden ruft Gloucester gegen den tosenden Sturm an.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „wagen“ gehört mir."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -380,49 +505,79 @@
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
           "sentence": "Im dunklen Zelt der Feldärzte sitzt Gloucester bei der flackernden Kerze. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „blenden“ gehört mir.",
-          "sentence_translation": "В тёмном шатре полевых лекарей Глостер сидит у мерцающей свечи. Буря за окнами усиливает клятву: слово «ослеплять» принадлежит мне."
+          "sentence_translation": "В тёмном шатре полевых лекарей Глостер сидит у мерцающей свечи. Буря за окнами усиливает клятву: слово «ослеплять» принадлежит мне.",
+          "sentence_parts": [
+            "Im dunklen Zelt der Feldärzte sitzt Gloucester bei der flackernden Kerze.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „blenden“ gehört mir."
+          ]
         },
         {
           "german": "die Folter",
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
           "sentence": "Zwischen zerbeulten Rüstungen streicht Gloucester über ein altes Wappen. Ich presse das Wort „die Folter“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Среди помятых доспехов Глостер гладит старый герб. Я стискиваю слово «пытка» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Среди помятых доспехов Глостер гладит старый герб. Я стискиваю слово «пытка» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Zwischen zerbeulten Rüstungen streicht Gloucester über ein altes Wappen.",
+            "Ich presse das Wort „die Folter“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "der Schmerz",
           "russian": "боль",
           "transcription": "[дер ШМЕРЦ]",
           "sentence": "Am niedrigen Dachbalken der Hütte stößt Gloucester fast den Kopf. Ich umarme das Wort „der Schmerz“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "О низкую балку хижины Глостер едва не ударяется головой. Я обнимаю слово «боль», будто это единственный союзник."
+          "sentence_translation": "О низкую балку хижины Глостер едва не ударяется головой. Я обнимаю слово «боль», будто это единственный союзник.",
+          "sentence_parts": [
+            "Am niedrigen Dachbalken der Hütte stößt Gloucester fast den Kopf.",
+            "Ich umarme das Wort „der Schmerz“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Dunkelheit",
           "russian": "темнота",
           "transcription": "[ди ДУН-кель-хайт]",
           "sentence": "Neben der schlafenden Wache flüstert Gloucester in die schwere Nacht. Ich presse das Wort „die Dunkelheit“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Рядом со спящим стражем Глостер шепчет в тяжёлую ночь. Я стискиваю слово «темнота» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Рядом со спящим стражем Глостер шепчет в тяжёлую ночь. Я стискиваю слово «темнота» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Neben der schlafenden Wache flüstert Gloucester in die schwere Nacht.",
+            "Ich presse das Wort „die Dunkelheit“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "schreien",
           "russian": "кричать",
           "transcription": "[ШРАЙ-ен]",
           "sentence": "Vor dem einfachen Feldbett betrachtet Gloucester die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „schreien“ wird heute nicht verraten.",
-          "sentence_translation": "Перед грубой походной койкой Глостер разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «кричать» сегодня не будет предано."
+          "sentence_translation": "Перед грубой походной койкой Глостер разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «кричать» сегодня не будет предано.",
+          "sentence_parts": [
+            "Vor dem einfachen Feldbett betrachtet Gloucester die Narben vergangener Schlachten.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „schreien“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "erblinden",
           "russian": "слепнуть",
           "transcription": "[ер-БЛИН-ден]",
           "sentence": "Im Geruch von feuchtem Stroh legt Gloucester den Mantel zur Seite. Ich flüstere den Wächtern des Schicksals zu: Das Wort „erblinden“ darf nicht vergehen.",
-          "sentence_translation": "В запахе влажной соломы Глостер откладывает плащ в сторону. Я шепчу стражам судьбы: слово «слепнуть» не должно исчезнуть."
+          "sentence_translation": "В запахе влажной соломы Глостер откладывает плащ в сторону. Я шепчу стражам судьбы: слово «слепнуть» не должно исчезнуть.",
+          "sentence_parts": [
+            "Im Geruch von feuchtem Stroh legt Gloucester den Mantel zur Seite.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „erblinden“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
           "sentence": "Auf dem wackligen Holztisch ordnet Gloucester zerlesene Briefe. Wie ein stilles Gebet legt sich das Wort „die Rache“ auf meine Lippen.",
-          "sentence_translation": "На шатком деревянном столе Глостер раскладывает зачитанные письма. Как тихая молитва слово «месть» ложится на мои губы."
+          "sentence_translation": "На шатком деревянном столе Глостер раскладывает зачитанные письма. Как тихая молитва слово «месть» ложится на мои губы.",
+          "sentence_parts": [
+            "Auf dem wackligen Holztisch ordnet Gloucester zerlesene Briefe.",
+            "Wie ein stilles Gebet legt sich das Wort „die Rache“ auf meine Lippen."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -466,56 +621,88 @@
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
           "sentence": "Auf den weißen Klippen von Dover blickt Gloucester in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „die Verzweiflung“ mein Nordstern.",
-          "sentence_translation": "На белых скалах Дувра Глостер смотрит в вздыбленный пролив. Даже если мир распадается, слово «отчаяние» остаётся моим северным светом."
+          "sentence_translation": "На белых скалах Дувра Глостер смотрит в вздыбленный пролив. Даже если мир распадается, слово «отчаяние» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Auf den weißen Klippen von Dover blickt Gloucester in den aufgewühlten Kanal.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Verzweiflung“ mein Nordstern."
+          ]
         },
         {
           "german": "springen",
           "russian": "прыгать",
           "transcription": "[ШПРИН-ген]",
           "sentence": "Zwischen flatternden Feldzeichen richtet Gloucester den Helm. Das Echo des Wortes „springen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Среди хлопающих штандартов Глостер поправляет шлем. Эхо слова «прыгать» заглушает шёпот придворных."
+          "sentence_translation": "Среди хлопающих штандартов Глостер поправляет шлем. Эхо слова «прыгать» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Zwischen flatternden Feldzeichen richtet Gloucester den Helm.",
+            "Das Echo des Wortes „springen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Täuschung",
           "russian": "обман",
           "transcription": "[ди ТОЙ-шунг]",
           "sentence": "Am Lagerfeuer der Franzosen zeichnet Gloucester Marschrouten in den Sand. Ich halte das Wort „die Täuschung“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У французского костра Глостер рисует в песке путь марша. Я держу слово «обман» как факел у сердца."
+          "sentence_translation": "У французского костра Глостер рисует в песке путь марша. Я держу слово «обман» как факел у сердца.",
+          "sentence_parts": [
+            "Am Lagerfeuer der Franzosen zeichnet Gloucester Marschrouten in den Sand.",
+            "Ich halte das Wort „die Täuschung“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "der Abgrund",
           "russian": "пропасть",
           "transcription": "[дер АБ-грунд]",
           "sentence": "Neben verschnürten Versorgungskisten kontrolliert Gloucester das Siegel. Ich halte das Wort „der Abgrund“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У перевязанных провиантных ящиков Глостер проверяет печати. Я держу слово «пропасть» как факел у сердца."
+          "sentence_translation": "У перевязанных провиантных ящиков Глостер проверяет печати. Я держу слово «пропасть» как факел у сердца.",
+          "sentence_parts": [
+            "Neben verschnürten Versorgungskisten kontrolliert Gloucester das Siegel.",
+            "Ich halte das Wort „der Abgrund“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "aufgeben",
           "russian": "сдаваться",
           "transcription": "[АУФ-ге-бен]",
           "sentence": "Vor dem Seidenzelt der Heerführer lauscht Gloucester dem dumpfen Meer. Das kalte Licht lässt das Wort „aufgeben“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Перед шёлковым шатром полководцев Глостер слушает глухой шум моря. Холодный свет заставляет слово «сдаваться» сиять словно расплавленное золото."
+          "sentence_translation": "Перед шёлковым шатром полководцев Глостер слушает глухой шум моря. Холодный свет заставляет слово «сдаваться» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Vor dem Seidenzelt der Heerführer lauscht Gloucester dem dumpfen Meer.",
+            "Das kalte Licht lässt das Wort „aufgeben“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "die Hoffnungslosigkeit",
           "russian": "безнадёжность",
           "transcription": "[ди ХОФ-нунгс-ло-зиг-кайт]",
           "sentence": "Auf dem sandigen Trainingsplatz übt Gloucester das Ziehen des Schwerts. Mein Atem zeichnet das Wort „die Hoffnungslosigkeit“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "На песчаном плацу Глостер отрабатывает выхват меча. Моё дыхание рисует слово «безнадёжность» в холодном воздухе между нами."
+          "sentence_translation": "На песчаном плацу Глостер отрабатывает выхват меча. Моё дыхание рисует слово «безнадёжность» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Auf dem sandigen Trainingsplatz übt Gloucester das Ziehen des Schwerts.",
+            "Mein Atem zeichnet das Wort „die Hoffnungslosigkeit“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "stürzen",
           "russian": "падать",
           "transcription": "[ШТЮР-цен]",
           "sentence": "Zwischen pochenden Trommeln hebt Gloucester das Banner der Hoffnung. Das kalte Licht lässt das Wort „stürzen“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Под гул барабанов Глостер поднимает знамя надежды. Холодный свет заставляет слово «падать» сиять словно расплавленное золото."
+          "sentence_translation": "Под гул барабанов Глостер поднимает знамя надежды. Холодный свет заставляет слово «падать» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Zwischen pochenden Trommeln hebt Gloucester das Banner der Hoffnung.",
+            "Das kalte Licht lässt das Wort „stürzen“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "erlösen",
           "russian": "избавлять",
           "transcription": "[ер-ЛЁ-зен]",
           "sentence": "Am Morgennebel der Küste legt Gloucester die Hand auf das pochende Herz. Ich presse das Wort „erlösen“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "В утреннем тумане побережья Глостер кладёт ладонь на бьющееся сердце. Я стискиваю слово «избавлять» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "В утреннем тумане побережья Глостер кладёт ладонь на бьющееся сердце. Я стискиваю слово «избавлять» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Am Morgennebel der Küste legt Gloucester die Hand auf das pochende Herz.",
+            "Ich presse das Wort „erlösen“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -559,56 +746,88 @@
           "russian": "узнавать",
           "transcription": "[ер-КЕН-нен]",
           "sentence": "Im feuchten Kerker stützt Gloucester sich an den tropfenden Stein. Ich umarme das Wort „erkennen“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В сыром подземелье Глостер опирается на сочащийся камень. Я обнимаю слово «узнавать», будто это единственный союзник."
+          "sentence_translation": "В сыром подземелье Глостер опирается на сочащийся камень. Я обнимаю слово «узнавать», будто это единственный союзник.",
+          "sentence_parts": [
+            "Im feuchten Kerker stützt Gloucester sich an den tropfenden Stein.",
+            "Ich umarme das Wort „erkennen“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "vergeben",
           "russian": "прощать",
           "transcription": "[фер-ГЕ-бен]",
           "sentence": "Unter der trüben Laterne zählt Gloucester die eisernen Ringe der Kette. Ich zeichne das Wort „vergeben“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Под мутным фонарём Глостер пересчитывает железные кольца цепи. Я черчу слово «прощать» в мыслях поверх линий судьбы."
+          "sentence_translation": "Под мутным фонарём Глостер пересчитывает железные кольца цепи. Я черчу слово «прощать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Unter der trüben Laterne zählt Gloucester die eisernen Ringe der Kette.",
+            "Ich zeichne das Wort „vergeben“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
           "sentence": "Neben der schweren Holztür horcht Gloucester auf entferntes Schluchzen. Ich halte das Wort „sterben“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У тяжёлой двери Глостер прислушивается к далёким рыданиям. Я держу слово «умирать» как факел у сердца."
+          "sentence_translation": "У тяжёлой двери Глостер прислушивается к далёким рыданиям. Я держу слово «умирать» как факел у сердца.",
+          "sentence_parts": [
+            "Neben der schweren Holztür horcht Gloucester auf entferntes Schluchzen.",
+            "Ich halte das Wort „sterben“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Erkenntnis",
           "russian": "осознание",
           "transcription": "[ди ер-КЕНТ-нис]",
           "sentence": "Auf der kalten Steinbank zieht Gloucester den Mantel enger um die Schultern. Das Echo des Wortes „die Erkenntnis“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "На холодной каменной скамье Глостер плотнее кутается в плащ. Эхо слова «осознание» заглушает шёпот придворных."
+          "sentence_translation": "На холодной каменной скамье Глостер плотнее кутается в плащ. Эхо слова «осознание» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Auf der kalten Steinbank zieht Gloucester den Mantel enger um die Schultern.",
+            "Das Echo des Wortes „die Erkenntnis“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Reue",
           "russian": "раскаяние",
           "transcription": "[ди РОЙ-е]",
           "sentence": "Zwischen Schatten der Gitterstäbe hebt Gloucester das Gesicht zum Licht. Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Между тенями решёток Глостер поднимает лицо к свету. Я черчу слово «раскаяние» в мыслях поверх линий судьбы."
+          "sentence_translation": "Между тенями решёток Глостер поднимает лицо к свету. Я черчу слово «раскаяние» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Zwischen Schatten der Gitterstäbe hebt Gloucester das Gesicht zum Licht.",
+            "Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "umarmen",
           "russian": "обнимать",
           "transcription": "[ум-АР-мен]",
           "sentence": "Am rostigen Wassereimer spiegelt Gloucester kurz die eigenen Augen. Wie ein stilles Gebet legt sich das Wort „umarmen“ auf meine Lippen.",
-          "sentence_translation": "У ржавого ведра с водой Глостер на мгновение видит отражение глаз. Как тихая молитва слово «обнимать» ложится на мои губы."
+          "sentence_translation": "У ржавого ведра с водой Глостер на мгновение видит отражение глаз. Как тихая молитва слово «обнимать» ложится на мои губы.",
+          "sentence_parts": [
+            "Am rostigen Wassereimer spiegelt Gloucester kurz die eigenen Augen.",
+            "Wie ein stilles Gebet legt sich das Wort „umarmen“ auf meine Lippen."
+          ]
         },
         {
           "german": "die Versöhnung",
           "russian": "примирение",
           "transcription": "[ди фер-ЗЁ-нунг]",
           "sentence": "Im dumpfen Hall der Schritte zählt Gloucester den Rhythmus der Wachen. Mein Atem zeichnet das Wort „die Versöhnung“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В глухом эхе шагов Глостер отсчитывает ритм часовых. Моё дыхание рисует слово «примирение» в холодном воздухе между нами."
+          "sentence_translation": "В глухом эхе шагов Глостер отсчитывает ритм часовых. Моё дыхание рисует слово «примирение» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im dumpfen Hall der Schritte zählt Gloucester den Rhythmus der Wachen.",
+            "Mein Atem zeichnet das Wort „die Versöhnung“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "das Herz",
           "russian": "сердце",
           "transcription": "[дас ХЕРЦ]",
           "sentence": "Vor dem verriegelten Fenster zeichnet Gloucester Kreise in den Staub. Ich halte das Wort „das Herz“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Перед заколоченным окном Глостер чертит круги в пыли. Я держу слово «сердце» как факел у сердца."
+          "sentence_translation": "Перед заколоченным окном Глостер чертит круги в пыли. Я держу слово «сердце» как факел у сердца.",
+          "sentence_parts": [
+            "Vor dem verriegelten Fenster zeichnet Gloucester Kreise in den Staub.",
+            "Ich halte das Wort „das Herz“ wie eine Fackel vor meinem Herzen."
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/goneril.json
+++ b/data/characters/goneril.json
@@ -21,56 +21,88 @@
           "russian": "ложь",
           "transcription": "[ди ЛЮ-ге]",
           "sentence": "Goneril steht unter dem glühenden Kronleuchter des Thronsaals. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Lüge“ bleibt lebendig.",
-          "sentence_translation": "Гонерилья стоит под пылающей люстрой тронного зала. Каждой клеткой тела я обещаю: слово «ложь» останется живым."
+          "sentence_translation": "Гонерилья стоит под пылающей люстрой тронного зала. Каждой клеткой тела я обещаю: слово «ложь» останется живым.",
+          "sentence_parts": [
+            "Goneril steht unter dem glühenden Kronleuchter des Thronsaals.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Lüge“ bleibt lebendig."
+          ]
         },
         {
           "german": "schwören",
           "russian": "клясться",
           "transcription": "[ШВЁ-рен]",
           "sentence": "Neben der ausgerollten Reichskarte beugt sich Goneril über Lears schweren Tisch. Ich flüstere den Wächtern des Schicksals zu: Das Wort „schwören“ darf nicht vergehen.",
-          "sentence_translation": "У развернутой карты королевства Гонерилья склоняется над тяжёлым столом Лира. Я шепчу стражам судьбы: слово «клясться» не должно исчезнуть."
+          "sentence_translation": "У развернутой карты королевства Гонерилья склоняется над тяжёлым столом Лира. Я шепчу стражам судьбы: слово «клясться» не должно исчезнуть.",
+          "sentence_parts": [
+            "Neben der ausgerollten Reichskarte beugt sich Goneril über Lears schweren Tisch.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „schwören“ darf nicht vergehen."
+          ]
         },
         {
           "german": "das Erbe",
           "russian": "наследство",
           "transcription": "[дас ЕР-бе]",
           "sentence": "Vor den steinernen Ahnenstatuen verschränkt Goneril die Hände hinter dem Rücken. Mit jeder Faser meines Körpers verspreche ich: Das Wort „das Erbe“ bleibt lebendig.",
-          "sentence_translation": "Перед каменными статуями предков Гонерилья сцепляет руки за спиной. Каждой клеткой тела я обещаю: слово «наследство» останется живым."
+          "sentence_translation": "Перед каменными статуями предков Гонерилья сцепляет руки за спиной. Каждой клеткой тела я обещаю: слово «наследство» останется живым.",
+          "sentence_parts": [
+            "Vor den steinernen Ahnenstatuen verschränkt Goneril die Hände hinter dem Rücken.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „das Erbe“ bleibt lebendig."
+          ]
         },
         {
           "german": "heucheln",
           "russian": "лицемерить",
           "transcription": "[ХОЙ-хельн]",
           "sentence": "Zwischen flüsternden Höflingen gleitet Goneril über den kalten Marmorboden. Ich umarme das Wort „heucheln“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Между шепчущимися придворными Гонерилья скользит по холодному мраморному полу. Я обнимаю слово «лицемерить», будто это единственный союзник."
+          "sentence_translation": "Между шепчущимися придворными Гонерилья скользит по холодному мраморному полу. Я обнимаю слово «лицемерить», будто это единственный союзник.",
+          "sentence_parts": [
+            "Zwischen flüsternden Höflingen gleitet Goneril über den kalten Marmorboden.",
+            "Ich umarme das Wort „heucheln“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Gier",
           "russian": "жадность",
           "transcription": "[ди ГИР]",
           "sentence": "Am Rand des purpurnen Teppichs wartet Goneril auf ein Zeichen des Königs. Ich zeichne das Wort „die Gier“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "На краю пурпурного ковра Гонерилья ждёт знака от короля. Я черчу слово «жадность» в мыслях поверх линий судьбы."
+          "sentence_translation": "На краю пурпурного ковра Гонерилья ждёт знака от короля. Я черчу слово «жадность» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Am Rand des purpurnen Teppichs wartet Goneril auf ein Zeichen des Königs.",
+            "Ich zeichne das Wort „die Gier“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "täuschen",
           "russian": "обманывать",
           "transcription": "[ТОЙ-шен]",
           "sentence": "Unter wehenden Standarten der Schwestern senkt Goneril kurz den Blick. Mit jeder Faser meines Körpers verspreche ich: Das Wort „täuschen“ bleibt lebendig.",
-          "sentence_translation": "Под развевающимися штандартами сестёр Гонерилья на миг опускает взгляд. Каждой клеткой тела я обещаю: слово «обманывать» останется живым."
+          "sentence_translation": "Под развевающимися штандартами сестёр Гонерилья на миг опускает взгляд. Каждой клеткой тела я обещаю: слово «обманывать» останется живым.",
+          "sentence_parts": [
+            "Unter wehenden Standarten der Schwestern senkt Goneril kurz den Blick.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „täuschen“ bleibt lebendig."
+          ]
         },
         {
           "german": "schmeicheln",
           "russian": "льстить",
           "transcription": "[ШМАЙ-хельн]",
           "sentence": "Hinter der vergoldeten Balustrade beobachtet Goneril das gespannte Antlitz des Hofes. Das Echo des Wortes „schmeicheln“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "За позолоченной балюстрадой Гонерилья наблюдает за напряжёнными лицами двора. Эхо слова «льстить» заглушает шёпот придворных."
+          "sentence_translation": "За позолоченной балюстрадой Гонерилья наблюдает за напряжёнными лицами двора. Эхо слова «льстить» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Hinter der vergoldeten Balustrade beobachtet Goneril das gespannte Antlitz des Hofes.",
+            "Das Echo des Wortes „schmeicheln“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "das Vermögen",
           "russian": "состояние",
           "transcription": "[дас фер-МЁ-ген]",
           "sentence": "Im Schein der offenen Feuerbecken erhebt Goneril langsam die Stimme. Ich umarme das Wort „das Vermögen“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В отблесках открытых жаровен Гонерилья медленно поднимает голос. Я обнимаю слово «состояние», будто это единственный союзник."
+          "sentence_translation": "В отблесках открытых жаровен Гонерилья медленно поднимает голос. Я обнимаю слово «состояние», будто это единственный союзник.",
+          "sentence_parts": [
+            "Im Schein der offenen Feuerbecken erhebt Goneril langsam die Stimme.",
+            "Ich umarme das Wort „das Vermögen“, als wäre es mein einziger Verbündeter."
+          ]
         }
       ],
       "quizzes": [
@@ -114,56 +146,88 @@
           "russian": "власть",
           "transcription": "[ди МАХТ]",
           "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Goneril zwischen gepackten Kisten. Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В гулком проёме ворот замка Гонерильи Гонерилья замирает среди нагруженных ящиков. Я обнимаю слово «власть», будто это единственный союзник."
+          "sentence_translation": "В гулком проёме ворот замка Гонерильи Гонерилья замирает среди нагруженных ящиков. Я обнимаю слово «власть», будто это единственный союзник.",
+          "sentence_parts": [
+            "Im hallenden Torbogen von Gonerils Burg verharrt Goneril zwischen gepackten Kisten.",
+            "Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "herrschen",
           "russian": "править",
           "transcription": "[ХЕР-шен]",
           "sentence": "Auf der windigen Freitreppe blickt Goneril zum schweigenden Hof hinunter. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „herrschen“ gehört mir.",
-          "sentence_translation": "На продуваемой ветром лестнице Гонерилья смотрит вниз на молчаливый двор. Буря за окнами усиливает клятву: слово «править» принадлежит мне."
+          "sentence_translation": "На продуваемой ветром лестнице Гонерилья смотрит вниз на молчаливый двор. Буря за окнами усиливает клятву: слово «править» принадлежит мне.",
+          "sentence_parts": [
+            "Auf der windigen Freitreppe blickt Goneril zum schweigenden Hof hinunter.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „herrschen“ gehört mir."
+          ]
         },
         {
           "german": "befehlen",
           "russian": "приказывать",
           "transcription": "[бе-ФЕ-лен]",
           "sentence": "Zwischen zurückgelassenen Dienern schließt Goneril den Reisemantel enger. Das Echo des Wortes „befehlen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Среди оставленных слуг Гонерилья плотнее запахивает дорожный плащ. Эхо слова «приказывать» заглушает шёпот придворных."
+          "sentence_translation": "Среди оставленных слуг Гонерилья плотнее запахивает дорожный плащ. Эхо слова «приказывать» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Zwischen zurückgelassenen Dienern schließt Goneril den Reisemantel enger.",
+            "Das Echo des Wortes „befehlen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "der Thron",
           "russian": "трон",
           "transcription": "[дер ТРОН]",
           "sentence": "Am dunklen Pferdestall streicht Goneril einem nervösen Tier über die Mähne. Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "У тёмного конюшенного ряда Гонерилья гладит гриву нервного коня. Моё дыхание рисует слово «трон» в холодном воздухе между нами."
+          "sentence_translation": "У тёмного конюшенного ряда Гонерилья гладит гриву нервного коня. Моё дыхание рисует слово «трон» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Am dunklen Pferdestall streicht Goneril einem nervösen Tier über die Mähne.",
+            "Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "erobern",
           "russian": "завоёвывать",
           "transcription": "[ер-О-берн]",
           "sentence": "Vor dem knarrenden Fallgatter tastet Goneril ein letztes Mal nach dem Haustor. Mit jeder Faser meines Körpers verspreche ich: Das Wort „erobern“ bleibt lebendig.",
-          "sentence_translation": "Перед скрипящим подъёмным мостом Гонерилья в последний раз касается родной двери. Каждой клеткой тела я обещаю: слово «завоёвывать» останется живым."
+          "sentence_translation": "Перед скрипящим подъёмным мостом Гонерилья в последний раз касается родной двери. Каждой клеткой тела я обещаю: слово «завоёвывать» останется живым.",
+          "sentence_parts": [
+            "Vor dem knarrenden Fallgatter tastet Goneril ein letztes Mal nach dem Haustor.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „erobern“ bleibt lebendig."
+          ]
         },
         {
           "german": "die Herrschaft",
           "russian": "господство",
           "transcription": "[ди ХЕР-шафт]",
           "sentence": "Zwischen verstreuten Schriftrollen dreht Goneril den Ring an der Hand. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Herrschaft“ gehört mir.",
-          "sentence_translation": "Среди разбросанных свитков Гонерилья вертит кольцо на пальце. Буря за окнами усиливает клятву: слово «господство» принадлежит мне."
+          "sentence_translation": "Среди разбросанных свитков Гонерилья вертит кольцо на пальце. Буря за окнами усиливает клятву: слово «господство» принадлежит мне.",
+          "sentence_parts": [
+            "Zwischen verstreuten Schriftrollen dreht Goneril den Ring an der Hand.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Herrschaft“ gehört mir."
+          ]
         },
         {
           "german": "regieren",
           "russian": "управлять",
           "transcription": "[ре-ГИ-рен]",
           "sentence": "Am leeren Bankettisch zählt Goneril die verlöschenden Kerzen. Mit fester Stimme schwöre ich mir: Das Wort „regieren“ wird heute nicht verraten.",
-          "sentence_translation": "У пустого банкетного стола Гонерилья пересчитывает гаснущие свечи. Твёрдым голосом я клянусь себе: слово «управлять» сегодня не будет предано."
+          "sentence_translation": "У пустого банкетного стола Гонерилья пересчитывает гаснущие свечи. Твёрдым голосом я клянусь себе: слово «управлять» сегодня не будет предано.",
+          "sentence_parts": [
+            "Am leeren Bankettisch zählt Goneril die verlöschenden Kerzen.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „regieren“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "unterwerfen",
           "russian": "подчинять",
           "transcription": "[ун-тер-ВЕР-фен]",
           "sentence": "Zwischen schweigenden Wachen geht Goneril auf den kalten Hof hinaus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „unterwerfen“ bleibt lebendig.",
-          "sentence_translation": "Между молчаливыми стражниками Гонерилья выходит на холодный двор. Каждой клеткой тела я обещаю: слово «подчинять» останется живым."
+          "sentence_translation": "Между молчаливыми стражниками Гонерилья выходит на холодный двор. Каждой клеткой тела я обещаю: слово «подчинять» останется живым.",
+          "sentence_parts": [
+            "Zwischen schweigenden Wachen geht Goneril auf den kalten Hof hinaus.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „unterwerfen“ bleibt lebendig."
+          ]
         }
       ],
       "quizzes": [
@@ -207,56 +271,88 @@
           "russian": "унижать",
           "transcription": "[де-МЮ-ти-ген]",
           "sentence": "Im zugigen Seitenflügel lauscht Goneril dem Heulen der Küstenwinde. Ich zeichne das Wort „demütigen“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "В продуваемом ветром боковом крыле Гонерилья слушает вой прибрежного ветра. Я вывожу слово «унижать» невидимыми чернилами на ладони."
+          "sentence_translation": "В продуваемом ветром боковом крыле Гонерилья слушает вой прибрежного ветра. Я вывожу слово «унижать» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Im zugigen Seitenflügel lauscht Goneril dem Heulen der Küstenwinde.",
+            "Ich zeichne das Wort „demütigen“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "grausam",
           "russian": "жестокий",
           "transcription": "[ГРАУ-зам]",
           "sentence": "Vor dem rauchigen Kamin der Burg faltet Goneril einen zerknitterten Brief. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „grausam“ gehört mir.",
-          "sentence_translation": "Перед дымным камином замка Гонерилья складывает измятый лист. Буря за окнами усиливает клятву: слово «жестокий» принадлежит мне."
+          "sentence_translation": "Перед дымным камином замка Гонерилья складывает измятый лист. Буря за окнами усиливает клятву: слово «жестокий» принадлежит мне.",
+          "sentence_parts": [
+            "Vor dem rauchigen Kamin der Burg faltet Goneril einen zerknitterten Brief.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „grausam“ gehört mir."
+          ]
         },
         {
           "german": "die Rache",
           "russian": "месть",
           "transcription": "[ди РА-хе]",
           "sentence": "Unter farblosen Wandteppichen schreitet Goneril rastlos auf und ab. Selbst wenn die Welt zerfällt, bleibt das Wort „die Rache“ mein Nordstern.",
-          "sentence_translation": "Под выцветшими гобеленами Гонерилья беспокойно меряет шагами зал. Даже если мир распадается, слово «месть» остаётся моим северным светом."
+          "sentence_translation": "Под выцветшими гобеленами Гонерилья беспокойно меряет шагами зал. Даже если мир распадается, слово «месть» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Unter farblosen Wandteppichen schreitet Goneril rastlos auf und ab.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Rache“ mein Nordstern."
+          ]
         },
         {
           "german": "vertreiben",
           "russian": "изгонять",
           "transcription": "[фер-ТРАЙ-бен]",
           "sentence": "An der schmalen Fensterluke zählt Goneril die Fackeln auf dem Hof. Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten.",
-          "sentence_translation": "У узкой бойницы Гонерилья считает факелы на дворе. Твёрдым голосом я клянусь себе: слово «изгонять» сегодня не будет предано."
+          "sentence_translation": "У узкой бойницы Гонерилья считает факелы на дворе. Твёрдым голосом я клянусь себе: слово «изгонять» сегодня не будет предано.",
+          "sentence_parts": [
+            "An der schmalen Fensterluke zählt Goneril die Fackeln auf dem Hof.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "verachten",
           "russian": "презирать",
           "transcription": "[фер-АХ-тен]",
           "sentence": "Zwischen Reisekoffern der Gesandten sucht Goneril nach frischen Botschaften. Mit fester Stimme schwöre ich mir: Das Wort „verachten“ wird heute nicht verraten.",
-          "sentence_translation": "Среди дорожных сундуков послов Гонерилья ищет свежие вести. Твёрдым голосом я клянусь себе: слово «презирать» сегодня не будет предано."
+          "sentence_translation": "Среди дорожных сундуков послов Гонерилья ищет свежие вести. Твёрдым голосом я клянусь себе: слово «презирать» сегодня не будет предано.",
+          "sentence_parts": [
+            "Zwischen Reisekoffern der Gesandten sucht Goneril nach frischen Botschaften.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „verachten“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "verweigern",
           "russian": "отказывать",
           "transcription": "[фер-ВАЙ-герн]",
           "sentence": "Im stillen Kapellenraum kniet Goneril vor der kalten Steinfigur. Ich zeichne das Wort „verweigern“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "В тихой капелле Гонерилья преклоняет колени перед холодной каменной фигурой. Я черчу слово «отказывать» в мыслях поверх линий судьбы."
+          "sentence_translation": "В тихой капелле Гонерилья преклоняет колени перед холодной каменной фигурой. Я черчу слово «отказывать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Im stillen Kapellenraum kniet Goneril vor der kalten Steinfigur.",
+            "Ich zeichne das Wort „verweigern“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "quälen",
           "russian": "мучить",
           "transcription": "[КВЕ-лен]",
           "sentence": "Auf dem Balkon, den das Meer besprüht, hält Goneril die Laterne fest. Selbst wenn die Welt zerfällt, bleibt das Wort „quälen“ mein Nordstern.",
-          "sentence_translation": "На балконе, омываемом морскими брызгами, Гонерилья крепко держит фонарь. Даже если мир распадается, слово «мучить» остаётся моим северным светом."
+          "sentence_translation": "На балконе, омываемом морскими брызгами, Гонерилья крепко держит фонарь. Даже если мир распадается, слово «мучить» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Auf dem Balkon, den das Meer besprüht, hält Goneril die Laterne fest.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „quälen“ mein Nordstern."
+          ]
         },
         {
           "german": "beschränken",
           "russian": "ограничивать",
           "transcription": "[бе-ШРЕН-кен]",
           "sentence": "Im Schatten der hohen Burgmauern schreibt Goneril eine fiebrige Antwort. Ich presse das Wort „beschränken“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "В тени высоких стен Гонерилья пишет лихорадочный ответ. Я стискиваю слово «ограничивать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "В тени высоких стен Гонерилья пишет лихорадочный ответ. Я стискиваю слово «ограничивать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Im Schatten der hohen Burgmauern schreibt Goneril eine fiebrige Antwort.",
+            "Ich presse das Wort „beschränken“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         }
       ],
       "quizzes": [
@@ -300,49 +396,77 @@
           "russian": "отвергать",
           "transcription": "[фер-ШТО-сен]",
           "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Goneril gegen den Wind. Wie ein stilles Gebet legt sich das Wort „verstoßen“ auf meine Lippen.",
-          "sentence_translation": "Посреди хлещущей дождём пустоши Гонерилья упирается в ветер. Как тихая молитва слово «отвергать» ложится на мои губы."
+          "sentence_translation": "Посреди хлещущей дождём пустоши Гонерилья упирается в ветер. Как тихая молитва слово «отвергать» ложится на мои губы.",
+          "sentence_parts": [
+            "Mitten auf der vom Regen gepeitschten Heide stemmt sich Goneril gegen den Wind.",
+            "Wie ein stilles Gebet legt sich das Wort „verstoßen“ auf meine Lippen."
+          ]
         },
         {
           "german": "der Sturm",
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
           "sentence": "Unter einem zerrissenen Banner schützt Goneril die Augen vor den Blitzen. Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Под разорванным знаменем Гонерилья прикрывает глаза от молний. Я обнимаю слово «буря», будто это единственный союзник."
+          "sentence_translation": "Под разорванным знаменем Гонерилья прикрывает глаза от молний. Я обнимаю слово «буря», будто это единственный союзник.",
+          "sentence_parts": [
+            "Unter einem zerrissenen Banner schützt Goneril die Augen vor den Blitzen.",
+            "Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "gnadenlos",
           "russian": "безжалостный",
           "transcription": "[ГНА-ден-лос]",
           "sentence": "Am Rand eines umgestürzten Baumes sucht Goneril Deckung vor dem Donner. Ich halte das Wort „gnadenlos“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У поваленного дерева Гонерилья ищет укрытия от грома. Я держу слово «безжалостный» как факел у сердца."
+          "sentence_translation": "У поваленного дерева Гонерилья ищет укрытия от грома. Я держу слово «безжалостный» как факел у сердца.",
+          "sentence_parts": [
+            "Am Rand eines umgestürzten Baumes sucht Goneril Deckung vor dem Donner.",
+            "Ich halte das Wort „gnadenlos“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "verschließen",
           "russian": "запирать",
           "transcription": "[фер-ШЛИ-сен]",
           "sentence": "Zwischen schäumenden Wassergräben stolpert Goneril durch den Schlamm. Ich presse das Wort „verschließen“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Между пенящимися лужами Гонерилья пробирается через грязь. Я стискиваю слово «запирать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Между пенящимися лужами Гонерилья пробирается через грязь. Я стискиваю слово «запирать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Zwischen schäumenden Wassergräben stolpert Goneril durch den Schlamm.",
+            "Ich presse das Wort „verschließen“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Kälte",
           "russian": "холод",
           "transcription": "[ди КЕЛ-те]",
           "sentence": "Vor einem zuckenden Himmel hebt Goneril die Arme trotzig an. Ich atme tief ein und lasse nur das Wort „die Kälte“ wieder hinaus.",
-          "sentence_translation": "На фоне вспыхивающего неба Гонерилья упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «холод»."
+          "sentence_translation": "На фоне вспыхивающего неба Гонерилья упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «холод».",
+          "sentence_parts": [
+            "Vor einem zuckenden Himmel hebt Goneril die Arme trotzig an.",
+            "Ich atme tief ein und lasse nur das Wort „die Kälte“ wieder hinaus."
+          ]
         },
         {
           "german": "erbarmungslos",
           "russian": "беспощадный",
           "transcription": "[ер-БАР-мунгс-лос]",
           "sentence": "Unter dem durchtränkten Umhang presst Goneril den Atem gegen die Kälte. Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Под промокшим плащом Гонерилья прижимает дыхание к груди, спасаясь от холода. Я стискиваю слово «беспощадный» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Под промокшим плащом Гонерилья прижимает дыхание к груди, спасаясь от холода. Я стискиваю слово «беспощадный» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Unter dem durchtränkten Umhang presst Goneril den Atem gegen die Kälte.",
+            "Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "verhärten",
           "russian": "ожесточаться",
           "transcription": "[фер-ХЕР-тен]",
           "sentence": "Am kläglichen Feuerrest wärmt Goneril zitternde Finger. Ich atme tief ein und lasse nur das Wort „verhärten“ wieder hinaus.",
-          "sentence_translation": "У жалких огненных углей Гонерилья греет дрожащие пальцы. Я глубоко вдыхаю и выпускаю только слово «ожесточаться»."
+          "sentence_translation": "У жалких огненных углей Гонерилья греет дрожащие пальцы. Я глубоко вдыхаю и выпускаю только слово «ожесточаться».",
+          "sentence_parts": [
+            "Am kläglichen Feuerrest wärmt Goneril zitternde Finger.",
+            "Ich atme tief ein und lasse nur das Wort „verhärten“ wieder hinaus."
+          ]
         }
       ],
       "quizzes": [
@@ -386,56 +510,88 @@
           "russian": "ссориться",
           "transcription": "[ШТРАЙ-тен]",
           "sentence": "Im dunklen Zelt der Feldärzte sitzt Goneril bei der flackernden Kerze. Ich atme tief ein und lasse nur das Wort „streiten“ wieder hinaus.",
-          "sentence_translation": "В тёмном шатре полевых лекарей Гонерилья сидит у мерцающей свечи. Я глубоко вдыхаю и выпускаю только слово «ссориться»."
+          "sentence_translation": "В тёмном шатре полевых лекарей Гонерилья сидит у мерцающей свечи. Я глубоко вдыхаю и выпускаю только слово «ссориться».",
+          "sentence_parts": [
+            "Im dunklen Zelt der Feldärzte sitzt Goneril bei der flackernden Kerze.",
+            "Ich atme tief ein und lasse nur das Wort „streiten“ wieder hinaus."
+          ]
         },
         {
           "german": "verraten",
           "russian": "предавать",
           "transcription": "[фер-РА-тен]",
           "sentence": "Zwischen zerbeulten Rüstungen streicht Goneril über ein altes Wappen. Ich atme tief ein und lasse nur das Wort „verraten“ wieder hinaus.",
-          "sentence_translation": "Среди помятых доспехов Гонерилья гладит старый герб. Я глубоко вдыхаю и выпускаю только слово «предавать»."
+          "sentence_translation": "Среди помятых доспехов Гонерилья гладит старый герб. Я глубоко вдыхаю и выпускаю только слово «предавать».",
+          "sentence_parts": [
+            "Zwischen zerbeulten Rüstungen streicht Goneril über ein altes Wappen.",
+            "Ich atme tief ein und lasse nur das Wort „verraten“ wieder hinaus."
+          ]
         },
         {
           "german": "die Zwietracht",
           "russian": "раздор",
           "transcription": "[ди ЦВИ-трахт]",
           "sentence": "Am niedrigen Dachbalken der Hütte stößt Goneril fast den Kopf. Ich zeichne das Wort „die Zwietracht“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "О низкую балку хижины Гонерилья едва не ударяется головой. Я черчу слово «раздор» в мыслях поверх линий судьбы."
+          "sentence_translation": "О низкую балку хижины Гонерилья едва не ударяется головой. Я черчу слово «раздор» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Am niedrigen Dachbalken der Hütte stößt Goneril fast den Kopf.",
+            "Ich zeichne das Wort „die Zwietracht“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "hassen",
           "russian": "ненавидеть",
           "transcription": "[ХА-сен]",
           "sentence": "Neben der schlafenden Wache flüstert Goneril in die schwere Nacht. Ich zeichne das Wort „hassen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Рядом со спящим стражем Гонерилья шепчет в тяжёлую ночь. Я черчу слово «ненавидеть» в мыслях поверх линий судьбы."
+          "sentence_translation": "Рядом со спящим стражем Гонерилья шепчет в тяжёлую ночь. Я черчу слово «ненавидеть» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Neben der schlafenden Wache flüstert Goneril in die schwere Nacht.",
+            "Ich zeichne das Wort „hassen“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "betrügen",
           "russian": "изменять",
           "transcription": "[бе-ТРЮ-ген]",
           "sentence": "Vor dem einfachen Feldbett betrachtet Goneril die Narben vergangener Schlachten. Ich zeichne das Wort „betrügen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Перед грубой походной койкой Гонерилья разглядывает шрамы прошлых битв. Я черчу слово «изменять» в мыслях поверх линий судьбы."
+          "sentence_translation": "Перед грубой походной койкой Гонерилья разглядывает шрамы прошлых битв. Я черчу слово «изменять» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Vor dem einfachen Feldbett betrachtet Goneril die Narben vergangener Schlachten.",
+            "Ich zeichne das Wort „betrügen“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "die Verachtung",
           "russian": "презрение",
           "transcription": "[ди фер-АХ-тунг]",
           "sentence": "Im Geruch von feuchtem Stroh legt Goneril den Mantel zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verachtung“ bleibt lebendig.",
-          "sentence_translation": "В запахе влажной соломы Гонерилья откладывает плащ в сторону. Каждой клеткой тела я обещаю: слово «презрение» останется живым."
+          "sentence_translation": "В запахе влажной соломы Гонерилья откладывает плащ в сторону. Каждой клеткой тела я обещаю: слово «презрение» останется живым.",
+          "sentence_parts": [
+            "Im Geruch von feuchtem Stroh legt Goneril den Mantel zur Seite.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verachtung“ bleibt lebendig."
+          ]
         },
         {
           "german": "zerstören",
           "russian": "разрушать",
           "transcription": "[цер-ШТЁ-рен]",
           "sentence": "Auf dem wackligen Holztisch ordnet Goneril zerlesene Briefe. Ich presse das Wort „zerstören“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "На шатком деревянном столе Гонерилья раскладывает зачитанные письма. Я стискиваю слово «разрушать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "На шатком деревянном столе Гонерилья раскладывает зачитанные письма. Я стискиваю слово «разрушать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Auf dem wackligen Holztisch ordnet Goneril zerlesene Briefe.",
+            "Ich presse das Wort „zerstören“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Leidenschaft",
           "russian": "страсть",
           "transcription": "[ди ЛАЙ-ден-шафт]",
           "sentence": "Am Eingang der Hütte späht Goneril nach einem vertrauten Schatten. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leidenschaft“ bleibt lebendig.",
-          "sentence_translation": "У входа в хижину Гонерилья высматривает знакомую тень. Каждой клеткой тела я обещаю: слово «страсть» останется живым."
+          "sentence_translation": "У входа в хижину Гонерилья высматривает знакомую тень. Каждой клеткой тела я обещаю: слово «страсть» останется живым.",
+          "sentence_parts": [
+            "Am Eingang der Hütte späht Goneril nach einem vertrauten Schatten.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leidenschaft“ bleibt lebendig."
+          ]
         }
       ],
       "quizzes": [
@@ -479,56 +635,88 @@
           "russian": "ревность",
           "transcription": "[ди АЙ-фер-зухт]",
           "sentence": "Auf den weißen Klippen von Dover blickt Goneril in den aufgewühlten Kanal. Wie ein stilles Gebet legt sich das Wort „die Eifersucht“ auf meine Lippen.",
-          "sentence_translation": "На белых скалах Дувра Гонерилья смотрит в вздыбленный пролив. Как тихая молитва слово «ревность» ложится на мои губы."
+          "sentence_translation": "На белых скалах Дувра Гонерилья смотрит в вздыбленный пролив. Как тихая молитва слово «ревность» ложится на мои губы.",
+          "sentence_parts": [
+            "Auf den weißen Klippen von Dover blickt Goneril in den aufgewühlten Kanal.",
+            "Wie ein stilles Gebet legt sich das Wort „die Eifersucht“ auf meine Lippen."
+          ]
         },
         {
           "german": "rivalisieren",
           "russian": "соперничать",
           "transcription": "[ри-ва-ли-ЗИ-рен]",
           "sentence": "Zwischen flatternden Feldzeichen richtet Goneril den Helm. Wie ein stilles Gebet legt sich das Wort „rivalisieren“ auf meine Lippen.",
-          "sentence_translation": "Среди хлопающих штандартов Гонерилья поправляет шлем. Как тихая молитва слово «соперничать» ложится на мои губы."
+          "sentence_translation": "Среди хлопающих штандартов Гонерилья поправляет шлем. Как тихая молитва слово «соперничать» ложится на мои губы.",
+          "sentence_parts": [
+            "Zwischen flatternden Feldzeichen richtet Goneril den Helm.",
+            "Wie ein stilles Gebet legt sich das Wort „rivalisieren“ auf meine Lippen."
+          ]
         },
         {
           "german": "kämpfen",
           "russian": "бороться",
           "transcription": "[КЕМП-фен]",
           "sentence": "Am Lagerfeuer der Franzosen zeichnet Goneril Marschrouten in den Sand. Selbst wenn die Welt zerfällt, bleibt das Wort „kämpfen“ mein Nordstern.",
-          "sentence_translation": "У французского костра Гонерилья рисует в песке путь марша. Даже если мир распадается, слово «бороться» остаётся моим северным светом."
+          "sentence_translation": "У французского костра Гонерилья рисует в песке путь марша. Даже если мир распадается, слово «бороться» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Am Lagerfeuer der Franzosen zeichnet Goneril Marschrouten in den Sand.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „kämpfen“ mein Nordstern."
+          ]
         },
         {
           "german": "begehren",
           "russian": "желать",
           "transcription": "[бе-ГЕ-рен]",
           "sentence": "Neben verschnürten Versorgungskisten kontrolliert Goneril das Siegel. Mit fester Stimme schwöre ich mir: Das Wort „begehren“ wird heute nicht verraten.",
-          "sentence_translation": "У перевязанных провиантных ящиков Гонерилья проверяет печати. Твёрдым голосом я клянусь себе: слово «желать» сегодня не будет предано."
+          "sentence_translation": "У перевязанных провиантных ящиков Гонерилья проверяет печати. Твёрдым голосом я клянусь себе: слово «желать» сегодня не будет предано.",
+          "sentence_parts": [
+            "Neben verschnürten Versorgungskisten kontrolliert Goneril das Siegel.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „begehren“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "beseitigen",
           "russian": "устранять",
           "transcription": "[бе-ЗАЙ-ти-ген]",
           "sentence": "Vor dem Seidenzelt der Heerführer lauscht Goneril dem dumpfen Meer. Ich zeichne das Wort „beseitigen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Перед шёлковым шатром полководцев Гонерилья слушает глухой шум моря. Я черчу слово «устранять» в мыслях поверх линий судьбы."
+          "sentence_translation": "Перед шёлковым шатром полководцев Гонерилья слушает глухой шум моря. Я черчу слово «устранять» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Vor dem Seidenzelt der Heerführer lauscht Goneril dem dumpfen Meer.",
+            "Ich zeichne das Wort „beseitigen“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "das Gift",
           "russian": "яд",
           "transcription": "[дас ГИФТ]",
           "sentence": "Auf dem sandigen Trainingsplatz übt Goneril das Ziehen des Schwerts. Ich zeichne das Wort „das Gift“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "На песчаном плацу Гонерилья отрабатывает выхват меча. Я вывожу слово «яд» невидимыми чернилами на ладони."
+          "sentence_translation": "На песчаном плацу Гонерилья отрабатывает выхват меча. Я вывожу слово «яд» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Auf dem sandigen Trainingsplatz übt Goneril das Ziehen des Schwerts.",
+            "Ich zeichne das Wort „das Gift“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "die Intrige",
           "russian": "интрига",
           "transcription": "[ди ин-ТРИ-ге]",
           "sentence": "Zwischen pochenden Trommeln hebt Goneril das Banner der Hoffnung. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Intrige“ darf nicht vergehen.",
-          "sentence_translation": "Под гул барабанов Гонерилья поднимает знамя надежды. Я шепчу стражам судьбы: слово «интрига» не должно исчезнуть."
+          "sentence_translation": "Под гул барабанов Гонерилья поднимает знамя надежды. Я шепчу стражам судьбы: слово «интрига» не должно исчезнуть.",
+          "sentence_parts": [
+            "Zwischen pochenden Trommeln hebt Goneril das Banner der Hoffnung.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Intrige“ darf nicht vergehen."
+          ]
         },
         {
           "german": "morden",
           "russian": "убивать",
           "transcription": "[МОР-ден]",
           "sentence": "Am Morgennebel der Küste legt Goneril die Hand auf das pochende Herz. Wie ein stilles Gebet legt sich das Wort „morden“ auf meine Lippen.",
-          "sentence_translation": "В утреннем тумане побережья Гонерилья кладёт ладонь на бьющееся сердце. Как тихая молитва слово «убивать» ложится на мои губы."
+          "sentence_translation": "В утреннем тумане побережья Гонерилья кладёт ладонь на бьющееся сердце. Как тихая молитва слово «убивать» ложится на мои губы.",
+          "sentence_parts": [
+            "Am Morgennebel der Küste legt Goneril die Hand auf das pochende Herz.",
+            "Wie ein stilles Gebet legt sich das Wort „morden“ auf meine Lippen."
+          ]
         }
       ],
       "quizzes": [
@@ -572,56 +760,88 @@
           "russian": "отравлять",
           "transcription": "[фер-ГИФ-тен]",
           "sentence": "Im feuchten Kerker stützt Goneril sich an den tropfenden Stein. Das Echo des Wortes „vergiften“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "В сыром подземелье Гонерилья опирается на сочащийся камень. Эхо слова «отравлять» заглушает шёпот придворных."
+          "sentence_translation": "В сыром подземелье Гонерилья опирается на сочащийся камень. Эхо слова «отравлять» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Im feuchten Kerker stützt Goneril sich an den tropfenden Stein.",
+            "Das Echo des Wortes „vergiften“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Verzweiflung",
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
           "sentence": "Unter der trüben Laterne zählt Goneril die eisernen Ringe der Kette. Das Echo des Wortes „die Verzweiflung“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Под мутным фонарём Гонерилья пересчитывает железные кольца цепи. Эхо слова «отчаяние» заглушает шёпот придворных."
+          "sentence_translation": "Под мутным фонарём Гонерилья пересчитывает железные кольца цепи. Эхо слова «отчаяние» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Unter der trüben Laterne zählt Goneril die eisernen Ringe der Kette.",
+            "Das Echo des Wortes „die Verzweiflung“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
           "sentence": "Neben der schweren Holztür horcht Goneril auf entferntes Schluchzen. Ich zeichne das Wort „sterben“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "У тяжёлой двери Гонерилья прислушивается к далёким рыданиям. Я черчу слово «умирать» в мыслях поверх линий судьбы."
+          "sentence_translation": "У тяжёлой двери Гонерилья прислушивается к далёким рыданиям. Я черчу слово «умирать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Neben der schweren Holztür horcht Goneril auf entferntes Schluchzen.",
+            "Ich zeichne das Wort „sterben“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "die Schuld",
           "russian": "вина",
           "transcription": "[ди ШУЛЬД]",
           "sentence": "Auf der kalten Steinbank zieht Goneril den Mantel enger um die Schultern. Ich halte das Wort „die Schuld“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "На холодной каменной скамье Гонерилья плотнее кутается в плащ. Я держу слово «вина» как факел у сердца."
+          "sentence_translation": "На холодной каменной скамье Гонерилья плотнее кутается в плащ. Я держу слово «вина» как факел у сердца.",
+          "sentence_parts": [
+            "Auf der kalten Steinbank zieht Goneril den Mantel enger um die Schultern.",
+            "Ich halte das Wort „die Schuld“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "vernichten",
           "russian": "уничтожать",
           "transcription": "[фер-НИХ-тен]",
           "sentence": "Zwischen Schatten der Gitterstäbe hebt Goneril das Gesicht zum Licht. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vernichten“ gehört mir.",
-          "sentence_translation": "Между тенями решёток Гонерилья поднимает лицо к свету. Буря за окнами усиливает клятву: слово «уничтожать» принадлежит мне."
+          "sentence_translation": "Между тенями решёток Гонерилья поднимает лицо к свету. Буря за окнами усиливает клятву: слово «уничтожать» принадлежит мне.",
+          "sentence_parts": [
+            "Zwischen Schatten der Gitterstäbe hebt Goneril das Gesicht zum Licht.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vernichten“ gehört mir."
+          ]
         },
         {
           "german": "das Verderben",
           "russian": "погибель",
           "transcription": "[дас фер-ДЕР-бен]",
           "sentence": "Am rostigen Wassereimer spiegelt Goneril kurz die eigenen Augen. Mein Atem zeichnet das Wort „das Verderben“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "У ржавого ведра с водой Гонерилья на мгновение видит отражение глаз. Моё дыхание рисует слово «погибель» в холодном воздухе между нами."
+          "sentence_translation": "У ржавого ведра с водой Гонерилья на мгновение видит отражение глаз. Моё дыхание рисует слово «погибель» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Am rostigen Wassereimer spiegelt Goneril kurz die eigenen Augen.",
+            "Mein Atem zeichnet das Wort „das Verderben“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
           "sentence": "Im dumpfen Hall der Schritte zählt Goneril den Rhythmus der Wachen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „bereuen“ darf nicht vergehen.",
-          "sentence_translation": "В глухом эхе шагов Гонерилья отсчитывает ритм часовых. Я шепчу стражам судьбы: слово «сожалеть» не должно исчезнуть."
+          "sentence_translation": "В глухом эхе шагов Гонерилья отсчитывает ритм часовых. Я шепчу стражам судьбы: слово «сожалеть» не должно исчезнуть.",
+          "sentence_parts": [
+            "Im dumpfen Hall der Schritte zählt Goneril den Rhythmus der Wachen.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „bereuen“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Hölle",
           "russian": "ад",
           "transcription": "[ди ХЁ-ле]",
           "sentence": "Vor dem verriegelten Fenster zeichnet Goneril Kreise in den Staub. Selbst wenn die Welt zerfällt, bleibt das Wort „die Hölle“ mein Nordstern.",
-          "sentence_translation": "Перед заколоченным окном Гонерилья чертит круги в пыли. Даже если мир распадается, слово «ад» остаётся моим северным светом."
+          "sentence_translation": "Перед заколоченным окном Гонерилья чертит круги в пыли. Даже если мир распадается, слово «ад» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Vor dem verriegelten Fenster zeichnet Goneril Kreise in den Staub.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Hölle“ mein Nordstern."
+          ]
         }
       ],
       "quizzes": [

--- a/data/characters/kent.json
+++ b/data/characters/kent.json
@@ -15,56 +15,88 @@
           "russian": "верность",
           "transcription": "[ди ТРОЙ-е]",
           "sentence": "Mitten im Tumult der Thronfeier tritt Kent vor den Königsthron. Ich zeichne das Wort „die Treue“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Посреди суматохи тронной церемонии Кент выходит к королевскому трону. Я вывожу слово «верность» невидимыми чернилами на ладони."
+          "sentence_translation": "Посреди суматохи тронной церемонии Кент выходит к королевскому трону. Я вывожу слово «верность» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Mitten im Tumult der Thronfeier tritt Kent vor den Königsthron.",
+            "Ich zeichne das Wort „die Treue“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "der Mut",
           "russian": "мужество",
           "transcription": "[дер МУТ]",
           "sentence": "Zwischen scharfgezogenen Schwertern stellt sich Kent vor die jüngste Tochter. Ich halte das Wort „der Mut“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Между обнажёнными мечами Кент встаёт перед младшей дочерью. Я держу слово «мужество» как факел у сердца."
+          "sentence_translation": "Между обнажёнными мечами Кент встаёт перед младшей дочерью. Я держу слово «мужество» как факел у сердца.",
+          "sentence_parts": [
+            "Zwischen scharfgezogenen Schwertern stellt sich Kent vor die jüngste Tochter.",
+            "Ich halte das Wort „der Mut“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "widersprechen",
           "russian": "возражать",
           "transcription": "[ВИ-дер-шпре-хен]",
           "sentence": "Vor der erstaunten Ritterschar reißt Kent sein Wappen vom Brustpanzer. Ich presse das Wort „widersprechen“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Перед изумлёнными рыцарями Кент срывает герб с нагрудника. Я стискиваю слово «возражать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Перед изумлёнными рыцарями Кент срывает герб с нагрудника. Я стискиваю слово «возражать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Vor der erstaunten Ritterschar reißt Kent sein Wappen vom Brustpanzer.",
+            "Ich presse das Wort „widersprechen“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "verteidigen",
           "russian": "защищать",
           "transcription": "[фер-ТАЙ-ди-ген]",
           "sentence": "Unter den strengen Blicken des Hofes schlägt Kent die Faust auf das Geländer. Ich flüstere den Wächtern des Schicksals zu: Das Wort „verteidigen“ darf nicht vergehen.",
-          "sentence_translation": "Под строгими взглядами двора Кент бьёт кулаком по перилам. Я шепчу стражам судьбы: слово «защищать» не должно исчезнуть."
+          "sentence_translation": "Под строгими взглядами двора Кент бьёт кулаком по перилам. Я шепчу стражам судьбы: слово «защищать» не должно исчезнуть.",
+          "sentence_parts": [
+            "Unter den strengen Blicken des Hofes schlägt Kent die Faust auf das Geländer.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „verteidigen“ darf nicht vergehen."
+          ]
         },
         {
           "german": "aufrichtig",
           "russian": "искренний",
           "transcription": "[АУФ-рих-тиг]",
           "sentence": "Neben Lears Stab kniet Kent und hebt unbeirrbar den Kopf. Das Echo des Wortes „aufrichtig“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "У посоха Лира Кент встаёт на колено и упрямо поднимает голову. Эхо слова «искренний» заглушает шёпот придворных."
+          "sentence_translation": "У посоха Лира Кент встаёт на колено и упрямо поднимает голову. Эхо слова «искренний» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Neben Lears Stab kniet Kent und hebt unbeirrbar den Kopf.",
+            "Das Echo des Wortes „aufrichtig“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "der Diener",
           "russian": "слуга",
           "transcription": "[дер ДИ-нер]",
           "sentence": "Auf den Stufen zur Thronrampe breitet Kent schützend die Arme aus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Diener“ bleibt lebendig.",
-          "sentence_translation": "На ступенях ведущих к трону Кент защитно разводит руки. Каждой клеткой тела я обещаю: слово «слуга» останется живым."
+          "sentence_translation": "На ступенях ведущих к трону Кент защитно разводит руки. Каждой клеткой тела я обещаю: слово «слуга» останется живым.",
+          "sentence_parts": [
+            "Auf den Stufen zur Thronrampe breitet Kent schützend die Arme aus.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Diener“ bleibt lebendig."
+          ]
         },
         {
           "german": "warnen",
           "russian": "предупреждать",
           "transcription": "[ВАР-нен]",
           "sentence": "Zwischen höfischen Fanfaren ruft Kent seine Warnung gegen das Hofgeflüster. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „warnen“ gehört mir.",
-          "sentence_translation": "Среди придворных фанфар Кент выкрикивает предупреждение против шёпота двора. Буря за окнами усиливает клятву: слово «предупреждать» принадлежит мне."
+          "sentence_translation": "Среди придворных фанфар Кент выкрикивает предупреждение против шёпота двора. Буря за окнами усиливает клятву: слово «предупреждать» принадлежит мне.",
+          "sentence_parts": [
+            "Zwischen höfischen Fanfaren ruft Kent seine Warnung gegen das Hofgeflüster.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „warnen“ gehört mir."
+          ]
         },
         {
           "german": "gerecht",
           "russian": "справедливый",
           "transcription": "[ге-РЕХТ]",
           "sentence": "Im Schatten des Königsbanners legt Kent die Hand auf das Herz. Ich presse das Wort „gerecht“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "В тени королевского знамени Кент кладёт руку на сердце. Я стискиваю слово «справедливый» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "В тени королевского знамени Кент кладёт руку на сердце. Я стискиваю слово «справедливый» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Im Schatten des Königsbanners legt Kent die Hand auf das Herz.",
+            "Ich presse das Wort „gerecht“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -108,49 +140,78 @@
           "russian": "изгнание",
           "transcription": "[ди фер-БА-нунг]",
           "sentence": "Auf den kalten Stufen des Hofes hört Kent das Urteil der Verbannung. Ich zeichne das Wort „die Verbannung“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "На холодных ступенях двора Кент слышит приговор об изгнании. Я черчу слово «изгнание» в мыслях поверх линий судьбы."
+          "sentence_translation": "На холодных ступенях двора Кент слышит приговор об изгнании. Я черчу слово «изгнание» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Auf den kalten Stufen des Hofes hört Kent das Urteil der Verbannung.",
+            "Ich zeichne das Wort „die Verbannung“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "die Ungerechtigkeit",
           "russian": "несправедливость",
           "transcription": "[ди УН-ге-рех-тиг-кайт]",
           "sentence": "Zwischen abziehenden Soldaten hält Kent nur den Reisestock in der Hand. Wie ein stilles Gebet legt sich das Wort „die Ungerechtigkeit“ auf meine Lippen.",
-          "sentence_translation": "Среди расходящихся солдат Кент сжимает в руке лишь дорожный посох. Как тихая молитва слово «несправедливость» ложится на мои губы."
+          "sentence_translation": "Среди расходящихся солдат Кент сжимает в руке лишь дорожный посох. Как тихая молитва слово «несправедливость» ложится на мои губы.",
+          "sentence_parts": [
+            "Zwischen abziehenden Soldaten hält Kent nur den Reisestock in der Hand.",
+            "Wie ein stilles Gebet legt sich das Wort „die Ungerechtigkeit“ auf meine Lippen."
+          ]
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
           "sentence": "Vor dem geschlossenen Burgtor wirft Kent den Blick noch einmal zurück. Das kalte Licht lässt das Wort „der Zorn“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "У закрытых ворот замка Кент бросает последний взгляд назад. Холодный свет заставляет слово «гнев» сиять словно расплавленное золото."
+          "sentence_translation": "У закрытых ворот замка Кент бросает последний взгляд назад. Холодный свет заставляет слово «гнев» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Vor dem geschlossenen Burgtor wirft Kent den Blick noch einmal zurück.",
+            "Das kalte Licht lässt das Wort „der Zorn“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "verbannt",
           "russian": "изгнанный",
           "transcription": "[фер-БАНТ]",
           "sentence": "Auf dem Regenpflaster bleibt Kent stehen, während die Trommeln schweigen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbannt“ gehört mir.",
-          "sentence_translation": "На мокрой мостовой Кент замирает, пока барабаны смолкают. Буря за окнами усиливает клятву: слово «изгнанный» принадлежит мне."
+          "sentence_translation": "На мокрой мостовой Кент замирает, пока барабаны смолкают. Буря за окнами усиливает клятву: слово «изгнанный» принадлежит мне.",
+          "sentence_parts": [
+            "Auf dem Regenpflaster bleibt Kent stehen, während die Trommeln schweigen.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbannt“ gehört mir."
+          ]
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
           "sentence": "Zwischen verstreuten Reisebündeln befestigt Kent das Schwert am Gürtel. Ich atme tief ein und lasse nur das Wort „der Abschied“ wieder hinaus.",
-          "sentence_translation": "Среди разбросанных узлов Кент затягивает меч на поясе. Я глубоко вдыхаю и выпускаю только слово «прощание»."
+          "sentence_translation": "Среди разбросанных узлов Кент затягивает меч на поясе. Я глубоко вдыхаю и выпускаю только слово «прощание».",
+          "sentence_parts": [
+            "Zwischen verstreuten Reisebündeln befestigt Kent das Schwert am Gürtel.",
+            "Ich atme tief ein und lasse nur das Wort „der Abschied“ wieder hinaus."
+          ]
         },
         {
           "german": "die Strafe",
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
           "sentence": "Unter dem grauen Himmel zieht Kent den Mantelkragen hoch. Ich presse das Wort „die Strafe“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Под серым небом Кент поднимает ворот плаща. Я стискиваю слово «наказание» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Под серым небом Кент поднимает ворот плаща. Я стискиваю слово «наказание» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Unter dem grauen Himmel zieht Kent den Mantelkragen hoch.",
+            "Ich presse das Wort „die Strafe“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "zurückkehren",
           "russian": "возвращаться",
           "transcription": "[цу-РЮК-ке-рен]",
           "sentence": "Vor der trostlosen Landstraße richtet Kent den Blick entschlossen nach vorn. Mein Atem zeichnet das Wort „zurückkehren“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Перед пустынной дорогой Кент решительно смотрит вперёд. Моё дыхание рисует слово «возвращаться» в холодном воздухе между нами."
+          "sentence_translation": "Перед пустынной дорогой Кент решительно смотрит вперёд. Моё дыхание рисует слово «возвращаться» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Vor der trostlosen Landstraße richtet Kent den Blick entschlossen nach vorn.",
+            "Mein Atem zeichnet das Wort „zurückkehren“ in die kalte Luft zwischen uns."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -194,56 +255,88 @@
           "russian": "переодевание",
           "transcription": "[ди фер-КЛАЙ-дунг]",
           "sentence": "In der verqualmten Herberge streift Kent das grobe Knechtsgewand über. Wie ein stilles Gebet legt sich das Wort „die Verkleidung“ auf meine Lippen.",
-          "sentence_translation": "В задымлённой харчевне Кент натягивает грубое платье слуги. Как тихая молитва слово «переодевание» ложится на мои губы."
+          "sentence_translation": "В задымлённой харчевне Кент натягивает грубое платье слуги. Как тихая молитва слово «переодевание» ложится на мои губы.",
+          "sentence_parts": [
+            "In der verqualmten Herberge streift Kent das grobe Knechtsgewand über.",
+            "Wie ein stilles Gebet legt sich das Wort „die Verkleidung“ auf meine Lippen."
+          ]
         },
         {
           "german": "die List",
           "russian": "хитрость",
           "transcription": "[ди ЛИСТ]",
           "sentence": "Vor einem beschlagenen Spiegel übt Kent die raue Stimme des Kays. Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern.",
-          "sentence_translation": "Перед запотевшим зеркалом Кент тренирует хриплый голос Кая. Даже если мир распадается, слово «хитрость» остаётся моим северным светом."
+          "sentence_translation": "Перед запотевшим зеркалом Кент тренирует хриплый голос Кая. Даже если мир распадается, слово «хитрость» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Vor einem beschlagenen Spiegel übt Kent die raue Stimme des Kays.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern."
+          ]
         },
         {
           "german": "unerkannt",
           "russian": "неузнанный",
           "transcription": "[УН-ер-кант]",
           "sentence": "Unter einem zerknitterten Hut verbirgt Kent die königliche Haltung. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unerkannt“ gehört mir.",
-          "sentence_translation": "Под мятой шляпой Кент скрывает королевскую осанку. Буря за окнами усиливает клятву: слово «неузнанный» принадлежит мне."
+          "sentence_translation": "Под мятой шляпой Кент скрывает королевскую осанку. Буря за окнами усиливает клятву: слово «неузнанный» принадлежит мне.",
+          "sentence_parts": [
+            "Unter einem zerknitterten Hut verbirgt Kent die königliche Haltung.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unerkannt“ gehört mir."
+          ]
         },
         {
           "german": "vorgeben",
           "russian": "притворяться",
           "transcription": "[ФОР-ге-бен]",
           "sentence": "Zwischen neugierigen Fuhrknechten studiert Kent die Dienstbefehle. Ich zeichne das Wort „vorgeben“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Среди любопытных возниц Кент изучает служебные приказы. Я вывожу слово «притворяться» невидимыми чернилами на ладони."
+          "sentence_translation": "Среди любопытных возниц Кент изучает служебные приказы. Я вывожу слово «притворяться» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Zwischen neugierigen Fuhrknechten studiert Kent die Dienstbefehle.",
+            "Ich zeichne das Wort „vorgeben“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "verstellen",
           "russian": "изменять",
           "transcription": "[фер-ШТЕ-лен]",
           "sentence": "Am Ufer des Hafens wäscht Kent die Spuren des alten Lebens ab. Ich atme tief ein und lasse nur das Wort „verstellen“ wieder hinaus.",
-          "sentence_translation": "На пристани Кент смывает следы прежней жизни. Я глубоко вдыхаю и выпускаю только слово «изменять»."
+          "sentence_translation": "На пристани Кент смывает следы прежней жизни. Я глубоко вдыхаю и выпускаю только слово «изменять».",
+          "sentence_parts": [
+            "Am Ufer des Hafens wäscht Kent die Spuren des alten Lebens ab.",
+            "Ich atme tief ein und lasse nur das Wort „verstellen“ wieder hinaus."
+          ]
         },
         {
           "german": "der Bart",
           "russian": "борода",
           "transcription": "[дер БАРТ]",
           "sentence": "Auf dem staubigen Markt prüft Kent die Tragriemen des Gepäcks. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Bart“ darf nicht vergehen.",
-          "sentence_translation": "На пыльном рынке Кент проверяет ремни поклажи. Я шепчу стражам судьбы: слово «борода» не должно исчезнуть."
+          "sentence_translation": "На пыльном рынке Кент проверяет ремни поклажи. Я шепчу стражам судьбы: слово «борода» не должно исчезнуть.",
+          "sentence_parts": [
+            "Auf dem staubigen Markt prüft Kent die Tragriemen des Gepäcks.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Bart“ darf nicht vergehen."
+          ]
         },
         {
           "german": "anheuern",
           "russian": "наниматься",
           "transcription": "[АН-хой-ерн]",
           "sentence": "Im Schatten einer Gasse versteckt Kent den einst glänzenden Siegelring. Das kalte Licht lässt das Wort „anheuern“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "В тени переулка Кент прячет некогда блестящий перстень. Холодный свет заставляет слово «наниматься» сиять словно расплавленное золото."
+          "sentence_translation": "В тени переулка Кент прячет некогда блестящий перстень. Холодный свет заставляет слово «наниматься» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Im Schatten einer Gasse versteckt Kent den einst glänzenden Siegelring.",
+            "Das kalte Licht lässt das Wort „anheuern“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "treu",
           "russian": "верный",
           "transcription": "[ТРОЙ]",
           "sentence": "Unter einem Wagenrad kauert Kent, bis der Ruf nach Dienern erschallt. Das Echo des Wortes „treu“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Под колесом телеги Кент затаивается, пока не прозвучит зов для слуг. Эхо слова «верный» заглушает шёпот придворных."
+          "sentence_translation": "Под колесом телеги Кент затаивается, пока не прозвучит зов для слуг. Эхо слова «верный» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Unter einem Wagenrad kauert Kent, bis der Ruf nach Dienern erschallt.",
+            "Das Echo des Wortes „treu“ übertönt das Flüstern der Höflinge."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -287,49 +380,77 @@
           "russian": "служба",
           "transcription": "[дер ДИНСТ]",
           "sentence": "Im nächtlichen Wachraum poliert Kent schweigend die Rüstung des Königs. Das Echo des Wortes „der Dienst“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "В ночной караульной Кент молча полирует королевские доспехи. Эхо слова «служба» заглушает шёпот придворных."
+          "sentence_translation": "В ночной караульной Кент молча полирует королевские доспехи. Эхо слова «служба» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Im nächtlichen Wachraum poliert Kent schweigend die Rüstung des Königs.",
+            "Das Echo des Wortes „der Dienst“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "der Schutz",
           "russian": "защита",
           "transcription": "[дер ШУТЦ]",
           "sentence": "Neben dem Lager des erschöpften Herrschers hält Kent unbeweglich Wache. Das Echo des Wortes „der Schutz“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "У ложа измождённого правителя Кент неподвижно несёт стражу. Эхо слова «защита» заглушает шёпот придворных."
+          "sentence_translation": "У ложа измождённого правителя Кент неподвижно несёт стражу. Эхо слова «защита» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Neben dem Lager des erschöpften Herrschers hält Kent unbeweglich Wache.",
+            "Das Echo des Wortes „der Schutz“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Gefahr",
           "russian": "опасность",
           "transcription": "[ди ге-ФАР]",
           "sentence": "Unter Regenmänteln der Wachen verbirgt Kent seine Narben. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Gefahr“ bleibt lebendig.",
-          "sentence_translation": "Под дождевыми плащами стражей Кент скрывает свои шрамы. Каждой клеткой тела я обещаю: слово «опасность» останется живым."
+          "sentence_translation": "Под дождевыми плащами стражей Кент скрывает свои шрамы. Каждой клеткой тела я обещаю: слово «опасность» останется живым.",
+          "sentence_parts": [
+            "Unter Regenmänteln der Wachen verbirgt Kent seine Narben.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Gefahr“ bleibt lebendig."
+          ]
         },
         {
           "german": "bewachen",
           "russian": "охранять",
           "transcription": "[бе-ВА-хен]",
           "sentence": "Am Stalltor sattelt Kent in der Dunkelheit ein trotziges Pferd. Selbst wenn die Welt zerfällt, bleibt das Wort „bewachen“ mein Nordstern.",
-          "sentence_translation": "У дверей конюшни Кент в темноте осёдлывает упрямого коня. Даже если мир распадается, слово «охранять» остаётся моим северным светом."
+          "sentence_translation": "У дверей конюшни Кент в темноте осёдлывает упрямого коня. Даже если мир распадается, слово «охранять» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Am Stalltor sattelt Kent in der Dunkelheit ein trotziges Pferd.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „bewachen“ mein Nordstern."
+          ]
         },
         {
           "german": "kämpfen",
           "russian": "сражаться",
           "transcription": "[КЕМП-фен]",
           "sentence": "In der Küche der Dienerschaft füllt Kent den dampfenden Becher. Ich zeichne das Wort „kämpfen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "В кухне прислуги Кент наполняет дымящийся кубок. Я черчу слово «сражаться» в мыслях поверх линий судьбы."
+          "sentence_translation": "В кухне прислуги Кент наполняет дымящийся кубок. Я черчу слово «сражаться» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "In der Küche der Dienerschaft füllt Kent den dampfenden Becher.",
+            "Ich zeichne das Wort „kämpfen“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "raten",
           "russian": "советовать",
           "transcription": "[РА-тен]",
           "sentence": "Vor der Schlafstatt des Königs ordnet Kent die verstreuten Decken. Ich umarme das Wort „raten“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Перед ложем короля Кент раскладывает разбросанные покрывала. Я обнимаю слово «советовать», будто это единственный союзник."
+          "sentence_translation": "Перед ложем короля Кент раскладывает разбросанные покрывала. Я обнимаю слово «советовать», будто это единственный союзник.",
+          "sentence_parts": [
+            "Vor der Schlafstatt des Königs ordnet Kent die verstreuten Decken.",
+            "Ich umarme das Wort „raten“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Wache",
           "russian": "стража",
           "transcription": "[ди ВА-хе]",
           "sentence": "Auf dem Hof prüft Kent das Zaumzeug, bevor der Morgen graut. Selbst wenn die Welt zerfällt, bleibt das Wort „die Wache“ mein Nordstern.",
-          "sentence_translation": "Во дворе Кент проверяет уздечку, пока не рассвело. Даже если мир распадается, слово «стража» остаётся моим северным светом."
+          "sentence_translation": "Во дворе Кент проверяет уздечку, пока не рассвело. Даже если мир распадается, слово «стража» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Auf dem Hof prüft Kent das Zaumzeug, bevor der Morgen graut.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Wache“ mein Nordstern."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -373,56 +494,89 @@
           "russian": "наказание",
           "transcription": "[ди ШТРА-фе]",
           "sentence": "Im Regen der Burgmauer sitzt Kent mit gefesselten Füßen in den harten Hölzern. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Strafe“ darf nicht vergehen.",
-          "sentence_translation": "Под дождём у крепостной стены Кент сидит с закреплёнными ногами в жёстких колодках. Я шепчу стражам судьбы: слово «наказание» не должно исчезнуть."
+          "sentence_translation": "Под дождём у крепостной стены Кент сидит с закреплёнными ногами в жёстких колодках. Я шепчу стражам судьбы: слово «наказание» не должно исчезнуть.",
+          "sentence_parts": [
+            "Im Regen der Burgmauer sitzt Kent mit gefesselten Füßen in den harten Hölzern.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Strafe“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Demütigung",
           "russian": "унижение",
           "transcription": "[ди де-МЮ-ти-гунг]",
           "sentence": "Neben den Spottliedern der Wachen hält Kent den Kopf stolz erhoben. Ich presse das Wort „die Demütigung“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Под насмешливые песни стражи Кент гордо держит голову. Я стискиваю слово «унижение» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Под насмешливые песни стражи Кент гордо держит голову. Я стискиваю слово «унижение» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Neben den Spottliedern der Wachen hält Kent den Kopf stolz erhoben.",
+            "Ich presse das Wort „die Demütigung“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Standhaftigkeit",
           "russian": "стойкость",
           "transcription": "[ди ШТАНД-хаф-тиг-кайт]",
           "sentence": "Vor dem trüben Mondlicht reibt Kent den schmerzenden Nacken. Ich zeichne das Wort „die Standhaftigkeit“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "В тусклом лунном свете Кент растирает затёкшую шею. Я черчу слово «стойкость» в мыслях поверх линий судьбы."
+          "sentence_translation": "В тусклом лунном свете Кент растирает затёкшую шею. Я черчу слово «стойкость» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Vor dem trüben Mondlicht reibt Kent den schmerzenden Nacken.",
+            "Ich zeichne das Wort „die Standhaftigkeit“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "fesseln",
           "russian": "сковывать",
           "transcription": "[ФЕ-сельн]",
           "sentence": "Zwischen den Pfützen der Nacht starren Kents Schuhe in den Himmel. Selbst wenn die Welt zerfällt, bleibt das Wort „fesseln“ mein Nordstern.",
-          "sentence_translation": "Среди ночных луж сапоги Кент устремлены в небо. Даже если мир распадается, слово «сковывать» остаётся моим северным светом."
+          "sentence_translation": "Среди ночных луж сапоги Кент устремлены в небо. Даже если мир распадается, слово «сковывать» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Zwischen den Pfützen der Nacht starren Kents Schuhe in den Himmel.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „fesseln“ mein Nordstern."
+          ]
         },
         {
           "german": "erdulden",
           "russian": "терпеть",
           "transcription": "[ер-ДУЛЬ-ден]",
           "sentence": "Am Morgenfrost haucht Kent Eisblumen auf das Holz. Selbst wenn die Welt zerfällt, bleibt das Wort „erdulden“ mein Nordstern.",
-          "sentence_translation": "В утренний мороз Кент выдыхает ледяные узоры на дерево. Даже если мир распадается, слово «терпеть» остаётся моим северным светом."
+          "sentence_translation": "В утренний мороз Кент выдыхает ледяные узоры на дерево. Даже если мир распадается, слово «терпеть» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Am Morgenfrost haucht Kent Eisblumen auf das Holz.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „erdulden“ mein Nordstern."
+          ]
         },
         {
           "german": "der Stock",
           "russian": "колодка",
           "transcription": "[дер ШТОК]",
           "sentence": "Neben einem verirrten Bauernkind lächelt Kent trotz der Demütigung. Das kalte Licht lässt das Wort „der Stock“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Рядом с заблудившимся крестьянином Кент улыбается несмотря на унижение. Холодный свет заставляет слово «колодка» сиять словно расплавленное золото."
+          "sentence_translation": "Рядом с заблудившимся крестьянином Кент улыбается несмотря на унижение. Холодный свет заставляет слово «колодка» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Neben einem verirrten Bauernkind lächelt Kent trotz der Demütigung.",
+            "Das kalte Licht lässt das Wort „der Stock“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "ausharren",
           "russian": "выдерживать",
           "transcription": "[АУС-ха-рен]",
           "sentence": "Unter dem grauen Himmel zählt Kent geduldig die Tropfen auf dem Gesicht. Ich flüstere den Wächtern des Schicksals zu: Das Wort „ausharren“ darf nicht vergehen.",
-          "sentence_translation": "Под серым небом Кент терпеливо считает капли на лице. Я шепчу стражам судьбы: слово «выдерживать» не должно исчезнуть."
+          "sentence_translation": "Под серым небом Кент терпеливо считает капли на лице. Я шепчу стражам судьбы: слово «выдерживать» не должно исчезнуть.",
+          "sentence_parts": [
+            "Unter dem grauen Himmel zählt Kent geduldig die Tropfen auf dem Gesicht.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „ausharren“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Schande",
           "russian": "позор",
           "transcription": "[ди ШАН-де]",
           "sentence": "Auf dem verlassenen Hof lauscht Kent dem fern rollenden Donner. Das kalte Licht lässt das Wort „die Schande“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "На пустынном дворе Кент прислушивается к далёкому грохоту грома. Холодный свет заставляет слово «позор» сиять словно расплавленное золото."
+          "sentence_translation": "На пустынном дворе Кент прислушивается к далёкому грохоту грома. Холодный свет заставляет слово «позор» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Auf dem verlassenen Hof lauscht Kent dem fern rollenden Donner.",
+            "Das kalte Licht lässt das Wort „die Schande“ wie geschmolzenes Gold erscheinen."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -466,49 +620,79 @@
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
           "sentence": "Mit der Laterne in der Faust sucht Kent nach dem Schatten des Königs. Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen.",
-          "sentence_translation": "С фонарём в кулаке Кент ищет тень короля. Как тихая молитва слово «буря» ложится на мои губы."
+          "sentence_translation": "С фонарём в кулаке Кент ищет тень короля. Как тихая молитва слово «буря» ложится на мои губы.",
+          "sentence_parts": [
+            "Mit der Laterne in der Faust sucht Kent nach dem Schatten des Königs.",
+            "Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen."
+          ]
         },
         {
           "german": "der Beistand",
           "russian": "поддержка",
           "transcription": "[дер БАЙ-штанд]",
           "sentence": "Neben dem tobenden Monarchen breitet Kent den Mantel wie ein Schild. Das kalte Licht lässt das Wort „der Beistand“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Рядом с бушующим монархом Кент раскрывает плащ как щит. Холодный свет заставляет слово «поддержка» сиять словно расплавленное золото."
+          "sentence_translation": "Рядом с бушующим монархом Кент раскрывает плащ как щит. Холодный свет заставляет слово «поддержка» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Neben dem tobenden Monarchen breitet Kent den Mantel wie ein Schild.",
+            "Das kalte Licht lässt das Wort „der Beistand“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "begleiten",
           "russian": "сопровождать",
           "transcription": "[бе-ГЛАЙ-тен]",
           "sentence": "Auf dem überfluteten Pfad hält Kent das Pferd am Zügel. Ich zeichne das Wort „begleiten“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "На затопленной тропе Кент держит коня за повод. Я вывожу слово «сопровождать» невидимыми чернилами на ладони."
+          "sentence_translation": "На затопленной тропе Кент держит коня за повод. Я вывожу слово «сопровождать» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Auf dem überfluteten Pfad hält Kent das Pferd am Zügel.",
+            "Ich zeichne das Wort „begleiten“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "trösten",
           "russian": "утешать",
           "transcription": "[ТРЁС-тен]",
           "sentence": "Zwischen klatschenden Ästen ruft Kent beruhigende Worte. Mein Atem zeichnet das Wort „trösten“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Среди хлещущих веток Кент говорит успокаивающие слова. Моё дыхание рисует слово «утешать» в холодном воздухе между нами."
+          "sentence_translation": "Среди хлещущих веток Кент говорит успокаивающие слова. Моё дыхание рисует слово «утешать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Zwischen klatschenden Ästen ruft Kent beruhigende Worte.",
+            "Mein Atem zeichnet das Wort „trösten“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Zuflucht",
           "russian": "убежище",
           "transcription": "[ди ЦУ-флухт]",
           "sentence": "Vor der klappernden Hütte hebt Kent die Fackel, um den Weg zu zeigen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Zuflucht“ bleibt lebendig.",
-          "sentence_translation": "Перед дрожащей хижиной Кент поднимает факел, освещая путь. Каждой клеткой тела я обещаю: слово «убежище» останется живым."
+          "sentence_translation": "Перед дрожащей хижиной Кент поднимает факел, освещая путь. Каждой клеткой тела я обещаю: слово «убежище» останется живым.",
+          "sentence_parts": [
+            "Vor der klappernden Hütte hebt Kent die Fackel,",
+            "um den Weg zu zeigen.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Zuflucht“ bleibt lebendig."
+          ]
         },
         {
           "german": "durchhalten",
           "russian": "выдерживать",
           "transcription": "[ДУРХ-халь-тен]",
           "sentence": "Am Rand des Moorfelds stützt Kent den taumelnden Herrscher. Ich umarme das Wort „durchhalten“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "На краю болотного поля Кент поддерживает качающегося правителя. Я обнимаю слово «выдерживать», будто это единственный союзник."
+          "sentence_translation": "На краю болотного поля Кент поддерживает качающегося правителя. Я обнимаю слово «выдерживать», будто это единственный союзник.",
+          "sentence_parts": [
+            "Am Rand des Moorfelds stützt Kent den taumelnden Herrscher.",
+            "Ich umarme das Wort „durchhalten“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Kälte",
           "russian": "холод",
           "transcription": "[ди КЕЛ-те]",
           "sentence": "Unter dem peitschenden Regen spricht Kent ein leises Trostlied. Ich presse das Wort „die Kälte“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Под хлещущим дождём Кент тихо напевает утешительную песнь. Я стискиваю слово «холод» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Под хлещущим дождём Кент тихо напевает утешительную песнь. Я стискиваю слово «холод» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Unter dem peitschenden Regen spricht Kent ein leises Trostlied.",
+            "Ich presse das Wort „die Kälte“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -552,56 +736,88 @@
           "russian": "смерть",
           "transcription": "[дер ТОД]",
           "sentence": "Im stillen Sterbezimmer wacht Kent an Lears letztem Lager. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Tod“ gehört mir.",
-          "sentence_translation": "В тихой опочивальне смерти Кент стоит у последнего ложа Лира. Буря за окнами усиливает клятву: слово «смерть» принадлежит мне."
+          "sentence_translation": "В тихой опочивальне смерти Кент стоит у последнего ложа Лира. Буря за окнами усиливает клятву: слово «смерть» принадлежит мне.",
+          "sentence_parts": [
+            "Im stillen Sterbezimmer wacht Kent an Lears letztem Lager.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Tod“ gehört mir."
+          ]
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
           "sentence": "Neben der verlöschenden Kerze streicht Kent über den zerrissenen Umhang. Wie ein stilles Gebet legt sich das Wort „der Abschied“ auf meine Lippen.",
-          "sentence_translation": "У догорающей свечи Кент гладит разорванный плащ. Как тихая молитва слово «прощание» ложится на мои губы."
+          "sentence_translation": "У догорающей свечи Кент гладит разорванный плащ. Как тихая молитва слово «прощание» ложится на мои губы.",
+          "sentence_parts": [
+            "Neben der verlöschenden Kerze streicht Kent über den zerrissenen Umhang.",
+            "Wie ein stilles Gebet legt sich das Wort „der Abschied“ auf meine Lippen."
+          ]
         },
         {
           "german": "ewig",
           "russian": "вечный",
           "transcription": "[Э-виг]",
           "sentence": "Vor den starren Wachen flüstert Kent ein letztes Versprechen. Mit fester Stimme schwöre ich mir: Das Wort „ewig“ wird heute nicht verraten.",
-          "sentence_translation": "Перед оцепеневшими стражами Кент шепчет последнее обещание. Твёрдым голосом я клянусь себе: слово «вечный» сегодня не будет предано."
+          "sentence_translation": "Перед оцепеневшими стражами Кент шепчет последнее обещание. Твёрдым голосом я клянусь себе: слово «вечный» сегодня не будет предано.",
+          "sentence_parts": [
+            "Vor den starren Wachen flüstert Kent ein letztes Versprechen.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „ewig“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "weinen",
           "russian": "плакать",
           "transcription": "[ВАЙ-нен]",
           "sentence": "Auf dem leeren Thronstuhl legt Kent den eigenen Stab nieder. Mein Atem zeichnet das Wort „weinen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "На пустом троне Кент кладёт свой посох. Моё дыхание рисует слово «плакать» в холодном воздухе между нами."
+          "sentence_translation": "На пустом троне Кент кладёт свой посох. Моё дыхание рисует слово «плакать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Auf dem leeren Thronstuhl legt Kent den eigenen Stab nieder.",
+            "Mein Atem zeichnet das Wort „weinen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Erschöpfung",
           "russian": "истощение",
           "transcription": "[ди ер-ШЁП-фунг]",
           "sentence": "Zwischen verblassenden Wandmalereien schließt Kent kurz die Augen. Selbst wenn die Welt zerfällt, bleibt das Wort „die Erschöpfung“ mein Nordstern.",
-          "sentence_translation": "Среди блекнущих настенных росписей Кент на мгновение закрывает глаза. Даже если мир распадается, слово «истощение» остаётся моим северным светом."
+          "sentence_translation": "Среди блекнущих настенных росписей Кент на мгновение закрывает глаза. Даже если мир распадается, слово «истощение» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Zwischen verblassenden Wandmalereien schließt Kent kurz die Augen.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Erschöpfung“ mein Nordstern."
+          ]
         },
         {
           "german": "aufgeben",
           "russian": "сдаваться",
           "transcription": "[АУФ-ге-бен]",
           "sentence": "Am offenen Fenster lässt Kent den kalten Morgen herein. Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufgeben“ darf nicht vergehen.",
-          "sentence_translation": "У распахнутого окна Кент впускает холодное утро. Я шепчу стражам судьбы: слово «сдаваться» не должно исчезнуть."
+          "sentence_translation": "У распахнутого окна Кент впускает холодное утро. Я шепчу стражам судьбы: слово «сдаваться» не должно исчезнуть.",
+          "sentence_parts": [
+            "Am offenen Fenster lässt Kent den kalten Morgen herein.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufgeben“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Trauer",
           "russian": "скорбь",
           "transcription": "[ди ТРАУ-ер]",
           "sentence": "Im Schatten der Trauernden hält Kent Lears Hand bis zum letzten Schlag. Ich zeichne das Wort „die Trauer“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "В тени скорбящих Кент держит руку Лира до последнего удара. Я вывожу слово «скорбь» невидимыми чернилами на ладони."
+          "sentence_translation": "В тени скорбящих Кент держит руку Лира до последнего удара. Я вывожу слово «скорбь» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Im Schatten der Trauernden hält Kent Lears Hand bis zum letzten Schlag.",
+            "Ich zeichne das Wort „die Trauer“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "folgen",
           "russian": "следовать",
           "transcription": "[ФОЛЬ-ген]",
           "sentence": "Vor der stillen Hofkapelle beugt Kent das Knie für ein stummes Gebet. Ich halte das Wort „folgen“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Перед молчаливой придворной часовней Кент преклоняет колено в безмолвной молитве. Я держу слово «следовать» как факел у сердца."
+          "sentence_translation": "Перед молчаливой придворной часовней Кент преклоняет колено в безмолвной молитве. Я держу слово «следовать» как факел у сердца.",
+          "sentence_parts": [
+            "Vor der stillen Hofkapelle beugt Kent das Knie für ein stummes Gebet.",
+            "Ich halte das Wort „folgen“ wie eine Fackel vor meinem Herzen."
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/king_lear.json
+++ b/data/characters/king_lear.json
@@ -21,56 +21,88 @@
           "russian": "трон",
           "transcription": "[дер ТРОН]",
           "sentence": "König Lear steht unter dem glühenden Kronleuchter des Thronsaals. Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Лир стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «трон» в холодном воздухе между нами."
+          "sentence_translation": "Лир стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «трон» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "König Lear steht unter dem glühenden Kronleuchter des Thronsaals.",
+            "Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "das Königreich",
           "russian": "королевство",
           "transcription": "[дас КЁ-ниг-райх]",
           "sentence": "Neben der ausgerollten Reichskarte beugt sich König Lear über Lears schweren Tisch. Das kalte Licht lässt das Wort „das Königreich“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "У развернутой карты королевства Лир склоняется над тяжёлым столом Лира. Холодный свет заставляет слово «королевство» сиять словно расплавленное золото."
+          "sentence_translation": "У развернутой карты королевства Лир склоняется над тяжёлым столом Лира. Холодный свет заставляет слово «королевство» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Neben der ausgerollten Reichskarte beugt sich König Lear über Lears schweren Tisch.",
+            "Das kalte Licht lässt das Wort „das Königreich“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "die Macht",
           "russian": "власть",
           "transcription": "[ди МАХТ]",
           "sentence": "Vor den steinernen Ahnenstatuen verschränkt König Lear die Hände hinter dem Rücken. Mein Atem zeichnet das Wort „die Macht“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Перед каменными статуями предков Лир сцепляет руки за спиной. Моё дыхание рисует слово «власть» в холодном воздухе между нами."
+          "sentence_translation": "Перед каменными статуями предков Лир сцепляет руки за спиной. Моё дыхание рисует слово «власть» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Vor den steinernen Ahnenstatuen verschränkt König Lear die Hände hinter dem Rücken.",
+            "Mein Atem zeichnet das Wort „die Macht“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "herrschen",
           "russian": "править",
           "transcription": "[ХЕР-шен]",
           "sentence": "Zwischen flüsternden Höflingen gleitet König Lear über den kalten Marmorboden. Mein Atem zeichnet das Wort „herrschen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Между шепчущимися придворными Лир скользит по холодному мраморному полу. Моё дыхание рисует слово «править» в холодном воздухе между нами."
+          "sentence_translation": "Между шепчущимися придворными Лир скользит по холодному мраморному полу. Моё дыхание рисует слово «править» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Zwischen flüsternden Höflingen gleitet König Lear über den kalten Marmorboden.",
+            "Mein Atem zeichnet das Wort „herrschen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "verkünden",
           "russian": "провозглашать",
           "transcription": "[фер-КЮН-ден]",
           "sentence": "Am Rand des purpurnen Teppichs wartet König Lear auf ein Zeichen des Königs. Ich zeichne das Wort „verkünden“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "На краю пурпурного ковра Лир ждёт знака от короля. Я вывожу слово «провозглашать» невидимыми чернилами на ладони."
+          "sentence_translation": "На краю пурпурного ковра Лир ждёт знака от короля. Я вывожу слово «провозглашать» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Am Rand des purpurnen Teppichs wartet König Lear auf ein Zeichen des Königs.",
+            "Ich zeichne das Wort „verkünden“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "die Krone",
           "russian": "корона",
           "transcription": "[ди КРО-не]",
           "sentence": "Unter wehenden Standarten der Schwestern senkt König Lear kurz den Blick. Ich zeichne das Wort „die Krone“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Под развевающимися штандартами сестёр Лир на миг опускает взгляд. Я вывожу слово «корона» невидимыми чернилами на ладони."
+          "sentence_translation": "Под развевающимися штандартами сестёр Лир на миг опускает взгляд. Я вывожу слово «корона» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Unter wehenden Standarten der Schwestern senkt König Lear kurz den Blick.",
+            "Ich zeichne das Wort „die Krone“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "die Zeremonie",
           "russian": "церемония",
           "transcription": "[ди це-ре-мо-НИ]",
           "sentence": "Hinter der vergoldeten Balustrade beobachtet König Lear das gespannte Antlitz des Hofes. Mit fester Stimme schwöre ich mir: Das Wort „die Zeremonie“ wird heute nicht verraten.",
-          "sentence_translation": "За позолоченной балюстрадой Лир наблюдает за напряжёнными лицами двора. Твёрдым голосом я клянусь себе: слово «церемония» сегодня не будет предано."
+          "sentence_translation": "За позолоченной балюстрадой Лир наблюдает за напряжёнными лицами двора. Твёрдым голосом я клянусь себе: слово «церемония» сегодня не будет предано.",
+          "sentence_parts": [
+            "Hinter der vergoldeten Balustrade beobachtet König Lear das gespannte Antlitz des Hofes.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „die Zeremonie“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "prächtig",
           "russian": "великолепный",
           "transcription": "[ПРЕХ-тиг]",
           "sentence": "Im Schein der offenen Feuerbecken erhebt König Lear langsam die Stimme. Ich halte das Wort „prächtig“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "В отблесках открытых жаровен Лир медленно поднимает голос. Я держу слово «великолепный» как факел у сердца."
+          "sentence_translation": "В отблесках открытых жаровен Лир медленно поднимает голос. Я держу слово «великолепный» как факел у сердца.",
+          "sentence_parts": [
+            "Im Schein der offenen Feuerbecken erhebt König Lear langsam die Stimme.",
+            "Ich halte das Wort „prächtig“ wie eine Fackel vor meinem Herzen."
+          ]
         }
       ],
       "quizzes": [
@@ -114,56 +146,89 @@
           "russian": "унижать",
           "transcription": "[де-МЮ-ти-ген]",
           "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt König Lear zwischen gepackten Kisten. Ich halte das Wort „demütigen“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "В гулком проёме ворот замка Гонерильи Лир замирает среди нагруженных ящиков. Я держу слово «унижать» как факел у сердца."
+          "sentence_translation": "В гулком проёме ворот замка Гонерильи Лир замирает среди нагруженных ящиков. Я держу слово «унижать» как факел у сердца.",
+          "sentence_parts": [
+            "Im hallenden Torbogen von Gonerils Burg verharrt König Lear zwischen gepackten Kisten.",
+            "Ich halte das Wort „demütigen“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "der Zorn",
           "russian": "гнев",
           "transcription": "[дер ЦОРН]",
           "sentence": "Auf der windigen Freitreppe blickt König Lear zum schweigenden Hof hinunter. Ich presse das Wort „der Zorn“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "На продуваемой ветром лестнице Лир смотрит вниз на молчаливый двор. Я стискиваю слово «гнев» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "На продуваемой ветром лестнице Лир смотрит вниз на молчаливый двор. Я стискиваю слово «гнев» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Auf der windigen Freitreppe blickt König Lear zum schweigenden Hof hinunter.",
+            "Ich presse das Wort „der Zorn“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Undankbarkeit",
           "russian": "неблагодарность",
           "transcription": "[ди УН-данк-бар-кайт]",
           "sentence": "Zwischen zurückgelassenen Dienern schließt König Lear den Reisemantel enger. Selbst wenn die Welt zerfällt, bleibt das Wort „die Undankbarkeit“ mein Nordstern.",
-          "sentence_translation": "Среди оставленных слуг Лир плотнее запахивает дорожный плащ. Даже если мир распадается, слово «неблагодарность» остаётся моим северным светом."
+          "sentence_translation": "Среди оставленных слуг Лир плотнее запахивает дорожный плащ. Даже если мир распадается, слово «неблагодарность» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Zwischen zurückgelassenen Dienern schließt König Lear den Reisemantel enger.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Undankbarkeit“ mein Nordstern."
+          ]
         },
         {
           "german": "verfluchen",
           "russian": "проклинать",
           "transcription": "[фер-ФЛУ-хен]",
           "sentence": "Am dunklen Pferdestall streicht König Lear einem nervösen Tier über die Mähne. Ich flüstere den Wächtern des Schicksals zu: Das Wort „verfluchen“ darf nicht vergehen.",
-          "sentence_translation": "У тёмного конюшенного ряда Лир гладит гриву нервного коня. Я шепчу стражам судьбы: слово «проклинать» не должно исчезнуть."
+          "sentence_translation": "У тёмного конюшенного ряда Лир гладит гриву нервного коня. Я шепчу стражам судьбы: слово «проклинать» не должно исчезнуть.",
+          "sentence_parts": [
+            "Am dunklen Pferdestall streicht König Lear einem nervösen Tier über die Mähne.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „verfluchen“ darf nicht vergehen."
+          ]
         },
         {
           "german": "vertreiben",
           "russian": "изгонять",
           "transcription": "[фер-ТРАЙ-бен]",
           "sentence": "Vor dem knarrenden Fallgatter tastet König Lear ein letztes Mal nach dem Haustor. Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten.",
-          "sentence_translation": "Перед скрипящим подъёмным мостом Лир в последний раз касается родной двери. Твёрдым голосом я клянусь себе: слово «изгонять» сегодня не будет предано."
+          "sentence_translation": "Перед скрипящим подъёмным мостом Лир в последний раз касается родной двери. Твёрдым голосом я клянусь себе: слово «изгонять» сегодня не будет предано.",
+          "sentence_parts": [
+            "Vor dem knarrenden Fallgatter tastet König Lear ein letztes Mal nach dem Haustor.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "die Kränkung",
           "russian": "обида",
           "transcription": "[ди КРЭН-кунг]",
           "sentence": "Zwischen verstreuten Schriftrollen dreht König Lear den Ring an der Hand. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Kränkung“ bleibt lebendig.",
-          "sentence_translation": "Среди разбросанных свитков Лир вертит кольцо на пальце. Каждой клеткой тела я обещаю: слово «обида» останется живым."
+          "sentence_translation": "Среди разбросанных свитков Лир вертит кольцо на пальце. Каждой клеткой тела я обещаю: слово «обида» останется живым.",
+          "sentence_parts": [
+            "Zwischen verstreuten Schriftrollen dreht König Lear den Ring an der Hand.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Kränkung“ bleibt lebendig."
+          ]
         },
         {
           "german": "bereuen",
           "russian": "сожалеть",
           "transcription": "[бе-РОЙ-ен]",
           "sentence": "Am leeren Bankettisch zählt König Lear die verlöschenden Kerzen. Wie ein stilles Gebet legt sich das Wort „bereuen“ auf meine Lippen.",
-          "sentence_translation": "У пустого банкетного стола Лир пересчитывает гаснущие свечи. Как тихая молитва слово «сожалеть» ложится на мои губы."
+          "sentence_translation": "У пустого банкетного стола Лир пересчитывает гаснущие свечи. Как тихая молитва слово «сожалеть» ложится на мои губы.",
+          "sentence_parts": [
+            "Am leeren Bankettisch zählt König Lear die verlöschenden Kerzen.",
+            "Wie ein stilles Gebet legt sich das Wort „bereuen“ auf meine Lippen."
+          ]
         },
         {
           "german": "der Fluch",
           "russian": "проклятие",
           "transcription": "[дер ФЛУХ]",
           "sentence": "Zwischen schweigenden Wachen geht König Lear auf den kalten Hof hinaus. Ich zeichne das Wort „der Fluch“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Между молчаливыми стражниками Лир выходит на холодный двор. Я черчу слово «проклятие» в мыслях поверх линий судьбы."
+          "sentence_translation": "Между молчаливыми стражниками Лир выходит на холодный двор. Я черчу слово «проклятие» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Zwischen schweigenden Wachen geht König Lear auf den kalten Hof hinaus.",
+            "Ich zeichne das Wort „der Fluch“ in Gedanken über die Linien des Schicksals."
+          ]
         }
       ],
       "quizzes": [
@@ -207,56 +272,90 @@
           "russian": "покидать",
           "transcription": "[фер-ЛА-сен]",
           "sentence": "Im zugigen Seitenflügel lauscht König Lear dem Heulen der Küstenwinde. Wie ein stilles Gebet legt sich das Wort „verlassen“ auf meine Lippen.",
-          "sentence_translation": "В продуваемом ветром боковом крыле Лир слушает вой прибрежного ветра. Как тихая молитва слово «покидать» ложится на мои губы."
+          "sentence_translation": "В продуваемом ветром боковом крыле Лир слушает вой прибрежного ветра. Как тихая молитва слово «покидать» ложится на мои губы.",
+          "sentence_parts": [
+            "Im zugigen Seitenflügel lauscht König Lear dem Heulen der Küstenwinde.",
+            "Wie ein stilles Gebet legt sich das Wort „verlassen“ auf meine Lippen."
+          ]
         },
         {
           "german": "verstoßen",
           "russian": "отвергать",
           "transcription": "[фер-ШТО-сен]",
           "sentence": "Vor dem rauchigen Kamin der Burg faltet König Lear einen zerknitterten Brief. Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig.",
-          "sentence_translation": "Перед дымным камином замка Лир складывает измятый лист. Каждой клеткой тела я обещаю: слово «отвергать» останется живым."
+          "sentence_translation": "Перед дымным камином замка Лир складывает измятый лист. Каждой клеткой тела я обещаю: слово «отвергать» останется живым.",
+          "sentence_parts": [
+            "Vor dem rauchigen Kamin der Burg faltet König Lear einen zerknitterten Brief.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig."
+          ]
         },
         {
           "german": "die Grausamkeit",
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
           "sentence": "Unter farblosen Wandteppichen schreitet König Lear rastlos auf und ab. Wie ein stilles Gebet legt sich das Wort „die Grausamkeit“ auf meine Lippen.",
-          "sentence_translation": "Под выцветшими гобеленами Лир беспокойно меряет шагами зал. Как тихая молитва слово «жестокость» ложится на мои губы."
+          "sentence_translation": "Под выцветшими гобеленами Лир беспокойно меряет шагами зал. Как тихая молитва слово «жестокость» ложится на мои губы.",
+          "sentence_parts": [
+            "Unter farblosen Wandteppichen schreitet König Lear rastlos auf und ab.",
+            "Wie ein stilles Gebet legt sich das Wort „die Grausamkeit“ auf meine Lippen."
+          ]
         },
         {
           "german": "die Verzweiflung",
           "russian": "отчаяние",
           "transcription": "[ди фер-ЦВАЙ-флунг]",
           "sentence": "An der schmalen Fensterluke zählt König Lear die Fackeln auf dem Hof. Ich zeichne das Wort „die Verzweiflung“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "У узкой бойницы Лир считает факелы на дворе. Я черчу слово «отчаяние» в мыслях поверх линий судьбы."
+          "sentence_translation": "У узкой бойницы Лир считает факелы на дворе. Я черчу слово «отчаяние» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "An der schmalen Fensterluke zählt König Lear die Fackeln auf dem Hof.",
+            "Ich zeichne das Wort „die Verzweiflung“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "betteln",
           "russian": "просить",
           "transcription": "[БЕ-тельн]",
           "sentence": "Zwischen Reisekoffern der Gesandten sucht König Lear nach frischen Botschaften. Ich presse das Wort „betteln“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Среди дорожных сундуков послов Лир ищет свежие вести. Я стискиваю слово «просить» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Среди дорожных сундуков послов Лир ищет свежие вести. Я стискиваю слово «просить» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Zwischen Reisekoffern der Gesandten sucht König Lear nach frischen Botschaften.",
+            "Ich presse das Wort „betteln“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "die Einsamkeit",
           "russian": "одиночество",
           "transcription": "[ди АЙН-зам-кайт]",
           "sentence": "Im stillen Kapellenraum kniet König Lear vor der kalten Steinfigur. Ich umarme das Wort „die Einsamkeit“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В тихой капелле Лир преклоняет колени перед холодной каменной фигурой. Я обнимаю слово «одиночество», будто это единственный союзник."
+          "sentence_translation": "В тихой капелле Лир преклоняет колени перед холодной каменной фигурой. Я обнимаю слово «одиночество», будто это единственный союзник.",
+          "sentence_parts": [
+            "Im stillen Kapellenraum kniet König Lear vor der kalten Steinfigur.",
+            "Ich umarme das Wort „die Einsamkeit“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Träne",
           "russian": "слеза",
           "transcription": "[ди ТРЭ-не]",
           "sentence": "Auf dem Balkon, den das Meer besprüht, hält König Lear die Laterne fest. Selbst wenn die Welt zerfällt, bleibt das Wort „die Träne“ mein Nordstern.",
-          "sentence_translation": "На балконе, омываемом морскими брызгами, Лир крепко держит фонарь. Даже если мир распадается, слово «слеза» остаётся моим северным светом."
+          "sentence_translation": "На балконе, омываемом морскими брызгами, Лир крепко держит фонарь. Даже если мир распадается, слово «слеза» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Auf dem Balkon,",
+            "den das Meer besprüht,",
+            "hält König Lear die Laterne fest.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Träne“ mein Nordstern."
+          ]
         },
         {
           "german": "die Not",
           "russian": "нужда",
           "transcription": "[ди НОТ]",
           "sentence": "Im Schatten der hohen Burgmauern schreibt König Lear eine fiebrige Antwort. Mein Atem zeichnet das Wort „die Not“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В тени высоких стен Лир пишет лихорадочный ответ. Моё дыхание рисует слово «нужда» в холодном воздухе между нами."
+          "sentence_translation": "В тени высоких стен Лир пишет лихорадочный ответ. Моё дыхание рисует слово «нужда» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im Schatten der hohen Burgmauern schreibt König Lear eine fiebrige Antwort.",
+            "Mein Atem zeichnet das Wort „die Not“ in die kalte Luft zwischen uns."
+          ]
         }
       ],
       "quizzes": [
@@ -300,56 +399,88 @@
           "russian": "буря",
           "transcription": "[дер ШТУРМ]",
           "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich König Lear gegen den Wind. Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Посреди хлещущей дождём пустоши Лир упирается в ветер. Я обнимаю слово «буря», будто это единственный союзник."
+          "sentence_translation": "Посреди хлещущей дождём пустоши Лир упирается в ветер. Я обнимаю слово «буря», будто это единственный союзник.",
+          "sentence_parts": [
+            "Mitten auf der vom Regen gepeitschten Heide stemmt sich König Lear gegen den Wind.",
+            "Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "der Wahnsinn",
           "russian": "безумие",
           "transcription": "[дер ВАН-зин]",
           "sentence": "Unter einem zerrissenen Banner schützt König Lear die Augen vor den Blitzen. Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Под разорванным знаменем Лир прикрывает глаза от молний. Моё дыхание рисует слово «безумие» в холодном воздухе между нами."
+          "sentence_translation": "Под разорванным знаменем Лир прикрывает глаза от молний. Моё дыхание рисует слово «безумие» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Unter einem zerrissenen Banner schützt König Lear die Augen vor den Blitzen.",
+            "Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "toben",
           "russian": "бушевать",
           "transcription": "[ТО-бен]",
           "sentence": "Am Rand eines umgestürzten Baumes sucht König Lear Deckung vor dem Donner. Ich flüstere den Wächtern des Schicksals zu: Das Wort „toben“ darf nicht vergehen.",
-          "sentence_translation": "У поваленного дерева Лир ищет укрытия от грома. Я шепчу стражам судьбы: слово «бушевать» не должно исчезнуть."
+          "sentence_translation": "У поваленного дерева Лир ищет укрытия от грома. Я шепчу стражам судьбы: слово «бушевать» не должно исчезнуть.",
+          "sentence_parts": [
+            "Am Rand eines umgestürzten Baumes sucht König Lear Deckung vor dem Donner.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „toben“ darf nicht vergehen."
+          ]
         },
         {
           "german": "der Donner",
           "russian": "гром",
           "transcription": "[дер ДО-нер]",
           "sentence": "Zwischen schäumenden Wassergräben stolpert König Lear durch den Schlamm. Ich umarme das Wort „der Donner“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Между пенящимися лужами Лир пробирается через грязь. Я обнимаю слово «гром», будто это единственный союзник."
+          "sentence_translation": "Между пенящимися лужами Лир пробирается через грязь. Я обнимаю слово «гром», будто это единственный союзник.",
+          "sentence_parts": [
+            "Zwischen schäumenden Wassergräben stolpert König Lear durch den Schlamm.",
+            "Ich umarme das Wort „der Donner“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "der Blitz",
           "russian": "молния",
           "transcription": "[дер БЛИЦ]",
           "sentence": "Vor einem zuckenden Himmel hebt König Lear die Arme trotzig an. Ich atme tief ein und lasse nur das Wort „der Blitz“ wieder hinaus.",
-          "sentence_translation": "На фоне вспыхивающего неба Лир упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «молния»."
+          "sentence_translation": "На фоне вспыхивающего неба Лир упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «молния».",
+          "sentence_parts": [
+            "Vor einem zuckenden Himmel hebt König Lear die Arme trotzig an.",
+            "Ich atme tief ein und lasse nur das Wort „der Blitz“ wieder hinaus."
+          ]
         },
         {
           "german": "schreien",
           "russian": "кричать",
           "transcription": "[ШРАЙ-ен]",
           "sentence": "Unter dem durchtränkten Umhang presst König Lear den Atem gegen die Kälte. Ich zeichne das Wort „schreien“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Под промокшим плащом Лир прижимает дыхание к груди, спасаясь от холода. Я вывожу слово «кричать» невидимыми чернилами на ладони."
+          "sentence_translation": "Под промокшим плащом Лир прижимает дыхание к груди, спасаясь от холода. Я вывожу слово «кричать» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Unter dem durchtränkten Umhang presst König Lear den Atem gegen die Kälte.",
+            "Ich zeichne das Wort „schreien“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "nackt",
           "russian": "голый",
           "transcription": "[НАКТ]",
           "sentence": "Am kläglichen Feuerrest wärmt König Lear zitternde Finger. Ich zeichne das Wort „nackt“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "У жалких огненных углей Лир греет дрожащие пальцы. Я черчу слово «голый» в мыслях поверх линий судьбы."
+          "sentence_translation": "У жалких огненных углей Лир греет дрожащие пальцы. Я черчу слово «голый» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Am kläglichen Feuerrest wärmt König Lear zitternde Finger.",
+            "Ich zeichne das Wort „nackt“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "das Chaos",
           "russian": "хаос",
           "transcription": "[дас ХА-ос]",
           "sentence": "Zwischen heulenden Hunden ruft König Lear gegen den tosenden Sturm an. Ich halte das Wort „das Chaos“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Среди воющих псов Лир перекрикивает беснующуюся бурю. Я держу слово «хаос» как факел у сердца."
+          "sentence_translation": "Среди воющих псов Лир перекрикивает беснующуюся бурю. Я держу слово «хаос» как факел у сердца.",
+          "sentence_parts": [
+            "Zwischen heulenden Hunden ruft König Lear gegen den tosenden Sturm an.",
+            "Ich halte das Wort „das Chaos“ wie eine Fackel vor meinem Herzen."
+          ]
         }
       ],
       "quizzes": [
@@ -393,56 +524,88 @@
           "russian": "нищета",
           "transcription": "[дас Э-ленд]",
           "sentence": "Im dunklen Zelt der Feldärzte sitzt König Lear bei der flackernden Kerze. Selbst wenn die Welt zerfällt, bleibt das Wort „das Elend“ mein Nordstern.",
-          "sentence_translation": "В тёмном шатре полевых лекарей Лир сидит у мерцающей свечи. Даже если мир распадается, слово «нищета» остаётся моим северным светом."
+          "sentence_translation": "В тёмном шатре полевых лекарей Лир сидит у мерцающей свечи. Даже если мир распадается, слово «нищета» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Im dunklen Zelt der Feldärzte sitzt König Lear bei der flackernden Kerze.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „das Elend“ mein Nordstern."
+          ]
         },
         {
           "german": "der Bettler",
           "russian": "нищий",
           "transcription": "[дер БЕТ-лер]",
           "sentence": "Zwischen zerbeulten Rüstungen streicht König Lear über ein altes Wappen. Mit fester Stimme schwöre ich mir: Das Wort „der Bettler“ wird heute nicht verraten.",
-          "sentence_translation": "Среди помятых доспехов Лир гладит старый герб. Твёрдым голосом я клянусь себе: слово «нищий» сегодня не будет предано."
+          "sentence_translation": "Среди помятых доспехов Лир гладит старый герб. Твёрдым голосом я клянусь себе: слово «нищий» сегодня не будет предано.",
+          "sentence_parts": [
+            "Zwischen zerbeulten Rüstungen streicht König Lear über ein altes Wappen.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „der Bettler“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "arm",
           "russian": "бедный",
           "transcription": "[АРМ]",
           "sentence": "Am niedrigen Dachbalken der Hütte stößt König Lear fast den Kopf. Selbst wenn die Welt zerfällt, bleibt das Wort „arm“ mein Nordstern.",
-          "sentence_translation": "О низкую балку хижины Лир едва не ударяется головой. Даже если мир распадается, слово «бедный» остаётся моим северным светом."
+          "sentence_translation": "О низкую балку хижины Лир едва не ударяется головой. Даже если мир распадается, слово «бедный» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Am niedrigen Dachbalken der Hütte stößt König Lear fast den Kopf.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „arm“ mein Nordstern."
+          ]
         },
         {
           "german": "frieren",
           "russian": "мёрзнуть",
           "transcription": "[ФРИ-рен]",
           "sentence": "Neben der schlafenden Wache flüstert König Lear in die schwere Nacht. Das kalte Licht lässt das Wort „frieren“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Рядом со спящим стражем Лир шепчет в тяжёлую ночь. Холодный свет заставляет слово «мёрзнуть» сиять словно расплавленное золото."
+          "sentence_translation": "Рядом со спящим стражем Лир шепчет в тяжёлую ночь. Холодный свет заставляет слово «мёрзнуть» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Neben der schlafenden Wache flüstert König Lear in die schwere Nacht.",
+            "Das kalte Licht lässt das Wort „frieren“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "die Hütte",
           "russian": "хижина",
           "transcription": "[ди ХЮ-те]",
           "sentence": "Vor dem einfachen Feldbett betrachtet König Lear die Narben vergangener Schlachten. Ich zeichne das Wort „die Hütte“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Перед грубой походной койкой Лир разглядывает шрамы прошлых битв. Я черчу слово «хижина» в мыслях поверх линий судьбы."
+          "sentence_translation": "Перед грубой походной койкой Лир разглядывает шрамы прошлых битв. Я черчу слово «хижина» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Vor dem einfachen Feldbett betrachtet König Lear die Narben vergangener Schlachten.",
+            "Ich zeichne das Wort „die Hütte“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
           "sentence": "Im Geruch von feuchtem Stroh legt König Lear den Mantel zur Seite. Mein Atem zeichnet das Wort „leiden“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В запахе влажной соломы Лир откладывает плащ в сторону. Моё дыхание рисует слово «страдать» в холодном воздухе между нами."
+          "sentence_translation": "В запахе влажной соломы Лир откладывает плащ в сторону. Моё дыхание рисует слово «страдать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im Geruch von feuchtem Stroh legt König Lear den Mantel zur Seite.",
+            "Mein Atem zeichnet das Wort „leiden“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "der Narr",
           "russian": "шут",
           "transcription": "[дер НАР]",
           "sentence": "Auf dem wackligen Holztisch ordnet König Lear zerlesene Briefe. Selbst wenn die Welt zerfällt, bleibt das Wort „der Narr“ mein Nordstern.",
-          "sentence_translation": "На шатком деревянном столе Лир раскладывает зачитанные письма. Даже если мир распадается, слово «шут» остаётся моим северным светом."
+          "sentence_translation": "На шатком деревянном столе Лир раскладывает зачитанные письма. Даже если мир распадается, слово «шут» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Auf dem wackligen Holztisch ordnet König Lear zerlesene Briefe.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „der Narr“ mein Nordstern."
+          ]
         },
         {
           "german": "die Erkenntnis",
           "russian": "познание",
           "transcription": "[ди ер-КЕНТ-нис]",
           "sentence": "Am Eingang der Hütte späht König Lear nach einem vertrauten Schatten. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Erkenntnis“ darf nicht vergehen.",
-          "sentence_translation": "У входа в хижину Лир высматривает знакомую тень. Я шепчу стражам судьбы: слово «познание» не должно исчезнуть."
+          "sentence_translation": "У входа в хижину Лир высматривает знакомую тень. Я шепчу стражам судьбы: слово «познание» не должно исчезнуть.",
+          "sentence_parts": [
+            "Am Eingang der Hütte späht König Lear nach einem vertrauten Schatten.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Erkenntnis“ darf nicht vergehen."
+          ]
         }
       ],
       "quizzes": [
@@ -486,56 +649,88 @@
           "russian": "узнавать",
           "transcription": "[эр-КЕ-нен]",
           "sentence": "Auf den weißen Klippen von Dover blickt König Lear in den aufgewühlten Kanal. Ich halte das Wort „erkennen“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "На белых скалах Дувра Лир смотрит в вздыбленный пролив. Я держу слово «узнавать» как факел у сердца."
+          "sentence_translation": "На белых скалах Дувра Лир смотрит в вздыбленный пролив. Я держу слово «узнавать» как факел у сердца.",
+          "sentence_parts": [
+            "Auf den weißen Klippen von Dover blickt König Lear in den aufgewühlten Kanal.",
+            "Ich halte das Wort „erkennen“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "verstehen",
           "russian": "понимать",
           "transcription": "[фер-ШТЕ-ен]",
           "sentence": "Zwischen flatternden Feldzeichen richtet König Lear den Helm. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verstehen“ gehört mir.",
-          "sentence_translation": "Среди хлопающих штандартов Лир поправляет шлем. Буря за окнами усиливает клятву: слово «понимать» принадлежит мне."
+          "sentence_translation": "Среди хлопающих штандартов Лир поправляет шлем. Буря за окнами усиливает клятву: слово «понимать» принадлежит мне.",
+          "sentence_parts": [
+            "Zwischen flatternden Feldzeichen richtet König Lear den Helm.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verstehen“ gehört mir."
+          ]
         },
         {
           "german": "die Wahrheit",
           "russian": "правда",
           "transcription": "[ди ВАР-хайт]",
           "sentence": "Am Lagerfeuer der Franzosen zeichnet König Lear Marschrouten in den Sand. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Wahrheit“ gehört mir.",
-          "sentence_translation": "У французского костра Лир рисует в песке путь марша. Буря за окнами усиливает клятву: слово «правда» принадлежит мне."
+          "sentence_translation": "У французского костра Лир рисует в песке путь марша. Буря за окнами усиливает клятву: слово «правда» принадлежит мне.",
+          "sentence_parts": [
+            "Am Lagerfeuer der Franzosen zeichnet König Lear Marschrouten in den Sand.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Wahrheit“ gehört mir."
+          ]
         },
         {
           "german": "die Reue",
           "russian": "раскаяние",
           "transcription": "[ди РОЙ-е]",
           "sentence": "Neben verschnürten Versorgungskisten kontrolliert König Lear das Siegel. Das Echo des Wortes „die Reue“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "У перевязанных провиантных ящиков Лир проверяет печати. Эхо слова «раскаяние» заглушает шёпот придворных."
+          "sentence_translation": "У перевязанных провиантных ящиков Лир проверяет печати. Эхо слова «раскаяние» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Neben verschnürten Versorgungskisten kontrolliert König Lear das Siegel.",
+            "Das Echo des Wortes „die Reue“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Weisheit",
           "russian": "мудрость",
           "transcription": "[ди ВАЙС-хайт]",
           "sentence": "Vor dem Seidenzelt der Heerführer lauscht König Lear dem dumpfen Meer. Ich umarme das Wort „die Weisheit“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Перед шёлковым шатром полководцев Лир слушает глухой шум моря. Я обнимаю слово «мудрость», будто это единственный союзник."
+          "sentence_translation": "Перед шёлковым шатром полководцев Лир слушает глухой шум моря. Я обнимаю слово «мудрость», будто это единственный союзник.",
+          "sentence_parts": [
+            "Vor dem Seidenzelt der Heerführer lauscht König Lear dem dumpfen Meer.",
+            "Ich umarme das Wort „die Weisheit“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "vergeben",
           "russian": "прощать",
           "transcription": "[фер-ГЕ-бен]",
           "sentence": "Auf dem sandigen Trainingsplatz übt König Lear das Ziehen des Schwerts. Wie ein stilles Gebet legt sich das Wort „vergeben“ auf meine Lippen.",
-          "sentence_translation": "На песчаном плацу Лир отрабатывает выхват меча. Как тихая молитва слово «прощать» ложится на мои губы."
+          "sentence_translation": "На песчаном плацу Лир отрабатывает выхват меча. Как тихая молитва слово «прощать» ложится на мои губы.",
+          "sentence_parts": [
+            "Auf dem sandigen Trainingsplatz übt König Lear das Ziehen des Schwerts.",
+            "Wie ein stilles Gebet legt sich das Wort „vergeben“ auf meine Lippen."
+          ]
         },
         {
           "german": "die Einsicht",
           "russian": "прозрение",
           "transcription": "[ди АЙН-зихт]",
           "sentence": "Zwischen pochenden Trommeln hebt König Lear das Banner der Hoffnung. Mein Atem zeichnet das Wort „die Einsicht“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Под гул барабанов Лир поднимает знамя надежды. Моё дыхание рисует слово «прозрение» в холодном воздухе между нами."
+          "sentence_translation": "Под гул барабанов Лир поднимает знамя надежды. Моё дыхание рисует слово «прозрение» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Zwischen pochenden Trommeln hebt König Lear das Banner der Hoffnung.",
+            "Mein Atem zeichnet das Wort „die Einsicht“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "schuldig",
           "russian": "виновный",
           "transcription": "[ШУЛЬ-диг]",
           "sentence": "Am Morgennebel der Küste legt König Lear die Hand auf das pochende Herz. Selbst wenn die Welt zerfällt, bleibt das Wort „schuldig“ mein Nordstern.",
-          "sentence_translation": "В утреннем тумане побережья Лир кладёт ладонь на бьющееся сердце. Даже если мир распадается, слово «виновный» остаётся моим северным светом."
+          "sentence_translation": "В утреннем тумане побережья Лир кладёт ладонь на бьющееся сердце. Даже если мир распадается, слово «виновный» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Am Morgennebel der Küste legt König Lear die Hand auf das pochende Herz.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „schuldig“ mein Nordstern."
+          ]
         }
       ],
       "quizzes": [
@@ -579,56 +774,90 @@
           "russian": "прощать",
           "transcription": "[фер-ЦАЙ-ен]",
           "sentence": "Im feuchten Kerker stützt König Lear sich an den tropfenden Stein. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verzeihen“ gehört mir.",
-          "sentence_translation": "В сыром подземелье Лир опирается на сочащийся камень. Буря за окнами усиливает клятву: слово «прощать» принадлежит мне."
+          "sentence_translation": "В сыром подземелье Лир опирается на сочащийся камень. Буря за окнами усиливает клятву: слово «прощать» принадлежит мне.",
+          "sentence_parts": [
+            "Im feuchten Kerker stützt König Lear sich an den tropfenden Stein.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verzeihen“ gehört mir."
+          ]
         },
         {
           "german": "der Tod",
           "russian": "смерть",
           "transcription": "[дер ТОД]",
           "sentence": "Unter der trüben Laterne zählt König Lear die eisernen Ringe der Kette. Ich umarme das Wort „der Tod“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Под мутным фонарём Лир пересчитывает железные кольца цепи. Я обнимаю слово «смерть», будто это единственный союзник."
+          "sentence_translation": "Под мутным фонарём Лир пересчитывает железные кольца цепи. Я обнимаю слово «смерть», будто это единственный союзник.",
+          "sentence_parts": [
+            "Unter der trüben Laterne zählt König Lear die eisernen Ringe der Kette.",
+            "Ich umarme das Wort „der Tod“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "sterben",
           "russian": "умирать",
           "transcription": "[ШТЕР-бен]",
           "sentence": "Neben der schweren Holztür horcht König Lear auf entferntes Schluchzen. Wie ein stilles Gebet legt sich das Wort „sterben“ auf meine Lippen.",
-          "sentence_translation": "У тяжёлой двери Лир прислушивается к далёким рыданиям. Как тихая молитва слово «умирать» ложится на мои губы."
+          "sentence_translation": "У тяжёлой двери Лир прислушивается к далёким рыданиям. Как тихая молитва слово «умирать» ложится на мои губы.",
+          "sentence_parts": [
+            "Neben der schweren Holztür horcht König Lear auf entferntes Schluchzen.",
+            "Wie ein stilles Gebet legt sich das Wort „sterben“ auf meine Lippen."
+          ]
         },
         {
           "german": "das Ende",
           "russian": "конец",
           "transcription": "[дас ЕН-де]",
           "sentence": "Auf der kalten Steinbank zieht König Lear den Mantel enger um die Schultern. Ich presse das Wort „das Ende“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "На холодной каменной скамье Лир плотнее кутается в плащ. Я стискиваю слово «конец» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "На холодной каменной скамье Лир плотнее кутается в плащ. Я стискиваю слово «конец» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Auf der kalten Steinbank zieht König Lear den Mantel enger um die Schultern.",
+            "Ich presse das Wort „das Ende“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "das Herz",
           "russian": "сердце",
           "transcription": "[дас ХЕРЦ]",
           "sentence": "Zwischen Schatten der Gitterstäbe hebt König Lear das Gesicht zum Licht. Ich umarme das Wort „das Herz“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Между тенями решёток Лир поднимает лицо к свету. Я обнимаю слово «сердце», будто это единственный союзник."
+          "sentence_translation": "Между тенями решёток Лир поднимает лицо к свету. Я обнимаю слово «сердце», будто это единственный союзник.",
+          "sentence_parts": [
+            "Zwischen Schatten der Gitterstäbe hebt König Lear das Gesicht zum Licht.",
+            "Ich umarme das Wort „das Herz“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "die Trauer",
           "russian": "скорбь",
           "transcription": "[ди ТРАУ-ер]",
           "sentence": "Am rostigen Wassereimer spiegelt König Lear kurz die eigenen Augen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Trauer“ gehört mir.",
-          "sentence_translation": "У ржавого ведра с водой Лир на мгновение видит отражение глаз. Буря за окнами усиливает клятву: слово «скорбь» принадлежит мне."
+          "sentence_translation": "У ржавого ведра с водой Лир на мгновение видит отражение глаз. Буря за окнами усиливает клятву: слово «скорбь» принадлежит мне.",
+          "sentence_parts": [
+            "Am rostigen Wassereimer spiegelt König Lear kurz die eigenen Augen.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Trauer“ gehört mir."
+          ]
         },
         {
           "german": "der Abschied",
           "russian": "прощание",
           "transcription": "[дер АБ-шид]",
           "sentence": "Im dumpfen Hall der Schritte zählt König Lear den Rhythmus der Wachen. Ich presse das Wort „der Abschied“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "В глухом эхе шагов Лир отсчитывает ритм часовых. Я стискиваю слово «прощание» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "В глухом эхе шагов Лир отсчитывает ритм часовых. Я стискиваю слово «прощание» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Im dumpfen Hall der Schritte zählt König Lear den Rhythmus der Wachen.",
+            "Ich presse das Wort „der Abschied“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "ewig",
           "russian": "вечный",
           "transcription": "[Э-виг]",
           "sentence": "Vor dem verriegelten Fenster zeichnet König Lear Kreise in den Staub. Ich flüstere den Wächtern des Schicksals zu: Das Wort „ewig“ darf nicht vergehen.",
-          "sentence_translation": "Перед заколоченным окном Лир чертит круги в пыли. Я шепчу стражам судьбы: слово «вечный» не должно исчезнуть."
+          "sentence_translation": "Перед заколоченным окном Лир чертит круги в пыли. Я шепчу стражам судьбы: слово «вечный» не должно исчезнуть.",
+          "sentence_parts": [
+            "Vor dem verriegelten Fenster zeichnet König Lear Kreise in den Staub.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „ewig“ darf nicht vergehen."
+          ]
         }
       ],
       "quizzes": [

--- a/data/characters/oswald.json
+++ b/data/characters/oswald.json
@@ -15,56 +15,89 @@
           "russian": "слуга",
           "transcription": "[дер ДИ-нер]",
           "sentence": "Im Saal der Herrin richtet Oswald die silbernen Teller entlang der langen Tafel aus. Ich zeichne das Wort „der Diener“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "В зале госпожи Освальд выравнивает серебряные блюда вдоль длинного стола. Я черчу слово «слуга» в мыслях поверх линий судьбы."
+          "sentence_translation": "В зале госпожи Освальд выравнивает серебряные блюда вдоль длинного стола. Я черчу слово «слуга» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Im Saal der Herrin richtet Oswald die silbernen Teller entlang der langen Tafel aus.",
+            "Ich zeichne das Wort „der Diener“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "der Gehorsam",
           "russian": "послушание",
           "transcription": "[дер ге-ХОР-зам]",
           "sentence": "Vor dem Spiegel prüft Oswald den makellosen Sitz des Dienerkleids. Ich halte das Wort „der Gehorsam“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Перед зеркалом Освальд проверяет безупречную посадку дворецкого наряда. Я держу слово «послушание» как факел у сердца."
+          "sentence_translation": "Перед зеркалом Освальд проверяет безупречную посадку дворецкого наряда. Я держу слово «послушание» как факел у сердца.",
+          "sentence_parts": [
+            "Vor dem Spiegel prüft Oswald den makellosen Sitz des Dienerkleids.",
+            "Ich halte das Wort „der Gehorsam“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Ergebenheit",
           "russian": "преданность",
           "transcription": "[ди ер-ГЕ-бен-хайт]",
           "sentence": "Zwischen Rechnungsbüchern notiert Oswald jedes Fass Wein. Ich presse das Wort „die Ergebenheit“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Среди бухгалтерских книг Освальд записывает каждую бочку вина. Я стискиваю слово «преданность» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Среди бухгалтерских книг Освальд записывает каждую бочку вина. Я стискиваю слово «преданность» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Zwischen Rechnungsbüchern notiert Oswald jedes Fass Wein.",
+            "Ich presse das Wort „die Ergebenheit“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "dienen",
           "russian": "служить",
           "transcription": "[ДИ-нен]",
           "sentence": "Am Hofeingang begrüßt Oswald mit steifem Nicken die ankommenden Lords. Wie ein stilles Gebet legt sich das Wort „dienen“ auf meine Lippen.",
-          "sentence_translation": "У входа во двор Освальд сдержанно кивает прибывающим лордам. Как тихая молитва слово «служить» ложится на мои губы."
+          "sentence_translation": "У входа во двор Освальд сдержанно кивает прибывающим лордам. Как тихая молитва слово «служить» ложится на мои губы.",
+          "sentence_parts": [
+            "Am Hofeingang begrüßt Oswald mit steifem Nicken die ankommenden Lords.",
+            "Wie ein stilles Gebet legt sich das Wort „dienen“ auf meine Lippen."
+          ]
         },
         {
           "german": "der Verwalter",
           "russian": "управляющий",
           "transcription": "[дер фер-ВАЛЬ-тер]",
           "sentence": "Unter den wachsamen Augen Gonerils verteilt Oswald die Tagesbefehle. Mit fester Stimme schwöre ich mir: Das Wort „der Verwalter“ wird heute nicht verraten.",
-          "sentence_translation": "Под внимательным взглядом Гонерильи Освальд раздаёт дневные распоряжения. Твёрдым голосом я клянусь себе: слово «управляющий» сегодня не будет предано."
+          "sentence_translation": "Под внимательным взглядом Гонерильи Освальд раздаёт дневные распоряжения. Твёрдым голосом я клянусь себе: слово «управляющий» сегодня не будет предано.",
+          "sentence_parts": [
+            "Unter den wachsamen Augen Gonerils verteilt Oswald die Tagesbefehle.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „der Verwalter“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "ergeben",
           "russian": "покорный",
           "transcription": "[ер-ГЕ-бен]",
           "sentence": "Auf der Küchenrampe kontrolliert Oswald die frischen Vorräte. Das Echo des Wortes „ergeben“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "На кухонном пандусе Освальд проверяет свежие припасы. Эхо слова «покорный» заглушает шёпот придворных."
+          "sentence_translation": "На кухонном пандусе Освальд проверяет свежие припасы. Эхо слова «покорный» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Auf der Küchenrampe kontrolliert Oswald die frischen Vorräte.",
+            "Das Echo des Wortes „ergeben“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "unterwürfig",
           "russian": "раболепный",
           "transcription": "[УН-тер-вюр-фиг]",
           "sentence": "Neben der Ahnengalerie wischt Oswald letzte Staubkörner fort. Ich umarme das Wort „unterwürfig“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "Рядом с галереей предков Освальд смахивает последние пылинки. Я обнимаю слово «раболепный», будто это единственный союзник."
+          "sentence_translation": "Рядом с галереей предков Освальд смахивает последние пылинки. Я обнимаю слово «раболепный», будто это единственный союзник.",
+          "sentence_parts": [
+            "Neben der Ahnengalerie wischt Oswald letzte Staubkörner fort.",
+            "Ich umarme das Wort „unterwürfig“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "befolgen",
           "russian": "исполнять",
           "transcription": "[бе-ФОЛЬ-ген]",
           "sentence": "Im Kontor versiegelt Oswald sorgsam die königliche Korrespondenz. Ich atme tief ein und lasse nur das Wort „befolgen“ wieder hinaus.",
-          "sentence_translation": "В конторе Освальд тщательно запечатывает королевскую корреспонденцию. Я глубоко вдыхаю и выпускаю только слово «исполнять»."
+          "sentence_translation": "В конторе Освальд тщательно запечатывает королевскую корреспонденцию. Я глубоко вдыхаю и выпускаю только слово «исполнять».",
+          "sentence_parts": [
+            "Im Kontor versiegelt Oswald sorgsam die königliche Korrespondenz.",
+            "Ich atme tief ein und lasse nur das Wort „befolgen“ wieder hinaus."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -108,49 +141,77 @@
           "russian": "гонец",
           "transcription": "[дер БО-те]",
           "sentence": "Auf staubigen Straßen peitscht Oswald das Pferd zu größerer Eile. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Bote“ gehört mir.",
-          "sentence_translation": "На пыльных дорогах Освальд подгоняет коня к большей скорости. Буря за окнами усиливает клятву: слово «гонец» принадлежит мне."
+          "sentence_translation": "На пыльных дорогах Освальд подгоняет коня к большей скорости. Буря за окнами усиливает клятву: слово «гонец» принадлежит мне.",
+          "sentence_parts": [
+            "Auf staubigen Straßen peitscht Oswald das Pferd zu größerer Eile.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Bote“ gehört mir."
+          ]
         },
         {
           "german": "der Auftrag",
           "russian": "поручение",
           "transcription": "[дер АУФ-траг]",
           "sentence": "Vor verschlossenen Toren zeigt Oswald das mit Wachs versiegelte Schreiben. Das kalte Licht lässt das Wort „der Auftrag“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Перед закрытыми воротами Освальд предъявляет письмо, запечатанное воском. Холодный свет заставляет слово «поручение» сиять словно расплавленное золото."
+          "sentence_translation": "Перед закрытыми воротами Освальд предъявляет письмо, запечатанное воском. Холодный свет заставляет слово «поручение» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Vor verschlossenen Toren zeigt Oswald das mit Wachs versiegelte Schreiben.",
+            "Das kalte Licht lässt das Wort „der Auftrag“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "die Eile",
           "russian": "спешка",
           "transcription": "[ди АЙ-ле]",
           "sentence": "In der Nacht rast Oswald mit einer Laterne als einzigem Stern. Selbst wenn die Welt zerfällt, bleibt das Wort „die Eile“ mein Nordstern.",
-          "sentence_translation": "Ночью Освальд мчится, освещаемый одной лишь латерной. Даже если мир распадается, слово «спешка» остаётся моим северным светом."
+          "sentence_translation": "Ночью Освальд мчится, освещаемый одной лишь латерной. Даже если мир распадается, слово «спешка» остаётся моим северным светом.",
+          "sentence_parts": [
+            "In der Nacht rast Oswald mit einer Laterne als einzigem Stern.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Eile“ mein Nordstern."
+          ]
         },
         {
           "german": "überbringen",
           "russian": "передавать",
           "transcription": "[ю-бер-БРИН-ген]",
           "sentence": "Am Grenzposten überreicht Oswald den Befehl mit überheblichem Lächeln. Das Echo des Wortes „überbringen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "На пограничной заставе Освальд вручает приказ с высокомерной улыбкой. Эхо слова «передавать» заглушает шёпот придворных."
+          "sentence_translation": "На пограничной заставе Освальд вручает приказ с высокомерной улыбкой. Эхо слова «передавать» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Am Grenzposten überreicht Oswald den Befehl mit überheblichem Lächeln.",
+            "Das Echo des Wortes „überbringen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "hasten",
           "russian": "спешить",
           "transcription": "[ХАС-тен]",
           "sentence": "Zwischen zerrissenen Bannern schützt Oswald die Nachricht vor dem Regen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „hasten“ darf nicht vergehen.",
-          "sentence_translation": "Среди порванных знамён Освальд прикрывает письмо от дождя. Я шепчу стражам судьбы: слово «спешить» не должно исчезнуть."
+          "sentence_translation": "Среди порванных знамён Освальд прикрывает письмо от дождя. Я шепчу стражам судьбы: слово «спешить» не должно исчезнуть.",
+          "sentence_parts": [
+            "Zwischen zerrissenen Bannern schützt Oswald die Nachricht vor dem Regen.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „hasten“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Botschaft",
           "russian": "послание",
           "transcription": "[ди БОТ-шафт]",
           "sentence": "Auf dem Hofe Lear erhebt Oswald die Stimme über den Tumult. Das Echo des Wortes „die Botschaft“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "На дворе Лира Освальд возвышает голос над шумом. Эхо слова «послание» заглушает шёпот придворных."
+          "sentence_translation": "На дворе Лира Освальд возвышает голос над шумом. Эхо слова «послание» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Auf dem Hofe Lear erhebt Oswald die Stimme über den Tumult.",
+            "Das Echo des Wortes „die Botschaft“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "eilen",
           "russian": "торопиться",
           "transcription": "[АЙ-лен]",
           "sentence": "Im Schatten der Stallungen tauscht Oswald heimlich versiegelte Rollen. Mit fester Stimme schwöre ich mir: Das Wort „eilen“ wird heute nicht verraten.",
-          "sentence_translation": "В тени конюшен Освальд тайно меняет запечатанные свитки. Твёрдым голосом я клянусь себе: слово «торопиться» сегодня не будет предано."
+          "sentence_translation": "В тени конюшен Освальд тайно меняет запечатанные свитки. Твёрдым голосом я клянусь себе: слово «торопиться» сегодня не будет предано.",
+          "sentence_parts": [
+            "Im Schatten der Stallungen tauscht Oswald heimlich versiegelte Rollen.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „eilen“ wird heute nicht verraten."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -194,56 +255,88 @@
           "russian": "оскорбление",
           "transcription": "[ди бе-ЛАЙ-ди-гунг]",
           "sentence": "Vor dem gealterten König verneigt sich Oswald nur einen Hauch zu wenig. Das Echo des Wortes „die Beleidigung“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Перед постаревшим королём Освальд кланяется лишь на долю меньше. Эхо слова «оскорбление» заглушает шёпот придворных."
+          "sentence_translation": "Перед постаревшим королём Освальд кланяется лишь на долю меньше. Эхо слова «оскорбление» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Vor dem gealterten König verneigt sich Oswald nur einen Hauch zu wenig.",
+            "Das Echo des Wortes „die Beleidigung“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Respektlosigkeit",
           "russian": "неуважение",
           "transcription": "[ди рес-ПЕКТ-ло-зиг-кайт]",
           "sentence": "Am Torbogen blockiert Oswald den Weg mit erhobenem Stab. Ich halte das Wort „die Respektlosigkeit“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "В проёме ворот Освальд преграждает путь поднятым жезлом. Я держу слово «неуважение» как факел у сердца."
+          "sentence_translation": "В проёме ворот Освальд преграждает путь поднятым жезлом. Я держу слово «неуважение» как факел у сердца.",
+          "sentence_parts": [
+            "Am Torbogen blockiert Oswald den Weg mit erhobenem Stab.",
+            "Ich halte das Wort „die Respektlosigkeit“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Feigheit",
           "russian": "трусость",
           "transcription": "[ди ФАЙГ-хайт]",
           "sentence": "Zwischen entrüsteten Rittern rollt Oswald mit den Augen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Feigheit“ bleibt lebendig.",
-          "sentence_translation": "Среди возмущённых рыцарей Освальд закатывает глаза. Каждой клеткой тела я обещаю: слово «трусость» останется живым."
+          "sentence_translation": "Среди возмущённых рыцарей Освальд закатывает глаза. Каждой клеткой тела я обещаю: слово «трусость» останется живым.",
+          "sentence_parts": [
+            "Zwischen entrüsteten Rittern rollt Oswald mit den Augen.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Feigheit“ bleibt lebendig."
+          ]
         },
         {
           "german": "beleidigen",
           "russian": "оскорблять",
           "transcription": "[бе-ЛАЙ-ди-ген]",
           "sentence": "Auf der Treppe wischt Oswald imaginären Staub von Lears Mantel. Ich halte das Wort „beleidigen“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "На лестнице Освальд стряхивает воображаемую пыль с плаща Лира. Я держу слово «оскорблять» как факел у сердца."
+          "sentence_translation": "На лестнице Освальд стряхивает воображаемую пыль с плаща Лира. Я держу слово «оскорблять» как факел у сердца.",
+          "sentence_parts": [
+            "Auf der Treppe wischt Oswald imaginären Staub von Lears Mantel.",
+            "Ich halte das Wort „beleidigen“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "verhöhnen",
           "russian": "высмеивать",
           "transcription": "[фер-ХЁ-нен]",
           "sentence": "Neben Gonerils kühlen Blick flüstert Oswald eine spitze Bemerkung. Das kalte Licht lässt das Wort „verhöhnen“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Рядом с холодным взглядом Гонерильи Освальд шепчет едкое замечание. Холодный свет заставляет слово «высмеивать» сиять словно расплавленное золото."
+          "sentence_translation": "Рядом с холодным взглядом Гонерильи Освальд шепчет едкое замечание. Холодный свет заставляет слово «высмеивать» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Neben Gonerils kühlen Blick flüstert Oswald eine spitze Bemerkung.",
+            "Das kalte Licht lässt das Wort „verhöhnen“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "frech",
           "russian": "дерзкий",
           "transcription": "[ФРЕХ]",
           "sentence": "Auf dem Hof setzt Oswald sich mit verschränkten Armen gegen jede Bitte zur Wehr. Selbst wenn die Welt zerfällt, bleibt das Wort „frech“ mein Nordstern.",
-          "sentence_translation": "На дворе Освальд скрестив руки сопротивляется любой просьбе. Даже если мир распадается, слово «дерзкий» остаётся моим северным светом."
+          "sentence_translation": "На дворе Освальд скрестив руки сопротивляется любой просьбе. Даже если мир распадается, слово «дерзкий» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Auf dem Hof setzt Oswald sich mit verschränkten Armen gegen jede Bitte zur Wehr.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „frech“ mein Nordstern."
+          ]
         },
         {
           "german": "missachten",
           "russian": "пренебрегать",
           "transcription": "[МИС-ах-тен]",
           "sentence": "Im Flur stößt Oswald den alten König absichtlich zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „missachten“ bleibt lebendig.",
-          "sentence_translation": "В коридоре Освальд нарочно отталкивает старого короля в сторону. Каждой клеткой тела я обещаю: слово «пренебрегать» останется живым."
+          "sentence_translation": "В коридоре Освальд нарочно отталкивает старого короля в сторону. Каждой клеткой тела я обещаю: слово «пренебрегать» останется живым.",
+          "sentence_parts": [
+            "Im Flur stößt Oswald den alten König absichtlich zur Seite.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „missachten“ bleibt lebendig."
+          ]
         },
         {
           "german": "feige",
           "russian": "трусливый",
           "transcription": "[ФАЙ-ге]",
           "sentence": "Auf dem Balkon lacht Oswald laut über Lears Hilflosigkeit. Ich halte das Wort „feige“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "На балконе Освальд громко смеётся над беспомощностью Лира. Я держу слово «трусливый» как факел у сердца."
+          "sentence_translation": "На балконе Освальд громко смеётся над беспомощностью Лира. Я держу слово «трусливый» как факел у сердца.",
+          "sentence_parts": [
+            "Auf dem Balkon lacht Oswald laut über Lears Hilflosigkeit.",
+            "Ich halte das Wort „feige“ wie eine Fackel vor meinem Herzen."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -287,49 +380,78 @@
           "russian": "шпион",
           "transcription": "[дер шпи-ОН]",
           "sentence": "Im Dunkel des Treppenhauses hält Oswald den Atem an, um Gespräche zu belauschen. Wie ein stilles Gebet legt sich das Wort „der Spion“ auf meine Lippen.",
-          "sentence_translation": "В темноте лестницы Освальд задерживает дыхание, подслушивая разговоры. Как тихая молитва слово «шпион» ложится на мои губы."
+          "sentence_translation": "В темноте лестницы Освальд задерживает дыхание, подслушивая разговоры. Как тихая молитва слово «шпион» ложится на мои губы.",
+          "sentence_parts": [
+            "Im Dunkel des Treppenhauses hält Oswald den Atem an,",
+            "um Gespräche zu belauschen.",
+            "Wie ein stilles Gebet legt sich das Wort „der Spion“ auf meine Lippen."
+          ]
         },
         {
           "german": "der Verrat",
           "russian": "предательство",
           "transcription": "[дер фер-РАТ]",
           "sentence": "Hinter schweren Vorhängen notiert Oswald jedes geflüsterte Wort. Das kalte Licht lässt das Wort „der Verrat“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "За тяжёлыми портьерами Освальд записывает каждое прошептанное слово. Холодный свет заставляет слово «предательство» сиять словно расплавленное золото."
+          "sentence_translation": "За тяжёлыми портьерами Освальд записывает каждое прошептанное слово. Холодный свет заставляет слово «предательство» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Hinter schweren Vorhängen notiert Oswald jedes geflüsterte Wort.",
+            "Das kalte Licht lässt das Wort „der Verrat“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "die Heimlichkeit",
           "russian": "скрытность",
           "transcription": "[ди ХАЙМ-лих-кайт]",
           "sentence": "Auf den Mauern späht Oswald nach Reitern am Horizont. Ich halte das Wort „die Heimlichkeit“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "На стенах Освальд высматривает всадников на горизонте. Я держу слово «скрытность» как факел у сердца."
+          "sentence_translation": "На стенах Освальд высматривает всадников на горизонте. Я держу слово «скрытность» как факел у сердца.",
+          "sentence_parts": [
+            "Auf den Mauern späht Oswald nach Reitern am Horizont.",
+            "Ich halte das Wort „die Heimlichkeit“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "spionieren",
           "russian": "шпионить",
           "transcription": "[шпи-о-НИ-рен]",
           "sentence": "Zwischen Küchenmägden tauscht Oswald Gerüchte gegen Kupferstücke. Ich halte das Wort „spionieren“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Среди кухонных служанок Освальд обменивает слухи на медяки. Я держу слово «шпионить» как факел у сердца."
+          "sentence_translation": "Среди кухонных служанок Освальд обменивает слухи на медяки. Я держу слово «шпионить» как факел у сердца.",
+          "sentence_parts": [
+            "Zwischen Küchenmägden tauscht Oswald Gerüchte gegen Kupferstücke.",
+            "Ich halte das Wort „spionieren“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "lauschen",
           "russian": "подслушивать",
           "transcription": "[ЛАУ-шен]",
           "sentence": "Im Kerzenlicht zeichnet Oswald geheime Wege auf Pergament. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „lauschen“ gehört mir.",
-          "sentence_translation": "При свете свечи Освальд вычерчивает тайные пути на пергаменте. Буря за окнами усиливает клятву: слово «подслушивать» принадлежит мне."
+          "sentence_translation": "При свете свечи Освальд вычерчивает тайные пути на пергаменте. Буря за окнами усиливает клятву: слово «подслушивать» принадлежит мне.",
+          "sentence_parts": [
+            "Im Kerzenlicht zeichnet Oswald geheime Wege auf Pergament.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „lauschen“ gehört mir."
+          ]
         },
         {
           "german": "verraten",
           "russian": "выдавать",
           "transcription": "[фер-РА-тен]",
           "sentence": "Unter dem Fenster von Regan beugt Oswald sich tief in die Nacht hinaus. Ich zeichne das Wort „verraten“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Под окном Реганы Освальд глубоко склоняется в ночную тьму. Я вывожу слово «выдавать» невидимыми чернилами на ладони."
+          "sentence_translation": "Под окном Реганы Освальд глубоко склоняется в ночную тьму. Я вывожу слово «выдавать» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Unter dem Fenster von Regan beugt Oswald sich tief in die Nacht hinaus.",
+            "Ich zeichne das Wort „verraten“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "schnüffeln",
           "russian": "вынюхивать",
           "transcription": "[ШНЮФ-фельн]",
           "sentence": "Vor Gonerils Gemach übergibt Oswald flüsternd die gesammelten Nachrichten. Ich zeichne das Wort „schnüffeln“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Перед покоями Гонерильи Освальд шёпотом передаёт собранные вести. Я черчу слово «вынюхивать» в мыслях поверх линий судьбы."
+          "sentence_translation": "Перед покоями Гонерильи Освальд шёпотом передаёт собранные вести. Я черчу слово «вынюхивать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Vor Gonerils Gemach übergibt Oswald flüsternd die gesammelten Nachrichten.",
+            "Ich zeichne das Wort „schnüffeln“ in Gedanken über die Linien des Schicksals."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -373,56 +495,91 @@
           "russian": "интрига",
           "transcription": "[ди ин-ТРИ-ге]",
           "sentence": "In der Schreibstube entwirft Oswald ein Netz aus widersprüchlichen Botschaften. Ich presse das Wort „die Intrige“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "В писчей комнате Освальд плетёт сеть противоречивых посланий. Я стискиваю слово «интрига» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "В писчей комнате Освальд плетёт сеть противоречивых посланий. Я стискиваю слово «интрига» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "In der Schreibstube entwirft Oswald ein Netz aus widersprüchlichen Botschaften.",
+            "Ich presse das Wort „die Intrige“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "der Plan",
           "russian": "план",
           "transcription": "[дер ПЛАН]",
           "sentence": "Neben Gonerils Lager zeichnet Oswald heimlich zwei Namen auf ein Pergament. Ich zeichne das Wort „der Plan“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Рядом с ложем Гонерильи Освальд тайком выводит два имени на пергаменте. Я черчу слово «план» в мыслях поверх линий судьбы."
+          "sentence_translation": "Рядом с ложем Гонерильи Освальд тайком выводит два имени на пергаменте. Я черчу слово «план» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Neben Gonerils Lager zeichnet Oswald heimlich zwei Namen auf ein Pergament.",
+            "Ich zeichne das Wort „der Plan“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "die Hinterlist",
           "russian": "коварство",
           "transcription": "[ди ХИН-тер-лист]",
           "sentence": "Auf der Gartenterrasse verbrennt Oswald Beweise im bronzezeitigen Becken. Ich presse das Wort „die Hinterlist“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "На садовой террасе Освальд сжигает улики в бронзовой чаше. Я стискиваю слово «коварство» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "На садовой террасе Освальд сжигает улики в бронзовой чаше. Я стискиваю слово «коварство» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Auf der Gartenterrasse verbrennt Oswald Beweise im bronzezeitigen Becken.",
+            "Ich presse das Wort „die Hinterlist“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "schmieden",
           "russian": "ковать",
           "transcription": "[ШМИ-ден]",
           "sentence": "Im Stall flüstert Oswald falsche Befehle in die Ohren der Reiter. Ich umarme das Wort „schmieden“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В конюшне Освальд шепчет ложные приказы в уши всадников. Я обнимаю слово «ковать», будто это единственный союзник."
+          "sentence_translation": "В конюшне Освальд шепчет ложные приказы в уши всадников. Я обнимаю слово «ковать», будто это единственный союзник.",
+          "sentence_parts": [
+            "Im Stall flüstert Oswald falsche Befehle in die Ohren der Reiter.",
+            "Ich umarme das Wort „schmieden“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "hintergehen",
           "russian": "обманывать",
           "transcription": "[ХИН-тер-ге-ен]",
           "sentence": "Vor Regans Dienern versteckt Oswald die Briefe im Futter der Pferde. Das Echo des Wortes „hintergehen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "Перед слугами Реганы Освальд прячет письма в корме лошадей. Эхо слова «обманывать» заглушает шёпот придворных."
+          "sentence_translation": "Перед слугами Реганы Освальд прячет письма в корме лошадей. Эхо слова «обманывать» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Vor Regans Dienern versteckt Oswald die Briefe im Futter der Pferde.",
+            "Das Echo des Wortes „hintergehen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "tückisch",
           "russian": "коварный",
           "transcription": "[ТЮ-киш]",
           "sentence": "Unter der Laube formt Oswald aus Wachs ein neues Siegel. Selbst wenn die Welt zerfällt, bleibt das Wort „tückisch“ mein Nordstern.",
-          "sentence_translation": "Под беседкой Освальд отливает из воска новую печать. Даже если мир распадается, слово «коварный» остаётся моим северным светом."
+          "sentence_translation": "Под беседкой Освальд отливает из воска новую печать. Даже если мир распадается, слово «коварный» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Unter der Laube formt Oswald aus Wachs ein neues Siegel.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „tückisch“ mein Nordstern."
+          ]
         },
         {
           "german": "verschlagen",
           "russian": "хитрый",
           "transcription": "[фер-ШЛАГ-ен]",
           "sentence": "In der Mitternachtspause verteilt Oswald verschlüsselte Notizen. Das Echo des Wortes „verschlagen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "В полночный перерыв Освальд раздаёт зашифрованные записки. Эхо слова «хитрый» заглушает шёпот придворных."
+          "sentence_translation": "В полночный перерыв Освальд раздаёт зашифрованные записки. Эхо слова «хитрый» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "In der Mitternachtspause verteilt Oswald verschlüsselte Notizen.",
+            "Das Echo des Wortes „verschlagen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Falle",
           "russian": "ловушка",
           "transcription": "[ди ФА-ле]",
           "sentence": "Auf dem Kartentisch verschiebt Oswald Figuren, als wären es echte Menschen. Ich presse das Wort „die Falle“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "На столе с картами Освальд переставляет фигурки, будто это живые люди. Я стискиваю слово «ловушка» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "На столе с картами Освальд переставляет фигурки, будто это живые люди. Я стискиваю слово «ловушка» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Auf dem Kartentisch verschiebt Oswald Figuren, als wären es echte Menschen.",
+            "Ich presse das Wort „die Falle“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -466,49 +623,77 @@
           "russian": "преследование",
           "transcription": "[ди фер-ФОЛЬ-гунг]",
           "sentence": "Mit gespannter Armbrust durchstreift Oswald die nächtlichen Felder. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verfolgung“ bleibt lebendig.",
-          "sentence_translation": "С натянутым арбалетом Освальд прочёсывает ночные поля. Каждой клеткой тела я обещаю: слово «преследование» останется живым."
+          "sentence_translation": "С натянутым арбалетом Освальд прочёсывает ночные поля. Каждой клеткой тела я обещаю: слово «преследование» останется живым.",
+          "sentence_parts": [
+            "Mit gespannter Armbrust durchstreift Oswald die nächtlichen Felder.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verfolgung“ bleibt lebendig."
+          ]
         },
         {
           "german": "die Jagd",
           "russian": "охота",
           "transcription": "[ди ЯГДТ]",
           "sentence": "Auf dem Küstenpfad späht Oswald nach Spuren des fliehenden Grafen. Das Echo des Wortes „die Jagd“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "На прибрежной тропе Освальд высматривает следы бегущего графа. Эхо слова «охота» заглушает шёпот придворных."
+          "sentence_translation": "На прибрежной тропе Освальд высматривает следы бегущего графа. Эхо слова «охота» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Auf dem Küstenpfad späht Oswald nach Spuren des fliehenden Grafen.",
+            "Das Echo des Wortes „die Jagd“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "verfolgen",
           "russian": "преследовать",
           "transcription": "[фер-ФОЛЬ-ген]",
           "sentence": "Zwischen Dornenhecken zückt Oswald das versteckte Messer. Mein Atem zeichnet das Wort „verfolgen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Среди колючих кустов Освальд выхватывает спрятанный нож. Моё дыхание рисует слово «преследовать» в холодном воздухе между нами."
+          "sentence_translation": "Среди колючих кустов Освальд выхватывает спрятанный нож. Моё дыхание рисует слово «преследовать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Zwischen Dornenhecken zückt Oswald das versteckte Messer.",
+            "Mein Atem zeichnet das Wort „verfolgen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "jagen",
           "russian": "гнаться",
           "transcription": "[Я-ген]",
           "sentence": "Am Moorloch testet Oswald die Tiefe mit der Spitze der Lanze. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „jagen“ gehört mir.",
-          "sentence_translation": "У болотной ямы Освальд проверяет глубину наконечником копья. Буря за окнами усиливает клятву: слово «гнаться» принадлежит мне."
+          "sentence_translation": "У болотной ямы Освальд проверяет глубину наконечником копья. Буря за окнами усиливает клятву: слово «гнаться» принадлежит мне.",
+          "sentence_parts": [
+            "Am Moorloch testet Oswald die Tiefe mit der Spitze der Lanze.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „jagen“ gehört mir."
+          ]
         },
         {
           "german": "aufspüren",
           "russian": "выслеживать",
           "transcription": "[АУФ-шпю-рен]",
           "sentence": "Vor einem verlassenen Hof horcht Oswald auf das Schnaufen der Pferde. Wie ein stilles Gebet legt sich das Wort „aufspüren“ auf meine Lippen.",
-          "sentence_translation": "У заброшенного двора Освальд прислушивается к сопению коней. Как тихая молитва слово «выслеживать» ложится на мои губы."
+          "sentence_translation": "У заброшенного двора Освальд прислушивается к сопению коней. Как тихая молитва слово «выслеживать» ложится на мои губы.",
+          "sentence_parts": [
+            "Vor einem verlassenen Hof horcht Oswald auf das Schnaufen der Pferde.",
+            "Wie ein stilles Gebet legt sich das Wort „aufspüren“ auf meine Lippen."
+          ]
         },
         {
           "german": "hetzen",
           "russian": "травить",
           "transcription": "[ХЕ-цен]",
           "sentence": "Unter Regans Banner motiviert Oswald die Soldaten zu schnellerer Jagd. Ich halte das Wort „hetzen“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Под знаменем Реганы Освальд подгоняет солдат к более быстрой охоте. Я держу слово «травить» как факел у сердца."
+          "sentence_translation": "Под знаменем Реганы Освальд подгоняет солдат к более быстрой охоте. Я держу слово «травить» как факел у сердца.",
+          "sentence_parts": [
+            "Unter Regans Banner motiviert Oswald die Soldaten zu schnellerer Jagd.",
+            "Ich halte das Wort „hetzen“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Beute",
           "russian": "добыча",
           "transcription": "[ди БОЙ-те]",
           "sentence": "Auf den Klippen über Dover späht Oswald in die graue Ferne. Mit fester Stimme schwöre ich mir: Das Wort „die Beute“ wird heute nicht verraten.",
-          "sentence_translation": "На скалах над Дувром Освальд вглядывается в серую даль. Твёрдым голосом я клянусь себе: слово «добыча» сегодня не будет предано."
+          "sentence_translation": "На скалах над Дувром Освальд вглядывается в серую даль. Твёрдым голосом я клянусь себе: слово «добыча» сегодня не будет предано.",
+          "sentence_parts": [
+            "Auf den Klippen über Dover späht Oswald in die graue Ferne.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „die Beute“ wird heute nicht verraten."
+          ]
         }
       ],
       "theatrical_scene": {
@@ -552,56 +737,88 @@
           "russian": "смерть",
           "transcription": "[дер ТОД]",
           "sentence": "Im dunstigen Wald stürzt Oswald vor Edgars Klinge rückwärts. Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В туманном лесу Освальд падает навзничь перед клинком Эдгара. Моё дыхание рисует слово «смерть» в холодном воздухе между нами."
+          "sentence_translation": "В туманном лесу Освальд падает навзничь перед клинком Эдгара. Моё дыхание рисует слово «смерть» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im dunstigen Wald stürzt Oswald vor Edgars Klinge rückwärts.",
+            "Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Feigheit",
           "russian": "трусость",
           "transcription": "[ди ФАЙГ-хайт]",
           "sentence": "Neben einem morschen Baum bittet Oswald mit erhobenen Händen um Gnade. Ich halte das Wort „die Feigheit“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У трухлявого дерева Освальд вздымает руки, умоляя о пощаде. Я держу слово «трусость» как факел у сердца."
+          "sentence_translation": "У трухлявого дерева Освальд вздымает руки, умоляя о пощаде. Я держу слово «трусость» как факел у сердца.",
+          "sentence_parts": [
+            "Neben einem morschen Baum bittet Oswald mit erhobenen Händen um Gnade.",
+            "Ich halte das Wort „die Feigheit“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Niederlage",
           "russian": "поражение",
           "transcription": "[ди НИ-дер-ла-ге]",
           "sentence": "Am Boden liegend tastet Oswald vergeblich nach dem verlorenen Schwert. Ich halte das Wort „die Niederlage“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Лежа на земле, Освальд тщетно ищет потерянный меч. Я держу слово «поражение» как факел у сердца."
+          "sentence_translation": "Лежа на земле, Освальд тщетно ищет потерянный меч. Я держу слово «поражение» как факел у сердца.",
+          "sentence_parts": [
+            "Am Boden liegend tastet Oswald vergeblich nach dem verlorenen Schwert.",
+            "Ich halte das Wort „die Niederlage“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "fallen",
           "russian": "падать",
           "transcription": "[ФА-лен]",
           "sentence": "Vor Edgars ernster Miene rutscht Oswald im nassen Laub aus. Wie ein stilles Gebet legt sich das Wort „fallen“ auf meine Lippen.",
-          "sentence_translation": "Перед суровым взглядом Эдгара Освальд скользит на мокрой листве. Как тихая молитва слово «падать» ложится на мои губы."
+          "sentence_translation": "Перед суровым взглядом Эдгара Освальд скользит на мокрой листве. Как тихая молитва слово «падать» ложится на мои губы.",
+          "sentence_parts": [
+            "Vor Edgars ernster Miene rutscht Oswald im nassen Laub aus.",
+            "Wie ein stilles Gebet legt sich das Wort „fallen“ auf meine Lippen."
+          ]
         },
         {
           "german": "unterliegen",
           "russian": "проигрывать",
           "transcription": "[ун-тер-ЛИ-ген]",
           "sentence": "Unter einem kalten Regen stammelt Oswald letzte Ausflüchte. Mein Atem zeichnet das Wort „unterliegen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Под холодным дождём Освальд лепечет последние оправдания. Моё дыхание рисует слово «проигрывать» в холодном воздухе между нами."
+          "sentence_translation": "Под холодным дождём Освальд лепечет последние оправдания. Моё дыхание рисует слово «проигрывать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Unter einem kalten Regen stammelt Oswald letzte Ausflüchte.",
+            "Mein Atem zeichnet das Wort „unterliegen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "wimmern",
           "russian": "хныкать",
           "transcription": "[ВИМ-мерн]",
           "sentence": "Im Schatten der Bäume erkennt Oswald zu spät die gerechte Vergeltung. Ich umarme das Wort „wimmern“, als wäre es mein einziger Verbündeter.",
-          "sentence_translation": "В тени деревьев Освальд слишком поздно осознаёт справедливое возмездие. Я обнимаю слово «хныкать», будто это единственный союзник."
+          "sentence_translation": "В тени деревьев Освальд слишком поздно осознаёт справедливое возмездие. Я обнимаю слово «хныкать», будто это единственный союзник.",
+          "sentence_parts": [
+            "Im Schatten der Bäume erkennt Oswald zu spät die gerechte Vergeltung.",
+            "Ich umarme das Wort „wimmern“, als wäre es mein einziger Verbündeter."
+          ]
         },
         {
           "german": "betteln",
           "russian": "умолять",
           "transcription": "[БЕ-тельн]",
           "sentence": "Auf dem Waldboden erlischt Oswalds Atem ohne Ehrenwache. Ich zeichne das Wort „betteln“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "На лесной земле дыхание Освальд гаснет без почётного караула. Я черчу слово «умолять» в мыслях поверх линий судьбы."
+          "sentence_translation": "На лесной земле дыхание Освальд гаснет без почётного караула. Я черчу слово «умолять» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Auf dem Waldboden erlischt Oswalds Atem ohne Ehrenwache.",
+            "Ich zeichne das Wort „betteln“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "erbärmlich",
           "russian": "жалкий",
           "transcription": "[ер-БЕРМ-лих]",
           "sentence": "Neben dem fallengelassenen Brief liegt Oswald reglos im Schlamm. Das kalte Licht lässt das Wort „erbärmlich“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Рядом с оброненным письмом Освальд неподвижно лежит в грязи. Холодный свет заставляет слово «жалкий» сиять словно расплавленное золото."
+          "sentence_translation": "Рядом с оброненным письмом Освальд неподвижно лежит в грязи. Холодный свет заставляет слово «жалкий» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Neben dem fallengelassenen Brief liegt Oswald reglos im Schlamm.",
+            "Das kalte Licht lässt das Wort „erbärmlich“ wie geschmolzenes Gold erscheinen."
+          ]
         }
       ],
       "theatrical_scene": {

--- a/data/characters/regan.json
+++ b/data/characters/regan.json
@@ -21,56 +21,88 @@
           "russian": "притворяться",
           "transcription": "[ФОР-той-шен]",
           "sentence": "Regan steht unter dem glühenden Kronleuchter des Thronsaals. Mein Atem zeichnet das Wort „vortäuschen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "Регана стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «притворяться» в холодном воздухе между нами."
+          "sentence_translation": "Регана стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «притворяться» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Regan steht unter dem glühenden Kronleuchter des Thronsaals.",
+            "Mein Atem zeichnet das Wort „vortäuschen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "übertreffen",
           "russian": "превосходить",
           "transcription": "[ю-бер-ТРЕ-фен]",
           "sentence": "Neben der ausgerollten Reichskarte beugt sich Regan über Lears schweren Tisch. Mit jeder Faser meines Körpers verspreche ich: Das Wort „übertreffen“ bleibt lebendig.",
-          "sentence_translation": "У развернутой карты королевства Регана склоняется над тяжёлым столом Лира. Каждой клеткой тела я обещаю: слово «превосходить» останется живым."
+          "sentence_translation": "У развернутой карты королевства Регана склоняется над тяжёлым столом Лира. Каждой клеткой тела я обещаю: слово «превосходить» останется живым.",
+          "sentence_parts": [
+            "Neben der ausgerollten Reichskarte beugt sich Regan über Lears schweren Tisch.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „übertreffen“ bleibt lebendig."
+          ]
         },
         {
           "german": "wetteifern",
           "russian": "состязаться",
           "transcription": "[ВЕТ-ай-ферн]",
           "sentence": "Vor den steinernen Ahnenstatuen verschränkt Regan die Hände hinter dem Rücken. Ich flüstere den Wächtern des Schicksals zu: Das Wort „wetteifern“ darf nicht vergehen.",
-          "sentence_translation": "Перед каменными статуями предков Регана сцепляет руки за спиной. Я шепчу стражам судьбы: слово «состязаться» не должно исчезнуть."
+          "sentence_translation": "Перед каменными статуями предков Регана сцепляет руки за спиной. Я шепчу стражам судьбы: слово «состязаться» не должно исчезнуть.",
+          "sentence_parts": [
+            "Vor den steinernen Ahnenstatuen verschränkt Regan die Hände hinter dem Rücken.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „wetteifern“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Falschheit",
           "russian": "фальшь",
           "transcription": "[ди ФАЛЬШ-хайт]",
           "sentence": "Zwischen flüsternden Höflingen gleitet Regan über den kalten Marmorboden. Mit fester Stimme schwöre ich mir: Das Wort „die Falschheit“ wird heute nicht verraten.",
-          "sentence_translation": "Между шепчущимися придворными Регана скользит по холодному мраморному полу. Твёрдым голосом я клянусь себе: слово «фальшь» сегодня не будет предано."
+          "sentence_translation": "Между шепчущимися придворными Регана скользит по холодному мраморному полу. Твёрдым голосом я клянусь себе: слово «фальшь» сегодня не будет предано.",
+          "sentence_parts": [
+            "Zwischen flüsternden Höflingen gleitet Regan über den kalten Marmorboden.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „die Falschheit“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "vorspielen",
           "russian": "разыгрывать",
           "transcription": "[ФОР-шпи-лен]",
           "sentence": "Am Rand des purpurnen Teppichs wartet Regan auf ein Zeichen des Königs. Das Echo des Wortes „vorspielen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "На краю пурпурного ковра Регана ждёт знака от короля. Эхо слова «разыгрывать» заглушает шёпот придворных."
+          "sentence_translation": "На краю пурпурного ковра Регана ждёт знака от короля. Эхо слова «разыгрывать» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Am Rand des purpurnen Teppichs wartet Regan auf ein Zeichen des Königs.",
+            "Das Echo des Wortes „vorspielen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die List",
           "russian": "хитрость",
           "transcription": "[ди ЛИСТ]",
           "sentence": "Unter wehenden Standarten der Schwestern senkt Regan kurz den Blick. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die List“ darf nicht vergehen.",
-          "sentence_translation": "Под развевающимися штандартами сестёр Регана на миг опускает взгляд. Я шепчу стражам судьбы: слово «хитрость» не должно исчезнуть."
+          "sentence_translation": "Под развевающимися штандартами сестёр Регана на миг опускает взгляд. Я шепчу стражам судьбы: слово «хитрость» не должно исчезнуть.",
+          "sentence_parts": [
+            "Unter wehenden Standarten der Schwestern senkt Regan kurz den Blick.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die List“ darf nicht vergehen."
+          ]
         },
         {
           "german": "erschleichen",
           "russian": "выманивать",
           "transcription": "[ер-ШЛАЙ-хен]",
           "sentence": "Hinter der vergoldeten Balustrade beobachtet Regan das gespannte Antlitz des Hofes. Wie ein stilles Gebet legt sich das Wort „erschleichen“ auf meine Lippen.",
-          "sentence_translation": "За позолоченной балюстрадой Регана наблюдает за напряжёнными лицами двора. Как тихая молитва слово «выманивать» ложится на мои губы."
+          "sentence_translation": "За позолоченной балюстрадой Регана наблюдает за напряжёнными лицами двора. Как тихая молитва слово «выманивать» ложится на мои губы.",
+          "sentence_parts": [
+            "Hinter der vergoldeten Balustrade beobachtet Regan das gespannte Antlitz des Hofes.",
+            "Wie ein stilles Gebet legt sich das Wort „erschleichen“ auf meine Lippen."
+          ]
         },
         {
           "german": "die Habgier",
           "russian": "алчность",
           "transcription": "[ди ХАБ-гир]",
           "sentence": "Im Schein der offenen Feuerbecken erhebt Regan langsam die Stimme. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Habgier“ gehört mir.",
-          "sentence_translation": "В отблесках открытых жаровен Регана медленно поднимает голос. Буря за окнами усиливает клятву: слово «алчность» принадлежит мне."
+          "sentence_translation": "В отблесках открытых жаровен Регана медленно поднимает голос. Буря за окнами усиливает клятву: слово «алчность» принадлежит мне.",
+          "sentence_parts": [
+            "Im Schein der offenen Feuerbecken erhebt Regan langsam die Stimme.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Habgier“ gehört mir."
+          ]
         }
       ],
       "quizzes": [
@@ -114,49 +146,77 @@
           "russian": "союз",
           "transcription": "[дас БЮНД-нис]",
           "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Regan zwischen gepackten Kisten. Mein Atem zeichnet das Wort „das Bündnis“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В гулком проёме ворот замка Гонерильи Регана замирает среди нагруженных ящиков. Моё дыхание рисует слово «союз» в холодном воздухе между нами."
+          "sentence_translation": "В гулком проёме ворот замка Гонерильи Регана замирает среди нагруженных ящиков. Моё дыхание рисует слово «союз» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im hallenden Torbogen von Gonerils Burg verharrt Regan zwischen gepackten Kisten.",
+            "Mein Atem zeichnet das Wort „das Bündnis“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "teilen",
           "russian": "делить",
           "transcription": "[ТАЙ-лен]",
           "sentence": "Auf der windigen Freitreppe blickt Regan zum schweigenden Hof hinunter. Mit fester Stimme schwöre ich mir: Das Wort „teilen“ wird heute nicht verraten.",
-          "sentence_translation": "На продуваемой ветром лестнице Регана смотрит вниз на молчаливый двор. Твёрдым голосом я клянусь себе: слово «делить» сегодня не будет предано."
+          "sentence_translation": "На продуваемой ветром лестнице Регана смотрит вниз на молчаливый двор. Твёрдым голосом я клянусь себе: слово «делить» сегодня не будет предано.",
+          "sentence_parts": [
+            "Auf der windigen Freitreppe blickt Regan zum schweigenden Hof hinunter.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „teilen“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "planen",
           "russian": "планировать",
           "transcription": "[ПЛА-нен]",
           "sentence": "Zwischen zurückgelassenen Dienern schließt Regan den Reisemantel enger. Mit jeder Faser meines Körpers verspreche ich: Das Wort „planen“ bleibt lebendig.",
-          "sentence_translation": "Среди оставленных слуг Регана плотнее запахивает дорожный плащ. Каждой клеткой тела я обещаю: слово «планировать» останется живым."
+          "sentence_translation": "Среди оставленных слуг Регана плотнее запахивает дорожный плащ. Каждой клеткой тела я обещаю: слово «планировать» останется живым.",
+          "sentence_parts": [
+            "Zwischen zurückgelassenen Dienern schließt Regan den Reisemantel enger.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „planen“ bleibt lebendig."
+          ]
         },
         {
           "german": "verschwören",
           "russian": "заговорить",
           "transcription": "[фер-ШВЁ-рен]",
           "sentence": "Am dunklen Pferdestall streicht Regan einem nervösen Tier über die Mähne. Ich halte das Wort „verschwören“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У тёмного конюшенного ряда Регана гладит гриву нервного коня. Я держу слово «заговорить» как факел у сердца."
+          "sentence_translation": "У тёмного конюшенного ряда Регана гладит гриву нервного коня. Я держу слово «заговорить» как факел у сердца.",
+          "sentence_parts": [
+            "Am dunklen Pferdestall streicht Regan einem nervösen Tier über die Mähne.",
+            "Ich halte das Wort „verschwören“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Absprache",
           "russian": "сговор",
           "transcription": "[ди АБ-шпра-хе]",
           "sentence": "Vor dem knarrenden Fallgatter tastet Regan ein letztes Mal nach dem Haustor. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Absprache“ darf nicht vergehen.",
-          "sentence_translation": "Перед скрипящим подъёмным мостом Регана в последний раз касается родной двери. Я шепчу стражам судьбы: слово «сговор» не должно исчезнуть."
+          "sentence_translation": "Перед скрипящим подъёмным мостом Регана в последний раз касается родной двери. Я шепчу стражам судьбы: слово «сговор» не должно исчезнуть.",
+          "sentence_parts": [
+            "Vor dem knarrenden Fallgatter tastet Regan ein letztes Mal nach dem Haustor.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Absprache“ darf nicht vergehen."
+          ]
         },
         {
           "german": "vereinbaren",
           "russian": "договариваться",
           "transcription": "[фер-АЙН-ба-рен]",
           "sentence": "Zwischen verstreuten Schriftrollen dreht Regan den Ring an der Hand. Mit jeder Faser meines Körpers verspreche ich: Das Wort „vereinbaren“ bleibt lebendig.",
-          "sentence_translation": "Среди разбросанных свитков Регана вертит кольцо на пальце. Каждой клеткой тела я обещаю: слово «договариваться» останется живым."
+          "sentence_translation": "Среди разбросанных свитков Регана вертит кольцо на пальце. Каждой клеткой тела я обещаю: слово «договариваться» останется живым.",
+          "sentence_parts": [
+            "Zwischen verstreuten Schriftrollen dreht Regan den Ring an der Hand.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „vereinbaren“ bleibt lebendig."
+          ]
         },
         {
           "german": "die Strategie",
           "russian": "стратегия",
           "transcription": "[ди штра-те-ГИ]",
           "sentence": "Am leeren Bankettisch zählt Regan die verlöschenden Kerzen. Das Echo des Wortes „die Strategie“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "У пустого банкетного стола Регана пересчитывает гаснущие свечи. Эхо слова «стратегия» заглушает шёпот придворных."
+          "sentence_translation": "У пустого банкетного стола Регана пересчитывает гаснущие свечи. Эхо слова «стратегия» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Am leeren Bankettisch zählt Regan die verlöschenden Kerzen.",
+            "Das Echo des Wortes „die Strategie“ übertönt das Flüstern der Höflinge."
+          ]
         }
       ],
       "quizzes": [
@@ -200,56 +260,89 @@
           "russian": "пытать",
           "transcription": "[ФОЛЬ-терн]",
           "sentence": "Im zugigen Seitenflügel lauscht Regan dem Heulen der Küstenwinde. Mein Atem zeichnet das Wort „foltern“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В продуваемом ветром боковом крыле Регана слушает вой прибрежного ветра. Моё дыхание рисует слово «пытать» в холодном воздухе между нами."
+          "sentence_translation": "В продуваемом ветром боковом крыле Регана слушает вой прибрежного ветра. Моё дыхание рисует слово «пытать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im zugigen Seitenflügel lauscht Regan dem Heulen der Küstenwinde.",
+            "Mein Atem zeichnet das Wort „foltern“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "erniedrigen",
           "russian": "унижать",
           "transcription": "[ер-НИД-ри-ген]",
           "sentence": "Vor dem rauchigen Kamin der Burg faltet Regan einen zerknitterten Brief. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erniedrigen“ gehört mir.",
-          "sentence_translation": "Перед дымным камином замка Регана складывает измятый лист. Буря за окнами усиливает клятву: слово «унижать» принадлежит мне."
+          "sentence_translation": "Перед дымным камином замка Регана складывает измятый лист. Буря за окнами усиливает клятву: слово «унижать» принадлежит мне.",
+          "sentence_parts": [
+            "Vor dem rauchigen Kamin der Burg faltet Regan einen zerknitterten Brief.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erniedrigen“ gehört mir."
+          ]
         },
         {
           "german": "verhöhnen",
           "russian": "насмехаться",
           "transcription": "[фер-ХЁ-нен]",
           "sentence": "Unter farblosen Wandteppichen schreitet Regan rastlos auf und ab. Ich halte das Wort „verhöhnen“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Под выцветшими гобеленами Регана беспокойно меряет шагами зал. Я держу слово «насмехаться» как факел у сердца."
+          "sentence_translation": "Под выцветшими гобеленами Регана беспокойно меряет шагами зал. Я держу слово «насмехаться» как факел у сердца.",
+          "sentence_parts": [
+            "Unter farblosen Wandteppichen schreitet Regan rastlos auf und ab.",
+            "Ich halte das Wort „verhöhnen“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "die Bosheit",
           "russian": "злоба",
           "transcription": "[ди БОС-хайт]",
           "sentence": "An der schmalen Fensterluke zählt Regan die Fackeln auf dem Hof. Ich halte das Wort „die Bosheit“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "У узкой бойницы Регана считает факелы на дворе. Я держу слово «злоба» как факел у сердца."
+          "sentence_translation": "У узкой бойницы Регана считает факелы на дворе. Я держу слово «злоба» как факел у сердца.",
+          "sentence_parts": [
+            "An der schmalen Fensterluke zählt Regan die Fackeln auf dem Hof.",
+            "Ich halte das Wort „die Bosheit“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "misshandeln",
           "russian": "жестоко обращаться",
           "transcription": "[МИС-хан-дельн]",
           "sentence": "Zwischen Reisekoffern der Gesandten sucht Regan nach frischen Botschaften. Mit jeder Faser meines Körpers verspreche ich: Das Wort „misshandeln“ bleibt lebendig.",
-          "sentence_translation": "Среди дорожных сундуков послов Регана ищет свежие вести. Каждой клеткой тела я обещаю: слово «жестоко обращаться» останется живым."
+          "sentence_translation": "Среди дорожных сундуков послов Регана ищет свежие вести. Каждой клеткой тела я обещаю: слово «жестоко обращаться» останется живым.",
+          "sentence_parts": [
+            "Zwischen Reisekoffern der Gesandten sucht Regan nach frischen Botschaften.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „misshandeln“ bleibt lebendig."
+          ]
         },
         {
           "german": "die Härte",
           "russian": "жёсткость",
           "transcription": "[ди ХЕР-те]",
           "sentence": "Im stillen Kapellenraum kniet Regan vor der kalten Steinfigur. Ich presse das Wort „die Härte“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "В тихой капелле Регана преклоняет колени перед холодной каменной фигурой. Я стискиваю слово «жёсткость» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "В тихой капелле Регана преклоняет колени перед холодной каменной фигурой. Я стискиваю слово «жёсткость» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Im stillen Kapellenraum kniet Regan vor der kalten Steinfigur.",
+            "Ich presse das Wort „die Härte“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "abweisen",
           "russian": "отвергать",
           "transcription": "[АБ-вай-зен]",
           "sentence": "Auf dem Balkon, den das Meer besprüht, hält Regan die Laterne fest. Mein Atem zeichnet das Wort „abweisen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "На балконе, омываемом морскими брызгами, Регана крепко держит фонарь. Моё дыхание рисует слово «отвергать» в холодном воздухе между нами."
+          "sentence_translation": "На балконе, омываемом морскими брызгами, Регана крепко держит фонарь. Моё дыхание рисует слово «отвергать» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Auf dem Balkon, den das Meer besprüht, hält Regan die Laterne fest.",
+            "Mein Atem zeichnet das Wort „abweisen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Grausamkeit",
           "russian": "жестокость",
           "transcription": "[ди ГРАУ-зам-кайт]",
           "sentence": "Im Schatten der hohen Burgmauern schreibt Regan eine fiebrige Antwort. Mein Atem zeichnet das Wort „die Grausamkeit“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "В тени высоких стен Регана пишет лихорадочный ответ. Моё дыхание рисует слово «жестокость» в холодном воздухе между нами."
+          "sentence_translation": "В тени высоких стен Регана пишет лихорадочный ответ. Моё дыхание рисует слово «жестокость» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Im Schatten der hohen Burgmauern schreibt Regan eine fiebrige Antwort.",
+            "Mein Atem zeichnet das Wort „die Grausamkeit“ in die kalte Luft zwischen uns."
+          ]
         }
       ],
       "quizzes": [
@@ -293,56 +386,88 @@
           "russian": "ослеплять",
           "transcription": "[БЛЕН-ден]",
           "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Regan gegen den Wind. Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen.",
-          "sentence_translation": "Посреди хлещущей дождём пустоши Регана упирается в ветер. Я шепчу стражам судьбы: слово «ослеплять» не должно исчезнуть."
+          "sentence_translation": "Посреди хлещущей дождём пустоши Регана упирается в ветер. Я шепчу стражам судьбы: слово «ослеплять» не должно исчезнуть.",
+          "sentence_parts": [
+            "Mitten auf der vom Regen gepeitschten Heide stemmt sich Regan gegen den Wind.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen."
+          ]
         },
         {
           "german": "der Sadismus",
           "russian": "садизм",
           "transcription": "[дер за-ДИС-мус]",
           "sentence": "Unter einem zerrissenen Banner schützt Regan die Augen vor den Blitzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Sadismus“ bleibt lebendig.",
-          "sentence_translation": "Под разорванным знаменем Регана прикрывает глаза от молний. Каждой клеткой тела я обещаю: слово «садизм» останется живым."
+          "sentence_translation": "Под разорванным знаменем Регана прикрывает глаза от молний. Каждой клеткой тела я обещаю: слово «садизм» останется живым.",
+          "sentence_parts": [
+            "Unter einem zerrissenen Banner schützt Regan die Augen vor den Blitzen.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Sadismus“ bleibt lebendig."
+          ]
         },
         {
           "german": "genießen",
           "russian": "наслаждаться",
           "transcription": "[ге-НИ-сен]",
           "sentence": "Am Rand eines umgestürzten Baumes sucht Regan Deckung vor dem Donner. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „genießen“ gehört mir.",
-          "sentence_translation": "У поваленного дерева Регана ищет укрытия от грома. Буря за окнами усиливает клятву: слово «наслаждаться» принадлежит мне."
+          "sentence_translation": "У поваленного дерева Регана ищет укрытия от грома. Буря за окнами усиливает клятву: слово «наслаждаться» принадлежит мне.",
+          "sentence_parts": [
+            "Am Rand eines umgestürzten Baumes sucht Regan Deckung vor dem Donner.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „genießen“ gehört mir."
+          ]
         },
         {
           "german": "ausstechen",
           "russian": "выкалывать",
           "transcription": "[АУС-ште-хен]",
           "sentence": "Zwischen schäumenden Wassergräben stolpert Regan durch den Schlamm. Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus.",
-          "sentence_translation": "Между пенящимися лужами Регана пробирается через грязь. Я глубоко вдыхаю и выпускаю только слово «выкалывать»."
+          "sentence_translation": "Между пенящимися лужами Регана пробирается через грязь. Я глубоко вдыхаю и выпускаю только слово «выкалывать».",
+          "sentence_parts": [
+            "Zwischen schäumenden Wassergräben stolpert Regan durch den Schlamm.",
+            "Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus."
+          ]
         },
         {
           "german": "die Folter",
           "russian": "пытка",
           "transcription": "[ди ФОЛЬ-тер]",
           "sentence": "Vor einem zuckenden Himmel hebt Regan die Arme trotzig an. Ich zeichne das Wort „die Folter“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "На фоне вспыхивающего неба Регана упрямо поднимает руки. Я черчу слово «пытка» в мыслях поверх линий судьбы."
+          "sentence_translation": "На фоне вспыхивающего неба Регана упрямо поднимает руки. Я черчу слово «пытка» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Vor einem zuckenden Himmel hebt Regan die Arme trotzig an.",
+            "Ich zeichne das Wort „die Folter“ in Gedanken über die Linien des Schicksals."
+          ]
         },
         {
           "german": "erbarmungslos",
           "russian": "беспощадный",
           "transcription": "[ер-БАР-мунгс-лос]",
           "sentence": "Unter dem durchtränkten Umhang presst Regan den Atem gegen die Kälte. Ich flüstere den Wächtern des Schicksals zu: Das Wort „erbarmungslos“ darf nicht vergehen.",
-          "sentence_translation": "Под промокшим плащом Регана прижимает дыхание к груди, спасаясь от холода. Я шепчу стражам судьбы: слово «беспощадный» не должно исчезнуть."
+          "sentence_translation": "Под промокшим плащом Регана прижимает дыхание к груди, спасаясь от холода. Я шепчу стражам судьбы: слово «беспощадный» не должно исчезнуть.",
+          "sentence_parts": [
+            "Unter dem durchtränkten Umhang presst Regan den Atem gegen die Kälte.",
+            "Ich flüstere den Wächtern des Schicksals zu: Das Wort „erbarmungslos“ darf nicht vergehen."
+          ]
         },
         {
           "german": "die Brutalität",
           "russian": "брутальность",
           "transcription": "[ди бру-та-ли-ТЕТ]",
           "sentence": "Am kläglichen Feuerrest wärmt Regan zitternde Finger. Das kalte Licht lässt das Wort „die Brutalität“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "У жалких огненных углей Регана греет дрожащие пальцы. Холодный свет заставляет слово «брутальность» сиять словно расплавленное золото."
+          "sentence_translation": "У жалких огненных углей Регана греет дрожащие пальцы. Холодный свет заставляет слово «брутальность» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Am kläglichen Feuerrest wärmt Regan zitternde Finger.",
+            "Das kalte Licht lässt das Wort „die Brutalität“ wie geschmolzenes Gold erscheinen."
+          ]
         },
         {
           "german": "zertreten",
           "russian": "растаптывать",
           "transcription": "[цер-ТРЕ-тен]",
           "sentence": "Zwischen heulenden Hunden ruft Regan gegen den tosenden Sturm an. Mit jeder Faser meines Körpers verspreche ich: Das Wort „zertreten“ bleibt lebendig.",
-          "sentence_translation": "Среди воющих псов Регана перекрикивает беснующуюся бурю. Каждой клеткой тела я обещаю: слово «растаптывать» останется живым."
+          "sentence_translation": "Среди воющих псов Регана перекрикивает беснующуюся бурю. Каждой клеткой тела я обещаю: слово «растаптывать» останется живым.",
+          "sentence_parts": [
+            "Zwischen heulenden Hunden ruft Regan gegen den tosenden Sturm an.",
+            "Mit jeder Faser meines Körpers verspreche ich: Das Wort „zertreten“ bleibt lebendig."
+          ]
         }
       ],
       "quizzes": [
@@ -386,49 +511,77 @@
           "russian": "вдова",
           "transcription": "[ди ВИТ-ве]",
           "sentence": "Im dunklen Zelt der Feldärzte sitzt Regan bei der flackernden Kerze. Selbst wenn die Welt zerfällt, bleibt das Wort „die Witwe“ mein Nordstern.",
-          "sentence_translation": "В тёмном шатре полевых лекарей Регана сидит у мерцающей свечи. Даже если мир распадается, слово «вдова» остаётся моим северным светом."
+          "sentence_translation": "В тёмном шатре полевых лекарей Регана сидит у мерцающей свечи. Даже если мир распадается, слово «вдова» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Im dunklen Zelt der Feldärzte sitzt Regan bei der flackernden Kerze.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „die Witwe“ mein Nordstern."
+          ]
         },
         {
           "german": "begehren",
           "russian": "вожделеть",
           "transcription": "[бе-ГЕ-рен]",
           "sentence": "Zwischen zerbeulten Rüstungen streicht Regan über ein altes Wappen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „begehren“ gehört mir.",
-          "sentence_translation": "Среди помятых доспехов Регана гладит старый герб. Буря за окнами усиливает клятву: слово «вожделеть» принадлежит мне."
+          "sentence_translation": "Среди помятых доспехов Регана гладит старый герб. Буря за окнами усиливает клятву: слово «вожделеть» принадлежит мне.",
+          "sentence_parts": [
+            "Zwischen zerbeulten Rüstungen streicht Regan über ein altes Wappen.",
+            "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „begehren“ gehört mir."
+          ]
         },
         {
           "german": "verführen",
           "russian": "соблазнять",
           "transcription": "[фер-ФЮ-рен]",
           "sentence": "Am niedrigen Dachbalken der Hütte stößt Regan fast den Kopf. Mein Atem zeichnet das Wort „verführen“ in die kalte Luft zwischen uns.",
-          "sentence_translation": "О низкую балку хижины Регана едва не ударяется головой. Моё дыхание рисует слово «соблазнять» в холодном воздухе между нами."
+          "sentence_translation": "О низкую балку хижины Регана едва не ударяется головой. Моё дыхание рисует слово «соблазнять» в холодном воздухе между нами.",
+          "sentence_parts": [
+            "Am niedrigen Dachbalken der Hütte stößt Regan fast den Kopf.",
+            "Mein Atem zeichnet das Wort „verführen“ in die kalte Luft zwischen uns."
+          ]
         },
         {
           "german": "die Begierde",
           "russian": "вожделение",
           "transcription": "[ди бе-ГИР-де]",
           "sentence": "Neben der schlafenden Wache flüstert Regan in die schwere Nacht. Ich halte das Wort „die Begierde“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "Рядом со спящим стражем Регана шепчет в тяжёлую ночь. Я держу слово «вожделение» как факел у сердца."
+          "sentence_translation": "Рядом со спящим стражем Регана шепчет в тяжёлую ночь. Я держу слово «вожделение» как факел у сердца.",
+          "sentence_parts": [
+            "Neben der schlafenden Wache flüstert Regan in die schwere Nacht.",
+            "Ich halte das Wort „die Begierde“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "locken",
           "russian": "заманивать",
           "transcription": "[ЛО-кен]",
           "sentence": "Vor dem einfachen Feldbett betrachtet Regan die Narben vergangener Schlachten. Wie ein stilles Gebet legt sich das Wort „locken“ auf meine Lippen.",
-          "sentence_translation": "Перед грубой походной койкой Регана разглядывает шрамы прошлых битв. Как тихая молитва слово «заманивать» ложится на мои губы."
+          "sentence_translation": "Перед грубой походной койкой Регана разглядывает шрамы прошлых битв. Как тихая молитва слово «заманивать» ложится на мои губы.",
+          "sentence_parts": [
+            "Vor dem einfachen Feldbett betrachtet Regan die Narben vergangener Schlachten.",
+            "Wie ein stilles Gebet legt sich das Wort „locken“ auf meine Lippen."
+          ]
         },
         {
           "german": "die Lust",
           "russian": "похоть",
           "transcription": "[ди ЛУСТ]",
           "sentence": "Im Geruch von feuchtem Stroh legt Regan den Mantel zur Seite. Mit fester Stimme schwöre ich mir: Das Wort „die Lust“ wird heute nicht verraten.",
-          "sentence_translation": "В запахе влажной соломы Регана откладывает плащ в сторону. Твёрдым голосом я клянусь себе: слово «похоть» сегодня не будет предано."
+          "sentence_translation": "В запахе влажной соломы Регана откладывает плащ в сторону. Твёрдым голосом я клянусь себе: слово «похоть» сегодня не будет предано.",
+          "sentence_parts": [
+            "Im Geruch von feuchtem Stroh legt Regan den Mantel zur Seite.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „die Lust“ wird heute nicht verraten."
+          ]
         },
         {
           "german": "werben",
           "russian": "добиваться",
           "transcription": "[ВЕР-бен]",
           "sentence": "Auf dem wackligen Holztisch ordnet Regan zerlesene Briefe. Mit fester Stimme schwöre ich mir: Das Wort „werben“ wird heute nicht verraten.",
-          "sentence_translation": "На шатком деревянном столе Регана раскладывает зачитанные письма. Твёрдым голосом я клянусь себе: слово «добиваться» сегодня не будет предано."
+          "sentence_translation": "На шатком деревянном столе Регана раскладывает зачитанные письма. Твёрдым голосом я клянусь себе: слово «добиваться» сегодня не будет предано.",
+          "sentence_parts": [
+            "Auf dem wackligen Holztisch ordnet Regan zerlesene Briefe.",
+            "Mit fester Stimme schwöre ich mir: Das Wort „werben“ wird heute nicht verraten."
+          ]
         }
       ],
       "quizzes": [
@@ -472,49 +625,78 @@
           "russian": "соревноваться",
           "transcription": "[ВЕТ-кемп-фен]",
           "sentence": "Auf den weißen Klippen von Dover blickt Regan in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „wettkämpfen“ mein Nordstern.",
-          "sentence_translation": "На белых скалах Дувра Регана смотрит в вздыбленный пролив. Даже если мир распадается, слово «соревноваться» остаётся моим северным светом."
+          "sentence_translation": "На белых скалах Дувра Регана смотрит в вздыбленный пролив. Даже если мир распадается, слово «соревноваться» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Auf den weißen Klippen von Dover blickt Regan in den aufgewühlten Kanal.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „wettkämpfen“ mein Nordstern."
+          ]
         },
         {
           "german": "hassen",
           "russian": "ненавидеть",
           "transcription": "[ХА-сен]",
           "sentence": "Zwischen flatternden Feldzeichen richtet Regan den Helm. Ich zeichne das Wort „hassen“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Среди хлопающих штандартов Регана поправляет шлем. Я вывожу слово «ненавидеть» невидимыми чернилами на ладони."
+          "sentence_translation": "Среди хлопающих штандартов Регана поправляет шлем. Я вывожу слово «ненавидеть» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Zwischen flatternden Feldzeichen richtet Regan den Helm.",
+            "Ich zeichne das Wort „hassen“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "bedrohen",
           "russian": "угрожать",
           "transcription": "[бе-ДРО-ен]",
           "sentence": "Am Lagerfeuer der Franzosen zeichnet Regan Marschrouten in den Sand. Das Echo des Wortes „bedrohen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "У французского костра Регана рисует в песке путь марша. Эхо слова «угрожать» заглушает шёпот придворных."
+          "sentence_translation": "У французского костра Регана рисует в песке путь марша. Эхо слова «угрожать» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Am Lagerfeuer der Franzosen zeichnet Regan Marschrouten in den Sand.",
+            "Das Echo des Wortes „bedrohen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "die Rivalität",
           "russian": "соперничество",
           "transcription": "[ди ри-ва-ли-ТЕТ]",
           "sentence": "Neben verschnürten Versorgungskisten kontrolliert Regan das Siegel. Ich presse das Wort „die Rivalität“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "У перевязанных провиантных ящиков Регана проверяет печати. Я стискиваю слово «соперничество» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "У перевязанных провиантных ящиков Регана проверяет печати. Я стискиваю слово «соперничество» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Neben verschnürten Versorgungskisten kontrolliert Regan das Siegel.",
+            "Ich presse das Wort „die Rivalität“ zwischen die Zähne,",
+            "damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "bekämpfen",
           "russian": "бороться",
           "transcription": "[бе-КЕМП-фен]",
           "sentence": "Vor dem Seidenzelt der Heerführer lauscht Regan dem dumpfen Meer. Ich zeichne das Wort „bekämpfen“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Перед шёлковым шатром полководцев Регана слушает глухой шум моря. Я вывожу слово «бороться» невидимыми чернилами на ладони."
+          "sentence_translation": "Перед шёлковым шатром полководцев Регана слушает глухой шум моря. Я вывожу слово «бороться» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Vor dem Seidenzelt der Heerführer lauscht Regan dem dumpfen Meer.",
+            "Ich zeichne das Wort „bekämpfen“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "misstrauen",
           "russian": "не доверять",
           "transcription": "[МИС-трау-ен]",
           "sentence": "Auf dem sandigen Trainingsplatz übt Regan das Ziehen des Schwerts. Das Echo des Wortes „misstrauen“ übertönt das Flüstern der Höflinge.",
-          "sentence_translation": "На песчаном плацу Регана отрабатывает выхват меча. Эхо слова «не доверять» заглушает шёпот придворных."
+          "sentence_translation": "На песчаном плацу Регана отрабатывает выхват меча. Эхо слова «не доверять» заглушает шёпот придворных.",
+          "sentence_parts": [
+            "Auf dem sandigen Trainingsplatz übt Regan das Ziehen des Schwerts.",
+            "Das Echo des Wortes „misstrauen“ übertönt das Flüstern der Höflinge."
+          ]
         },
         {
           "german": "argwöhnen",
           "russian": "подозревать",
           "transcription": "[АРГ-вё-нен]",
           "sentence": "Zwischen pochenden Trommeln hebt Regan das Banner der Hoffnung. Ich zeichne das Wort „argwöhnen“ in Gedanken über die Linien des Schicksals.",
-          "sentence_translation": "Под гул барабанов Регана поднимает знамя надежды. Я черчу слово «подозревать» в мыслях поверх линий судьбы."
+          "sentence_translation": "Под гул барабанов Регана поднимает знамя надежды. Я черчу слово «подозревать» в мыслях поверх линий судьбы.",
+          "sentence_parts": [
+            "Zwischen pochenden Trommeln hebt Regan das Banner der Hoffnung.",
+            "Ich zeichne das Wort „argwöhnen“ in Gedanken über die Linien des Schicksals."
+          ]
         }
       ],
       "quizzes": [
@@ -558,56 +740,88 @@
           "russian": "отравленный",
           "transcription": "[фер-ГИФ-тет]",
           "sentence": "Im feuchten Kerker stützt Regan sich an den tropfenden Stein. Ich atme tief ein und lasse nur das Wort „vergiftet“ wieder hinaus.",
-          "sentence_translation": "В сыром подземелье Регана опирается на сочащийся камень. Я глубоко вдыхаю и выпускаю только слово «отравленный»."
+          "sentence_translation": "В сыром подземелье Регана опирается на сочащийся камень. Я глубоко вдыхаю и выпускаю только слово «отравленный».",
+          "sentence_parts": [
+            "Im feuchten Kerker stützt Regan sich an den tropfenden Stein.",
+            "Ich atme tief ein und lasse nur das Wort „vergiftet“ wieder hinaus."
+          ]
         },
         {
           "german": "leiden",
           "russian": "страдать",
           "transcription": "[ЛАЙ-ден]",
           "sentence": "Unter der trüben Laterne zählt Regan die eisernen Ringe der Kette. Ich zeichne das Wort „leiden“ mit unsichtbarer Tinte auf meine Handfläche.",
-          "sentence_translation": "Под мутным фонарём Регана пересчитывает железные кольца цепи. Я вывожу слово «страдать» невидимыми чернилами на ладони."
+          "sentence_translation": "Под мутным фонарём Регана пересчитывает железные кольца цепи. Я вывожу слово «страдать» невидимыми чернилами на ладони.",
+          "sentence_parts": [
+            "Unter der trüben Laterne zählt Regan die eisernen Ringe der Kette.",
+            "Ich zeichne das Wort „leiden“ mit unsichtbarer Tinte auf meine Handfläche."
+          ]
         },
         {
           "german": "verenden",
           "russian": "издыхать",
           "transcription": "[фер-ЕН-ден]",
           "sentence": "Neben der schweren Holztür horcht Regan auf entferntes Schluchzen. Wie ein stilles Gebet legt sich das Wort „verenden“ auf meine Lippen.",
-          "sentence_translation": "У тяжёлой двери Регана прислушивается к далёким рыданиям. Как тихая молитва слово «издыхать» ложится на мои губы."
+          "sentence_translation": "У тяжёлой двери Регана прислушивается к далёким рыданиям. Как тихая молитва слово «издыхать» ложится на мои губы.",
+          "sentence_parts": [
+            "Neben der schweren Holztür horcht Regan auf entferntes Schluchzen.",
+            "Wie ein stilles Gebet legt sich das Wort „verenden“ auf meine Lippen."
+          ]
         },
         {
           "german": "die Qual",
           "russian": "мучение",
           "transcription": "[ди КВАЛЬ]",
           "sentence": "Auf der kalten Steinbank zieht Regan den Mantel enger um die Schultern. Ich atme tief ein und lasse nur das Wort „die Qual“ wieder hinaus.",
-          "sentence_translation": "На холодной каменной скамье Регана плотнее кутается в плащ. Я глубоко вдыхаю и выпускаю только слово «мучение»."
+          "sentence_translation": "На холодной каменной скамье Регана плотнее кутается в плащ. Я глубоко вдыхаю и выпускаю только слово «мучение».",
+          "sentence_parts": [
+            "Auf der kalten Steinbank zieht Regan den Mantel enger um die Schultern.",
+            "Ich atme tief ein und lasse nur das Wort „die Qual“ wieder hinaus."
+          ]
         },
         {
           "german": "verwünschen",
           "russian": "проклинать",
           "transcription": "[фер-ВЮН-шен]",
           "sentence": "Zwischen Schatten der Gitterstäbe hebt Regan das Gesicht zum Licht. Ich presse das Wort „verwünschen“ zwischen die Zähne, damit kein Zweifel entweicht.",
-          "sentence_translation": "Между тенями решёток Регана поднимает лицо к свету. Я стискиваю слово «проклинать» зубами, чтобы не вырвалось сомнение."
+          "sentence_translation": "Между тенями решёток Регана поднимает лицо к свету. Я стискиваю слово «проклинать» зубами, чтобы не вырвалось сомнение.",
+          "sentence_parts": [
+            "Zwischen Schatten der Gitterstäbe hebt Regan das Gesicht zum Licht.",
+            "Ich presse das Wort „verwünschen“ zwischen die Zähne, damit kein Zweifel entweicht."
+          ]
         },
         {
           "german": "das Verhängnis",
           "russian": "рок",
           "transcription": "[дас фер-ХЕНГ-нис]",
           "sentence": "Am rostigen Wassereimer spiegelt Regan kurz die eigenen Augen. Selbst wenn die Welt zerfällt, bleibt das Wort „das Verhängnis“ mein Nordstern.",
-          "sentence_translation": "У ржавого ведра с водой Регана на мгновение видит отражение глаз. Даже если мир распадается, слово «рок» остаётся моим северным светом."
+          "sentence_translation": "У ржавого ведра с водой Регана на мгновение видит отражение глаз. Даже если мир распадается, слово «рок» остаётся моим северным светом.",
+          "sentence_parts": [
+            "Am rostigen Wassereimer spiegelt Regan kurz die eigenen Augen.",
+            "Selbst wenn die Welt zerfällt, bleibt das Wort „das Verhängnis“ mein Nordstern."
+          ]
         },
         {
           "german": "büßen",
           "russian": "расплачиваться",
           "transcription": "[БЮ-сен]",
           "sentence": "Im dumpfen Hall der Schritte zählt Regan den Rhythmus der Wachen. Ich halte das Wort „büßen“ wie eine Fackel vor meinem Herzen.",
-          "sentence_translation": "В глухом эхе шагов Регана отсчитывает ритм часовых. Я держу слово «расплачиваться» как факел у сердца."
+          "sentence_translation": "В глухом эхе шагов Регана отсчитывает ритм часовых. Я держу слово «расплачиваться» как факел у сердца.",
+          "sentence_parts": [
+            "Im dumpfen Hall der Schritte zählt Regan den Rhythmus der Wachen.",
+            "Ich halte das Wort „büßen“ wie eine Fackel vor meinem Herzen."
+          ]
         },
         {
           "german": "verflucht",
           "russian": "проклятый",
           "transcription": "[фер-ФЛУХТ]",
           "sentence": "Vor dem verriegelten Fenster zeichnet Regan Kreise in den Staub. Das kalte Licht lässt das Wort „verflucht“ wie geschmolzenes Gold erscheinen.",
-          "sentence_translation": "Перед заколоченным окном Регана чертит круги в пыли. Холодный свет заставляет слово «проклятый» сиять словно расплавленное золото."
+          "sentence_translation": "Перед заколоченным окном Регана чертит круги в пыли. Холодный свет заставляет слово «проклятый» сиять словно расплавленное золото.",
+          "sentence_parts": [
+            "Vor dem verriegelten Fenster zeichnet Regan Kreise in den Staub.",
+            "Das kalte Licht lässt das Wort „verflucht“ wie geschmolzenes Gold erscheinen."
+          ]
         }
       ],
       "quizzes": [

--- a/generators/html_lira.py
+++ b/generators/html_lira.py
@@ -179,11 +179,28 @@ class LiraHTMLGenerator(BaseGenerator):
             scene = phase.get("theatrical_scene")
 
             vocabulary_words = []
+            constructor_entries = []
             for entry in phase.get("vocabulary", []):
                 german = (entry.get("german") or "").strip()
                 russian = (entry.get("russian") or "").strip()
                 if german and russian:
                     vocabulary_words.append((german, russian))
+
+                sentence_parts = entry.get("sentence_parts")
+                if isinstance(sentence_parts, list) and len(sentence_parts) > 1:
+                    constructor_entries.append(
+                        {
+                            "german": german,
+                            "russian": russian,
+                            "sentence": entry.get("sentence", ""),
+                            "sentence_translation": entry.get(
+                                "sentence_translation", ""
+                            ),
+                            "parts": sentence_parts,
+                        }
+                    )
+
+            phase["sentence_parts"] = constructor_entries
 
             existing_quizzes_data = list(phase.get("quizzes", []))
             referenced_words = {

--- a/generators/js_lira.py
+++ b/generators/js_lira.py
@@ -45,6 +45,12 @@ class LiraJSGenerator:
                 elif not isinstance(collocations, list):
                     collocations = []
 
+                sentence_parts = word.get('sentence_parts') or []
+                if isinstance(sentence_parts, str):
+                    sentence_parts = [sentence_parts]
+                elif not isinstance(sentence_parts, list):
+                    sentence_parts = []
+
                 words.append({
                     'word': word.get('german', ''),
                     'translation': word.get('russian', ''),
@@ -55,7 +61,8 @@ class LiraJSGenerator:
                     'themes': themes,
                     'wordFamily': word_family,  # Для relations
                     'synonyms': synonyms,        # Для relations
-                    'collocations': collocations # Для relations
+                    'collocations': collocations, # Для relations
+                    'sentenceParts': sentence_parts,
                 })
 
             quizzes = []
@@ -76,12 +83,30 @@ class LiraJSGenerator:
                     'correctIndex': correct_index,
                 })
 
+            constructor_sets = []
+            for vocab in phase.get('vocabulary', []):
+                parts = vocab.get('sentence_parts') or []
+                if isinstance(parts, str):
+                    parts = [parts]
+                elif not isinstance(parts, list):
+                    parts = []
+
+                if len(parts) > 1:
+                    constructor_sets.append({
+                        'word': vocab.get('german', ''),
+                        'translation': vocab.get('russian', ''),
+                        'parts': parts,
+                        'sentence': vocab.get('sentence', ''),
+                        'sentenceTranslation': vocab.get('sentence_translation', ''),
+                    })
+
             phase_vocabularies[phase_id] = {
                 'title': phase.get('title', ''),
                 'description': phase.get('description', ''),
                 'words': words,
                 'quizzes': quizzes,
                 'quizAttempts': {},
+                'sentenceParts': constructor_sets,
             }
 
         character_id = character_data.get('id') or character_data.get('slug') or 'journey'
@@ -104,6 +129,7 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -540,6 +566,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -607,6 +950,9 @@ function displayVocabulary(phaseKey) {
 
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
+
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
 
     grid.innerHTML = '';
 
@@ -1549,6 +1895,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/static/css/journey.css
+++ b/static/css/journey.css
@@ -199,6 +199,215 @@ body {
     color: #333;
 }
 
+.constructor-section {
+    background: white;
+    border-radius: 20px;
+    padding: 40px;
+    margin-bottom: 40px;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.15);
+}
+
+.constructor-section h2 {
+    font-size: 2em;
+    text-align: center;
+    margin-bottom: 20px;
+    color: #333;
+}
+
+.constructor-intro {
+    text-align: center;
+    color: #555;
+    margin-bottom: 24px;
+}
+
+.constructor-panel {
+    display: none;
+}
+
+.constructor-panel.active {
+    display: block;
+}
+
+.constructor-empty {
+    margin-top: 16px;
+    text-align: center;
+    color: #777;
+    font-style: italic;
+}
+
+.constructor-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.constructor-word {
+    font-size: 1.5em;
+    font-weight: 600;
+    color: #4a3f8c;
+}
+
+.constructor-translation {
+    color: #666;
+    font-size: 1em;
+}
+
+.constructor-progress {
+    margin-left: auto;
+    font-size: 0.9em;
+    color: #888;
+}
+
+.constructor-hint {
+    color: #555;
+    margin-bottom: 20px;
+}
+
+.constructor-areas {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    margin-bottom: 24px;
+}
+
+.constructor-source,
+.constructor-target {
+    background: #f7f7ff;
+    border: 2px dashed rgba(118, 75, 162, 0.3);
+    border-radius: 16px;
+    padding: 20px;
+    min-height: 140px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: flex-start;
+    position: relative;
+}
+
+.constructor-target {
+    border-style: solid;
+    background: #fbf8ff;
+}
+
+.constructor-placeholder {
+    color: #aaa;
+    font-size: 0.95em;
+}
+
+.constructor-target.has-fragments .constructor-placeholder {
+    display: none;
+}
+
+.constructor-fragment {
+    background: white;
+    border: 1px solid rgba(102, 126, 234, 0.4);
+    border-radius: 12px;
+    padding: 10px 14px;
+    font-size: 0.95em;
+    color: #4a3f8c;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s;
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.15);
+}
+
+.constructor-fragment:active {
+    transform: scale(0.98);
+}
+
+.constructor-fragment.in-target {
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.1), rgba(118, 75, 162, 0.2));
+    border-color: rgba(118, 75, 162, 0.5);
+}
+
+.constructor-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
+    margin-bottom: 16px;
+}
+
+.constructor-control {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    border: none;
+    border-radius: 999px;
+    padding: 12px 24px;
+    font-size: 0.95em;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.constructor-control:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 20px rgba(102, 126, 234, 0.3);
+}
+
+.constructor-control:disabled,
+.constructor-control[disabled] {
+    background: #ccc;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.constructor-feedback {
+    text-align: center;
+    min-height: 24px;
+    font-weight: 600;
+}
+
+.constructor-feedback.success {
+    color: #2e8b57;
+}
+
+.constructor-feedback.error {
+    color: #c0392b;
+}
+
+.constructor-original {
+    text-align: center;
+    color: #555;
+    font-size: 0.95em;
+}
+
+@media (max-width: 900px) {
+    .constructor-areas {
+        grid-template-columns: 1fr;
+    }
+
+    .constructor-source,
+    .constructor-target {
+        min-height: 120px;
+    }
+}
+
+@media (max-width: 600px) {
+    .constructor-section {
+        padding: 28px 20px;
+    }
+
+    .constructor-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .constructor-word {
+        font-size: 1.3em;
+    }
+
+    .constructor-controls {
+        flex-direction: column;
+    }
+
+    .constructor-control {
+        width: 100%;
+        text-align: center;
+    }
+}
+
 .vocabulary-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));

--- a/templates/journey.html
+++ b/templates/journey.html
@@ -66,6 +66,42 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            {% for phase in journey_phases %}
+            <section class="constructor-panel{% if loop.first %} active{% endif %}" data-phase="{{ phase.id }}">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                {% if not phase.sentence_parts %}
+                <p class="constructor-empty">Для этой фазы пока нет предложений для конструктора, они появятся позже.</p>
+                {% endif %}
+            </section>
+            {% endfor %}
+        </div>
+
         <div class="relations-wrapper">
             {% for phase in journey_phases %}
             {% set phase_id = phase.id if phase.id else 'phase-' ~ loop.index0 %}


### PR DESCRIPTION
## Summary
- add sentence fragment arrays to character vocab entries for the constructor exercise
- expose constructor data from the HTML/JS generators and render the new UI with ordering checks
- style the constructor section so it works on desktop and mobile layouts

## Testing
- pytest *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'F:\\AiKlientBank\\KingLearComic')*


------
https://chatgpt.com/codex/tasks/task_e_68cdbd06ab808320826b6cc5ff94e313