### PR TITLE
Add study metadata to vocabulary cards

### DIFF
--- a/generators/js_lira.py
+++ b/generators/js_lira.py
@@ -51,7 +51,15 @@ class LiraJSGenerator:
                 elif not isinstance(sentence_parts, list):
                     sentence_parts = []
 
+                word_id = (
+                    word.get('id')
+                    or word.get('word_id')
+                    or word.get('wordId')
+                    or ''
+                )
+
                 words.append({
+                    'wordId': word_id,
                     'word': word.get('german', ''),
                     'translation': word.get('russian', ''),
                     'transcription': word.get('transcription', ''),
@@ -130,6 +138,353 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -962,13 +1317,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });

--- a/output/journeys/albany.html
+++ b/output/journeys/albany.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="passive_duke">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="first_doubts">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="awakening">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="confrontation">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="moral_stand">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="justice_seeker">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="new_ruler">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["молчание", "терпеть", "слабость", "брак"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["брак", "слабость", "терпеть", "молчание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["брак", "колебаться", "слабость", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["терпеть", "молчание", "колебаться", "брак"], "correct_index": 0}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["мягкий", "пассивный", "терпеть", "брак"], "correct_index": 1}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["уступать", "брак", "слабость", "мягкий"], "correct_index": 0}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["терпеть", "колебаться", "слабость", "брак"], "correct_index": 1}, {"question": "Что означает немецкое слово «mild»?", "choices": ["мягкий", "молчание", "уступать", "колебаться"], "correct_index": 0}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["подвергать сомнению", "беспокойство", "сомнение", "совесть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["подвергать сомнению", "сомнение", "беспокойство", "совесть"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["тревожить", "неуверенный", "беспокойство", "сомнение"], "correct_index": 2}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["подвергать сомнению", "беспокойство", "неуверенный", "совесть"], "correct_index": 0}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["тревожить", "подвергать сомнению", "сомнение", "неуверенный"], "correct_index": 0}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["сомнение", "размышлять", "тревожить", "неуверенный"], "correct_index": 3}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["тревожить", "совесть", "размышлять", "сомнение"], "correct_index": 2}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["пробуждаться", "понимать", "ужас", "осознание"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["ужас", "пробуждаться", "понимать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["просыпаться", "осознание", "ясно видеть", "пробуждаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["ясно видеть", "осознание", "понимать", "пробуждаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["пробуждаться", "пугаться", "превращение", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["пробуждаться", "просыпаться", "ужас", "пугаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["осознание", "пугаться", "просыпаться", "ясно видеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["ясно видеть", "пугаться", "ужас", "превращение"], "correct_index": 3}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["мужество", "сопротивление", "спор", "противостоять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "противостоять", "сопротивление", "спор"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["спор", "защищаться", "противостоять", "сопротивление"], "correct_index": 3}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["мужество", "спор", "восставать", "противостоять"], "correct_index": 3}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["противостоять", "мужество", "спор", "обвинять"], "correct_index": 3}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["мужество", "противостоять", "защищаться", "спор"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["обвинять", "восставать", "мужество", "спор"], "correct_index": 1}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["выбирать", "мораль", "решение", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["выбирать", "справедливость", "решение", "мораль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["решение", "мораль", "справедливость", "принцип"], "correct_index": 0}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["выбирать", "мораль", "добродетель", "решение"], "correct_index": 0}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["решение", "добродетель", "праведный", "благородный"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["принцип", "мораль", "решение", "справедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «edel»?", "choices": ["мораль", "принцип", "благородный", "праведный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["принцип", "праведный", "справедливость", "добродетель"], "correct_index": 3}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["право", "борьба", "наказывать", "доброта"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["доброта", "борьба", "право", "наказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["доброта", "защищать", "судить", "наказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["вмешиваться", "наказывать", "борьба", "судить"], "correct_index": 1}, {"question": "Что означает немецкое слово «richten»?", "choices": ["защищать", "наказывать", "судить", "доброта"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["наказывать", "право", "защищать", "борьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["вмешиваться", "доброта", "наказывать", "право"], "correct_index": 0}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["новое начало", "мудрость", "направлять", "правление"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["новое начало", "мудрость", "направлять", "правление"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["строить", "новое начало", "направлять", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["направлять", "мир", "правление", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["строить", "мир", "направлять", "обновлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["правление", "строить", "обновлять", "новое начало"], "correct_index": 2}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["примирять", "мир", "обновлять", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["мир", "новое начало", "примирять", "направлять"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["слабость", "терпеть", "молчание", "брак"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["терпеть", "молчание", "брак", "слабость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["мягкий", "терпеть", "брак", "слабость"], "correct_index": 2}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["уступать", "молчание", "брак", "терпеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["пассивный", "терпеть", "мягкий", "молчание"], "correct_index": 0}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["пассивный", "брак", "терпеть", "уступать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["слабость", "колебаться", "терпеть", "уступать"], "correct_index": 1}, {"question": "Что означает немецкое слово «mild»?", "choices": ["брак", "мягкий", "слабость", "молчание"], "correct_index": 1}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["беспокойство", "подвергать сомнению", "сомнение", "совесть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["беспокойство", "совесть", "сомнение", "подвергать сомнению"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["беспокойство", "размышлять", "подвергать сомнению", "тревожить"], "correct_index": 0}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["тревожить", "подвергать сомнению", "совесть", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["беспокойство", "подвергать сомнению", "размышлять", "тревожить"], "correct_index": 3}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["неуверенный", "сомнение", "тревожить", "подвергать сомнению"], "correct_index": 0}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["размышлять", "подвергать сомнению", "совесть", "сомнение"], "correct_index": 0}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["осознание", "пробуждаться", "понимать", "ужас"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["ужас", "понимать", "осознание", "пробуждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["понимать", "пугаться", "пробуждаться", "превращение"], "correct_index": 2}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["осознание", "пугаться", "понимать", "пробуждаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["осознание", "ясно видеть", "пробуждаться", "пугаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["пугаться", "пробуждаться", "превращение", "просыпаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["пробуждаться", "осознание", "ясно видеть", "просыпаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["ужас", "пугаться", "просыпаться", "превращение"], "correct_index": 3}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["спор", "сопротивление", "противостоять", "мужество"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "сопротивление", "спор", "противостоять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["спор", "восставать", "обвинять", "сопротивление"], "correct_index": 3}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["сопротивление", "обвинять", "противостоять", "спор"], "correct_index": 2}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["спор", "восставать", "сопротивление", "обвинять"], "correct_index": 3}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["восставать", "сопротивление", "противостоять", "защищаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["восставать", "спор", "противостоять", "сопротивление"], "correct_index": 0}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["мораль", "выбирать", "справедливость", "решение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["выбирать", "мораль", "решение", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["решение", "мораль", "принцип", "добродетель"], "correct_index": 0}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["добродетель", "выбирать", "решение", "благородный"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["выбирать", "мораль", "принцип", "праведный"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["мораль", "принцип", "справедливость", "добродетель"], "correct_index": 1}, {"question": "Что означает немецкое слово «edel»?", "choices": ["мораль", "добродетель", "справедливость", "благородный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["добродетель", "выбирать", "мораль", "благородный"], "correct_index": 0}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["наказывать", "право", "борьба", "доброта"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["борьба", "наказывать", "доброта", "право"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["право", "защищать", "судить", "доброта"], "correct_index": 3}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["защищать", "наказывать", "борьба", "доброта"], "correct_index": 1}, {"question": "Что означает немецкое слово «richten»?", "choices": ["борьба", "вмешиваться", "право", "судить"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["право", "защищать", "судить", "борьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["наказывать", "право", "вмешиваться", "судить"], "correct_index": 2}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["правление", "направлять", "мудрость", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["новое начало", "мудрость", "направлять", "правление"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["правление", "новое начало", "мудрость", "строить"], "correct_index": 1}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["примирять", "новое начало", "направлять", "мудрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["мудрость", "новое начало", "мир", "строить"], "correct_index": 3}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["направлять", "строить", "обновлять", "примирять"], "correct_index": 2}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["примирять", "правление", "строить", "мир"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["направлять", "примирять", "строить", "мир"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Пассивный герцог</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,15 +661,15 @@
             <div class="quiz-phase-container active" data-phase="passive_duke">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Schweigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
                             
@@ -481,31 +677,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Ehe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">уступать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                             
@@ -513,49 +725,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «passiv»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пассивный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «nachgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">уступать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -565,29 +761,29 @@
                         <div class="quiz-question">Что означает немецкое слово «zögern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">уступать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «mild»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">колебаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -604,9 +800,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Zweifel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
                             
@@ -616,95 +812,95 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Gewissen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Unbehagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тревожить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «hinterfragen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуверенный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">тревожить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неуверенный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">тревожить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «grübeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
                             
@@ -719,17 +915,17 @@
             <div class="quiz-phase-container" data-phase="awakening">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ужас</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -741,27 +937,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -771,9 +967,9 @@
                         <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
@@ -783,31 +979,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пугаться</button>
                             
@@ -815,17 +995,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «klar sehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -835,11 +1031,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Verwandlung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">просыпаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
                             
@@ -854,8 +1050,24 @@
             <div class="quiz-phase-container" data-phase="confrontation">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Streit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
@@ -870,31 +1082,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Widerstand»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сопротивление</button>
                             
@@ -902,17 +1098,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «konfrontieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -922,11 +1118,11 @@
                         <div class="quiz-question">Что означает немецкое слово «anklagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                             
@@ -934,33 +1130,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «sich wehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «aufbegehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопротивление</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,8 +1169,24 @@
             <div class="quiz-phase-container" data-phase="moral_stand">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Moral»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
@@ -984,22 +1196,6 @@
                             <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1013,39 +1209,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">добродетель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
                             
@@ -1053,31 +1233,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «edel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
                             
@@ -1085,17 +1249,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Tugend»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «edel»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Tugend»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,15 +1304,15 @@
             <div class="quiz-phase-container" data-phase="justice_seeker">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
                             
@@ -1124,33 +1320,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Recht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Güte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1160,27 +1356,11 @@
                         <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «richten»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
                             
@@ -1188,15 +1368,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «richten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
@@ -1204,17 +1400,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «eingreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вмешиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,17 +1423,17 @@
             <div class="quiz-phase-container" data-phase="new_ruler">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">правление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1263,7 +1459,23 @@
                         <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">строить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «lenken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">примирять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
                             
@@ -1275,33 +1487,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «lenken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «aufbauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обновлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">строить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1311,13 +1507,13 @@
                         <div class="quiz-question">Что означает немецкое слово «erneuern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">строить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1329,27 +1525,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">примирять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">строить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мир</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Friede»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">примирять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">примирять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">строить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мир</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1373,6 +1569,7 @@
         "description": "Акт I: Молчаливый муж Гонерильи",
         "words": [
             {
+                "wordId": "",
                 "word": "das Schweigen",
                 "translation": "молчание",
                 "transcription": "[дас ШВАЙ-ген]",
@@ -1394,9 +1591,14 @@
                 ],
                 "collocations": [
                     "Mein Schweigen macht mich zum Mitschuldigen. — Моё молчание делает меня соучастником."
+                ],
+                "sentenceParts": [
+                    "Im goldenen Saal sitzt Albany schweigend neben Gonerils Thron.",
+                    "Mein Atem zeichnet das Wort „das Schweigen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Schwäche",
                 "translation": "слабость",
                 "transcription": "[ди ШВЕ-хе]",
@@ -1418,9 +1620,14 @@
                 ],
                 "collocations": [
                     "Meine Schwäche erlaubt das Böse zu wachsen. — Моя слабость позволяет злу расти."
+                ],
+                "sentenceParts": [
+                    "Vor den streitenden Schwestern faltet Albany die Hände hinter dem Rücken.",
+                    "Ich halte das Wort „die Schwäche“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Ehe",
                 "translation": "брак",
                 "transcription": "[ди Э-е]",
@@ -1442,9 +1649,14 @@
                 ],
                 "collocations": [
                     "Die Ehe bindet mich an eine grausame Frau. — Брак связывает меня с жестокой женой."
+                ],
+                "sentenceParts": [
+                    "Am Fenster der Audienzhalle betrachtet Albany die vorbeiziehenden Wolken.",
+                    "Ich zeichne das Wort „die Ehe“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "dulden",
                 "translation": "терпеть",
                 "transcription": "[ДУЛЬ-ден]",
@@ -1468,9 +1680,14 @@
                 ],
                 "collocations": [
                     "Ich dulde ihre Grausamkeit zu lange. — Я слишком долго терплю её жестокость."
+                ],
+                "sentenceParts": [
+                    "Zwischen zerstreuten Ratsmitgliedern nickt Albany zu allem bereitwillig.",
+                    "Ich zeichne das Wort „dulden“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "passiv",
                 "translation": "пассивный",
                 "transcription": "[па-СИФ]",
@@ -1492,9 +1709,14 @@
                 ],
                 "collocations": [
                     "Passiv schaue ich dem Unrecht zu. — Пассивно я наблюдаю за несправедливостью."
+                ],
+                "sentenceParts": [
+                    "Am Ende der Tafel legt Albany das Besteck ordentlich beiseite.",
+                    "Wie ein stilles Gebet legt sich das Wort „passiv“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "nachgeben",
                 "translation": "уступать",
                 "transcription": "[НАХ-ге-бен]",
@@ -1516,9 +1738,14 @@
                 ],
                 "collocations": [
                     "Zu oft gebe ich ihrem Willen nach. — Слишком часто я уступаю её воле."
+                ],
+                "sentenceParts": [
+                    "Neben Gonerils triumphierendem Lächeln bleibt Albany reglos.",
+                    "Ich atme tief ein und lasse nur das Wort „nachgeben“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "zögern",
                 "translation": "колебаться",
                 "transcription": "[ЦЁ-герн]",
@@ -1540,9 +1767,14 @@
                 "collocations": [
                     "Das Zögern fällt Lear unerwartet schwer. — Лиру неожиданно тяжело медлить.",
                     "Ich zögere, wenn ich handeln sollte. — Я колеблюсь, когда должен действовать."
+                ],
+                "sentenceParts": [
+                    "Auf dem Balkon lauscht Albany stumm den Beschwerden der Diener.",
+                    "Das kalte Licht lässt das Wort „zögern“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "mild",
                 "translation": "мягкий",
                 "transcription": "[МИЛЬД]",
@@ -1564,6 +1796,10 @@
                 ],
                 "collocations": [
                     "Meine milde Art wird als Schwäche gesehen. — Моя мягкость воспринимается как слабость."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der Säulen lässt Albany den Streit an sich vorbeiziehen.",
+                    "Mein Atem zeichnet das Wort „mild“ in die kalte Luft zwischen uns."
                 ]
             }
         ],
@@ -1571,91 +1807,174 @@
             {
                 "question": "Что означает немецкое слово «das Schweigen»?",
                 "choices": [
-                    "молчание",
-                    "терпеть",
                     "слабость",
+                    "терпеть",
+                    "молчание",
                     "брак"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Schwäche»?",
                 "choices": [
-                    "брак",
-                    "слабость",
                     "терпеть",
-                    "молчание"
+                    "молчание",
+                    "брак",
+                    "слабость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ehe»?",
                 "choices": [
+                    "мягкий",
+                    "терпеть",
                     "брак",
-                    "колебаться",
-                    "слабость",
-                    "терпеть"
+                    "слабость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «dulden»?",
                 "choices": [
-                    "терпеть",
+                    "уступать",
                     "молчание",
-                    "колебаться",
-                    "брак"
+                    "брак",
+                    "терпеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «passiv»?",
                 "choices": [
-                    "мягкий",
                     "пассивный",
                     "терпеть",
-                    "брак"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «nachgeben»?",
-                "choices": [
-                    "уступать",
-                    "брак",
-                    "слабость",
-                    "мягкий"
+                    "мягкий",
+                    "молчание"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «nachgeben»?",
+                "choices": [
+                    "пассивный",
+                    "брак",
+                    "терпеть",
+                    "уступать"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «zögern»?",
                 "choices": [
-                    "терпеть",
-                    "колебаться",
                     "слабость",
-                    "брак"
+                    "колебаться",
+                    "терпеть",
+                    "уступать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «mild»?",
                 "choices": [
+                    "брак",
                     "мягкий",
-                    "молчание",
-                    "уступать",
-                    "колебаться"
+                    "слабость",
+                    "молчание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "das Schweigen",
+                "translation": "молчание",
+                "parts": [
+                    "Im goldenen Saal sitzt Albany schweigend neben Gonerils Thron.",
+                    "Mein Atem zeichnet das Wort „das Schweigen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im goldenen Saal sitzt Albany schweigend neben Gonerils Thron. Mein Atem zeichnet das Wort „das Schweigen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В золотом зале Олбани молча сидит рядом с троном Гонерильи. Моё дыхание рисует слово «молчание» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Schwäche",
+                "translation": "слабость",
+                "parts": [
+                    "Vor den streitenden Schwestern faltet Albany die Hände hinter dem Rücken.",
+                    "Ich halte das Wort „die Schwäche“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Vor den streitenden Schwestern faltet Albany die Hände hinter dem Rücken. Ich halte das Wort „die Schwäche“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед ссорящимися сёстрами Олбани складывает руки за спиной. Я держу слово «слабость» как факел у сердца."
+            },
+            {
+                "word": "die Ehe",
+                "translation": "брак",
+                "parts": [
+                    "Am Fenster der Audienzhalle betrachtet Albany die vorbeiziehenden Wolken.",
+                    "Ich zeichne das Wort „die Ehe“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Am Fenster der Audienzhalle betrachtet Albany die vorbeiziehenden Wolken. Ich zeichne das Wort „die Ehe“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "У окна зала приёмов Олбани наблюдает за плывущими облаками. Я вывожу слово «брак» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "dulden",
+                "translation": "терпеть",
+                "parts": [
+                    "Zwischen zerstreuten Ratsmitgliedern nickt Albany zu allem bereitwillig.",
+                    "Ich zeichne das Wort „dulden“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Zwischen zerstreuten Ratsmitgliedern nickt Albany zu allem bereitwillig. Ich zeichne das Wort „dulden“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Среди рассеянных советников Олбани покорно кивает всему. Я черчу слово «терпеть» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "passiv",
+                "translation": "пассивный",
+                "parts": [
+                    "Am Ende der Tafel legt Albany das Besteck ordentlich beiseite.",
+                    "Wie ein stilles Gebet legt sich das Wort „passiv“ auf meine Lippen."
+                ],
+                "sentence": "Am Ende der Tafel legt Albany das Besteck ordentlich beiseite. Wie ein stilles Gebet legt sich das Wort „passiv“ auf meine Lippen.",
+                "sentenceTranslation": "В конце стола Олбани аккуратно откладывает приборы. Как тихая молитва слово «пассивный» ложится на мои губы."
+            },
+            {
+                "word": "nachgeben",
+                "translation": "уступать",
+                "parts": [
+                    "Neben Gonerils triumphierendem Lächeln bleibt Albany reglos.",
+                    "Ich atme tief ein und lasse nur das Wort „nachgeben“ wieder hinaus."
+                ],
+                "sentence": "Neben Gonerils triumphierendem Lächeln bleibt Albany reglos. Ich atme tief ein und lasse nur das Wort „nachgeben“ wieder hinaus.",
+                "sentenceTranslation": "Рядом с торжествующей улыбкой Гонерильи Олбани остаётся неподвижным. Я глубоко вдыхаю и выпускаю только слово «уступать»."
+            },
+            {
+                "word": "zögern",
+                "translation": "колебаться",
+                "parts": [
+                    "Auf dem Balkon lauscht Albany stumm den Beschwerden der Diener.",
+                    "Das kalte Licht lässt das Wort „zögern“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Auf dem Balkon lauscht Albany stumm den Beschwerden der Diener. Das kalte Licht lässt das Wort „zögern“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На балконе Олбани безмолвно слушает жалобы слуг. Холодный свет заставляет слово «колебаться» сиять словно расплавленное золото."
+            },
+            {
+                "word": "mild",
+                "translation": "мягкий",
+                "parts": [
+                    "Im Schatten der Säulen lässt Albany den Streit an sich vorbeiziehen.",
+                    "Mein Atem zeichnet das Wort „mild“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im Schatten der Säulen lässt Albany den Streit an sich vorbeiziehen. Mein Atem zeichnet das Wort „mild“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тени колонн Олбани позволяет спору пройти мимо себя. Моё дыхание рисует слово «мягкий» в холодном воздухе между нами."
+            }
+        ]
     },
     "first_doubts": {
         "title": "Первые сомнения",
         "description": "Акт II: Начинает сомневаться",
         "words": [
             {
+                "wordId": "",
                 "word": "der Zweifel",
                 "translation": "сомнение",
                 "transcription": "[дер ЦВАЙ-фель]",
@@ -1677,9 +1996,14 @@
                 ],
                 "collocations": [
                     "Der Zweifel an ihrer Güte wächst in mir. — Сомнение в её доброте растёт во мне."
+                ],
+                "sentenceParts": [
+                    "In der nächtlichen Galerie betrachtet Albany das verblassende Familienwappen.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Zweifel“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Gewissen",
                 "translation": "совесть",
                 "transcription": "[дас ге-ВИ-сен]",
@@ -1700,9 +2024,14 @@
                 "collocations": [
                     "Während des Sturms wirkt das Gewissen noch bedrückender. — Во время бури само «совесть» звучит ещё тяжелее.",
                     "Mein Gewissen beginnt mich zu quälen. — Моя совесть начинает мучить меня."
+                ],
+                "sentenceParts": [
+                    "Vor dem Spiegel entdeckt Albany zum ersten Mal den Schatten des Zweifels.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „das Gewissen“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Unbehagen",
                 "translation": "беспокойство",
                 "transcription": "[дас УН-бе-ха-ген]",
@@ -1724,9 +2053,14 @@
                 ],
                 "collocations": [
                     "Ein tiefes Unbehagen erfüllt meine Seele. — Глубокое беспокойство наполняет мою душу."
+                ],
+                "sentenceParts": [
+                    "Neben gestapelten Tributschriften blättert Albany nervös.",
+                    "Das Echo des Wortes „das Unbehagen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "hinterfragen",
                 "translation": "подвергать сомнению",
                 "transcription": "[ХИН-тер-фра-ген]",
@@ -1749,9 +2083,14 @@
                 ],
                 "collocations": [
                     "Ich beginne ihre Taten zu hinterfragen. — Я начинаю подвергать сомнению её поступки."
+                ],
+                "sentenceParts": [
+                    "Am dunklen Hof beobachtet Albany heimlich die Grausamkeit der Wachen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „hinterfragen“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "beunruhigen",
                 "translation": "тревожить",
                 "transcription": "[бе-УН-ру-и-ген]",
@@ -1773,9 +2112,14 @@
                 ],
                 "collocations": [
                     "Ihre Grausamkeit beunruhigt mich zunehmend. — Её жестокость всё больше тревожит меня."
+                ],
+                "sentenceParts": [
+                    "Zwischen verlassenen Banketttischen greift Albany nach einem halb vollen Kelch.",
+                    "Das kalte Licht lässt das Wort „beunruhigen“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "unsicher",
                 "translation": "неуверенный",
                 "transcription": "[УН-зи-хер]",
@@ -1797,9 +2141,14 @@
                 ],
                 "collocations": [
                     "Ich werde unsicher in meinem Schweigen. — Я становлюсь неуверенным в своём молчании."
+                ],
+                "sentenceParts": [
+                    "Auf dem Flur belauscht Albany ein Gespräch über Lear.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „unsicher“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "grübeln",
                 "translation": "размышлять",
                 "transcription": "[ГРЮ-бельн]",
@@ -1823,6 +2172,10 @@
                 ],
                 "collocations": [
                     "Nachts grüble ich über richtig und falsch. — Ночами я размышляю о правильном и неправильном."
+                ],
+                "sentenceParts": [
+                    "Im Schlafgemach rollt Albany die Karten des Reiches unruhig zusammen.",
+                    "Das Echo des Wortes „grübeln“ übertönt das Flüstern der Höflinge."
                 ]
             }
         ],
@@ -1830,8 +2183,8 @@
             {
                 "question": "Что означает немецкое слово «der Zweifel»?",
                 "choices": [
-                    "подвергать сомнению",
                     "беспокойство",
+                    "подвергать сомнению",
                     "сомнение",
                     "совесть"
                 ],
@@ -1840,71 +2193,144 @@
             {
                 "question": "Что означает немецкое слово «das Gewissen»?",
                 "choices": [
-                    "подвергать сомнению",
-                    "сомнение",
                     "беспокойство",
-                    "совесть"
+                    "совесть",
+                    "сомнение",
+                    "подвергать сомнению"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Unbehagen»?",
                 "choices": [
-                    "тревожить",
-                    "неуверенный",
                     "беспокойство",
-                    "сомнение"
+                    "размышлять",
+                    "подвергать сомнению",
+                    "тревожить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «hinterfragen»?",
                 "choices": [
+                    "тревожить",
                     "подвергать сомнению",
-                    "беспокойство",
-                    "неуверенный",
-                    "совесть"
+                    "совесть",
+                    "размышлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beunruhigen»?",
                 "choices": [
-                    "тревожить",
+                    "беспокойство",
                     "подвергать сомнению",
-                    "сомнение",
-                    "неуверенный"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «unsicher»?",
-                "choices": [
-                    "сомнение",
                     "размышлять",
-                    "тревожить",
-                    "неуверенный"
+                    "тревожить"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «unsicher»?",
+                "choices": [
+                    "неуверенный",
+                    "сомнение",
+                    "тревожить",
+                    "подвергать сомнению"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «grübeln»?",
                 "choices": [
-                    "тревожить",
-                    "совесть",
                     "размышлять",
+                    "подвергать сомнению",
+                    "совесть",
                     "сомнение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Zweifel",
+                "translation": "сомнение",
+                "parts": [
+                    "In der nächtlichen Galerie betrachtet Albany das verblassende Familienwappen.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Zweifel“ auf meine Lippen."
+                ],
+                "sentence": "In der nächtlichen Galerie betrachtet Albany das verblassende Familienwappen. Wie ein stilles Gebet legt sich das Wort „der Zweifel“ auf meine Lippen.",
+                "sentenceTranslation": "В ночной галерее Олбани рассматривает тускнеющий семейный герб. Как тихая молитва слово «сомнение» ложится на мои губы."
+            },
+            {
+                "word": "das Gewissen",
+                "translation": "совесть",
+                "parts": [
+                    "Vor dem Spiegel entdeckt Albany zum ersten Mal den Schatten des Zweifels.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „das Gewissen“ wird heute nicht verraten."
+                ],
+                "sentence": "Vor dem Spiegel entdeckt Albany zum ersten Mal den Schatten des Zweifels. Mit fester Stimme schwöre ich mir: Das Wort „das Gewissen“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед зеркалом Олбани впервые замечает тень сомнения. Твёрдым голосом я клянусь себе: слово «совесть» сегодня не будет предано."
+            },
+            {
+                "word": "das Unbehagen",
+                "translation": "беспокойство",
+                "parts": [
+                    "Neben gestapelten Tributschriften blättert Albany nervös.",
+                    "Das Echo des Wortes „das Unbehagen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Neben gestapelten Tributschriften blättert Albany nervös. Das Echo des Wortes „das Unbehagen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Рядом с кипами податных свитков Олбани нервно перелистывает страницы. Эхо слова «беспокойство» заглушает шёпот придворных."
+            },
+            {
+                "word": "hinterfragen",
+                "translation": "подвергать сомнению",
+                "parts": [
+                    "Am dunklen Hof beobachtet Albany heimlich die Grausamkeit der Wachen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „hinterfragen“ wird heute nicht verraten."
+                ],
+                "sentence": "Am dunklen Hof beobachtet Albany heimlich die Grausamkeit der Wachen. Mit fester Stimme schwöre ich mir: Das Wort „hinterfragen“ wird heute nicht verraten.",
+                "sentenceTranslation": "Во тёмном дворе Олбани украдкой наблюдает жестокость стражи. Твёрдым голосом я клянусь себе: слово «подвергать сомнению» сегодня не будет предано."
+            },
+            {
+                "word": "beunruhigen",
+                "translation": "тревожить",
+                "parts": [
+                    "Zwischen verlassenen Banketttischen greift Albany nach einem halb vollen Kelch.",
+                    "Das kalte Licht lässt das Wort „beunruhigen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Zwischen verlassenen Banketttischen greift Albany nach einem halb vollen Kelch. Das kalte Licht lässt das Wort „beunruhigen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Среди пустых банкетных столов Олбани тянется к наполовину полному кубку. Холодный свет заставляет слово «тревожить» сиять словно расплавленное золото."
+            },
+            {
+                "word": "unsicher",
+                "translation": "неуверенный",
+                "parts": [
+                    "Auf dem Flur belauscht Albany ein Gespräch über Lear.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „unsicher“ wird heute nicht verraten."
+                ],
+                "sentence": "Auf dem Flur belauscht Albany ein Gespräch über Lear. Mit fester Stimme schwöre ich mir: Das Wort „unsicher“ wird heute nicht verraten.",
+                "sentenceTranslation": "В коридоре Олбани подслушивает разговор о Лире. Твёрдым голосом я клянусь себе: слово «неуверенный» сегодня не будет предано."
+            },
+            {
+                "word": "grübeln",
+                "translation": "размышлять",
+                "parts": [
+                    "Im Schlafgemach rollt Albany die Karten des Reiches unruhig zusammen.",
+                    "Das Echo des Wortes „grübeln“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Im Schlafgemach rollt Albany die Karten des Reiches unruhig zusammen. Das Echo des Wortes „grübeln“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В опочивальне Олбани беспокойно скручивает карты королевства. Эхо слова «размышлять» заглушает шёпот придворных."
+            }
+        ]
     },
     "awakening": {
         "title": "Пробуждение",
         "description": "Акт III: Осознаёт зло жены",
         "words": [
             {
+                "wordId": "",
                 "word": "die Erkenntnis",
                 "translation": "осознание",
                 "transcription": "[ди ер-КЕНТ-нис]",
@@ -1928,9 +2354,14 @@
                     "Die Erkenntnis ihrer Bosheit erschüttert mich. — Осознание её злобы потрясает меня.",
                     "Die Erkenntnis kommt durch Schmerz und Verlust. — Познание приходит через боль и утрату.",
                     "Die späte Erkenntnis bricht mein Herz. — Позднее осознание разбивает моё сердце."
+                ],
+                "sentenceParts": [
+                    "Vor einem zerschlagenen Spiegel erkennt Albany die eigene Ohnmacht.",
+                    "Mein Atem zeichnet das Wort „die Erkenntnis“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Entsetzen",
                 "translation": "ужас",
                 "transcription": "[дас энт-ЗЕ-цен]",
@@ -1953,9 +2384,14 @@
                 ],
                 "collocations": [
                     "Mit Entsetzen sehe ich ihr wahres Gesicht. — С ужасом я вижу её истинное лицо."
+                ],
+                "sentenceParts": [
+                    "Auf dem staubigen Kampfplatz zieht Albany zum ersten Mal das Schwert.",
+                    "Ich zeichne das Wort „das Entsetzen“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erwachen",
                 "translation": "пробуждаться",
                 "transcription": "[ер-ВА-хен]",
@@ -1978,9 +2414,14 @@
                 "collocations": [
                     "Das Erwachen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело просыпаться.",
                     "Endlich erwache ich aus meiner Blindheit. — Наконец я пробуждаюсь от своей слепоты."
+                ],
+                "sentenceParts": [
+                    "Zwischen aufgebrachten Dienern erhebt Albany die Stimme gegen Goneril.",
+                    "Ich presse das Wort „erwachen“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "begreifen",
                 "translation": "понимать",
                 "transcription": "[бе-ГРАЙ-фен]",
@@ -2002,9 +2443,14 @@
                 "collocations": [
                     "Das Begreifen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело понимать.",
                     "Ich begreife das Ausmaß ihrer Grausamkeit. — Я понимаю масштаб её жестокости."
+                ],
+                "sentenceParts": [
+                    "Am Fenster beobachtet Albany Lear, der in den Sturm getrieben wird.",
+                    "Ich halte das Wort „begreifen“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erschrecken",
                 "translation": "пугаться",
                 "transcription": "[ер-ШРЕК-кен]",
@@ -2026,9 +2472,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Erschrecken ist. — Во время бури становится понятно, насколько важно пугать.",
                     "Ihre Taten erschrecken mein gutes Herz. — Её поступки пугают моё доброе сердце."
+                ],
+                "sentenceParts": [
+                    "Auf dem Hof stoppt Albany eine grausame Strafe mit ausgestreckter Hand.",
+                    "Das kalte Licht lässt das Wort „erschrecken“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "aufwachen",
                 "translation": "просыпаться",
                 "transcription": "[АУФ-ва-хен]",
@@ -2051,9 +2502,14 @@
                 ],
                 "collocations": [
                     "Ich wache auf aus meinem langen Schlaf. — Я просыпаюсь от долгого сна."
+                ],
+                "sentenceParts": [
+                    "Im Kriegssaal zerreißt Albany einen falschen Befehl.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „aufwachen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "klar sehen",
                 "translation": "ясно видеть",
                 "transcription": "[КЛАР ЗЕ-ен]",
@@ -2077,9 +2533,14 @@
                 ],
                 "collocations": [
                     "Zum ersten Mal sehe ich klar. — Впервые я вижу ясно."
+                ],
+                "sentenceParts": [
+                    "Neben Kent tauscht Albany einen verständnisvollen Blick.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „klar sehen“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Verwandlung",
                 "translation": "превращение",
                 "transcription": "[ди фер-ВАНД-лунг]",
@@ -2100,6 +2561,10 @@
                 "collocations": [
                     "Im Thronsaal verstummen die Gespräche über die Verwandlung nie. — В тронном зале постоянно звучит слово «превращение».",
                     "Eine Verwandlung beginnt in meiner Seele. — Превращение начинается в моей душе."
+                ],
+                "sentenceParts": [
+                    "An der Grenze des Herzogtums schwört Albany dem Unrecht ab.",
+                    "Ich zeichne das Wort „die Verwandlung“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             }
         ],
@@ -2107,38 +2572,38 @@
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
+                    "осознание",
                     "пробуждаться",
                     "понимать",
-                    "ужас",
-                    "осознание"
+                    "ужас"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Entsetzen»?",
                 "choices": [
                     "ужас",
-                    "пробуждаться",
                     "понимать",
-                    "осознание"
+                    "осознание",
+                    "пробуждаться"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erwachen»?",
                 "choices": [
-                    "просыпаться",
-                    "осознание",
-                    "ясно видеть",
-                    "пробуждаться"
+                    "понимать",
+                    "пугаться",
+                    "пробуждаться",
+                    "превращение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «begreifen»?",
                 "choices": [
-                    "ясно видеть",
                     "осознание",
+                    "пугаться",
                     "понимать",
                     "пробуждаться"
                 ],
@@ -2147,51 +2612,134 @@
             {
                 "question": "Что означает немецкое слово «erschrecken»?",
                 "choices": [
-                    "пробуждаться",
-                    "пугаться",
-                    "превращение",
-                    "осознание"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «aufwachen»?",
-                "choices": [
-                    "пробуждаться",
-                    "просыпаться",
-                    "ужас",
-                    "пугаться"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «klar sehen»?",
-                "choices": [
                     "осознание",
-                    "пугаться",
-                    "просыпаться",
-                    "ясно видеть"
+                    "ясно видеть",
+                    "пробуждаться",
+                    "пугаться"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «aufwachen»?",
+                "choices": [
+                    "пугаться",
+                    "пробуждаться",
+                    "превращение",
+                    "просыпаться"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «klar sehen»?",
+                "choices": [
+                    "пробуждаться",
+                    "осознание",
+                    "ясно видеть",
+                    "просыпаться"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Verwandlung»?",
                 "choices": [
-                    "ясно видеть",
-                    "пугаться",
                     "ужас",
+                    "пугаться",
+                    "просыпаться",
                     "превращение"
                 ],
                 "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Erkenntnis",
+                "translation": "осознание",
+                "parts": [
+                    "Vor einem zerschlagenen Spiegel erkennt Albany die eigene Ohnmacht.",
+                    "Mein Atem zeichnet das Wort „die Erkenntnis“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Vor einem zerschlagenen Spiegel erkennt Albany die eigene Ohnmacht. Mein Atem zeichnet das Wort „die Erkenntnis“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед разбитым зеркалом Олбани понимает собственное бессилие. Моё дыхание рисует слово «осознание» в холодном воздухе между нами."
+            },
+            {
+                "word": "das Entsetzen",
+                "translation": "ужас",
+                "parts": [
+                    "Auf dem staubigen Kampfplatz zieht Albany zum ersten Mal das Schwert.",
+                    "Ich zeichne das Wort „das Entsetzen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Auf dem staubigen Kampfplatz zieht Albany zum ersten Mal das Schwert. Ich zeichne das Wort „das Entsetzen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На пыльном плацу Олбани впервые обнажает меч. Я черчу слово «ужас» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "erwachen",
+                "translation": "пробуждаться",
+                "parts": [
+                    "Zwischen aufgebrachten Dienern erhebt Albany die Stimme gegen Goneril.",
+                    "Ich presse das Wort „erwachen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Zwischen aufgebrachten Dienern erhebt Albany die Stimme gegen Goneril. Ich presse das Wort „erwachen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди взбунтовавшихся слуг Олбани поднимает голос против Гонерильи. Я стискиваю слово «пробуждаться» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "begreifen",
+                "translation": "понимать",
+                "parts": [
+                    "Am Fenster beobachtet Albany Lear, der in den Sturm getrieben wird.",
+                    "Ich halte das Wort „begreifen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Am Fenster beobachtet Albany Lear, der in den Sturm getrieben wird. Ich halte das Wort „begreifen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У окна Олбани видит, как Лира гонят в бурю. Я держу слово «понимать» как факел у сердца."
+            },
+            {
+                "word": "erschrecken",
+                "translation": "пугаться",
+                "parts": [
+                    "Auf dem Hof stoppt Albany eine grausame Strafe mit ausgestreckter Hand.",
+                    "Das kalte Licht lässt das Wort „erschrecken“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Auf dem Hof stoppt Albany eine grausame Strafe mit ausgestreckter Hand. Das kalte Licht lässt das Wort „erschrecken“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На дворе Олбани протянутой рукой останавливает жестокую казнь. Холодный свет заставляет слово «пугаться» сиять словно расплавленное золото."
+            },
+            {
+                "word": "aufwachen",
+                "translation": "просыпаться",
+                "parts": [
+                    "Im Kriegssaal zerreißt Albany einen falschen Befehl.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „aufwachen“ bleibt lebendig."
+                ],
+                "sentence": "Im Kriegssaal zerreißt Albany einen falschen Befehl. Mit jeder Faser meines Körpers verspreche ich: Das Wort „aufwachen“ bleibt lebendig.",
+                "sentenceTranslation": "В военном зале Олбани разрывает ложный приказ. Каждой клеткой тела я обещаю: слово «просыпаться» останется живым."
+            },
+            {
+                "word": "klar sehen",
+                "translation": "ясно видеть",
+                "parts": [
+                    "Neben Kent tauscht Albany einen verständnisvollen Blick.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „klar sehen“ wird heute nicht verraten."
+                ],
+                "sentence": "Neben Kent tauscht Albany einen verständnisvollen Blick. Mit fester Stimme schwöre ich mir: Das Wort „klar sehen“ wird heute nicht verraten.",
+                "sentenceTranslation": "Рядом с Кентом Олбани обменивается понимающим взглядом. Твёрдым голосом я клянусь себе: слово «ясно видеть» сегодня не будет предано."
+            },
+            {
+                "word": "die Verwandlung",
+                "translation": "превращение",
+                "parts": [
+                    "An der Grenze des Herzogtums schwört Albany dem Unrecht ab.",
+                    "Ich zeichne das Wort „die Verwandlung“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "An der Grenze des Herzogtums schwört Albany dem Unrecht ab. Ich zeichne das Wort „die Verwandlung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На границе герцогства Олбани отрекается от несправедливости. Я вывожу слово «превращение» невидимыми чернилами на ладони."
+            }
+        ]
     },
     "confrontation": {
         "title": "Противостояние",
         "description": "Акт IV: Спорит с Гонерильей",
         "words": [
             {
+                "wordId": "",
                 "word": "der Streit",
                 "translation": "спор",
                 "transcription": "[дер ШТРАЙТ]",
@@ -2213,9 +2761,14 @@
                 ],
                 "collocations": [
                     "Der Streit mit meiner Frau eskaliert. — Спор с моей женой обостряется."
+                ],
+                "sentenceParts": [
+                    "Im Kriegslager stellt sich Albany Goneril mitten zwischen die Zelte.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Streit“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Mut",
                 "translation": "мужество",
                 "transcription": "[дер МУТ]",
@@ -2237,9 +2790,14 @@
                     "Lears Herz wird schwer, wenn der Mut zur Sprache kommt. — Сердце Лира тяжелеет: «мужество» звучит слишком близко.",
                     "Endlich finde ich den Mut zu widersprechen. — Наконец я нахожу мужество возражать.",
                     "Der Mut fordert mich, die Wahrheit zu sagen. — Мужество требует от меня говорить правду."
+                ],
+                "sentenceParts": [
+                    "Vor den versammelten Offizieren wirft Albany den Handschuh auf den Tisch.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Mut“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Widerstand",
                 "translation": "сопротивление",
                 "transcription": "[дер ВИ-дер-штанд]",
@@ -2261,9 +2819,14 @@
                 ],
                 "collocations": [
                     "Mein Widerstand gegen das Böse beginnt. — Моё сопротивление злу начинается."
+                ],
+                "sentenceParts": [
+                    "Am Wagen voller Waffen blockiert Albany den Weg der Flüchtenden.",
+                    "Mein Atem zeichnet das Wort „der Widerstand“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "konfrontieren",
                 "translation": "противостоять",
                 "transcription": "[кон-фрон-ТИ-рен]",
@@ -2285,9 +2848,14 @@
                 ],
                 "collocations": [
                     "Ich konfrontiere sie mit ihrer Grausamkeit. — Я противостою ей с её жестокостью."
+                ],
+                "sentenceParts": [
+                    "Zwischen wehenden Bannern nennt Albany laut den Verrat.",
+                    "Ich zeichne das Wort „konfrontieren“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "anklagen",
                 "translation": "обвинять",
                 "transcription": "[АН-кла-ген]",
@@ -2311,9 +2879,14 @@
                 ],
                 "collocations": [
                     "Ich klage sie ihrer Unmenschlichkeit an. — Я обвиняю её в бесчеловечности."
+                ],
+                "sentenceParts": [
+                    "Auf dem Felsen bei Dover fordert Albany Edmund heraus.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „anklagen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "sich wehren",
                 "translation": "защищаться",
                 "transcription": "[зих ВЕ-рен]",
@@ -2336,9 +2909,14 @@
                 ],
                 "collocations": [
                     "Ich wehre mich gegen ihre Tyrannei. — Я защищаюсь от её тирании."
+                ],
+                "sentenceParts": [
+                    "Vor der Armee verliest Albany Gonerils geheime Briefe.",
+                    "Mein Atem zeichnet das Wort „sich wehren“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "aufbegehren",
                 "translation": "восставать",
                 "transcription": "[АУФ-бе-ге-рен]",
@@ -2360,6 +2938,10 @@
                 ],
                 "collocations": [
                     "Ich begehre auf gegen das Unrecht. — Я восстаю против несправедливости."
+                ],
+                "sentenceParts": [
+                    "Im hellen Tageslicht zeigt Albany auf die Verräter, ohne zu zittern.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufbegehren“ darf nicht vergehen."
                 ]
             }
         ],
@@ -2367,20 +2949,20 @@
             {
                 "question": "Что означает немецкое слово «der Streit»?",
                 "choices": [
-                    "мужество",
-                    "сопротивление",
                     "спор",
-                    "противостоять"
+                    "сопротивление",
+                    "противостоять",
+                    "мужество"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
                     "мужество",
-                    "противостоять",
                     "сопротивление",
-                    "спор"
+                    "спор",
+                    "противостоять"
                 ],
                 "correctIndex": 0
             },
@@ -2388,8 +2970,8 @@
                 "question": "Что означает немецкое слово «der Widerstand»?",
                 "choices": [
                     "спор",
-                    "защищаться",
-                    "противостоять",
+                    "восставать",
+                    "обвинять",
                     "сопротивление"
                 ],
                 "correctIndex": 3
@@ -2397,19 +2979,19 @@
             {
                 "question": "Что означает немецкое слово «konfrontieren»?",
                 "choices": [
-                    "мужество",
-                    "спор",
-                    "восставать",
-                    "противостоять"
+                    "сопротивление",
+                    "обвинять",
+                    "противостоять",
+                    "спор"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «anklagen»?",
                 "choices": [
-                    "противостоять",
-                    "мужество",
                     "спор",
+                    "восставать",
+                    "сопротивление",
                     "обвинять"
                 ],
                 "correctIndex": 3
@@ -2417,31 +2999,104 @@
             {
                 "question": "Что означает немецкое слово «sich wehren»?",
                 "choices": [
-                    "мужество",
+                    "восставать",
+                    "сопротивление",
                     "противостоять",
-                    "защищаться",
-                    "спор"
+                    "защищаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «aufbegehren»?",
                 "choices": [
-                    "обвинять",
                     "восставать",
-                    "мужество",
-                    "спор"
+                    "спор",
+                    "противостоять",
+                    "сопротивление"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Streit",
+                "translation": "спор",
+                "parts": [
+                    "Im Kriegslager stellt sich Albany Goneril mitten zwischen die Zelte.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Streit“ gehört mir."
+                ],
+                "sentence": "Im Kriegslager stellt sich Albany Goneril mitten zwischen die Zelte. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Streit“ gehört mir.",
+                "sentenceTranslation": "В военном лагере Олбани становится перед Гонерильей среди шатров. Буря за окнами усиливает клятву: слово «спор» принадлежит мне."
+            },
+            {
+                "word": "der Mut",
+                "translation": "мужество",
+                "parts": [
+                    "Vor den versammelten Offizieren wirft Albany den Handschuh auf den Tisch.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Mut“ darf nicht vergehen."
+                ],
+                "sentence": "Vor den versammelten Offizieren wirft Albany den Handschuh auf den Tisch. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Mut“ darf nicht vergehen.",
+                "sentenceTranslation": "Перед собравшимися офицерами Олбани бросает перчатку на стол. Я шепчу стражам судьбы: слово «мужество» не должно исчезнуть."
+            },
+            {
+                "word": "der Widerstand",
+                "translation": "сопротивление",
+                "parts": [
+                    "Am Wagen voller Waffen blockiert Albany den Weg der Flüchtenden.",
+                    "Mein Atem zeichnet das Wort „der Widerstand“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Am Wagen voller Waffen blockiert Albany den Weg der Flüchtenden. Mein Atem zeichnet das Wort „der Widerstand“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У повозки с оружием Олбани преграждает путь беглянке. Моё дыхание рисует слово «сопротивление» в холодном воздухе между нами."
+            },
+            {
+                "word": "konfrontieren",
+                "translation": "противостоять",
+                "parts": [
+                    "Zwischen wehenden Bannern nennt Albany laut den Verrat.",
+                    "Ich zeichne das Wort „konfrontieren“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Zwischen wehenden Bannern nennt Albany laut den Verrat. Ich zeichne das Wort „konfrontieren“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под развевающимися знамёнами Олбани громко называет предательство. Я черчу слово «противостоять» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "anklagen",
+                "translation": "обвинять",
+                "parts": [
+                    "Auf dem Felsen bei Dover fordert Albany Edmund heraus.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „anklagen“ bleibt lebendig."
+                ],
+                "sentence": "Auf dem Felsen bei Dover fordert Albany Edmund heraus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „anklagen“ bleibt lebendig.",
+                "sentenceTranslation": "На скале у Дувра Олбани вызывает Эдмунда. Каждой клеткой тела я обещаю: слово «обвинять» останется живым."
+            },
+            {
+                "word": "sich wehren",
+                "translation": "защищаться",
+                "parts": [
+                    "Vor der Armee verliest Albany Gonerils geheime Briefe.",
+                    "Mein Atem zeichnet das Wort „sich wehren“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Vor der Armee verliest Albany Gonerils geheime Briefe. Mein Atem zeichnet das Wort „sich wehren“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед войском Олбани зачитывает тайные письма Гонерильи. Моё дыхание рисует слово «защищаться» в холодном воздухе между нами."
+            },
+            {
+                "word": "aufbegehren",
+                "translation": "восставать",
+                "parts": [
+                    "Im hellen Tageslicht zeigt Albany auf die Verräter, ohne zu zittern.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufbegehren“ darf nicht vergehen."
+                ],
+                "sentence": "Im hellen Tageslicht zeigt Albany auf die Verräter, ohne zu zittern. Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufbegehren“ darf nicht vergehen.",
+                "sentenceTranslation": "При ярком дневном свете Олбани указывает на предателей без дрожи. Я шепчу стражам судьбы: слово «восставать» не должно исчезнуть."
+            }
+        ]
     },
     "moral_stand": {
         "title": "Моральный выбор",
         "description": "Акт IV: Встаёт на сторону добра",
         "words": [
             {
+                "wordId": "",
                 "word": "die Moral",
                 "translation": "мораль",
                 "transcription": "[ди мо-РАЛЬ]",
@@ -2463,9 +3118,14 @@
                 ],
                 "collocations": [
                     "Die Moral leitet nun meine Entscheidungen. — Мораль теперь руководит моими решениями."
+                ],
+                "sentenceParts": [
+                    "Im Feldzelt der Verbündeten zeichnet Albany eine Linie in den Sand.",
+                    "Mein Atem zeichnet das Wort „die Moral“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Gerechtigkeit",
                 "translation": "справедливость",
                 "transcription": "[ди ге-РЕХ-тиг-кайт]",
@@ -2488,9 +3148,14 @@
                     "Für Gerechtigkeit will ich kämpfen. — За справедливость я хочу бороться.",
                     "Die Gerechtigkeit fordert diesen Kampf. — Справедливость требует этого боя.",
                     "Die Gerechtigkeit führt meine Klinge. — Справедливость ведёт мой клинок."
+                ],
+                "sentenceParts": [
+                    "Zwischen verletzten Soldaten spricht Albany von Gnade.",
+                    "Mein Atem zeichnet das Wort „die Gerechtigkeit“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Entscheidung",
                 "translation": "решение",
                 "transcription": "[ди энт-ШАЙ-дунг]",
@@ -2511,9 +3176,14 @@
                 "collocations": [
                     "Während des Sturms wirkt die Entscheidung noch bedrückender. — Во время бури само «решение» звучит ещё тяжелее.",
                     "Meine Entscheidung steht fest: ich wähle das Gute. — Моё решение твёрдо: я выбираю добро."
+                ],
+                "sentenceParts": [
+                    "Am Schlachtplan stellt Albany die Figuren der Gerechten nach vorn.",
+                    "Ich zeichne das Wort „die Entscheidung“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "wählen",
                 "translation": "выбирать",
                 "transcription": "[ВЕ-лен]",
@@ -2534,9 +3204,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Wählen ist. — Во время бури становится понятно, насколько важно выбирать.",
                     "Ich wähle den schweren Weg der Tugend. — Я выбираю трудный путь добродетели."
+                ],
+                "sentenceParts": [
+                    "Im Rat der Feldherren widerspricht Albany einer grausamen Idee.",
+                    "Ich atme tief ein und lasse nur das Wort „wählen“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "rechtschaffen",
                 "translation": "праведный",
                 "transcription": "[РЕХТ-ша-фен]",
@@ -2562,9 +3237,14 @@
                 "collocations": [
                     "Ich will rechtschaffen leben und handeln. — Я хочу жить и действовать праведно.",
                     "Ich bin ein rechtschaffener Mann. — Я праведный человек."
+                ],
+                "sentenceParts": [
+                    "Vor dem Banner der Wahrheit hebt Albany die Stimme zu einem Eid.",
+                    "Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Prinzip",
                 "translation": "принцип",
                 "transcription": "[дас прин-ЦИП]",
@@ -2586,9 +3266,14 @@
                 ],
                 "collocations": [
                     "Meine Prinzipien sind wichtiger als meine Ehe. — Мои принципы важнее моего брака."
+                ],
+                "sentenceParts": [
+                    "Auf dem Hügel über dem Schlachtfeld hält Albany ein feierliches Gebet.",
+                    "Wie ein stilles Gebet legt sich das Wort „das Prinzip“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "edel",
                 "translation": "благородный",
                 "transcription": "[Э-дель]",
@@ -2610,9 +3295,14 @@
                 ],
                 "collocations": [
                     "Ich strebe nach edlen Taten. — Я стремлюсь к благородным поступкам."
+                ],
+                "sentenceParts": [
+                    "In der Morgensonne wäscht Albany das Blut vom Schwert und schwört Frieden.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „edel“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Tugend",
                 "translation": "добродетель",
                 "transcription": "[ди ТУ-генд]",
@@ -2634,6 +3324,10 @@
                 ],
                 "collocations": [
                     "Die Tugend wird mein Leitstern sein. — Добродетель будет моей путеводной звездой."
+                ],
+                "sentenceParts": [
+                    "Bei den Feldärzten verspricht Albany Schutz den Verwundeten.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Tugend“ darf nicht vergehen."
                 ]
             }
         ],
@@ -2641,91 +3335,174 @@
             {
                 "question": "Что означает немецкое слово «die Moral»?",
                 "choices": [
-                    "выбирать",
                     "мораль",
-                    "решение",
-                    "справедливость"
+                    "выбирать",
+                    "справедливость",
+                    "решение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
                     "выбирать",
-                    "справедливость",
+                    "мораль",
                     "решение",
-                    "мораль"
+                    "справедливость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Entscheidung»?",
                 "choices": [
                     "решение",
                     "мораль",
-                    "справедливость",
-                    "принцип"
+                    "принцип",
+                    "добродетель"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «wählen»?",
                 "choices": [
-                    "выбирать",
-                    "мораль",
                     "добродетель",
-                    "решение"
+                    "выбирать",
+                    "решение",
+                    "благородный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
-                    "решение",
-                    "добродетель",
-                    "праведный",
-                    "благородный"
+                    "выбирать",
+                    "мораль",
+                    "принцип",
+                    "праведный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Prinzip»?",
                 "choices": [
-                    "принцип",
                     "мораль",
-                    "решение",
-                    "справедливость"
+                    "принцип",
+                    "справедливость",
+                    "добродетель"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «edel»?",
                 "choices": [
                     "мораль",
-                    "принцип",
-                    "благородный",
-                    "праведный"
+                    "добродетель",
+                    "справедливость",
+                    "благородный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Tugend»?",
                 "choices": [
-                    "принцип",
-                    "праведный",
-                    "справедливость",
-                    "добродетель"
+                    "добродетель",
+                    "выбирать",
+                    "мораль",
+                    "благородный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Moral",
+                "translation": "мораль",
+                "parts": [
+                    "Im Feldzelt der Verbündeten zeichnet Albany eine Linie in den Sand.",
+                    "Mein Atem zeichnet das Wort „die Moral“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im Feldzelt der Verbündeten zeichnet Albany eine Linie in den Sand. Mein Atem zeichnet das Wort „die Moral“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В шатре союзников Олбани проводит линию на песке. Моё дыхание рисует слово «мораль» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Gerechtigkeit",
+                "translation": "справедливость",
+                "parts": [
+                    "Zwischen verletzten Soldaten spricht Albany von Gnade.",
+                    "Mein Atem zeichnet das Wort „die Gerechtigkeit“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Zwischen verletzten Soldaten spricht Albany von Gnade. Mein Atem zeichnet das Wort „die Gerechtigkeit“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Среди раненых солдат Олбани говорит о милосердии. Моё дыхание рисует слово «справедливость» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Entscheidung",
+                "translation": "решение",
+                "parts": [
+                    "Am Schlachtplan stellt Albany die Figuren der Gerechten nach vorn.",
+                    "Ich zeichne das Wort „die Entscheidung“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Am Schlachtplan stellt Albany die Figuren der Gerechten nach vorn. Ich zeichne das Wort „die Entscheidung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Над картой сражения Олбани выдвигает вперёд фигуры праведников. Я вывожу слово «решение» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "wählen",
+                "translation": "выбирать",
+                "parts": [
+                    "Im Rat der Feldherren widerspricht Albany einer grausamen Idee.",
+                    "Ich atme tief ein und lasse nur das Wort „wählen“ wieder hinaus."
+                ],
+                "sentence": "Im Rat der Feldherren widerspricht Albany einer grausamen Idee. Ich atme tief ein und lasse nur das Wort „wählen“ wieder hinaus.",
+                "sentenceTranslation": "На совете полководцев Олбани возражает жестокой задумке. Я глубоко вдыхаю и выпускаю только слово «выбирать»."
+            },
+            {
+                "word": "rechtschaffen",
+                "translation": "праведный",
+                "parts": [
+                    "Vor dem Banner der Wahrheit hebt Albany die Stimme zu einem Eid.",
+                    "Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Vor dem Banner der Wahrheit hebt Albany die Stimme zu einem Eid. Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Перед знаменем правды Олбани поднимает голос для клятвы. Я стискиваю слово «праведный» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "das Prinzip",
+                "translation": "принцип",
+                "parts": [
+                    "Auf dem Hügel über dem Schlachtfeld hält Albany ein feierliches Gebet.",
+                    "Wie ein stilles Gebet legt sich das Wort „das Prinzip“ auf meine Lippen."
+                ],
+                "sentence": "Auf dem Hügel über dem Schlachtfeld hält Albany ein feierliches Gebet. Wie ein stilles Gebet legt sich das Wort „das Prinzip“ auf meine Lippen.",
+                "sentenceTranslation": "На холме над полем битвы Олбани произносит торжественную молитву. Как тихая молитва слово «принцип» ложится на мои губы."
+            },
+            {
+                "word": "edel",
+                "translation": "благородный",
+                "parts": [
+                    "In der Morgensonne wäscht Albany das Blut vom Schwert und schwört Frieden.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „edel“ mein Nordstern."
+                ],
+                "sentence": "In der Morgensonne wäscht Albany das Blut vom Schwert und schwört Frieden. Selbst wenn die Welt zerfällt, bleibt das Wort „edel“ mein Nordstern.",
+                "sentenceTranslation": "В утреннем солнце Олбани смывает кровь с меча и клянётся миром. Даже если мир распадается, слово «благородный» остаётся моим северным светом."
+            },
+            {
+                "word": "die Tugend",
+                "translation": "добродетель",
+                "parts": [
+                    "Bei den Feldärzten verspricht Albany Schutz den Verwundeten.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Tugend“ darf nicht vergehen."
+                ],
+                "sentence": "Bei den Feldärzten verspricht Albany Schutz den Verwundeten. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Tugend“ darf nicht vergehen.",
+                "sentenceTranslation": "У полевых лекарей Олбани обещает защиту раненым. Я шепчу стражам судьбы: слово «добродетель» не должно исчезнуть."
+            }
+        ]
     },
     "justice_seeker": {
         "title": "Поиск справедливости",
         "description": "Акт V: Борется за правду",
         "words": [
             {
+                "wordId": "",
                 "word": "der Kampf",
                 "translation": "борьба",
                 "transcription": "[дер КАМПФ]",
@@ -2749,9 +3526,14 @@
                     "Der Kampf für das Recht beginnt jetzt. — Борьба за право начинается сейчас.",
                     "Der Kampf gegen meinen Bruder ist unvermeidlich. — Бой с моим братом неизбежен.",
                     "Dieser Kampf ist für die Ehre meines Vaters. — Эта борьба за честь моего отца."
+                ],
+                "sentenceParts": [
+                    "Auf dem Tribunal errichtet Albany einen einfachen Holzstuhl als Richterstuhl.",
+                    "Ich zeichne das Wort „der Kampf“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Recht",
                 "translation": "право",
                 "transcription": "[дас РЕХТ]",
@@ -2772,9 +3554,14 @@
                 "collocations": [
                     "Im Thronsaal verstummen die Gespräche über das Recht nie. — В тронном зале постоянно звучит слово «право».",
                     "Das Recht muss über das Unrecht siegen. — Право должно победить неправду."
+                ],
+                "sentenceParts": [
+                    "Vor den überlebenden Soldaten verliest Albany die Namen der Schuldigen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Recht“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Güte",
                 "translation": "доброта",
                 "transcription": "[ди ГЮ-те]",
@@ -2796,9 +3583,15 @@
                 ],
                 "collocations": [
                     "Mit Güte will ich das Böse besiegen. — Добротой я хочу победить зло."
+                ],
+                "sentenceParts": [
+                    "In der Kapelle legt Albany die Hand auf die Bibel,",
+                    "bevor er urteilt.",
+                    "Das Echo des Wortes „die Güte“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "strafen",
                 "translation": "наказывать",
                 "transcription": "[ШТРА-фен]",
@@ -2821,9 +3614,14 @@
                 "collocations": [
                     "Cordelia zeigt, dass das Strafen auch ohne Stolz möglich ist. — Корделия показывает, что наказывать можно и без гордыни.",
                     "Die Schuldigen müssen bestraft werden. — Виновные должны быть наказаны."
+                ],
+                "sentenceParts": [
+                    "Am Tor von Dover begrüßt Albany die Rückkehrer mit offenen Armen.",
+                    "Ich zeichne das Wort „strafen“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "richten",
                 "translation": "судить",
                 "transcription": "[РИХ-тен]",
@@ -2845,9 +3643,14 @@
                 "collocations": [
                     "Das Richten fällt Lear unerwartet schwer. — Лиру неожиданно тяжело судить.",
                     "Gerecht will ich über die Verbrecher richten. — Справедливо я хочу судить преступников."
+                ],
+                "sentenceParts": [
+                    "Auf dem Feldlager sammelt Albany Zeugnisse der Überlebenden.",
+                    "Ich zeichne das Wort „richten“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "beschützen",
                 "translation": "защищать",
                 "transcription": "[бе-ШЮ-цен]",
@@ -2872,9 +3675,14 @@
                     "Die Unschuldigen will ich beschützen. — Невинных я хочу защитить.",
                     "Heimlich beschütze ich den wahnsinnigen König. — Тайно я защищаю безумного короля.",
                     "Ich kann ihn aus der Ferne nicht beschützen. — Я не могу защитить его издалека."
+                ],
+                "sentenceParts": [
+                    "Zwischen verstummten Trommeln verliest Albany den Befehl zur Gerechtigkeit.",
+                    "Ich zeichne das Wort „beschützen“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "eingreifen",
                 "translation": "вмешиваться",
                 "transcription": "[АЙН-грай-фен]",
@@ -2896,6 +3704,10 @@
                 ],
                 "collocations": [
                     "Ich greife ein, um das Schlimmste zu verhindern. — Я вмешиваюсь, чтобы предотвратить худшее."
+                ],
+                "sentenceParts": [
+                    "Im Schatten des zerstörten Schlosses schwört Albany das Reich zu erneuern.",
+                    "Ich zeichne das Wort „eingreifen“ in Gedanken über die Linien des Schicksals."
                 ]
             }
         ],
@@ -2903,81 +3715,155 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "право",
-                    "борьба",
                     "наказывать",
-                    "доброта"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «das Recht»?",
-                "choices": [
-                    "доброта",
-                    "борьба",
                     "право",
-                    "наказывать"
+                    "борьба",
+                    "доброта"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «das Recht»?",
+                "choices": [
+                    "борьба",
+                    "наказывать",
+                    "доброта",
+                    "право"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Güte»?",
                 "choices": [
-                    "доброта",
+                    "право",
                     "защищать",
                     "судить",
-                    "наказывать"
+                    "доброта"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «strafen»?",
                 "choices": [
-                    "вмешиваться",
+                    "защищать",
                     "наказывать",
                     "борьба",
-                    "судить"
+                    "доброта"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «richten»?",
                 "choices": [
-                    "защищать",
-                    "наказывать",
-                    "судить",
-                    "доброта"
+                    "борьба",
+                    "вмешиваться",
+                    "право",
+                    "судить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
-                    "наказывать",
                     "право",
                     "защищать",
+                    "судить",
                     "борьба"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «eingreifen»?",
                 "choices": [
-                    "вмешиваться",
-                    "доброта",
                     "наказывать",
-                    "право"
+                    "право",
+                    "вмешиваться",
+                    "судить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Kampf",
+                "translation": "борьба",
+                "parts": [
+                    "Auf dem Tribunal errichtet Albany einen einfachen Holzstuhl als Richterstuhl.",
+                    "Ich zeichne das Wort „der Kampf“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Auf dem Tribunal errichtet Albany einen einfachen Holzstuhl als Richterstuhl. Ich zeichne das Wort „der Kampf“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На трибунале Олбани ставит простой деревянный стул как судейский. Я вывожу слово «борьба» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "das Recht",
+                "translation": "право",
+                "parts": [
+                    "Vor den überlebenden Soldaten verliest Albany die Namen der Schuldigen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Recht“ gehört mir."
+                ],
+                "sentence": "Vor den überlebenden Soldaten verliest Albany die Namen der Schuldigen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Recht“ gehört mir.",
+                "sentenceTranslation": "Перед уцелевшими солдатами Олбани читает имена виновных. Буря за окнами усиливает клятву: слово «право» принадлежит мне."
+            },
+            {
+                "word": "die Güte",
+                "translation": "доброта",
+                "parts": [
+                    "In der Kapelle legt Albany die Hand auf die Bibel,",
+                    "bevor er urteilt.",
+                    "Das Echo des Wortes „die Güte“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "In der Kapelle legt Albany die Hand auf die Bibel, bevor er urteilt. Das Echo des Wortes „die Güte“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В капелле Олбани кладёт руку на Библию, прежде чем судить. Эхо слова «доброта» заглушает шёпот придворных."
+            },
+            {
+                "word": "strafen",
+                "translation": "наказывать",
+                "parts": [
+                    "Am Tor von Dover begrüßt Albany die Rückkehrer mit offenen Armen.",
+                    "Ich zeichne das Wort „strafen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Am Tor von Dover begrüßt Albany die Rückkehrer mit offenen Armen. Ich zeichne das Wort „strafen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У ворот Дувра Олбани встречает возвращающихся с распахнутыми руками. Я черчу слово «наказывать» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "richten",
+                "translation": "судить",
+                "parts": [
+                    "Auf dem Feldlager sammelt Albany Zeugnisse der Überlebenden.",
+                    "Ich zeichne das Wort „richten“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Auf dem Feldlager sammelt Albany Zeugnisse der Überlebenden. Ich zeichne das Wort „richten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В походном лагере Олбани собирает свидетельства выживших. Я вывожу слово «судить» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "beschützen",
+                "translation": "защищать",
+                "parts": [
+                    "Zwischen verstummten Trommeln verliest Albany den Befehl zur Gerechtigkeit.",
+                    "Ich zeichne das Wort „beschützen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Zwischen verstummten Trommeln verliest Albany den Befehl zur Gerechtigkeit. Ich zeichne das Wort „beschützen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Среди смолкших барабанов Олбани зачитывает приказ о справедливости. Я черчу слово «защищать» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "eingreifen",
+                "translation": "вмешиваться",
+                "parts": [
+                    "Im Schatten des zerstörten Schlosses schwört Albany das Reich zu erneuern.",
+                    "Ich zeichne das Wort „eingreifen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Im Schatten des zerstörten Schlosses schwört Albany das Reich zu erneuern. Ich zeichne das Wort „eingreifen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В тени разрушенного замка Олбани клянётся обновить королевство. Я черчу слово «вмешиваться» в мыслях поверх линий судьбы."
+            }
+        ]
     },
     "new_ruler": {
         "title": "Новый правитель",
         "description": "Акт V: Становится мудрым лидером",
         "words": [
             {
+                "wordId": "",
                 "word": "die Herrschaft",
                 "translation": "правление",
                 "transcription": "[ди ХЕР-шафт]",
@@ -3004,9 +3890,14 @@
                 "collocations": [
                     "Die Herrschaft fällt nun in meine Hände. — Правление теперь переходит в мои руки.",
                     "Die Herrschaft über alle ist mein Ziel. — Господство над всеми - моя цель."
+                ],
+                "sentenceParts": [
+                    "Im Saal voller Verwundeter verteilt Albany sanfte Worte und Befehle zugleich.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Herrschaft“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Weisheit",
                 "translation": "мудрость",
                 "transcription": "[ди ВАЙС-хайт]",
@@ -3038,9 +3929,14 @@
                     "Die Weisheit kommt zu spät zu mir. — Мудрость приходит ко мне слишком поздно.",
                     "Durch Leiden habe ich Weisheit erlangt. — Через страдания я обрёл мудрость.",
                     "Hinter meinen Späßen verbirgt sich Weisheit. — За моими шутками скрывается мудрость."
+                ],
+                "sentenceParts": [
+                    "Auf dem behelfsmäßigen Thron richtet Albany das Reich wieder auf.",
+                    "Das Echo des Wortes „die Weisheit“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Neuanfang",
                 "translation": "новое начало",
                 "transcription": "[дер НОЙ-ан-фанг]",
@@ -3063,9 +3959,14 @@
                 ],
                 "collocations": [
                     "Ein Neuanfang für das Königreich beginnt. — Новое начало для королевства начинается."
+                ],
+                "sentenceParts": [
+                    "Zwischen vertrockneten Kränzen trägt Albany die neue Krone ohne Triumph.",
+                    "Ich umarme das Wort „der Neuanfang“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "lenken",
                 "translation": "направлять",
                 "transcription": "[ЛЕН-кен]",
@@ -3087,9 +3988,14 @@
                 ],
                 "collocations": [
                     "Ich lenke das Land in eine bessere Zukunft. — Я направляю страну в лучшее будущее."
+                ],
+                "sentenceParts": [
+                    "Vor dem Volk verspricht Albany Heilung für das verwundete Land.",
+                    "Das Echo des Wortes „lenken“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "aufbauen",
                 "translation": "строить",
                 "transcription": "[АУФ-бау-ен]",
@@ -3111,9 +4017,14 @@
                 ],
                 "collocations": [
                     "Ich baue auf, was zerstört wurde. — Я строю то, что было разрушено."
+                ],
+                "sentenceParts": [
+                    "Auf den Stufen des Tempels hebt Albany die Gefallenen in Ehren hervor.",
+                    "Ich halte das Wort „aufbauen“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erneuern",
                 "translation": "обновлять",
                 "transcription": "[ер-НОЙ-ерн]",
@@ -3135,9 +4046,14 @@
                 ],
                 "collocations": [
                     "Das Reich will ich erneuern und heilen. — Королевство я хочу обновить и исцелить."
+                ],
+                "sentenceParts": [
+                    "Unter wehenden Flaggen lässt Albany die Glocken der Hoffnung schlagen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erneuern“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "versöhnen",
                 "translation": "примирять",
                 "transcription": "[фер-ЗЁ-нен]",
@@ -3158,9 +4074,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Versöhnen ist. — Во время бури становится понятно, насколько важно примирять.",
                     "Ich will die Getrennten versöhnen. — Я хочу примирить разделённых."
+                ],
+                "sentenceParts": [
+                    "Im Rat der Überlebenden hört Albany jedem zu, bevor er entscheidet.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „versöhnen“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Friede",
                 "translation": "мир",
                 "transcription": "[дер ФРИ-де]",
@@ -3183,6 +4104,10 @@
                 ],
                 "collocations": [
                     "Der Friede soll wieder ins Land kommen. — Мир должен вернуться в страну."
+                ],
+                "sentenceParts": [
+                    "An der Küste von Dover lässt Albany neue Schiffe zum Schutz auslaufen.",
+                    "Ich zeichne das Wort „der Friede“ in Gedanken über die Linien des Schicksals."
                 ]
             }
         ],
@@ -3190,12 +4115,12 @@
             {
                 "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
-                    "новое начало",
-                    "мудрость",
+                    "правление",
                     "направлять",
-                    "правление"
+                    "мудрость",
+                    "новое начало"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
@@ -3210,40 +4135,40 @@
             {
                 "question": "Что означает немецкое слово «der Neuanfang»?",
                 "choices": [
-                    "строить",
+                    "правление",
                     "новое начало",
-                    "направлять",
-                    "мудрость"
+                    "мудрость",
+                    "строить"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «lenken»?",
                 "choices": [
+                    "примирять",
+                    "новое начало",
                     "направлять",
-                    "мир",
-                    "правление",
                     "мудрость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufbauen»?",
                 "choices": [
-                    "строить",
+                    "мудрость",
+                    "новое начало",
                     "мир",
-                    "направлять",
-                    "обновлять"
+                    "строить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erneuern»?",
                 "choices": [
-                    "правление",
+                    "направлять",
                     "строить",
                     "обновлять",
-                    "новое начало"
+                    "примирять"
                 ],
                 "correctIndex": 2
             },
@@ -3251,24 +4176,106 @@
                 "question": "Что означает немецкое слово «versöhnen»?",
                 "choices": [
                     "примирять",
-                    "мир",
-                    "обновлять",
-                    "мудрость"
+                    "правление",
+                    "строить",
+                    "мир"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Friede»?",
                 "choices": [
-                    "мир",
-                    "новое начало",
+                    "направлять",
                     "примирять",
-                    "направлять"
+                    "строить",
+                    "мир"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Herrschaft",
+                "translation": "правление",
+                "parts": [
+                    "Im Saal voller Verwundeter verteilt Albany sanfte Worte und Befehle zugleich.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Herrschaft“ darf nicht vergehen."
+                ],
+                "sentence": "Im Saal voller Verwundeter verteilt Albany sanfte Worte und Befehle zugleich. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Herrschaft“ darf nicht vergehen.",
+                "sentenceTranslation": "В зале, полном раненых, Олбани раздаёт мягкие слова и приказы одновременно. Я шепчу стражам судьбы: слово «правление» не должно исчезнуть."
+            },
+            {
+                "word": "die Weisheit",
+                "translation": "мудрость",
+                "parts": [
+                    "Auf dem behelfsmäßigen Thron richtet Albany das Reich wieder auf.",
+                    "Das Echo des Wortes „die Weisheit“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Auf dem behelfsmäßigen Thron richtet Albany das Reich wieder auf. Das Echo des Wortes „die Weisheit“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На временном троне Олбани вновь поднимает королевство. Эхо слова «мудрость» заглушает шёпот придворных."
+            },
+            {
+                "word": "der Neuanfang",
+                "translation": "новое начало",
+                "parts": [
+                    "Zwischen vertrockneten Kränzen trägt Albany die neue Krone ohne Triumph.",
+                    "Ich umarme das Wort „der Neuanfang“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Zwischen vertrockneten Kränzen trägt Albany die neue Krone ohne Triumph. Ich umarme das Wort „der Neuanfang“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Среди засохших венков Олбани носит новую корону без торжества. Я обнимаю слово «новое начало», будто это единственный союзник."
+            },
+            {
+                "word": "lenken",
+                "translation": "направлять",
+                "parts": [
+                    "Vor dem Volk verspricht Albany Heilung für das verwundete Land.",
+                    "Das Echo des Wortes „lenken“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Vor dem Volk verspricht Albany Heilung für das verwundete Land. Das Echo des Wortes „lenken“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Перед народом Олбани обещает исцеление раненой земле. Эхо слова «направлять» заглушает шёпот придворных."
+            },
+            {
+                "word": "aufbauen",
+                "translation": "строить",
+                "parts": [
+                    "Auf den Stufen des Tempels hebt Albany die Gefallenen in Ehren hervor.",
+                    "Ich halte das Wort „aufbauen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Auf den Stufen des Tempels hebt Albany die Gefallenen in Ehren hervor. Ich halte das Wort „aufbauen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На ступенях храма Олбани чтит павших. Я держу слово «строить» как факел у сердца."
+            },
+            {
+                "word": "erneuern",
+                "translation": "обновлять",
+                "parts": [
+                    "Unter wehenden Flaggen lässt Albany die Glocken der Hoffnung schlagen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erneuern“ gehört mir."
+                ],
+                "sentence": "Unter wehenden Flaggen lässt Albany die Glocken der Hoffnung schlagen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erneuern“ gehört mir.",
+                "sentenceTranslation": "Под развевающимися флагами Олбани велит бить колоколам надежды. Буря за окнами усиливает клятву: слово «обновлять» принадлежит мне."
+            },
+            {
+                "word": "versöhnen",
+                "translation": "примирять",
+                "parts": [
+                    "Im Rat der Überlebenden hört Albany jedem zu, bevor er entscheidet.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „versöhnen“ mein Nordstern."
+                ],
+                "sentence": "Im Rat der Überlebenden hört Albany jedem zu, bevor er entscheidet. Selbst wenn die Welt zerfällt, bleibt das Wort „versöhnen“ mein Nordstern.",
+                "sentenceTranslation": "На совете выживших Олбани выслушивает каждого, прежде чем решать. Даже если мир распадается, слово «примирять» остаётся моим северным светом."
+            },
+            {
+                "word": "der Friede",
+                "translation": "мир",
+                "parts": [
+                    "An der Küste von Dover lässt Albany neue Schiffe zum Schutz auslaufen.",
+                    "Ich zeichne das Wort „der Friede“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "An der Küste von Dover lässt Albany neue Schiffe zum Schutz auslaufen. Ich zeichne das Wort „der Friede“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У берега Дувра Олбани отправляет в море новые корабли для защиты. Я черчу слово «мир» в мыслях поверх линий судьбы."
+            }
+        ]
     }
 };
 
@@ -3284,6 +4291,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3720,6 +5075,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -3788,6 +5460,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -3796,13 +5471,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4713,6 +6436,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/journeys/cordelia.html
+++ b/output/journeys/cordelia.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="throne">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="goneril">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="regan">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="storm">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="hut">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="dover">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="prison">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["церемония", "провозглашать", "власть", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["власть", "правда", "церемония", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["верность", "торжественный", "церемония", "провозглашать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["провозглашать", "власть", "церемония", "правда"], "correct_index": 1}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["повиноваться", "долг", "провозглашать", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["торжественный", "провозглашать", "церемония", "долг"], "correct_index": 3}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["долг", "правда", "власть", "торжественный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["верность", "торжественный", "церемония", "повиноваться"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["покидать", "изгонять", "гнев", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["покидать", "изгонять", "наказание", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["чужой", "гнев", "принимать", "приданое"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["изгонять", "наказание", "приданое", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["наказание", "надежда", "изгонять", "чужой"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["приданое", "изгонять", "надежда", "чужой"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["изгонять", "принимать", "приданое", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["наказание", "надежда", "покидать", "приданое"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["страх", "забота", "известие", "одиночество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["страх", "одиночество", "известие", "забота"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["известие", "защищать", "забота", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["молиться", "тоска", "страх", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["известие", "страдать", "тоска", "молиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["забота", "защищать", "страх", "одиночество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["страдать", "тоска", "забота", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «beten»?", "choices": ["защищать", "одиночество", "страх", "молиться"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["спасать", "возвращаться", "борьба", "битва"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["возвращаться", "спасать", "битва", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["битва", "спасать", "борьба", "побеждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["возвращаться", "спасать", "справедливость", "битва"], "correct_index": 3}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["храбрый", "побеждать", "битва", "справедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["храбрый", "справедливость", "битва", "борьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["побеждать", "храбрый", "возвращаться", "спасать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["храбрый", "справедливость", "побеждать", "армия"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["прощать", "обнимать", "слёзы", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["прощать", "узнавать", "слёзы", "обнимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["обнимать", "узнавать", "исцелять", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["прощение", "узнавать", "раскаяние", "обнимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["раскаяние", "слёзы", "исцелять", "прощение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "исцелять", "нежный", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["обнимать", "прощать", "узнавать", "нежный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["слёзы", "обнимать", "прощать", "прощение"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["тюрьма", "утешать", "достоинство", "пленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["пленный", "утешать", "достоинство", "тюрьма"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["честь", "отважный", "достоинство", "смирение"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["пленный", "тюрьма", "утешать", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["честь", "отважный", "утешать", "смирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["смирение", "достоинство", "пленный", "отважный"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["судьба", "честь", "отважный", "смирение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["честь", "отважный", "смирение", "утешать"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "жертва", "душа", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "душа", "смерть", "жертва"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["вечный", "жертва", "смерть", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["спасение", "вечный", "душа", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["вечный", "душа", "спасение", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "умирать", "конец", "жертва"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["умирать", "прощание", "жертва", "душа"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["конец", "умирать", "спасение", "жертва"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["церемония", "правда", "власть", "провозглашать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["правда", "провозглашать", "церемония", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["верность", "торжественный", "правда", "провозглашать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["повиноваться", "провозглашать", "власть", "верность"], "correct_index": 2}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["торжественный", "долг", "повиноваться", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["долг", "торжественный", "провозглашать", "повиноваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["провозглашать", "торжественный", "власть", "церемония"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["верность", "провозглашать", "долг", "торжественный"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["изгонять", "гнев", "покидать", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["наказание", "гнев", "покидать", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["чужой", "надежда", "покидать", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "изгонять", "принимать", "приданое"], "correct_index": 0}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["принимать", "чужой", "покидать", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["приданое", "изгонять", "принимать", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["чужой", "наказание", "принимать", "гнев"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["приданое", "покидать", "надежда", "чужой"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["забота", "одиночество", "известие", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["известие", "забота", "одиночество", "страх"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["известие", "одиночество", "молиться", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["известие", "защищать", "страх", "молиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страх", "забота", "известие", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["молиться", "тоска", "защищать", "одиночество"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["забота", "тоска", "одиночество", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «beten»?", "choices": ["забота", "страх", "молиться", "одиночество"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["спасать", "битва", "возвращаться", "борьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["спасать", "возвращаться", "битва", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["спасать", "побеждать", "армия", "борьба"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["побеждать", "битва", "храбрый", "борьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["храбрый", "армия", "возвращаться", "спасать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["армия", "возвращаться", "справедливость", "борьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["армия", "побеждать", "храбрый", "битва"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["возвращаться", "битва", "армия", "справедливость"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["слёзы", "прощать", "узнавать", "обнимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["узнавать", "прощать", "обнимать", "слёзы"], "correct_index": 3}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["раскаяние", "обнимать", "слёзы", "исцелять"], "correct_index": 1}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["раскаяние", "обнимать", "узнавать", "слёзы"], "correct_index": 2}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["узнавать", "исцелять", "слёзы", "обнимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["прощение", "прощать", "узнавать", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["узнавать", "прощение", "прощать", "нежный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["обнимать", "исцелять", "раскаяние", "прощение"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["утешать", "пленный", "тюрьма", "достоинство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["тюрьма", "достоинство", "пленный", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["достоинство", "пленный", "честь", "судьба"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["честь", "достоинство", "утешать", "тюрьма"], "correct_index": 2}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["судьба", "смирение", "честь", "отважный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["пленный", "утешать", "достоинство", "смирение"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["судьба", "честь", "тюрьма", "смирение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["пленный", "достоинство", "утешать", "честь"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "душа", "смерть", "жертва"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["душа", "умирать", "жертва", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["вечный", "жертва", "смерть", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["конец", "смерть", "прощание", "душа"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["прощание", "душа", "конец", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["конец", "прощание", "смерть", "вечный"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["конец", "прощание", "умирать", "жертва"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["спасение", "смерть", "душа", "прощание"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,17 +661,17 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -485,13 +681,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -505,7 +701,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
                             
@@ -513,65 +709,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">торжественный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">повиноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">повиноваться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">торжественный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -583,11 +779,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">повиноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">торжественный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,15 +796,15 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
@@ -616,15 +812,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
@@ -632,13 +844,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
                             
@@ -648,33 +860,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «fremd»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">принимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -688,41 +884,41 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «aufnehmen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">принимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Hoffnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">приданое</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">приданое</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,33 +931,33 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Sorge»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -773,9 +969,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
@@ -787,27 +983,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Angst»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">тоска</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
                             
@@ -815,15 +995,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">молиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
                             
@@ -835,11 +1031,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Sehnsucht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                             
@@ -847,17 +1043,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «beten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -870,17 +1066,17 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -890,9 +1086,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
                             
@@ -902,33 +1098,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «retten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -940,39 +1136,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
                             
@@ -982,17 +1146,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">армия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">армия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Armee»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1005,29 +1201,77 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">исцелять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
                             
@@ -1037,65 +1281,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1105,11 +1301,11 @@
                         <div class="quiz-question">Что означает немецкое слово «sanft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
                             
@@ -1121,11 +1317,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Vergebung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощение</button>
                             
@@ -1140,49 +1336,49 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «gefangen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пленный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тюрьма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Würde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1192,45 +1388,45 @@
                         <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">смирение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отважный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1244,7 +1440,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отважный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
                             
@@ -1252,17 +1448,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1275,24 +1471,8 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
@@ -1302,6 +1482,22 @@
                             <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1317,21 +1513,37 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Seele»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1339,33 +1551,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1375,29 +1571,29 @@
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Erlösung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1421,6 +1617,7 @@
         "description": "Акт I: Честная любовь",
         "words": [
             {
+                "wordId": "",
                 "word": "die Wahrheit",
                 "translation": "правда",
                 "transcription": "[ди ВАР-хайт]",
@@ -1443,9 +1640,14 @@
                     "Die Wahrheit war immer in deinen Worten, Kind. — Правда всегда была в твоих словах, дитя.",
                     "Die Wahrheit war vor meinen Augen verborgen. — Правда была скрыта от моих глаз.",
                     "Die Wahrheit verpacke ich in lustige Lieder. — Правду я заворачиваю в весёлые песни."
+                ],
+                "sentenceParts": [
+                    "Cordelia steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Das kalte Licht lässt das Wort „die Wahrheit“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Zeremonie",
                 "translation": "церемония",
                 "transcription": "[ди це-ре-мо-НИ]",
@@ -1471,9 +1673,14 @@
                 "collocations": [
                     "Die Zeremonie der Teilung beginnt jetzt. — Церемония раздела начинается сейчас.",
                     "Die Zeremonie beginnt im prächtigen Thronsaal. — Церемония начинается в великолепном тронном зале."
+                ],
+                "sentenceParts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Cordelia über Lears schweren Tisch.",
+                    "Ich atme tief ein und lasse nur das Wort „die Zeremonie“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verkünden",
                 "translation": "провозглашать",
                 "transcription": "[фер-КЮН-ден]",
@@ -1499,9 +1706,14 @@
                 "collocations": [
                     "Ich verkünde die Teilung meines Reiches. — Я провозглашаю раздел моего королевства.",
                     "Ich verkünde nur die Wahrheit meines Herzens. — Я провозглашаю только правду моего сердца."
+                ],
+                "sentenceParts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Cordelia die Hände hinter dem Rücken.",
+                    "Ich presse das Wort „verkünden“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Macht",
                 "translation": "власть",
                 "transcription": "[ди МАХТ]",
@@ -1525,9 +1737,14 @@
                     "Die Macht über das Königreich ist nah. — Власть над королевством близка.",
                     "Die Macht bedeutet nichts ohne wahre Liebe. — Власть ничего не значит без истинной любви.",
                     "Die Macht über das halbe Königreich ist mein. — Власть над половиной королевства моя."
+                ],
+                "sentenceParts": [
+                    "Zwischen flüsternden Höflingen gleitet Cordelia über den kalten Marmorboden.",
+                    "Ich zeichne das Wort „die Macht“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "gehorchen",
                 "translation": "повиноваться",
                 "transcription": "[ге-ХОР-хен]",
@@ -1549,9 +1766,14 @@
                 "collocations": [
                     "Der Narr spürt, wie das Gehorchen alle verändert. — Шут чувствует, как умение подчиняться меняет всех.",
                     "Ich kann der Lüge nicht gehorchen. — Я не могу повиноваться лжи."
+                ],
+                "sentenceParts": [
+                    "Am Rand des purpurnen Teppichs wartet Cordelia auf ein Zeichen des Königs.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „gehorchen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Pflicht",
                 "translation": "долг",
                 "transcription": "[ди ПФЛИХТ]",
@@ -1573,9 +1795,14 @@
                     "Cordelia merkt sich genau, wie die Pflicht verteilt wird. — Корделия внимательно следит, кому достанется «долг».",
                     "Meine Pflicht ist es, ehrlich zu sein. — Мой долг - быть честной.",
                     "Meine Pflicht ruft mich zum König. — Мой долг зовёт меня к королю."
+                ],
+                "sentenceParts": [
+                    "Unter wehenden Standarten der Schwestern senkt Cordelia kurz den Blick.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Pflicht“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "feierlich",
                 "translation": "торжественный",
                 "transcription": "[ФАЙ-ер-лих]",
@@ -1597,9 +1824,14 @@
                 ],
                 "collocations": [
                     "Dieser feierliche Moment wird zur Tragödie. — Этот торжественный момент становится трагедией."
+                ],
+                "sentenceParts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Cordelia das gespannte Antlitz des Hofes.",
+                    "Ich presse das Wort „feierlich“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Treue",
                 "translation": "верность",
                 "transcription": "[ди ТРОЙ-е]",
@@ -1621,6 +1853,10 @@
                     "Der Narr spottet, sobald die Treue erwähnt wird. — Шут насмехается, едва кто-то произносит «верность».",
                     "Meine Treue gilt der Wahrheit und der echten Liebe. — Моя верность принадлежит правде и истинной любви.",
                     "Die Treue zu meinem König ist unerschütterlich. — Верность моему королю непоколебима."
+                ],
+                "sentenceParts": [
+                    "Im Schein der offenen Feuerbecken erhebt Cordelia langsam die Stimme.",
+                    "Das Echo des Wortes „die Treue“ übertönt das Flüstern der Höflinge."
                 ]
             }
         ],
@@ -1629,19 +1865,19 @@
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
                     "церемония",
-                    "провозглашать",
+                    "правда",
                     "власть",
-                    "правда"
+                    "провозглашать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
-                    "власть",
                     "правда",
+                    "провозглашать",
                     "церемония",
-                    "провозглашать"
+                    "власть"
                 ],
                 "correctIndex": 2
             },
@@ -1650,7 +1886,7 @@
                 "choices": [
                     "верность",
                     "торжественный",
-                    "церемония",
+                    "правда",
                     "провозглашать"
                 ],
                 "correctIndex": 3
@@ -1658,61 +1894,144 @@
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
+                    "повиноваться",
                     "провозглашать",
                     "власть",
-                    "церемония",
-                    "правда"
+                    "верность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «gehorchen»?",
                 "choices": [
-                    "повиноваться",
+                    "торжественный",
                     "долг",
-                    "провозглашать",
-                    "правда"
+                    "повиноваться",
+                    "провозглашать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
+                    "долг",
                     "торжественный",
                     "провозглашать",
-                    "церемония",
-                    "долг"
+                    "повиноваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «feierlich»?",
                 "choices": [
-                    "долг",
-                    "правда",
+                    "провозглашать",
+                    "торжественный",
                     "власть",
-                    "торжественный"
+                    "церемония"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
                     "верность",
-                    "торжественный",
-                    "церемония",
-                    "повиноваться"
+                    "провозглашать",
+                    "долг",
+                    "торжественный"
                 ],
                 "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Wahrheit",
+                "translation": "правда",
+                "parts": [
+                    "Cordelia steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Das kalte Licht lässt das Wort „die Wahrheit“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Cordelia steht unter dem glühenden Kronleuchter des Thronsaals. Das kalte Licht lässt das Wort „die Wahrheit“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Корделия стоит под пылающей люстрой тронного зала. Холодный свет заставляет слово «правда» сиять словно расплавленное золото."
+            },
+            {
+                "word": "die Zeremonie",
+                "translation": "церемония",
+                "parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Cordelia über Lears schweren Tisch.",
+                    "Ich atme tief ein und lasse nur das Wort „die Zeremonie“ wieder hinaus."
+                ],
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Cordelia über Lears schweren Tisch. Ich atme tief ein und lasse nur das Wort „die Zeremonie“ wieder hinaus.",
+                "sentenceTranslation": "У развернутой карты королевства Корделия склоняется над тяжёлым столом Лира. Я глубоко вдыхаю и выпускаю только слово «церемония»."
+            },
+            {
+                "word": "verkünden",
+                "translation": "провозглашать",
+                "parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Cordelia die Hände hinter dem Rücken.",
+                    "Ich presse das Wort „verkünden“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Cordelia die Hände hinter dem Rücken. Ich presse das Wort „verkünden“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Перед каменными статуями предков Корделия сцепляет руки за спиной. Я стискиваю слово «провозглашать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Macht",
+                "translation": "власть",
+                "parts": [
+                    "Zwischen flüsternden Höflingen gleitet Cordelia über den kalten Marmorboden.",
+                    "Ich zeichne das Wort „die Macht“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Zwischen flüsternden Höflingen gleitet Cordelia über den kalten Marmorboden. Ich zeichne das Wort „die Macht“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Между шепчущимися придворными Корделия скользит по холодному мраморному полу. Я вывожу слово «власть» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "gehorchen",
+                "translation": "повиноваться",
+                "parts": [
+                    "Am Rand des purpurnen Teppichs wartet Cordelia auf ein Zeichen des Königs.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „gehorchen“ bleibt lebendig."
+                ],
+                "sentence": "Am Rand des purpurnen Teppichs wartet Cordelia auf ein Zeichen des Königs. Mit jeder Faser meines Körpers verspreche ich: Das Wort „gehorchen“ bleibt lebendig.",
+                "sentenceTranslation": "На краю пурпурного ковра Корделия ждёт знака от короля. Каждой клеткой тела я обещаю: слово «повиноваться» останется живым."
+            },
+            {
+                "word": "die Pflicht",
+                "translation": "долг",
+                "parts": [
+                    "Unter wehenden Standarten der Schwestern senkt Cordelia kurz den Blick.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Pflicht“ wird heute nicht verraten."
+                ],
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Cordelia kurz den Blick. Mit fester Stimme schwöre ich mir: Das Wort „die Pflicht“ wird heute nicht verraten.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Корделия на миг опускает взгляд. Твёрдым голосом я клянусь себе: слово «долг» сегодня не будет предано."
+            },
+            {
+                "word": "feierlich",
+                "translation": "торжественный",
+                "parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Cordelia das gespannte Antlitz des Hofes.",
+                    "Ich presse das Wort „feierlich“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Cordelia das gespannte Antlitz des Hofes. Ich presse das Wort „feierlich“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "За позолоченной балюстрадой Корделия наблюдает за напряжёнными лицами двора. Я стискиваю слово «торжественный» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Treue",
+                "translation": "верность",
+                "parts": [
+                    "Im Schein der offenen Feuerbecken erhebt Cordelia langsam die Stimme.",
+                    "Das Echo des Wortes „die Treue“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Cordelia langsam die Stimme. Das Echo des Wortes „die Treue“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В отблесках открытых жаровен Корделия медленно поднимает голос. Эхо слова «верность» заглушает шёпот придворных."
+            }
+        ]
     },
     "goneril": {
         "title": "Изгнание",
         "description": "Акт I: Отъезд во Францию",
         "words": [
             {
+                "wordId": "",
                 "word": "verstoßen",
                 "translation": "изгонять",
                 "transcription": "[фер-ШТО-сен]",
@@ -1740,9 +2059,14 @@
                     "Der König verstößt mich aus seinem Herzen. — Король изгоняет меня из своего сердца.",
                     "Ich verstoße meinen unschuldigen Sohn. — Я изгоняю своего невинного сына.",
                     "Ich verstoße meinen Vater in die Nacht. — Я отвергаю отца в ночь."
+                ],
+                "sentenceParts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Cordelia zwischen gepackten Kisten.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verlassen",
                 "translation": "покидать",
                 "transcription": "[фер-ЛА-сен]",
@@ -1764,9 +2088,14 @@
                     "Der Narr spürt, wie das Verlassen alle verändert. — Шут чувствует, как умение покидать меняет всех.",
                     "Auch Regan will mich verlassen und verstoßen! — И Регана хочет меня покинуть и отвергнуть!",
                     "Schweren Herzens verlasse ich mein Vaterland. — С тяжёлым сердцем я покидаю родину."
+                ],
+                "sentenceParts": [
+                    "Auf der windigen Freitreppe blickt Cordelia zum schweigenden Hof hinunter.",
+                    "Ich atme tief ein und lasse nur das Wort „verlassen“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Zorn",
                 "translation": "гнев",
                 "transcription": "[дер ЦОРН]",
@@ -1790,9 +2119,14 @@
                     "Sein Zorn ist grenzenlos und blind. — Его гнев безграничен и слеп.",
                     "Der Zorn des Königs trifft mich ungerecht. — Гнев короля поражает меня несправедливо.",
                     "Mein Zorn kennt keine Barmherzigkeit. — Мой гнев не знает милосердия."
+                ],
+                "sentenceParts": [
+                    "Zwischen zurückgelassenen Dienern schließt Cordelia den Reisemantel enger.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Zorn“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Strafe",
                 "translation": "наказание",
                 "transcription": "[ди ШТРА-фе]",
@@ -1818,9 +2152,15 @@
                     "Diese Strafe erdulde ich für meinen König. — Это наказание я терплю ради короля.",
                     "Die Strafe für Widerspruch ist hart. — Наказание за возражение сурово.",
                     "Dies ist die gerechte Strafe für meine Grausamkeit. — Это справедливая кара за мою жестокость."
+                ],
+                "sentenceParts": [
+                    "Am dunklen Pferdestall streicht Cordelia einem nervösen Tier über die Mähne.",
+                    "Ich presse das Wort „die Strafe“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "fremd",
                 "translation": "чужой",
                 "transcription": "[ФРЕМД]",
@@ -1842,9 +2182,14 @@
                 ],
                 "collocations": [
                     "Ich bin jetzt fremd in meinem eigenen Land. — Я теперь чужая в своей собственной стране."
+                ],
+                "sentenceParts": [
+                    "Vor dem knarrenden Fallgatter tastet Cordelia ein letztes Mal nach dem Haustor.",
+                    "Mein Atem zeichnet das Wort „fremd“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Mitgift",
                 "translation": "приданое",
                 "transcription": "[ди МИТ-гифт]",
@@ -1866,9 +2211,14 @@
                 ],
                 "collocations": [
                     "Ohne Mitgift bin ich reicher an Ehre. — Без приданого я богаче честью."
+                ],
+                "sentenceParts": [
+                    "Zwischen verstreuten Schriftrollen dreht Cordelia den Ring an der Hand.",
+                    "Ich zeichne das Wort „die Mitgift“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "aufnehmen",
                 "translation": "принимать",
                 "transcription": "[АУФ-не-мен]",
@@ -1890,9 +2240,14 @@
                 ],
                 "collocations": [
                     "Der König von Frankreich nimmt mich liebevoll auf. — Король Франции принимает меня с любовью."
+                ],
+                "sentenceParts": [
+                    "Am leeren Bankettisch zählt Cordelia die verlöschenden Kerzen.",
+                    "Mein Atem zeichnet das Wort „aufnehmen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Hoffnung",
                 "translation": "надежда",
                 "transcription": "[ди ХОФ-нунг]",
@@ -1913,6 +2268,10 @@
                 "collocations": [
                     "Der Narr spottet, sobald die Hoffnung erwähnt wird. — Шут насмехается, едва кто-то произносит «надежда».",
                     "Die Hoffnung auf Versöhnung stirbt nie in meinem Herzen. — Надежда на примирение никогда не умирает в моём сердце."
+                ],
+                "sentenceParts": [
+                    "Zwischen schweigenden Wachen geht Cordelia auf den kalten Hof hinaus.",
+                    "Ich atme tief ein und lasse nur das Wort „die Hoffnung“ wieder hinaus."
                 ]
             }
         ],
@@ -1920,91 +2279,175 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "покидать",
                     "изгонять",
                     "гнев",
+                    "покидать",
                     "наказание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
-                    "покидать",
-                    "изгонять",
                     "наказание",
-                    "гнев"
+                    "гнев",
+                    "покидать",
+                    "изгонять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
                     "чужой",
-                    "гнев",
-                    "принимать",
-                    "приданое"
+                    "надежда",
+                    "покидать",
+                    "гнев"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "изгонять",
                     "наказание",
-                    "приданое",
-                    "покидать"
+                    "изгонять",
+                    "принимать",
+                    "приданое"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «fremd»?",
                 "choices": [
-                    "наказание",
-                    "надежда",
-                    "изгонять",
-                    "чужой"
+                    "принимать",
+                    "чужой",
+                    "покидать",
+                    "изгонять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Mitgift»?",
                 "choices": [
                     "приданое",
                     "изгонять",
-                    "надежда",
-                    "чужой"
+                    "принимать",
+                    "гнев"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «aufnehmen»?",
                 "choices": [
-                    "изгонять",
+                    "чужой",
+                    "наказание",
                     "принимать",
-                    "приданое",
-                    "наказание"
+                    "гнев"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Hoffnung»?",
                 "choices": [
-                    "наказание",
-                    "надежда",
+                    "приданое",
                     "покидать",
-                    "приданое"
+                    "надежда",
+                    "чужой"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "verstoßen",
+                "translation": "изгонять",
+                "parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Cordelia zwischen gepackten Kisten.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig."
+                ],
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Cordelia zwischen gepackten Kisten. Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Корделия замирает среди нагруженных ящиков. Каждой клеткой тела я обещаю: слово «изгонять» останется живым."
+            },
+            {
+                "word": "verlassen",
+                "translation": "покидать",
+                "parts": [
+                    "Auf der windigen Freitreppe blickt Cordelia zum schweigenden Hof hinunter.",
+                    "Ich atme tief ein und lasse nur das Wort „verlassen“ wieder hinaus."
+                ],
+                "sentence": "Auf der windigen Freitreppe blickt Cordelia zum schweigenden Hof hinunter. Ich atme tief ein und lasse nur das Wort „verlassen“ wieder hinaus.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Корделия смотрит вниз на молчаливый двор. Я глубоко вдыхаю и выпускаю только слово «покидать»."
+            },
+            {
+                "word": "der Zorn",
+                "translation": "гнев",
+                "parts": [
+                    "Zwischen zurückgelassenen Dienern schließt Cordelia den Reisemantel enger.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Zorn“ bleibt lebendig."
+                ],
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Cordelia den Reisemantel enger. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Zorn“ bleibt lebendig.",
+                "sentenceTranslation": "Среди оставленных слуг Корделия плотнее запахивает дорожный плащ. Каждой клеткой тела я обещаю: слово «гнев» останется живым."
+            },
+            {
+                "word": "die Strafe",
+                "translation": "наказание",
+                "parts": [
+                    "Am dunklen Pferdestall streicht Cordelia einem nervösen Tier über die Mähne.",
+                    "Ich presse das Wort „die Strafe“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Am dunklen Pferdestall streicht Cordelia einem nervösen Tier über die Mähne. Ich presse das Wort „die Strafe“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Корделия гладит гриву нервного коня. Я стискиваю слово «наказание» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "fremd",
+                "translation": "чужой",
+                "parts": [
+                    "Vor dem knarrenden Fallgatter tastet Cordelia ein letztes Mal nach dem Haustor.",
+                    "Mein Atem zeichnet das Wort „fremd“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Vor dem knarrenden Fallgatter tastet Cordelia ein letztes Mal nach dem Haustor. Mein Atem zeichnet das Wort „fremd“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Корделия в последний раз касается родной двери. Моё дыхание рисует слово «чужой» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Mitgift",
+                "translation": "приданое",
+                "parts": [
+                    "Zwischen verstreuten Schriftrollen dreht Cordelia den Ring an der Hand.",
+                    "Ich zeichne das Wort „die Mitgift“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Cordelia den Ring an der Hand. Ich zeichne das Wort „die Mitgift“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Среди разбросанных свитков Корделия вертит кольцо на пальце. Я черчу слово «приданое» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "aufnehmen",
+                "translation": "принимать",
+                "parts": [
+                    "Am leeren Bankettisch zählt Cordelia die verlöschenden Kerzen.",
+                    "Mein Atem zeichnet das Wort „aufnehmen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Am leeren Bankettisch zählt Cordelia die verlöschenden Kerzen. Mein Atem zeichnet das Wort „aufnehmen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У пустого банкетного стола Корделия пересчитывает гаснущие свечи. Моё дыхание рисует слово «принимать» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Hoffnung",
+                "translation": "надежда",
+                "parts": [
+                    "Zwischen schweigenden Wachen geht Cordelia auf den kalten Hof hinaus.",
+                    "Ich atme tief ein und lasse nur das Wort „die Hoffnung“ wieder hinaus."
+                ],
+                "sentence": "Zwischen schweigenden Wachen geht Cordelia auf den kalten Hof hinaus. Ich atme tief ein und lasse nur das Wort „die Hoffnung“ wieder hinaus.",
+                "sentenceTranslation": "Между молчаливыми стражниками Корделия выходит на холодный двор. Я глубоко вдыхаю и выпускаю только слово «надежда»."
+            }
+        ]
     },
     "regan": {
         "title": "Во Франции",
         "description": "Акт II-III: Беспокойство за отца",
         "words": [
             {
+                "wordId": "",
                 "word": "die Sorge",
                 "translation": "забота",
                 "transcription": "[ди ЗОР-ге]",
@@ -2025,9 +2468,14 @@
                 "collocations": [
                     "Der Narr spottet, sobald die Sorge erwähnt wird. — Шут насмехается, едва кто-то произносит «забота».",
                     "Die Sorge um meinen Vater lässt mich nicht schlafen. — Забота об отце не даёт мне спать."
+                ],
+                "sentenceParts": [
+                    "Im zugigen Seitenflügel lauscht Cordelia dem Heulen der Küstenwinde.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Sorge“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Einsamkeit",
                 "translation": "одиночество",
                 "transcription": "[ди АЙН-зам-кайт]",
@@ -2049,9 +2497,14 @@
                     "Cordelia merkt sich genau, wie die Einsamkeit verteilt wird. — Корделия внимательно следит, кому достанется «одиночество».",
                     "Die Einsamkeit umgibt mich wie ein kalter Mantel. — Одиночество окружает меня как холодный плащ.",
                     "In der Einsamkeit denke ich an ihn. — В одиночестве я думаю о нём."
+                ],
+                "sentenceParts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Cordelia einen zerknitterten Brief.",
+                    "Mein Atem zeichnet das Wort „die Einsamkeit“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Nachricht",
                 "translation": "известие",
                 "transcription": "[ди НАХ-рихт]",
@@ -2073,9 +2526,14 @@
                 ],
                 "collocations": [
                     "Schreckliche Nachrichten erreichen mich aus England. — Ужасные известия доходят до меня из Англии."
+                ],
+                "sentenceParts": [
+                    "Unter farblosen Wandteppichen schreitet Cordelia rastlos auf und ab.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Nachricht“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Angst",
                 "translation": "страх",
                 "transcription": "[ди АНГСТ]",
@@ -2097,9 +2555,14 @@
                 "collocations": [
                     "Im Thronsaal verstummen die Gespräche über die Angst nie. — В тронном зале постоянно звучит слово «страх».",
                     "Die Angst um meinen Vater wächst täglich. — Страх за отца растёт с каждым днём."
+                ],
+                "sentenceParts": [
+                    "An der schmalen Fensterluke zählt Cordelia die Fackeln auf dem Hof.",
+                    "Ich halte das Wort „die Angst“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "leiden",
                 "translation": "страдать",
                 "transcription": "[ЛАЙ-ден]",
@@ -2124,9 +2587,14 @@
                     "Er muss furchtbar leiden ohne mich. — Он должно быть ужасно страдает без меня.",
                     "Ich leide furchtbare Qualen. — Я страдаю от ужасных мук.",
                     "Zum ersten Mal leide ich selbst. — Впервые я сам страдаю."
+                ],
+                "sentenceParts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Cordelia nach frischen Botschaften.",
+                    "Das Echo des Wortes „leiden“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "beschützen",
                 "translation": "защищать",
                 "transcription": "[бе-ШЮ-цен]",
@@ -2151,9 +2619,14 @@
                     "Die Unschuldigen will ich beschützen. — Невинных я хочу защитить.",
                     "Heimlich beschütze ich den wahnsinnigen König. — Тайно я защищаю безумного короля.",
                     "Ich kann ihn aus der Ferne nicht beschützen. — Я не могу защитить его издалека."
+                ],
+                "sentenceParts": [
+                    "Im stillen Kapellenraum kniet Cordelia vor der kalten Steinfigur.",
+                    "Ich atme tief ein und lasse nur das Wort „beschützen“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Sehnsucht",
                 "translation": "тоска",
                 "transcription": "[ди ЗЕН-зухт]",
@@ -2175,9 +2648,14 @@
                 ],
                 "collocations": [
                     "Die Sehnsucht nach Versöhnung erfüllt mein Herz. — Тоска по примирению наполняет моё сердце."
+                ],
+                "sentenceParts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Cordelia die Laterne fest.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Sehnsucht“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "beten",
                 "translation": "молиться",
                 "transcription": "[БЕ-тен]",
@@ -2199,6 +2677,10 @@
                 ],
                 "collocations": [
                     "Jeden Tag bete ich für seine Sicherheit. — Каждый день я молюсь за его безопасность."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der hohen Burgmauern schreibt Cordelia eine fiebrige Antwort.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „beten“ mein Nordstern."
                 ]
             }
         ],
@@ -2206,29 +2688,29 @@
             {
                 "question": "Что означает немецкое слово «die Sorge»?",
                 "choices": [
-                    "страх",
                     "забота",
+                    "одиночество",
                     "известие",
-                    "одиночество"
+                    "страх"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
-                    "страх",
-                    "одиночество",
                     "известие",
-                    "забота"
+                    "забота",
+                    "одиночество",
+                    "страх"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Nachricht»?",
                 "choices": [
                     "известие",
-                    "защищать",
-                    "забота",
+                    "одиночество",
+                    "молиться",
                     "страдать"
                 ],
                 "correctIndex": 0
@@ -2236,39 +2718,39 @@
             {
                 "question": "Что означает немецкое слово «die Angst»?",
                 "choices": [
-                    "молиться",
-                    "тоска",
+                    "известие",
+                    "защищать",
                     "страх",
-                    "страдать"
+                    "молиться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
+                    "страх",
+                    "забота",
                     "известие",
-                    "страдать",
-                    "тоска",
-                    "молиться"
+                    "страдать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
-                    "забота",
+                    "молиться",
+                    "тоска",
                     "защищать",
-                    "страх",
                     "одиночество"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Sehnsucht»?",
                 "choices": [
-                    "страдать",
-                    "тоска",
                     "забота",
+                    "тоска",
+                    "одиночество",
                     "страх"
                 ],
                 "correctIndex": 1
@@ -2276,21 +2758,104 @@
             {
                 "question": "Что означает немецкое слово «beten»?",
                 "choices": [
-                    "защищать",
-                    "одиночество",
+                    "забота",
                     "страх",
-                    "молиться"
+                    "молиться",
+                    "одиночество"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Sorge",
+                "translation": "забота",
+                "parts": [
+                    "Im zugigen Seitenflügel lauscht Cordelia dem Heulen der Küstenwinde.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Sorge“ bleibt lebendig."
+                ],
+                "sentence": "Im zugigen Seitenflügel lauscht Cordelia dem Heulen der Küstenwinde. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Sorge“ bleibt lebendig.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Корделия слушает вой прибрежного ветра. Каждой клеткой тела я обещаю: слово «забота» останется живым."
+            },
+            {
+                "word": "die Einsamkeit",
+                "translation": "одиночество",
+                "parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Cordelia einen zerknitterten Brief.",
+                    "Mein Atem zeichnet das Wort „die Einsamkeit“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Cordelia einen zerknitterten Brief. Mein Atem zeichnet das Wort „die Einsamkeit“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед дымным камином замка Корделия складывает измятый лист. Моё дыхание рисует слово «одиночество» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Nachricht",
+                "translation": "известие",
+                "parts": [
+                    "Unter farblosen Wandteppichen schreitet Cordelia rastlos auf und ab.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Nachricht“ gehört mir."
+                ],
+                "sentence": "Unter farblosen Wandteppichen schreitet Cordelia rastlos auf und ab. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Nachricht“ gehört mir.",
+                "sentenceTranslation": "Под выцветшими гобеленами Корделия беспокойно меряет шагами зал. Буря за окнами усиливает клятву: слово «известие» принадлежит мне."
+            },
+            {
+                "word": "die Angst",
+                "translation": "страх",
+                "parts": [
+                    "An der schmalen Fensterluke zählt Cordelia die Fackeln auf dem Hof.",
+                    "Ich halte das Wort „die Angst“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "An der schmalen Fensterluke zählt Cordelia die Fackeln auf dem Hof. Ich halte das Wort „die Angst“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У узкой бойницы Корделия считает факелы на дворе. Я держу слово «страх» как факел у сердца."
+            },
+            {
+                "word": "leiden",
+                "translation": "страдать",
+                "parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Cordelia nach frischen Botschaften.",
+                    "Das Echo des Wortes „leiden“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Cordelia nach frischen Botschaften. Das Echo des Wortes „leiden“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Корделия ищет свежие вести. Эхо слова «страдать» заглушает шёпот придворных."
+            },
+            {
+                "word": "beschützen",
+                "translation": "защищать",
+                "parts": [
+                    "Im stillen Kapellenraum kniet Cordelia vor der kalten Steinfigur.",
+                    "Ich atme tief ein und lasse nur das Wort „beschützen“ wieder hinaus."
+                ],
+                "sentence": "Im stillen Kapellenraum kniet Cordelia vor der kalten Steinfigur. Ich atme tief ein und lasse nur das Wort „beschützen“ wieder hinaus.",
+                "sentenceTranslation": "В тихой капелле Корделия преклоняет колени перед холодной каменной фигурой. Я глубоко вдыхаю и выпускаю только слово «защищать»."
+            },
+            {
+                "word": "die Sehnsucht",
+                "translation": "тоска",
+                "parts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Cordelia die Laterne fest.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Sehnsucht“ gehört mir."
+                ],
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Cordelia die Laterne fest. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Sehnsucht“ gehört mir.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Корделия крепко держит фонарь. Буря за окнами усиливает клятву: слово «тоска» принадлежит мне."
+            },
+            {
+                "word": "beten",
+                "translation": "молиться",
+                "parts": [
+                    "Im Schatten der hohen Burgmauern schreibt Cordelia eine fiebrige Antwort.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „beten“ mein Nordstern."
+                ],
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Cordelia eine fiebrige Antwort. Selbst wenn die Welt zerfällt, bleibt das Wort „beten“ mein Nordstern.",
+                "sentenceTranslation": "В тени высоких стен Корделия пишет лихорадочный ответ. Даже если мир распадается, слово «молиться» остаётся моим северным светом."
+            }
+        ]
     },
     "storm": {
         "title": "Возвращение",
         "description": "Акт IV: Возвращение с армией",
         "words": [
             {
+                "wordId": "",
                 "word": "zurückkehren",
                 "translation": "возвращаться",
                 "transcription": "[цу-РЮК-ке-рен]",
@@ -2314,9 +2879,14 @@
                     "Cordelia zeigt, dass das Zurückkehren auch ohne Stolz möglich ist. — Корделия показывает, что возвращаться можно и без гордыни.",
                     "Mit einer Armee kehre ich zurück, meinen Vater zu retten. — С армией я возвращаюсь спасти моего отца.",
                     "Ich schwöre, verkleidet zurückzukehren. — Я клянусь вернуться переодетым."
+                ],
+                "sentenceParts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Cordelia gegen den Wind.",
+                    "Das kalte Licht lässt das Wort „zurückkehren“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Kampf",
                 "translation": "борьба",
                 "transcription": "[дер КАМПФ]",
@@ -2340,9 +2910,14 @@
                     "Der Kampf für das Recht beginnt jetzt. — Борьба за право начинается сейчас.",
                     "Der Kampf gegen meinen Bruder ist unvermeidlich. — Бой с моим братом неизбежен.",
                     "Dieser Kampf ist für die Ehre meines Vaters. — Эта борьба за честь моего отца."
+                ],
+                "sentenceParts": [
+                    "Unter einem zerrissenen Banner schützt Cordelia die Augen vor den Blitzen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Kampf“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "retten",
                 "translation": "спасать",
                 "transcription": "[РЕ-тен]",
@@ -2364,9 +2939,14 @@
                     "Der Narr spürt, wie das Retten alle verändert. — Шут чувствует, как умение спасать меняет всех.",
                     "Mit List will ich meinen Vater retten. — Хитростью я хочу спасти отца.",
                     "Ich muss meinen Vater vor seinen grausamen Töchtern retten. — Я должна спасти отца от его жестоких дочерей."
+                ],
+                "sentenceParts": [
+                    "Am Rand eines umgestürzten Baumes sucht Cordelia Deckung vor dem Donner.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „retten“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Schlacht",
                 "translation": "битва",
                 "transcription": "[ди ШЛАХТ]",
@@ -2387,9 +2967,14 @@
                 "collocations": [
                     "Cordelia merkt sich genau, wie die Schlacht verteilt wird. — Корделия внимательно следит, кому достанется «битва».",
                     "Diese Schlacht entscheidet über das Schicksal des Königreichs. — Эта битва решает судьбу королевства."
+                ],
+                "sentenceParts": [
+                    "Zwischen schäumenden Wassergräben stolpert Cordelia durch den Schlamm.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Schlacht“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "mutig",
                 "translation": "храбрый",
                 "transcription": "[МУ-тиг]",
@@ -2411,9 +2996,14 @@
                 ],
                 "collocations": [
                     "Sei mutig, mein Herz, für die gerechte Sache. — Будь храбрым, моё сердце, ради правого дела."
+                ],
+                "sentenceParts": [
+                    "Vor einem zuckenden Himmel hebt Cordelia die Arme trotzig an.",
+                    "Ich atme tief ein und lasse nur das Wort „mutig“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Gerechtigkeit",
                 "translation": "справедливость",
                 "transcription": "[ди ге-РЕХ-тиг-кайт]",
@@ -2436,9 +3026,14 @@
                     "Für Gerechtigkeit will ich kämpfen. — За справедливость я хочу бороться.",
                     "Die Gerechtigkeit fordert diesen Kampf. — Справедливость требует этого боя.",
                     "Die Gerechtigkeit führt meine Klinge. — Справедливость ведёт мой клинок."
+                ],
+                "sentenceParts": [
+                    "Unter dem durchtränkten Umhang presst Cordelia den Atem gegen die Kälte.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Gerechtigkeit“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "siegen",
                 "translation": "побеждать",
                 "transcription": "[ЗИ-ген]",
@@ -2460,9 +3055,14 @@
                     "Der Narr spürt, wie das Siegen alle verändert. — Шут чувствует, как умение побеждать меняет всех.",
                     "Die Wahrheit wird über die Lüge siegen. — Правда победит ложь.",
                     "Die Liebe wird über den Hass siegen. — Любовь победит ненависть."
+                ],
+                "sentenceParts": [
+                    "Am kläglichen Feuerrest wärmt Cordelia zitternde Finger.",
+                    "Wie ein stilles Gebet legt sich das Wort „siegen“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Armee",
                 "translation": "армия",
                 "transcription": "[ди ар-МЭ]",
@@ -2484,6 +3084,10 @@
                 ],
                 "collocations": [
                     "Diese Armee kämpft für Gerechtigkeit und Liebe. — Эта армия сражается за справедливость и любовь."
+                ],
+                "sentenceParts": [
+                    "Zwischen heulenden Hunden ruft Cordelia gegen den tosenden Sturm an.",
+                    "Ich zeichne das Wort „die Armee“ in Gedanken über die Linien des Schicksals."
                 ]
             }
         ],
@@ -2492,17 +3096,17 @@
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
                     "спасать",
+                    "битва",
                     "возвращаться",
-                    "борьба",
-                    "битва"
+                    "борьба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "возвращаться",
                     "спасать",
+                    "возвращаться",
                     "битва",
                     "борьба"
                 ],
@@ -2511,71 +3115,154 @@
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
-                    "битва",
                     "спасать",
-                    "борьба",
-                    "побеждать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Schlacht»?",
-                "choices": [
-                    "возвращаться",
-                    "спасать",
-                    "справедливость",
-                    "битва"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «mutig»?",
-                "choices": [
-                    "храбрый",
                     "побеждать",
-                    "битва",
-                    "справедливость"
+                    "армия",
+                    "борьба"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Gerechtigkeit»?",
+                "question": "Что означает немецкое слово «die Schlacht»?",
                 "choices": [
-                    "храбрый",
-                    "справедливость",
+                    "побеждать",
                     "битва",
+                    "храбрый",
                     "борьба"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «siegen»?",
+                "question": "Что означает немецкое слово «mutig»?",
                 "choices": [
-                    "побеждать",
                     "храбрый",
+                    "армия",
                     "возвращаться",
                     "спасать"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Gerechtigkeit»?",
+                "choices": [
+                    "армия",
+                    "возвращаться",
+                    "справедливость",
+                    "борьба"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «siegen»?",
+                "choices": [
+                    "армия",
+                    "побеждать",
+                    "храбрый",
+                    "битва"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Armee»?",
                 "choices": [
-                    "храбрый",
-                    "справедливость",
-                    "побеждать",
-                    "армия"
+                    "возвращаться",
+                    "битва",
+                    "армия",
+                    "справедливость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "zurückkehren",
+                "translation": "возвращаться",
+                "parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Cordelia gegen den Wind.",
+                    "Das kalte Licht lässt das Wort „zurückkehren“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Cordelia gegen den Wind. Das kalte Licht lässt das Wort „zurückkehren“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Корделия упирается в ветер. Холодный свет заставляет слово «возвращаться» сиять словно расплавленное золото."
+            },
+            {
+                "word": "der Kampf",
+                "translation": "борьба",
+                "parts": [
+                    "Unter einem zerrissenen Banner schützt Cordelia die Augen vor den Blitzen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Kampf“ darf nicht vergehen."
+                ],
+                "sentence": "Unter einem zerrissenen Banner schützt Cordelia die Augen vor den Blitzen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Kampf“ darf nicht vergehen.",
+                "sentenceTranslation": "Под разорванным знаменем Корделия прикрывает глаза от молний. Я шепчу стражам судьбы: слово «борьба» не должно исчезнуть."
+            },
+            {
+                "word": "retten",
+                "translation": "спасать",
+                "parts": [
+                    "Am Rand eines umgestürzten Baumes sucht Cordelia Deckung vor dem Donner.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „retten“ darf nicht vergehen."
+                ],
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Cordelia Deckung vor dem Donner. Ich flüstere den Wächtern des Schicksals zu: Das Wort „retten“ darf nicht vergehen.",
+                "sentenceTranslation": "У поваленного дерева Корделия ищет укрытия от грома. Я шепчу стражам судьбы: слово «спасать» не должно исчезнуть."
+            },
+            {
+                "word": "die Schlacht",
+                "translation": "битва",
+                "parts": [
+                    "Zwischen schäumenden Wassergräben stolpert Cordelia durch den Schlamm.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Schlacht“ wird heute nicht verraten."
+                ],
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Cordelia durch den Schlamm. Mit fester Stimme schwöre ich mir: Das Wort „die Schlacht“ wird heute nicht verraten.",
+                "sentenceTranslation": "Между пенящимися лужами Корделия пробирается через грязь. Твёрдым голосом я клянусь себе: слово «битва» сегодня не будет предано."
+            },
+            {
+                "word": "mutig",
+                "translation": "храбрый",
+                "parts": [
+                    "Vor einem zuckenden Himmel hebt Cordelia die Arme trotzig an.",
+                    "Ich atme tief ein und lasse nur das Wort „mutig“ wieder hinaus."
+                ],
+                "sentence": "Vor einem zuckenden Himmel hebt Cordelia die Arme trotzig an. Ich atme tief ein und lasse nur das Wort „mutig“ wieder hinaus.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Корделия упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «храбрый»."
+            },
+            {
+                "word": "die Gerechtigkeit",
+                "translation": "справедливость",
+                "parts": [
+                    "Unter dem durchtränkten Umhang presst Cordelia den Atem gegen die Kälte.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Gerechtigkeit“ mein Nordstern."
+                ],
+                "sentence": "Unter dem durchtränkten Umhang presst Cordelia den Atem gegen die Kälte. Selbst wenn die Welt zerfällt, bleibt das Wort „die Gerechtigkeit“ mein Nordstern.",
+                "sentenceTranslation": "Под промокшим плащом Корделия прижимает дыхание к груди, спасаясь от холода. Даже если мир распадается, слово «справедливость» остаётся моим северным светом."
+            },
+            {
+                "word": "siegen",
+                "translation": "побеждать",
+                "parts": [
+                    "Am kläglichen Feuerrest wärmt Cordelia zitternde Finger.",
+                    "Wie ein stilles Gebet legt sich das Wort „siegen“ auf meine Lippen."
+                ],
+                "sentence": "Am kläglichen Feuerrest wärmt Cordelia zitternde Finger. Wie ein stilles Gebet legt sich das Wort „siegen“ auf meine Lippen.",
+                "sentenceTranslation": "У жалких огненных углей Корделия греет дрожащие пальцы. Как тихая молитва слово «побеждать» ложится на мои губы."
+            },
+            {
+                "word": "die Armee",
+                "translation": "армия",
+                "parts": [
+                    "Zwischen heulenden Hunden ruft Cordelia gegen den tosenden Sturm an.",
+                    "Ich zeichne das Wort „die Armee“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Zwischen heulenden Hunden ruft Cordelia gegen den tosenden Sturm an. Ich zeichne das Wort „die Armee“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Среди воющих псов Корделия перекрикивает беснующуюся бурю. Я черчу слово «армия» в мыслях поверх линий судьбы."
+            }
+        ]
     },
     "hut": {
         "title": "Встреча",
         "description": "Акт IV: Встреча с отцом",
         "words": [
             {
+                "wordId": "",
                 "word": "verzeihen",
                 "translation": "прощать",
                 "transcription": "[фер-ЦАЙ-ен]",
@@ -2598,9 +3285,14 @@
                     "Cordelia zeigt, dass das Verzeihen auch ohne Stolz möglich ist. — Корделия показывает, что прощать можно и без гордыни.",
                     "Verzeih mir, ich bin nur ein törichter alter Mann. — Прости меня, я всего лишь глупый старик.",
                     "Ich verzeihe dir alles, mein lieber Vater. — Я прощаю тебе всё, мой дорогой отец."
+                ],
+                "sentenceParts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Cordelia bei der flackernden Kerze.",
+                    "Wie ein stilles Gebet legt sich das Wort „verzeihen“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Tränen",
                 "translation": "слёзы",
                 "transcription": "[ди ТРЕ-нен]",
@@ -2622,9 +3314,14 @@
                 ],
                 "collocations": [
                     "Unsere Tränen waschen den Schmerz fort. — Наши слёзы смывают боль."
+                ],
+                "sentenceParts": [
+                    "Zwischen zerbeulten Rüstungen streicht Cordelia über ein altes Wappen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Tränen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "umarmen",
                 "translation": "обнимать",
                 "transcription": "[ум-АР-мен]",
@@ -2650,9 +3347,14 @@
                 "collocations": [
                     "Lass mich dich umarmen und deine Tränen trocknen. — Позволь мне обнять тебя и вытереть твои слёзы.",
                     "Ein letztes Mal umarme ich meinen Sohn. — В последний раз я обнимаю сына."
+                ],
+                "sentenceParts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Cordelia fast den Kopf.",
+                    "Ich presse das Wort „umarmen“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erkennen",
                 "translation": "узнавать",
                 "transcription": "[ер-КЕН-нен]",
@@ -2679,9 +3381,14 @@
                     "Erkennst du mich, dein Kind Cordelia? — Узнаёшь ли ты меня, твоё дитя Корделия?",
                     "Endlich erkenne ich meinen treuen Edgar. — Наконец я узнаю моего верного Эдгара.",
                     "Ich erkenne die Wahrheit hinter dem Schein. — Я познаю правду за видимостью."
+                ],
+                "sentenceParts": [
+                    "Neben der schlafenden Wache flüstert Cordelia in die schwere Nacht.",
+                    "Ich zeichne das Wort „erkennen“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "heilen",
                 "translation": "исцелять",
                 "transcription": "[ХАЙ-лен]",
@@ -2703,9 +3410,14 @@
                 ],
                 "collocations": [
                     "Meine Liebe wird deine Wunden heilen. — Моя любовь исцелит твои раны."
+                ],
+                "sentenceParts": [
+                    "Vor dem einfachen Feldbett betrachtet Cordelia die Narben vergangener Schlachten.",
+                    "Ich umarme das Wort „heilen“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Reue",
                 "translation": "раскаяние",
                 "transcription": "[ди РОЙ-е]",
@@ -2728,9 +3440,14 @@
                     "Die Reue brennt heißer als alle Feuer der Hölle. — Раскаяние жжёт горячее всех адских огней.",
                     "Deine Reue ist nicht nötig, nur deine Liebe. — Твоё раскаяние не нужно, только твоя любовь.",
                     "Die Reue überwältigt meine Seele. — Раскаяние переполняет мою душу."
+                ],
+                "sentenceParts": [
+                    "Im Geruch von feuchtem Stroh legt Cordelia den Mantel zur Seite.",
+                    "Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "sanft",
                 "translation": "нежный",
                 "transcription": "[ЗАНФТ]",
@@ -2752,9 +3469,14 @@
                 ],
                 "collocations": [
                     "Sei sanft zu dir selbst, lieber Vater. — Будь нежен к себе, дорогой отец."
+                ],
+                "sentenceParts": [
+                    "Auf dem wackligen Holztisch ordnet Cordelia zerlesene Briefe.",
+                    "Ich zeichne das Wort „sanft“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Vergebung",
                 "translation": "прощение",
                 "transcription": "[ди фер-ГЕ-бунг]",
@@ -2776,6 +3498,10 @@
                 ],
                 "collocations": [
                     "Die Vergebung ist der Schlüssel zum Frieden. — Прощение - ключ к покою."
+                ],
+                "sentenceParts": [
+                    "Am Eingang der Hütte späht Cordelia nach einem vertrauten Schatten.",
+                    "Ich zeichne das Wort „die Vergebung“ in Gedanken über die Linien des Schicksals."
                 ]
             }
         ],
@@ -2783,69 +3509,69 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "прощать",
-                    "обнимать",
                     "слёзы",
-                    "узнавать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Tränen»?",
-                "choices": [
                     "прощать",
                     "узнавать",
-                    "слёзы",
-                    "обнимать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «umarmen»?",
-                "choices": [
-                    "обнимать",
-                    "узнавать",
-                    "исцелять",
-                    "раскаяние"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «erkennen»?",
-                "choices": [
-                    "прощение",
-                    "узнавать",
-                    "раскаяние",
                     "обнимать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «heilen»?",
+                "question": "Что означает немецкое слово «die Tränen»?",
+                "choices": [
+                    "узнавать",
+                    "прощать",
+                    "обнимать",
+                    "слёзы"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
                     "раскаяние",
+                    "обнимать",
                     "слёзы",
-                    "исцелять",
-                    "прощение"
+                    "исцелять"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «erkennen»?",
+                "choices": [
+                    "раскаяние",
+                    "обнимать",
+                    "узнавать",
+                    "слёзы"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «heilen»?",
+                "choices": [
+                    "узнавать",
+                    "исцелять",
+                    "слёзы",
+                    "обнимать"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "раскаяние",
-                    "исцелять",
-                    "нежный",
-                    "узнавать"
+                    "прощение",
+                    "прощать",
+                    "узнавать",
+                    "раскаяние"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sanft»?",
                 "choices": [
-                    "обнимать",
-                    "прощать",
                     "узнавать",
+                    "прощение",
+                    "прощать",
                     "нежный"
                 ],
                 "correctIndex": 3
@@ -2853,21 +3579,104 @@
             {
                 "question": "Что означает немецкое слово «die Vergebung»?",
                 "choices": [
-                    "слёзы",
                     "обнимать",
-                    "прощать",
+                    "исцелять",
+                    "раскаяние",
                     "прощение"
                 ],
                 "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "verzeihen",
+                "translation": "прощать",
+                "parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Cordelia bei der flackernden Kerze.",
+                    "Wie ein stilles Gebet legt sich das Wort „verzeihen“ auf meine Lippen."
+                ],
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Cordelia bei der flackernden Kerze. Wie ein stilles Gebet legt sich das Wort „verzeihen“ auf meine Lippen.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Корделия сидит у мерцающей свечи. Как тихая молитва слово «прощать» ложится на мои губы."
+            },
+            {
+                "word": "die Tränen",
+                "translation": "слёзы",
+                "parts": [
+                    "Zwischen zerbeulten Rüstungen streicht Cordelia über ein altes Wappen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Tränen“ gehört mir."
+                ],
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Cordelia über ein altes Wappen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Tränen“ gehört mir.",
+                "sentenceTranslation": "Среди помятых доспехов Корделия гладит старый герб. Буря за окнами усиливает клятву: слово «слёзы» принадлежит мне."
+            },
+            {
+                "word": "umarmen",
+                "translation": "обнимать",
+                "parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Cordelia fast den Kopf.",
+                    "Ich presse das Wort „umarmen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Cordelia fast den Kopf. Ich presse das Wort „umarmen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "О низкую балку хижины Корделия едва не ударяется головой. Я стискиваю слово «обнимать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "erkennen",
+                "translation": "узнавать",
+                "parts": [
+                    "Neben der schlafenden Wache flüstert Cordelia in die schwere Nacht.",
+                    "Ich zeichne das Wort „erkennen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Neben der schlafenden Wache flüstert Cordelia in die schwere Nacht. Ich zeichne das Wort „erkennen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Рядом со спящим стражем Корделия шепчет в тяжёлую ночь. Я вывожу слово «узнавать» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "heilen",
+                "translation": "исцелять",
+                "parts": [
+                    "Vor dem einfachen Feldbett betrachtet Cordelia die Narben vergangener Schlachten.",
+                    "Ich umarme das Wort „heilen“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Vor dem einfachen Feldbett betrachtet Cordelia die Narben vergangener Schlachten. Ich umarme das Wort „heilen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Перед грубой походной койкой Корделия разглядывает шрамы прошлых битв. Я обнимаю слово «исцелять», будто это единственный союзник."
+            },
+            {
+                "word": "die Reue",
+                "translation": "раскаяние",
+                "parts": [
+                    "Im Geruch von feuchtem Stroh legt Cordelia den Mantel zur Seite.",
+                    "Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Im Geruch von feuchtem Stroh legt Cordelia den Mantel zur Seite. Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В запахе влажной соломы Корделия откладывает плащ в сторону. Я черчу слово «раскаяние» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "sanft",
+                "translation": "нежный",
+                "parts": [
+                    "Auf dem wackligen Holztisch ordnet Cordelia zerlesene Briefe.",
+                    "Ich zeichne das Wort „sanft“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Auf dem wackligen Holztisch ordnet Cordelia zerlesene Briefe. Ich zeichne das Wort „sanft“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На шатком деревянном столе Корделия раскладывает зачитанные письма. Я черчу слово «нежный» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "die Vergebung",
+                "translation": "прощение",
+                "parts": [
+                    "Am Eingang der Hütte späht Cordelia nach einem vertrauten Schatten.",
+                    "Ich zeichne das Wort „die Vergebung“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Am Eingang der Hütte späht Cordelia nach einem vertrauten Schatten. Ich zeichne das Wort „die Vergebung“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У входа в хижину Корделия высматривает знакомую тень. Я черчу слово «прощение» в мыслях поверх линий судьбы."
+            }
+        ]
     },
     "dover": {
         "title": "Плен",
         "description": "Акт V: Захват в плен",
         "words": [
             {
+                "wordId": "",
                 "word": "gefangen",
                 "translation": "пленный",
                 "transcription": "[ге-ФАН-ген]",
@@ -2889,9 +3698,14 @@
                 ],
                 "collocations": [
                     "Obwohl gefangen, bin ich frei in meinem Herzen. — Хотя я в плену, в сердце я свободна."
+                ],
+                "sentenceParts": [
+                    "Auf den weißen Klippen von Dover blickt Cordelia in den aufgewühlten Kanal.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „gefangen“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Gefängnis",
                 "translation": "тюрьма",
                 "transcription": "[дас ге-ФЭНГ-нис]",
@@ -2912,9 +3726,14 @@
                 "collocations": [
                     "Der Narr spottet, sobald das Gefängnis erwähnt wird. — Шут насмехается, едва кто-то произносит «тюрьма».",
                     "Dieses Gefängnis kann meine Liebe nicht einsperren. — Эта тюрьма не может запереть мою любовь."
+                ],
+                "sentenceParts": [
+                    "Zwischen flatternden Feldzeichen richtet Cordelia den Helm.",
+                    "Ich umarme das Wort „das Gefängnis“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Würde",
                 "translation": "достоинство",
                 "transcription": "[ди ВЮР-де]",
@@ -2935,9 +3754,14 @@
                 "collocations": [
                     "Lears Herz wird schwer, wenn die Würde zur Sprache kommt. — Сердце Лира тяжелеет: «достоинство» звучит слишком близко.",
                     "Mit Würde trage ich mein Schicksal. — С достоинством я несу свою судьбу."
+                ],
+                "sentenceParts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Cordelia Marschrouten in den Sand.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Würde“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "trösten",
                 "translation": "утешать",
                 "transcription": "[ТРЁС-тен]",
@@ -2960,9 +3784,14 @@
                     "Als Fremder tröste ich meinen eigenen Vater. — Как чужой, я утешаю собственного отца.",
                     "Lass mich dich trösten in dieser dunklen Stunde. — Позволь мне утешить тебя в этот тёмный час.",
                     "Mit Worten tröste ich den wahnsinnigen König. — Словами я утешаю безумного короля."
+                ],
+                "sentenceParts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Cordelia das Siegel.",
+                    "Ich halte das Wort „trösten“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "tapfer",
                 "translation": "отважный",
                 "transcription": "[ТАП-фер]",
@@ -2984,9 +3813,14 @@
                 ],
                 "collocations": [
                     "Ich bleibe tapfer für dich, Vater. — Я остаюсь отважной ради тебя, отец."
+                ],
+                "sentenceParts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Cordelia dem dumpfen Meer.",
+                    "Ich umarme das Wort „tapfer“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Demut",
                 "translation": "смирение",
                 "transcription": "[ди ДЕ-мут]",
@@ -3008,9 +3842,14 @@
                 ],
                 "collocations": [
                     "In der Demut finden wir wahre Größe. — В смирении мы находим истинное величие."
+                ],
+                "sentenceParts": [
+                    "Auf dem sandigen Trainingsplatz übt Cordelia das Ziehen des Schwerts.",
+                    "Das kalte Licht lässt das Wort „die Demut“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Schicksal",
                 "translation": "судьба",
                 "transcription": "[дас ШИК-заль]",
@@ -3032,9 +3871,15 @@
                     "Der Narr spottet, sobald das Schicksal erwähnt wird. — Шут насмехается, едва кто-то произносит «судьба».",
                     "Unser Schicksal ist miteinander verwoben. — Наши судьбы переплетены.",
                     "Das Schicksal macht Narren aus uns allen. — Судьба делает дураков из всех нас."
+                ],
+                "sentenceParts": [
+                    "Zwischen pochenden Trommeln hebt Cordelia das Banner der Hoffnung.",
+                    "Ich presse das Wort „das Schicksal“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Ehre",
                 "translation": "честь",
                 "transcription": "[ди Э-ре]",
@@ -3057,6 +3902,10 @@
                     "Die Ehre der Familie liegt in meinen Händen. — Честь семьи в моих руках.",
                     "Unsere Ehre bleibt unbefleckt. — Наша честь остаётся незапятнанной.",
                     "Meine Ehre ist mein höchstes Gut. — Моя честь - моё высшее благо."
+                ],
+                "sentenceParts": [
+                    "Am Morgennebel der Küste legt Cordelia die Hand auf das pochende Herz.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Ehre“ mein Nordstern."
                 ]
             }
         ],
@@ -3064,69 +3913,69 @@
             {
                 "question": "Что означает немецкое слово «gefangen»?",
                 "choices": [
-                    "тюрьма",
                     "утешать",
-                    "достоинство",
-                    "пленный"
+                    "пленный",
+                    "тюрьма",
+                    "достоинство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Gefängnis»?",
                 "choices": [
-                    "пленный",
-                    "утешать",
+                    "тюрьма",
                     "достоинство",
-                    "тюрьма"
+                    "пленный",
+                    "утешать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Würde»?",
                 "choices": [
-                    "честь",
-                    "отважный",
                     "достоинство",
-                    "смирение"
+                    "пленный",
+                    "честь",
+                    "судьба"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "пленный",
-                    "тюрьма",
+                    "честь",
+                    "достоинство",
                     "утешать",
-                    "судьба"
+                    "тюрьма"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «tapfer»?",
                 "choices": [
+                    "судьба",
+                    "смирение",
                     "честь",
-                    "отважный",
-                    "утешать",
-                    "смирение"
+                    "отважный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Demut»?",
                 "choices": [
-                    "смирение",
-                    "достоинство",
                     "пленный",
-                    "отважный"
+                    "утешать",
+                    "достоинство",
+                    "смирение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
                     "судьба",
                     "честь",
-                    "отважный",
+                    "тюрьма",
                     "смирение"
                 ],
                 "correctIndex": 0
@@ -3134,21 +3983,105 @@
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "честь",
-                    "отважный",
-                    "смирение",
-                    "утешать"
+                    "пленный",
+                    "достоинство",
+                    "утешать",
+                    "честь"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "gefangen",
+                "translation": "пленный",
+                "parts": [
+                    "Auf den weißen Klippen von Dover blickt Cordelia in den aufgewühlten Kanal.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „gefangen“ mein Nordstern."
+                ],
+                "sentence": "Auf den weißen Klippen von Dover blickt Cordelia in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „gefangen“ mein Nordstern.",
+                "sentenceTranslation": "На белых скалах Дувра Корделия смотрит в вздыбленный пролив. Даже если мир распадается, слово «пленный» остаётся моим северным светом."
+            },
+            {
+                "word": "das Gefängnis",
+                "translation": "тюрьма",
+                "parts": [
+                    "Zwischen flatternden Feldzeichen richtet Cordelia den Helm.",
+                    "Ich umarme das Wort „das Gefängnis“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Zwischen flatternden Feldzeichen richtet Cordelia den Helm. Ich umarme das Wort „das Gefängnis“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Среди хлопающих штандартов Корделия поправляет шлем. Я обнимаю слово «тюрьма», будто это единственный союзник."
+            },
+            {
+                "word": "die Würde",
+                "translation": "достоинство",
+                "parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Cordelia Marschrouten in den Sand.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Würde“ mein Nordstern."
+                ],
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Cordelia Marschrouten in den Sand. Selbst wenn die Welt zerfällt, bleibt das Wort „die Würde“ mein Nordstern.",
+                "sentenceTranslation": "У французского костра Корделия рисует в песке путь марша. Даже если мир распадается, слово «достоинство» остаётся моим северным светом."
+            },
+            {
+                "word": "trösten",
+                "translation": "утешать",
+                "parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Cordelia das Siegel.",
+                    "Ich halte das Wort „trösten“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Cordelia das Siegel. Ich halte das Wort „trösten“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Корделия проверяет печати. Я держу слово «утешать» как факел у сердца."
+            },
+            {
+                "word": "tapfer",
+                "translation": "отважный",
+                "parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Cordelia dem dumpfen Meer.",
+                    "Ich umarme das Wort „tapfer“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Cordelia dem dumpfen Meer. Ich umarme das Wort „tapfer“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Корделия слушает глухой шум моря. Я обнимаю слово «отважный», будто это единственный союзник."
+            },
+            {
+                "word": "die Demut",
+                "translation": "смирение",
+                "parts": [
+                    "Auf dem sandigen Trainingsplatz übt Cordelia das Ziehen des Schwerts.",
+                    "Das kalte Licht lässt das Wort „die Demut“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Auf dem sandigen Trainingsplatz übt Cordelia das Ziehen des Schwerts. Das kalte Licht lässt das Wort „die Demut“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На песчаном плацу Корделия отрабатывает выхват меча. Холодный свет заставляет слово «смирение» сиять словно расплавленное золото."
+            },
+            {
+                "word": "das Schicksal",
+                "translation": "судьба",
+                "parts": [
+                    "Zwischen pochenden Trommeln hebt Cordelia das Banner der Hoffnung.",
+                    "Ich presse das Wort „das Schicksal“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Zwischen pochenden Trommeln hebt Cordelia das Banner der Hoffnung. Ich presse das Wort „das Schicksal“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под гул барабанов Корделия поднимает знамя надежды. Я стискиваю слово «судьба» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Ehre",
+                "translation": "честь",
+                "parts": [
+                    "Am Morgennebel der Küste legt Cordelia die Hand auf das pochende Herz.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Ehre“ mein Nordstern."
+                ],
+                "sentence": "Am Morgennebel der Küste legt Cordelia die Hand auf das pochende Herz. Selbst wenn die Welt zerfällt, bleibt das Wort „die Ehre“ mein Nordstern.",
+                "sentenceTranslation": "В утреннем тумане побережья Корделия кладёт ладонь на бьющееся сердце. Даже если мир распадается, слово «честь» остаётся моим северным светом."
+            }
+        ]
     },
     "prison": {
         "title": "Финал",
         "description": "Акт V: Трагический конец",
         "words": [
             {
+                "wordId": "",
                 "word": "der Tod",
                 "translation": "смерть",
                 "transcription": "[дер ТОД]",
@@ -3173,9 +4106,14 @@
                     "Der Tod trennt uns nur für kurze Zeit. — Смерть разлучает нас лишь ненадолго.",
                     "Bis zum Tod bleibe ich an seiner Seite. — До смерти я остаюсь рядом с ним.",
                     "Der Tod kommt für mich zu früh. — Смерть приходит ко мне слишком рано."
+                ],
+                "sentenceParts": [
+                    "Im feuchten Kerker stützt Cordelia sich an den tropfenden Stein.",
+                    "Ich atme tief ein und lasse nur das Wort „der Tod“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "sterben",
                 "translation": "умирать",
                 "transcription": "[ШТЕР-бен]",
@@ -3200,9 +4138,14 @@
                     "Ich sterbe ohne Reue für meine Taten. — Я умираю без раскаяния за свои дела.",
                     "Ich sterbe vor Freude und Kummer. — Я умираю от радости и горя.",
                     "Ich sterbe durch meine eigene Hand. — Я умираю от своей собственной руки."
+                ],
+                "sentenceParts": [
+                    "Unter der trüben Laterne zählt Cordelia die eisernen Ringe der Kette.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „sterben“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Opfer",
                 "translation": "жертва",
                 "transcription": "[дас ОП-фер]",
@@ -3223,9 +4166,14 @@
                 "collocations": [
                     "Für die Höflinge bleibt das Opfer ein ständiges Thema. — Для придворных «жертва» — постоянная тема.",
                     "Ich bin das Opfer der Wahrheit und Liebe. — Я жертва правды и любви."
+                ],
+                "sentenceParts": [
+                    "Neben der schweren Holztür horcht Cordelia auf entferntes Schluchzen.",
+                    "Ich halte das Wort „das Opfer“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Seele",
                 "translation": "душа",
                 "transcription": "[ди ЗЕ-ле]",
@@ -3246,9 +4194,14 @@
                 "collocations": [
                     "Lears Herz wird schwer, wenn die Seele zur Sprache kommt. — Сердце Лира тяжелеет: «душа» звучит слишком близко.",
                     "Meine Seele ist rein vor Gott. — Моя душа чиста перед Богом."
+                ],
+                "sentenceParts": [
+                    "Auf der kalten Steinbank zieht Cordelia den Mantel enger um die Schultern.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Seele“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Ende",
                 "translation": "конец",
                 "transcription": "[дас ЕН-де]",
@@ -3272,9 +4225,14 @@
                     "Das Ende kommt schnell und gerecht. — Конец приходит быстро и справедливо.",
                     "Dies ist nicht das Ende, nur ein Übergang. — Это не конец, только переход.",
                     "Mein Ende kommt durch eines Dieners Hand. — Мой конец приходит от руки слуги."
+                ],
+                "sentenceParts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Cordelia das Gesicht zum Licht.",
+                    "Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ewig",
                 "translation": "вечный",
                 "transcription": "[Э-виг]",
@@ -3303,9 +4261,14 @@
                     "Unsere Liebe wird ewig dauern, mein Kind. — Наша любовь будет вечной, дитя моё.",
                     "Unsere Liebe ist ewig, Vater. — Наша любовь вечна, отец.",
                     "Meine Treue ist ewig, über den Tod hinaus. — Моя верность вечна, за пределами смерти."
+                ],
+                "sentenceParts": [
+                    "Am rostigen Wassereimer spiegelt Cordelia kurz die eigenen Augen.",
+                    "Das Echo des Wortes „ewig“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Abschied",
                 "translation": "прощание",
                 "transcription": "[дер АБ-шид]",
@@ -3338,9 +4301,14 @@
                     "Unser Abschied ist nur vorübergehend. — Наше прощание лишь временно.",
                     "Der Abschied vom Hof schmerzt mich tief. — Прощание с двором глубоко ранит меня.",
                     "Der Abschied von meinem König bricht mein Herz. — Прощание с моим королём разбивает моё сердце."
+                ],
+                "sentenceParts": [
+                    "Im dumpfen Hall der Schritte zählt Cordelia den Rhythmus der Wachen.",
+                    "Das Echo des Wortes „der Abschied“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Erlösung",
                 "translation": "спасение",
                 "transcription": "[ди ер-ЛЁ-зунг]",
@@ -3361,6 +4329,10 @@
                 "collocations": [
                     "Der Narr spottet, sobald die Erlösung erwähnt wird. — Шут насмехается, едва кто-то произносит «спасение».",
                     "Im Tod finde ich Erlösung und Frieden. — В смерти я нахожу спасение и покой."
+                ],
+                "sentenceParts": [
+                    "Vor dem verriegelten Fenster zeichnet Cordelia Kreise in den Staub.",
+                    "Ich halte das Wort „die Erlösung“ wie eine Fackel vor meinem Herzen."
                 ]
             }
         ],
@@ -3369,21 +4341,21 @@
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
                     "умирать",
-                    "жертва",
-                    "душа",
-                    "смерть"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «sterben»?",
-                "choices": [
-                    "умирать",
                     "душа",
                     "смерть",
                     "жертва"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «sterben»?",
+                "choices": [
+                    "душа",
+                    "умирать",
+                    "жертва",
+                    "смерть"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Opfer»?",
@@ -3391,62 +4363,144 @@
                     "вечный",
                     "жертва",
                     "смерть",
-                    "умирать"
+                    "конец"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Seele»?",
                 "choices": [
-                    "спасение",
-                    "вечный",
+                    "конец",
+                    "смерть",
+                    "прощание",
+                    "душа"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «das Ende»?",
+                "choices": [
+                    "прощание",
                     "душа",
+                    "конец",
                     "смерть"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «das Ende»?",
+                "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "вечный",
-                    "душа",
-                    "спасение",
-                    "конец"
+                    "конец",
+                    "прощание",
+                    "смерть",
+                    "вечный"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «ewig»?",
-                "choices": [
-                    "вечный",
-                    "умирать",
-                    "конец",
-                    "жертва"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "умирать",
+                    "конец",
                     "прощание",
-                    "жертва",
-                    "душа"
+                    "умирать",
+                    "жертва"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Erlösung»?",
                 "choices": [
-                    "конец",
-                    "умирать",
                     "спасение",
-                    "жертва"
+                    "смерть",
+                    "душа",
+                    "прощание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Tod",
+                "translation": "смерть",
+                "parts": [
+                    "Im feuchten Kerker stützt Cordelia sich an den tropfenden Stein.",
+                    "Ich atme tief ein und lasse nur das Wort „der Tod“ wieder hinaus."
+                ],
+                "sentence": "Im feuchten Kerker stützt Cordelia sich an den tropfenden Stein. Ich atme tief ein und lasse nur das Wort „der Tod“ wieder hinaus.",
+                "sentenceTranslation": "В сыром подземелье Корделия опирается на сочащийся камень. Я глубоко вдыхаю и выпускаю только слово «смерть»."
+            },
+            {
+                "word": "sterben",
+                "translation": "умирать",
+                "parts": [
+                    "Unter der trüben Laterne zählt Cordelia die eisernen Ringe der Kette.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „sterben“ darf nicht vergehen."
+                ],
+                "sentence": "Unter der trüben Laterne zählt Cordelia die eisernen Ringe der Kette. Ich flüstere den Wächtern des Schicksals zu: Das Wort „sterben“ darf nicht vergehen.",
+                "sentenceTranslation": "Под мутным фонарём Корделия пересчитывает железные кольца цепи. Я шепчу стражам судьбы: слово «умирать» не должно исчезнуть."
+            },
+            {
+                "word": "das Opfer",
+                "translation": "жертва",
+                "parts": [
+                    "Neben der schweren Holztür horcht Cordelia auf entferntes Schluchzen.",
+                    "Ich halte das Wort „das Opfer“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Neben der schweren Holztür horcht Cordelia auf entferntes Schluchzen. Ich halte das Wort „das Opfer“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У тяжёлой двери Корделия прислушивается к далёким рыданиям. Я держу слово «жертва» как факел у сердца."
+            },
+            {
+                "word": "die Seele",
+                "translation": "душа",
+                "parts": [
+                    "Auf der kalten Steinbank zieht Cordelia den Mantel enger um die Schultern.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Seele“ auf meine Lippen."
+                ],
+                "sentence": "Auf der kalten Steinbank zieht Cordelia den Mantel enger um die Schultern. Wie ein stilles Gebet legt sich das Wort „die Seele“ auf meine Lippen.",
+                "sentenceTranslation": "На холодной каменной скамье Корделия плотнее кутается в плащ. Как тихая молитва слово «душа» ложится на мои губы."
+            },
+            {
+                "word": "das Ende",
+                "translation": "конец",
+                "parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Cordelia das Gesicht zum Licht.",
+                    "Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Cordelia das Gesicht zum Licht. Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Между тенями решёток Корделия поднимает лицо к свету. Я держу слово «конец» как факел у сердца."
+            },
+            {
+                "word": "ewig",
+                "translation": "вечный",
+                "parts": [
+                    "Am rostigen Wassereimer spiegelt Cordelia kurz die eigenen Augen.",
+                    "Das Echo des Wortes „ewig“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Am rostigen Wassereimer spiegelt Cordelia kurz die eigenen Augen. Das Echo des Wortes „ewig“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У ржавого ведра с водой Корделия на мгновение видит отражение глаз. Эхо слова «вечный» заглушает шёпот придворных."
+            },
+            {
+                "word": "der Abschied",
+                "translation": "прощание",
+                "parts": [
+                    "Im dumpfen Hall der Schritte zählt Cordelia den Rhythmus der Wachen.",
+                    "Das Echo des Wortes „der Abschied“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Im dumpfen Hall der Schritte zählt Cordelia den Rhythmus der Wachen. Das Echo des Wortes „der Abschied“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В глухом эхе шагов Корделия отсчитывает ритм часовых. Эхо слова «прощание» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Erlösung",
+                "translation": "спасение",
+                "parts": [
+                    "Vor dem verriegelten Fenster zeichnet Cordelia Kreise in den Staub.",
+                    "Ich halte das Wort „die Erlösung“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Vor dem verriegelten Fenster zeichnet Cordelia Kreise in den Staub. Ich halte das Wort „die Erlösung“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед заколоченным окном Корделия чертит круги в пыли. Я держу слово «спасение» как факел у сердца."
+            }
+        ]
     }
 };
 
@@ -3462,6 +4516,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3898,6 +5300,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -3966,6 +5685,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -3974,13 +5696,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4891,6 +6661,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/journeys/cornwall.html
+++ b/output/journeys/cornwall.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="ambitious_duke">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="cruel_husband">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="tyrant">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="punishment">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="torturer">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="wounded">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="death">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["желать", "честолюбие", "жадность", "стремиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["стремиться", "желать", "честолюбие", "жадность"], "correct_index": 3}, {"question": "Что означает немецкое слово «streben»?", "choices": ["вожделеть", "жадный", "стремиться", "жадность"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["властолюбие", "захватывать", "желать", "жадный"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["жадный", "стремиться", "вожделеть", "захватывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["желать", "захватывать", "стремиться", "жадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["жадность", "желать", "вожделеть", "властолюбие"], "correct_index": 3}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["жадный", "желать", "захватывать", "честолюбие"], "correct_index": 2}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["поддерживать", "одобрять", "злоба", "жестокость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["одобрять", "злоба", "жестокость", "поддерживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["суровость", "поддерживать", "поощрять", "одобрять"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["поддерживать", "злоба", "подстрекать", "суровость"], "correct_index": 0}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["подстрекать", "злоба", "поддерживать", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["поощрять", "одобрять", "подстрекать", "поддерживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["подстрекать", "поощрять", "одобрять", "суровость"], "correct_index": 3}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["тирания", "подавлять", "угнетение", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["подавлять", "тирания", "угнетение", "страх"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["страх", "подавлять", "угнетение", "принуждать"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["подавлять", "брутальный", "тирания", "принуждать"], "correct_index": 0}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["порабощать", "брутальный", "страх", "произвол"], "correct_index": 0}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["принуждать", "брутальный", "тирания", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["произвол", "тирания", "угнетение", "порабощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["страх", "тирания", "брутальный", "угнетение"], "correct_index": 2}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "наказывать", "гнев", "карать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["карать", "гнев", "наказание", "наказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["мучить", "наказывать", "гнев", "карать"], "correct_index": 3}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["унижать", "наказывать", "наказание", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["мучить", "гнев", "карать", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["унижать", "гнев", "карать", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["карать", "гнев", "унижать", "мучить"], "correct_index": 3}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["кровь", "садизм", "пытка", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытать", "садизм", "пытка", "кровь"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["выкалывать", "пытка", "кровь", "мука"], "correct_index": 2}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["пытать", "кровь", "садизм", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["ослеплять", "пытка", "мука", "калечить"], "correct_index": 3}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["калечить", "ослеплять", "пытать", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["ослеплять", "пытать", "садизм", "выкалывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["садизм", "пытка", "пытать", "мука"], "correct_index": 3}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["боль", "кровоточить", "удивление", "рана"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["удивление", "рана", "кровоточить", "боль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["кровоточить", "удивление", "страдать", "рана"], "correct_index": 1}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["раненый", "страдать", "рана", "кровоточить"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["раненый", "рана", "страдать", "удивление"], "correct_index": 0}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["страдать", "рана", "боль", "ослаблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["удивление", "рана", "страдать", "кровоточить"], "correct_index": 2}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "возмездие", "конец", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["смерть", "конец", "умирать", "возмездие"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["проклинать", "конец", "кара", "издыхать"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["проклинать", "хрипеть", "умирать", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["издыхать", "хрипеть", "возмездие", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["смерть", "возмездие", "кара", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["издыхать", "кара", "умирать", "хрипеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["издыхать", "смерть", "кара", "умирать"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["стремиться", "жадность", "честолюбие", "желать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["желать", "стремиться", "жадность", "честолюбие"], "correct_index": 2}, {"question": "Что означает немецкое слово «streben»?", "choices": ["стремиться", "захватывать", "жадность", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["захватывать", "желать", "жадность", "честолюбие"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["жадность", "вожделеть", "желать", "стремиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["жадный", "захватывать", "жадность", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["властолюбие", "вожделеть", "честолюбие", "захватывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["стремиться", "захватывать", "властолюбие", "желать"], "correct_index": 1}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["поддерживать", "жестокость", "злоба", "одобрять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["одобрять", "поддерживать", "жестокость", "злоба"], "correct_index": 3}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["суровость", "злоба", "одобрять", "поддерживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["жестокость", "суровость", "злоба", "поддерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["поощрять", "подстрекать", "поддерживать", "одобрять"], "correct_index": 1}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["подстрекать", "поддерживать", "жестокость", "поощрять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["суровость", "жестокость", "подстрекать", "поощрять"], "correct_index": 0}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["тирания", "страх", "подавлять", "угнетение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["угнетение", "тирания", "страх", "подавлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["порабощать", "принуждать", "страх", "угнетение"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["тирания", "подавлять", "страх", "порабощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["брутальный", "произвол", "тирания", "порабощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["страх", "принуждать", "подавлять", "угнетение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["порабощать", "страх", "произвол", "тирания"], "correct_index": 2}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["порабощать", "произвол", "брутальный", "страх"], "correct_index": 2}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказывать", "наказание", "гнев", "карать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["карать", "наказание", "гнев", "наказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["мучить", "карать", "унижать", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["наказывать", "мучить", "унижать", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "наказывать", "мучить", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["наказание", "мучить", "унижать", "карать"], "correct_index": 2}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["наказание", "карать", "мучить", "унижать"], "correct_index": 2}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["садизм", "кровь", "пытать", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытать", "садизм", "кровь", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["калечить", "выкалывать", "кровь", "пытка"], "correct_index": 2}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["выкалывать", "ослеплять", "мука", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["выкалывать", "пытка", "калечить", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["пытка", "кровь", "ослеплять", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["пытка", "ослеплять", "выкалывать", "мука"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["пытать", "мука", "пытка", "выкалывать"], "correct_index": 1}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["рана", "боль", "удивление", "кровоточить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["кровоточить", "боль", "удивление", "рана"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["раненый", "удивление", "рана", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["ослаблять", "страдать", "удивление", "кровоточить"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["ослаблять", "рана", "раненый", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["ослаблять", "раненый", "рана", "удивление"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["ослаблять", "раненый", "удивление", "страдать"], "correct_index": 3}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "конец", "возмездие", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["умирать", "конец", "смерть", "возмездие"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["издыхать", "смерть", "возмездие", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["смерть", "конец", "хрипеть", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["кара", "конец", "хрипеть", "издыхать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["смерть", "проклинать", "кара", "возмездие"], "correct_index": 1}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["смерть", "умирать", "хрипеть", "возмездие"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["проклинать", "кара", "возмездие", "издыхать"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Амбициозный герцог</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,15 +661,79 @@
             <div class="quiz-phase-container active" data-phase="ambitious_duke">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Ehrgeiz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «streben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verlangen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
                             
@@ -481,63 +741,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «streben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verlangen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">захватывать</button>
                             
@@ -545,49 +773,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «ergreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">властолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,47 +796,15 @@
             <div class="quiz-phase-container" data-phase="cruel_husband">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">суровость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
                             
@@ -648,47 +812,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">суровость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">суровость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поощрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
                             
@@ -696,17 +844,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">суровость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">поощрять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">подстрекать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">суровость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">суровость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -725,107 +921,107 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подавлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Furcht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">принуждать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «unterdrücken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тирания</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">принуждать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">принуждать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «zwingen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «unterdrücken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">принуждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">произвол</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">тирания</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «zwingen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">принуждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">произвол</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">произвол</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -835,13 +1031,13 @@
                         <div class="quiz-question">Что означает немецкое слово «brutal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">произвол</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,13 +1050,13 @@
             <div class="quiz-phase-container" data-phase="punishment">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
@@ -870,15 +1066,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
                             
@@ -886,63 +1082,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «bestrafen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «züchtigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
@@ -950,17 +1114,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,17 +1169,17 @@
             <div class="quiz-phase-container" data-phase="torturer">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -997,9 +1193,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1009,59 +1205,11 @@
                         <div class="quiz-question">Что означает немецкое слово «das Blut»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мука</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">калечить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
@@ -1069,33 +1217,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мука</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мука</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,13 +1304,29 @@
             <div class="quiz-phase-container" data-phase="wounded">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Wunde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
                             
@@ -1124,33 +1336,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">удивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1160,11 +1356,11 @@
                         <div class="quiz-question">Что означает немецкое слово «bluten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослаблять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
                             
@@ -1172,15 +1368,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослаблять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раненый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослаблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">раненый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
                             
@@ -1188,33 +1400,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослаблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">раненый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,17 +1423,17 @@
             <div class="quiz-phase-container" data-phase="death">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1247,11 +1443,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Vergeltung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
                             
@@ -1259,31 +1455,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
@@ -1291,15 +1471,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
@@ -1307,49 +1487,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">кара</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «röcheln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1373,6 +1569,7 @@
         "description": "Акт I: Жаждет власти",
         "words": [
             {
+                "wordId": "",
                 "word": "der Ehrgeiz",
                 "translation": "честолюбие",
                 "transcription": "[дер ЭР-гайц]",
@@ -1394,9 +1591,14 @@
                 ],
                 "collocations": [
                     "Mein Ehrgeiz kennt keine Grenzen mehr. — Моё честолюбие не знает больше границ."
+                ],
+                "sentenceParts": [
+                    "In der Waffenkammer betrachtet Cornwall gierig die ausgestellten Kronjuwelen.",
+                    "Das Echo des Wortes „der Ehrgeiz“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Gier",
                 "translation": "жадность",
                 "transcription": "[ди ГИР]",
@@ -1418,9 +1620,14 @@
                     "Der Narr spottet, sobald die Gier erwähnt wird. — Шут насмехается, едва кто-то произносит «жадность».",
                     "Die Gier nach Macht verzehrt meine Seele. — Жадность к власти пожирает мою душу.",
                     "Die Gier nach Macht treibt mich an. — Жадность к власти движет мной."
+                ],
+                "sentenceParts": [
+                    "Vor der Karte Englands fährt Cornwall mit dem Dolch über neue Grenzen.",
+                    "Mein Atem zeichnet das Wort „die Gier“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "streben",
                 "translation": "стремиться",
                 "transcription": "[ШТРЕ-бен]",
@@ -1442,9 +1649,14 @@
                 ],
                 "collocations": [
                     "Ich strebe nach absoluter Kontrolle. — Я стремлюсь к абсолютному контролю."
+                ],
+                "sentenceParts": [
+                    "Zwischen knienden Vasallen lässt Cornwall die Finger über den Thronsessel gleiten.",
+                    "Ich presse das Wort „streben“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verlangen",
                 "translation": "желать",
                 "transcription": "[фер-ЛАН-ген]",
@@ -1468,9 +1680,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Verlangen ist. — Во время бури становится понятно, насколько важно требовать.",
                     "Ich verlange mehr als mir zusteht. — Я желаю больше, чем мне положено."
+                ],
+                "sentenceParts": [
+                    "Am hohen Fenster misst Cornwall den Abstand zur Hauptstadt.",
+                    "Mein Atem zeichnet das Wort „verlangen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "begehren",
                 "translation": "вожделеть",
                 "transcription": "[бе-ГЕ-рен]",
@@ -1496,9 +1713,14 @@
                     "Ich begehre Edmund mit brennender Lust. — Я вожделею Эдмунда с пылающей страстью.",
                     "Ich begehre die Krone für mich selbst. — Я вожделею корону для себя.",
                     "Ich begehre Edmund mehr als mein Leben. — Я желаю Эдмунда больше жизни."
+                ],
+                "sentenceParts": [
+                    "Neben dem schwelenden Kamin testet Cornwall das Gewicht eines Schwertes.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „begehren“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "gierig",
                 "translation": "жадный",
                 "transcription": "[ГИ-риг]",
@@ -1520,9 +1742,14 @@
                 ],
                 "collocations": [
                     "Gierig greife ich nach jedem Stück Macht. — Жадно я хватаюсь за каждый кусок власти."
+                ],
+                "sentenceParts": [
+                    "Auf dem Turnierplatz lässt Cornwall seine Reiter zu später Stunde antreten.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „gierig“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Herrschsucht",
                 "translation": "властолюбие",
                 "transcription": "[ди ХЕР-зухт]",
@@ -1544,9 +1771,14 @@
                 ],
                 "collocations": [
                     "Die Herrschsucht bestimmt all meine Taten. — Властолюбие определяет все мои поступки."
+                ],
+                "sentenceParts": [
+                    "Zwischen Pergamentrollen überdenkt Cornwall geheime Bündnisse.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Herrschsucht“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ergreifen",
                 "translation": "захватывать",
                 "transcription": "[ер-ГРАЙ-фен]",
@@ -1568,6 +1800,10 @@
                 ],
                 "collocations": [
                     "Ich ergreife jede Gelegenheit zur Macht. — Я захватываю каждую возможность власти."
+                ],
+                "sentenceParts": [
+                    "Im Spiegel der Audienzhalle probt Cornwall das Lächeln eines Herrschers.",
+                    "Ich umarme das Wort „ergreifen“, als wäre es mein einziger Verbündeter."
                 ]
             }
         ],
@@ -1575,91 +1811,174 @@
             {
                 "question": "Что означает немецкое слово «der Ehrgeiz»?",
                 "choices": [
-                    "желать",
-                    "честолюбие",
+                    "стремиться",
                     "жадность",
+                    "честолюбие",
+                    "желать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Gier»?",
+                "choices": [
+                    "желать",
+                    "стремиться",
+                    "жадность",
+                    "честолюбие"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «streben»?",
+                "choices": [
+                    "стремиться",
+                    "захватывать",
+                    "жадность",
+                    "вожделеть"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verlangen»?",
+                "choices": [
+                    "захватывать",
+                    "желать",
+                    "жадность",
+                    "честолюбие"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «begehren»?",
+                "choices": [
+                    "жадность",
+                    "вожделеть",
+                    "желать",
                     "стремиться"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Gier»?",
-                "choices": [
-                    "стремиться",
-                    "желать",
-                    "честолюбие",
-                    "жадность"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «streben»?",
-                "choices": [
-                    "вожделеть",
-                    "жадный",
-                    "стремиться",
-                    "жадность"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «verlangen»?",
-                "choices": [
-                    "властолюбие",
-                    "захватывать",
-                    "желать",
-                    "жадный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «begehren»?",
-                "choices": [
-                    "жадный",
-                    "стремиться",
-                    "вожделеть",
-                    "захватывать"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «gierig»?",
                 "choices": [
-                    "желать",
+                    "жадный",
                     "захватывать",
-                    "стремиться",
-                    "жадный"
+                    "жадность",
+                    "вожделеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Herrschsucht»?",
                 "choices": [
-                    "жадность",
-                    "желать",
+                    "властолюбие",
                     "вожделеть",
-                    "властолюбие"
+                    "честолюбие",
+                    "захватывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ergreifen»?",
                 "choices": [
-                    "жадный",
-                    "желать",
+                    "стремиться",
                     "захватывать",
-                    "честолюбие"
+                    "властолюбие",
+                    "желать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Ehrgeiz",
+                "translation": "честолюбие",
+                "parts": [
+                    "In der Waffenkammer betrachtet Cornwall gierig die ausgestellten Kronjuwelen.",
+                    "Das Echo des Wortes „der Ehrgeiz“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "In der Waffenkammer betrachtet Cornwall gierig die ausgestellten Kronjuwelen. Das Echo des Wortes „der Ehrgeiz“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В оружейной Корнуолл жадно рассматривает выставленные коронные драгоценности. Эхо слова «честолюбие» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Gier",
+                "translation": "жадность",
+                "parts": [
+                    "Vor der Karte Englands fährt Cornwall mit dem Dolch über neue Grenzen.",
+                    "Mein Atem zeichnet das Wort „die Gier“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Vor der Karte Englands fährt Cornwall mit dem Dolch über neue Grenzen. Mein Atem zeichnet das Wort „die Gier“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед картой Англии Корнуолл проводит кинжалом новые границы. Моё дыхание рисует слово «жадность» в холодном воздухе между нами."
+            },
+            {
+                "word": "streben",
+                "translation": "стремиться",
+                "parts": [
+                    "Zwischen knienden Vasallen lässt Cornwall die Finger über den Thronsessel gleiten.",
+                    "Ich presse das Wort „streben“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Zwischen knienden Vasallen lässt Cornwall die Finger über den Thronsessel gleiten. Ich presse das Wort „streben“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди преклонивших колено вассалов Корнуолл проводит пальцами по тронному креслу. Я стискиваю слово «стремиться» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "verlangen",
+                "translation": "желать",
+                "parts": [
+                    "Am hohen Fenster misst Cornwall den Abstand zur Hauptstadt.",
+                    "Mein Atem zeichnet das Wort „verlangen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Am hohen Fenster misst Cornwall den Abstand zur Hauptstadt. Mein Atem zeichnet das Wort „verlangen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У высокого окна Корнуолл вымеряет расстояние до столицы. Моё дыхание рисует слово «желать» в холодном воздухе между нами."
+            },
+            {
+                "word": "begehren",
+                "translation": "вожделеть",
+                "parts": [
+                    "Neben dem schwelenden Kamin testet Cornwall das Gewicht eines Schwertes.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „begehren“ darf nicht vergehen."
+                ],
+                "sentence": "Neben dem schwelenden Kamin testet Cornwall das Gewicht eines Schwertes. Ich flüstere den Wächtern des Schicksals zu: Das Wort „begehren“ darf nicht vergehen.",
+                "sentenceTranslation": "У тлеющего камина Корнуолл взвешивает на руке меч. Я шепчу стражам судьбы: слово «вожделеть» не должно исчезнуть."
+            },
+            {
+                "word": "gierig",
+                "translation": "жадный",
+                "parts": [
+                    "Auf dem Turnierplatz lässt Cornwall seine Reiter zu später Stunde antreten.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „gierig“ mein Nordstern."
+                ],
+                "sentence": "Auf dem Turnierplatz lässt Cornwall seine Reiter zu später Stunde antreten. Selbst wenn die Welt zerfällt, bleibt das Wort „gierig“ mein Nordstern.",
+                "sentenceTranslation": "На турнирной площадке Корнуолл строит всадников поздним вечером. Даже если мир распадается, слово «жадный» остаётся моим северным светом."
+            },
+            {
+                "word": "die Herrschsucht",
+                "translation": "властолюбие",
+                "parts": [
+                    "Zwischen Pergamentrollen überdenkt Cornwall geheime Bündnisse.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Herrschsucht“ auf meine Lippen."
+                ],
+                "sentence": "Zwischen Pergamentrollen überdenkt Cornwall geheime Bündnisse. Wie ein stilles Gebet legt sich das Wort „die Herrschsucht“ auf meine Lippen.",
+                "sentenceTranslation": "Среди свитков пергамента Корнуолл обдумывает тайные союзы. Как тихая молитва слово «властолюбие» ложится на мои губы."
+            },
+            {
+                "word": "ergreifen",
+                "translation": "захватывать",
+                "parts": [
+                    "Im Spiegel der Audienzhalle probt Cornwall das Lächeln eines Herrschers.",
+                    "Ich umarme das Wort „ergreifen“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Im Spiegel der Audienzhalle probt Cornwall das Lächeln eines Herrschers. Ich umarme das Wort „ergreifen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В зеркале аудиенц-зала Корнуолл репетирует улыбку правителя. Я обнимаю слово «захватывать», будто это единственный союзник."
+            }
+        ]
     },
     "cruel_husband": {
         "title": "Жестокий муж",
         "description": "Акт II: Поддерживает жестокость Реганы",
         "words": [
             {
+                "wordId": "",
                 "word": "die Grausamkeit",
                 "translation": "жестокость",
                 "transcription": "[ди ГРАУ-зам-кайт]",
@@ -1692,9 +2011,14 @@
                     "Meine Grausamkeit kennt keine Grenzen. — Моя жестокость не знает границ.",
                     "Meine Grausamkeit übertrifft die meiner Schwester. — Моя жестокость превосходит жестокость сестры.",
                     "Die Grausamkeit meiner Frau gefällt mir. — Жестокость моей жены мне нравится."
+                ],
+                "sentenceParts": [
+                    "Neben Regans vergiftetem Lächeln hebt Cornwall den Kelch zum Spott.",
+                    "Ich umarme das Wort „die Grausamkeit“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Bosheit",
                 "translation": "злоба",
                 "transcription": "[ди БОС-хайт]",
@@ -1720,9 +2044,14 @@
                 "collocations": [
                     "Meine Bosheit kennt kein Erbarmen. — Моя злоба не знает милосердия.",
                     "Unsere Bosheit macht uns zum perfekten Paar. — Наша злоба делает нас идеальной парой."
+                ],
+                "sentenceParts": [
+                    "Auf der Galerie des Schlosses applaudiert Cornwall den Demütigungen des Königs.",
+                    "Ich umarme das Wort „die Bosheit“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "billigen",
                 "translation": "одобрять",
                 "transcription": "[БИ-ли-ген]",
@@ -1744,9 +2073,14 @@
                 ],
                 "collocations": [
                     "Ich billige alle ihre grausamen Pläne. — Я одобряю все её жестокие планы."
+                ],
+                "sentenceParts": [
+                    "Zwischen eingeschüchterten Dienern greift Cornwall nach der Peitsche.",
+                    "Das kalte Licht lässt das Wort „billigen“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "unterstützen",
                 "translation": "поддерживать",
                 "transcription": "[ун-тер-ШТЮ-цен]",
@@ -1767,9 +2101,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Unterstützen ist. — Во время бури становится понятно, насколько важно поддерживать.",
                     "Ich unterstütze ihre Unmenschlichkeit. — Я поддерживаю её бесчеловечность."
+                ],
+                "sentenceParts": [
+                    "Am hohen Lehnsessel sitzt Cornwall mit kalter Zufriedenheit.",
+                    "Ich zeichne das Wort „unterstützen“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "anstacheln",
                 "translation": "подстрекать",
                 "transcription": "[АН-шта-хельн]",
@@ -1791,9 +2130,14 @@
                 ],
                 "collocations": [
                     "Ich stachle sie zu größerer Grausamkeit an. — Я подстрекаю её к большей жестокости."
+                ],
+                "sentenceParts": [
+                    "Vor dem Bannerschrank zerreißt Cornwall einen höflichen Bittbrief.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „anstacheln“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ermutigen",
                 "translation": "поощрять",
                 "transcription": "[ер-МУ-ти-ген]",
@@ -1815,9 +2159,14 @@
                 ],
                 "collocations": [
                     "Ich ermutige ihre dunkelsten Impulse. — Я поощряю её самые тёмные импульсы."
+                ],
+                "sentenceParts": [
+                    "Unter stürmischen Trommeln befiehlt Cornwall den Wachen näherzukommen.",
+                    "Das Echo des Wortes „ermutigen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Härte",
                 "translation": "суровость",
                 "transcription": "[ди ХЕР-те]",
@@ -1844,6 +2193,10 @@
                 "collocations": [
                     "Mit eiserner Härte stoße ich ihn fort. — С железной жёсткостью я отталкиваю его.",
                     "Mit eiserner Härte regieren wir zusammen. — С железной суровостью мы правим вместе."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der Folterkammer tauscht Cornwall mit Regan heimliche Blicke.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Härte“ darf nicht vergehen."
                 ]
             }
         ],
@@ -1852,80 +2205,153 @@
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
                     "поддерживать",
-                    "одобрять",
+                    "жестокость",
                     "злоба",
-                    "жестокость"
+                    "одобрять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
                     "одобрять",
-                    "злоба",
+                    "поддерживать",
                     "жестокость",
-                    "поддерживать"
+                    "злоба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «billigen»?",
                 "choices": [
                     "суровость",
-                    "поддерживать",
-                    "поощрять",
-                    "одобрять"
+                    "злоба",
+                    "одобрять",
+                    "поддерживать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «unterstützen»?",
                 "choices": [
-                    "поддерживать",
+                    "жестокость",
+                    "суровость",
                     "злоба",
-                    "подстрекать",
-                    "суровость"
+                    "поддерживать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «anstacheln»?",
                 "choices": [
+                    "поощрять",
                     "подстрекать",
-                    "злоба",
                     "поддерживать",
-                    "жестокость"
+                    "одобрять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ermutigen»?",
                 "choices": [
-                    "поощрять",
-                    "одобрять",
                     "подстрекать",
-                    "поддерживать"
+                    "поддерживать",
+                    "жестокость",
+                    "поощрять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Härte»?",
                 "choices": [
+                    "суровость",
+                    "жестокость",
                     "подстрекать",
-                    "поощрять",
-                    "одобрять",
-                    "суровость"
+                    "поощрять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Grausamkeit",
+                "translation": "жестокость",
+                "parts": [
+                    "Neben Regans vergiftetem Lächeln hebt Cornwall den Kelch zum Spott.",
+                    "Ich umarme das Wort „die Grausamkeit“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Neben Regans vergiftetem Lächeln hebt Cornwall den Kelch zum Spott. Ich umarme das Wort „die Grausamkeit“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Рядом с ядовитой улыбкой Реганы Корнуолл поднимает кубок насмешки. Я обнимаю слово «жестокость», будто это единственный союзник."
+            },
+            {
+                "word": "die Bosheit",
+                "translation": "злоба",
+                "parts": [
+                    "Auf der Galerie des Schlosses applaudiert Cornwall den Demütigungen des Königs.",
+                    "Ich umarme das Wort „die Bosheit“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Auf der Galerie des Schlosses applaudiert Cornwall den Demütigungen des Königs. Ich umarme das Wort „die Bosheit“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "На галерее замка Корнуолл аплодирует унижениям короля. Я обнимаю слово «злоба», будто это единственный союзник."
+            },
+            {
+                "word": "billigen",
+                "translation": "одобрять",
+                "parts": [
+                    "Zwischen eingeschüchterten Dienern greift Cornwall nach der Peitsche.",
+                    "Das kalte Licht lässt das Wort „billigen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Zwischen eingeschüchterten Dienern greift Cornwall nach der Peitsche. Das kalte Licht lässt das Wort „billigen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Среди запуганных слуг Корнуолл тянется к плётке. Холодный свет заставляет слово «одобрять» сиять словно расплавленное золото."
+            },
+            {
+                "word": "unterstützen",
+                "translation": "поддерживать",
+                "parts": [
+                    "Am hohen Lehnsessel sitzt Cornwall mit kalter Zufriedenheit.",
+                    "Ich zeichne das Wort „unterstützen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Am hohen Lehnsessel sitzt Cornwall mit kalter Zufriedenheit. Ich zeichne das Wort „unterstützen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В высоком кресле-ленном Корнуолл сидит с холодным довольством. Я черчу слово «поддерживать» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "anstacheln",
+                "translation": "подстрекать",
+                "parts": [
+                    "Vor dem Bannerschrank zerreißt Cornwall einen höflichen Bittbrief.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „anstacheln“ mein Nordstern."
+                ],
+                "sentence": "Vor dem Bannerschrank zerreißt Cornwall einen höflichen Bittbrief. Selbst wenn die Welt zerfällt, bleibt das Wort „anstacheln“ mein Nordstern.",
+                "sentenceTranslation": "Перед шкафом со штандартами Корнуолл разрывает вежливое прошение. Даже если мир распадается, слово «подстрекать» остаётся моим северным светом."
+            },
+            {
+                "word": "ermutigen",
+                "translation": "поощрять",
+                "parts": [
+                    "Unter stürmischen Trommeln befiehlt Cornwall den Wachen näherzukommen.",
+                    "Das Echo des Wortes „ermutigen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Unter stürmischen Trommeln befiehlt Cornwall den Wachen näherzukommen. Das Echo des Wortes „ermutigen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Под грохот барабанов Корнуолл приказывает стражам подойти ближе. Эхо слова «поощрять» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Härte",
+                "translation": "суровость",
+                "parts": [
+                    "Im Schatten der Folterkammer tauscht Cornwall mit Regan heimliche Blicke.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Härte“ darf nicht vergehen."
+                ],
+                "sentence": "Im Schatten der Folterkammer tauscht Cornwall mit Regan heimliche Blicke. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Härte“ darf nicht vergehen.",
+                "sentenceTranslation": "В тени пыточной Корнуолл обменивается с Реганой тайными взглядами. Я шепчу стражам судьбы: слово «суровость» не должно исчезнуть."
+            }
+        ]
     },
     "tyrant": {
         "title": "Тиран",
         "description": "Акт II: Правит железной рукой",
         "words": [
             {
+                "wordId": "",
                 "word": "die Tyrannei",
                 "translation": "тирания",
                 "transcription": "[ди тю-ра-НАЙ]",
@@ -1947,9 +2373,14 @@
                 ],
                 "collocations": [
                     "Meine Tyrannei erstickt jeden Widerstand. — Моя тирания душит любое сопротивление."
+                ],
+                "sentenceParts": [
+                    "Auf dem Burghof verteilt Cornwall neue, erbarmungslose Dekrete.",
+                    "Ich zeichne das Wort „die Tyrannei“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Unterdrückung",
                 "translation": "угнетение",
                 "transcription": "[ди ун-тер-ДРЮ-кунг]",
@@ -1971,9 +2402,14 @@
                 ],
                 "collocations": [
                     "Die Unterdrückung ist mein Herrschaftsmittel. — Угнетение - моё средство правления."
+                ],
+                "sentenceParts": [
+                    "Vor gefesselten Gefangenen lässt Cornwall die Streitkolben prüfen.",
+                    "Mein Atem zeichnet das Wort „die Unterdrückung“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Furcht",
                 "translation": "страх",
                 "transcription": "[ди ФУРХТ]",
@@ -1996,9 +2432,14 @@
                 ],
                 "collocations": [
                     "Durch Furcht halte ich alle unter Kontrolle. — Страхом я держу всех под контролем."
+                ],
+                "sentenceParts": [
+                    "Zwischen klirrenden Ketten schreitet Cornwall mit schwerem Schritt.",
+                    "Ich halte das Wort „die Furcht“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "unterdrücken",
                 "translation": "подавлять",
                 "transcription": "[ун-тер-ДРЮ-кен]",
@@ -2019,9 +2460,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Unterdrücken ist. — Во время бури становится понятно, насколько важно подавлять.",
                     "Ich unterdrücke jeden freien Gedanken. — Я подавляю любую свободную мысль."
+                ],
+                "sentenceParts": [
+                    "Am schwarzen Banner der Macht schwört Cornwall sich ewige Herrschaft.",
+                    "Mein Atem zeichnet das Wort „unterdrücken“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "knechten",
                 "translation": "порабощать",
                 "transcription": "[КНЕХ-тен]",
@@ -2043,9 +2489,14 @@
                 ],
                 "collocations": [
                     "Ich knechte alle, die mir unterstehen. — Я порабощаю всех, кто мне подчинён."
+                ],
+                "sentenceParts": [
+                    "Auf dem Gerichtspodest stützt Cornwall sich auf den Stab aus Eisen.",
+                    "Ich presse das Wort „knechten“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "zwingen",
                 "translation": "принуждать",
                 "transcription": "[ЦВИН-ген]",
@@ -2067,9 +2518,14 @@
                 "collocations": [
                     "Das Zwingen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело заставлять.",
                     "Ich zwinge alle zu absolutem Gehorsam. — Я принуждаю всех к абсолютному послушанию."
+                ],
+                "sentenceParts": [
+                    "Unter den Blicken eingeschüchterter Edelleute reißt Cornwall das Urteil an sich.",
+                    "Ich zeichne das Wort „zwingen“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Willkür",
                 "translation": "произвол",
                 "transcription": "[ди ВИЛЬ-кюр]",
@@ -2091,9 +2547,14 @@
                 ],
                 "collocations": [
                     "Meine Willkür ist das einzige Gesetz. — Мой произвол - единственный закон."
+                ],
+                "sentenceParts": [
+                    "An der Treppe zum Kerker verteilt Cornwall grausame Befehle.",
+                    "Ich umarme das Wort „die Willkür“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "brutal",
                 "translation": "брутальный",
                 "transcription": "[бру-ТАЛЬ]",
@@ -2115,6 +2576,10 @@
                 ],
                 "collocations": [
                     "Brutal zerschlage ich jeden Widerstand. — Брутально я сокрушаю любое сопротивление."
+                ],
+                "sentenceParts": [
+                    "Im düsteren Thronsaal schlägt Cornwall mit der Faust auf die Armlehne.",
+                    "Ich halte das Wort „brutal“ wie eine Fackel vor meinem Herzen."
                 ]
             }
         ],
@@ -2123,90 +2588,173 @@
                 "question": "Что означает немецкое слово «die Tyrannei»?",
                 "choices": [
                     "тирания",
+                    "страх",
                     "подавлять",
-                    "угнетение",
-                    "страх"
+                    "угнетение"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Unterdrückung»?",
                 "choices": [
-                    "подавлять",
-                    "тирания",
                     "угнетение",
-                    "страх"
+                    "тирания",
+                    "страх",
+                    "подавлять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Furcht»?",
                 "choices": [
+                    "порабощать",
+                    "принуждать",
                     "страх",
-                    "подавлять",
-                    "угнетение",
-                    "принуждать"
+                    "угнетение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «unterdrücken»?",
                 "choices": [
-                    "подавлять",
-                    "брутальный",
                     "тирания",
-                    "принуждать"
+                    "подавлять",
+                    "страх",
+                    "порабощать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «knechten»?",
                 "choices": [
-                    "порабощать",
                     "брутальный",
-                    "страх",
-                    "произвол"
+                    "произвол",
+                    "тирания",
+                    "порабощать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «zwingen»?",
                 "choices": [
+                    "страх",
                     "принуждать",
-                    "брутальный",
-                    "тирания",
-                    "страх"
+                    "подавлять",
+                    "угнетение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Willkür»?",
                 "choices": [
+                    "порабощать",
+                    "страх",
                     "произвол",
-                    "тирания",
-                    "угнетение",
-                    "порабощать"
+                    "тирания"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «brutal»?",
                 "choices": [
-                    "страх",
-                    "тирания",
+                    "порабощать",
+                    "произвол",
                     "брутальный",
-                    "угнетение"
+                    "страх"
                 ],
                 "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Tyrannei",
+                "translation": "тирания",
+                "parts": [
+                    "Auf dem Burghof verteilt Cornwall neue, erbarmungslose Dekrete.",
+                    "Ich zeichne das Wort „die Tyrannei“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Auf dem Burghof verteilt Cornwall neue, erbarmungslose Dekrete. Ich zeichne das Wort „die Tyrannei“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На замковом дворе Корнуолл раздаёт новые беспощадные указы. Я вывожу слово «тирания» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "die Unterdrückung",
+                "translation": "угнетение",
+                "parts": [
+                    "Vor gefesselten Gefangenen lässt Cornwall die Streitkolben prüfen.",
+                    "Mein Atem zeichnet das Wort „die Unterdrückung“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Vor gefesselten Gefangenen lässt Cornwall die Streitkolben prüfen. Mein Atem zeichnet das Wort „die Unterdrückung“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед связанными пленниками Корнуолл приказывает проверить боевые булавы. Моё дыхание рисует слово «угнетение» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Furcht",
+                "translation": "страх",
+                "parts": [
+                    "Zwischen klirrenden Ketten schreitet Cornwall mit schwerem Schritt.",
+                    "Ich halte das Wort „die Furcht“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Zwischen klirrenden Ketten schreitet Cornwall mit schwerem Schritt. Ich halte das Wort „die Furcht“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Среди звенящих цепей Корнуолл идёт тяжёлым шагом. Я держу слово «страх» как факел у сердца."
+            },
+            {
+                "word": "unterdrücken",
+                "translation": "подавлять",
+                "parts": [
+                    "Am schwarzen Banner der Macht schwört Cornwall sich ewige Herrschaft.",
+                    "Mein Atem zeichnet das Wort „unterdrücken“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Am schwarzen Banner der Macht schwört Cornwall sich ewige Herrschaft. Mein Atem zeichnet das Wort „unterdrücken“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У чёрного знамени власти Корнуолл клянётся вечным господством. Моё дыхание рисует слово «подавлять» в холодном воздухе между нами."
+            },
+            {
+                "word": "knechten",
+                "translation": "порабощать",
+                "parts": [
+                    "Auf dem Gerichtspodest stützt Cornwall sich auf den Stab aus Eisen.",
+                    "Ich presse das Wort „knechten“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Auf dem Gerichtspodest stützt Cornwall sich auf den Stab aus Eisen. Ich presse das Wort „knechten“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На судейском помосте Корнуолл опирается на железный посох. Я стискиваю слово «порабощать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "zwingen",
+                "translation": "принуждать",
+                "parts": [
+                    "Unter den Blicken eingeschüchterter Edelleute reißt Cornwall das Urteil an sich.",
+                    "Ich zeichne das Wort „zwingen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Unter den Blicken eingeschüchterter Edelleute reißt Cornwall das Urteil an sich. Ich zeichne das Wort „zwingen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под взглядами запуганных дворян Корнуолл присваивает себе право суда. Я вывожу слово «принуждать» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "die Willkür",
+                "translation": "произвол",
+                "parts": [
+                    "An der Treppe zum Kerker verteilt Cornwall grausame Befehle.",
+                    "Ich umarme das Wort „die Willkür“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "An der Treppe zum Kerker verteilt Cornwall grausame Befehle. Ich umarme das Wort „die Willkür“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "У лестницы в темницу Корнуолл раздаёт жестокие приказы. Я обнимаю слово «произвол», будто это единственный союзник."
+            },
+            {
+                "word": "brutal",
+                "translation": "брутальный",
+                "parts": [
+                    "Im düsteren Thronsaal schlägt Cornwall mit der Faust auf die Armlehne.",
+                    "Ich halte das Wort „brutal“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Im düsteren Thronsaal schlägt Cornwall mit der Faust auf die Armlehne. Ich halte das Wort „brutal“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В мрачном тронном зале Корнуолл бьёт кулаком по подлокотнику. Я держу слово «брутальный» как факел у сердца."
+            }
+        ]
     },
     "punishment": {
         "title": "Каратель",
         "description": "Акт II: Наказывает Кента",
         "words": [
             {
+                "wordId": "",
                 "word": "die Strafe",
                 "translation": "наказание",
                 "transcription": "[ди ШТРА-фе]",
@@ -2232,9 +2780,14 @@
                     "Diese Strafe erdulde ich für meinen König. — Это наказание я терплю ради короля.",
                     "Die Strafe für Widerspruch ist hart. — Наказание за возражение сурово.",
                     "Dies ist die gerechte Strafe für meine Grausamkeit. — Это справедливая кара за мою жестокость."
+                ],
+                "sentenceParts": [
+                    "Vor den geschockten Höflingen deutet Cornwall auf die leeren Holzkolben.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Strafe“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Zorn",
                 "translation": "гнев",
                 "transcription": "[дер ЦОРН]",
@@ -2258,9 +2811,14 @@
                     "Sein Zorn ist grenzenlos und blind. — Его гнев безграничен и слеп.",
                     "Der Zorn des Königs trifft mich ungerecht. — Гнев короля поражает меня несправедливо.",
                     "Mein Zorn kennt keine Barmherzigkeit. — Мой гнев не знает милосердия."
+                ],
+                "sentenceParts": [
+                    "Auf dem nassen Hof befiehlt Cornwall die Fesselung des Widerspenstigen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „der Zorn“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "bestrafen",
                 "translation": "карать",
                 "transcription": "[бе-ШТРА-фен]",
@@ -2284,9 +2842,14 @@
                 "collocations": [
                     "Das Bestrafen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело наказывать.",
                     "Ich bestrafe Kent für seine Frechheit. — Я караю Кента за его дерзость."
+                ],
+                "sentenceParts": [
+                    "Neben Regans spöttischem Blick wirft Cornwall das Urteil in die Luft.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „bestrafen“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "züchtigen",
                 "translation": "наказывать",
                 "transcription": "[ЦЮХ-ти-ген]",
@@ -2310,9 +2873,14 @@
                 ],
                 "collocations": [
                     "Öffentlich züchtige ich die Widerspenstigen. — Публично я наказываю непокорных."
+                ],
+                "sentenceParts": [
+                    "Am Werkzeugtisch der Garde prüft Cornwall die scharfen Nägel.",
+                    "Ich presse das Wort „züchtigen“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "demütigen",
                 "translation": "унижать",
                 "transcription": "[де-МЮ-ти-ген]",
@@ -2341,9 +2909,14 @@
                     "Meine eigene Tochter will mich demütigen! — Моя собственная дочь хочет меня унизить!",
                     "Ich demütige ihn vor aller Augen. — Я унижаю его на глазах у всех.",
                     "Ich demütige meinen alten Vater ohne Mitleid. — Я унижаю старого отца без жалости."
+                ],
+                "sentenceParts": [
+                    "Vor den verschreckten Dienern lächelt Cornwall über das Flehen um Gnade.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „demütigen“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erniedrigen",
                 "translation": "унижать",
                 "transcription": "[ер-НИД-ри-ген]",
@@ -2370,9 +2943,14 @@
                 "collocations": [
                     "Ich erniedrige den einst mächtigen König. — Я унижаю некогда могущественного короля.",
                     "Ich erniedrige den treuen Diener. — Я унижаю верного слугу."
+                ],
+                "sentenceParts": [
+                    "Unter Donnerhall befiehlt Cornwall das Opfer in den Regen zu stellen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „erniedrigen“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "quälen",
                 "translation": "мучить",
                 "transcription": "[КВЕ-лен]",
@@ -2394,6 +2972,10 @@
                     "Der Narr spürt, wie das Quälen alle verändert. — Шут чувствует, как умение мучить меняет всех.",
                     "Es bereitet mir Freude, ihn zu quälen. — Мне доставляет радость мучить его.",
                     "Es macht mir Freude, ihn zu quälen. — Мне доставляет радость мучить его."
+                ],
+                "sentenceParts": [
+                    "Auf dem Steinboden hinterlässt Cornwall Spuren von Blut und Wasser.",
+                    "Ich halte das Wort „quälen“ wie eine Fackel vor meinem Herzen."
                 ]
             }
         ],
@@ -2401,81 +2983,154 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "наказание",
                     "наказывать",
+                    "наказание",
                     "гнев",
                     "карать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
                     "карать",
-                    "гнев",
                     "наказание",
+                    "гнев",
                     "наказывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «bestrafen»?",
                 "choices": [
                     "мучить",
-                    "наказывать",
-                    "гнев",
-                    "карать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «züchtigen»?",
-                "choices": [
+                    "карать",
                     "унижать",
-                    "наказывать",
-                    "наказание",
-                    "унижать"
+                    "гнев"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «demütigen»?",
+                "question": "Что означает немецкое слово «züchtigen»?",
                 "choices": [
+                    "наказывать",
                     "мучить",
-                    "гнев",
-                    "карать",
-                    "унижать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «erniedrigen»?",
-                "choices": [
                     "унижать",
-                    "гнев",
-                    "карать",
                     "наказание"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «demütigen»?",
+                "choices": [
+                    "унижать",
+                    "наказывать",
+                    "мучить",
+                    "наказание"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «erniedrigen»?",
+                "choices": [
+                    "наказание",
+                    "мучить",
+                    "унижать",
+                    "карать"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
+                    "наказание",
                     "карать",
-                    "гнев",
-                    "унижать",
-                    "мучить"
+                    "мучить",
+                    "унижать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Strafe",
+                "translation": "наказание",
+                "parts": [
+                    "Vor den geschockten Höflingen deutet Cornwall auf die leeren Holzkolben.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Strafe“ auf meine Lippen."
+                ],
+                "sentence": "Vor den geschockten Höflingen deutet Cornwall auf die leeren Holzkolben. Wie ein stilles Gebet legt sich das Wort „die Strafe“ auf meine Lippen.",
+                "sentenceTranslation": "Перед потрясёнными придворными Корнуолл указывает на пустые колодки. Как тихая молитва слово «наказание» ложится на мои губы."
+            },
+            {
+                "word": "der Zorn",
+                "translation": "гнев",
+                "parts": [
+                    "Auf dem nassen Hof befiehlt Cornwall die Fesselung des Widerspenstigen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „der Zorn“ wird heute nicht verraten."
+                ],
+                "sentence": "Auf dem nassen Hof befiehlt Cornwall die Fesselung des Widerspenstigen. Mit fester Stimme schwöre ich mir: Das Wort „der Zorn“ wird heute nicht verraten.",
+                "sentenceTranslation": "На мокром дворе Корнуолл приказывает заковать непокорного. Твёрдым голосом я клянусь себе: слово «гнев» сегодня не будет предано."
+            },
+            {
+                "word": "bestrafen",
+                "translation": "карать",
+                "parts": [
+                    "Neben Regans spöttischem Blick wirft Cornwall das Urteil in die Luft.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „bestrafen“ darf nicht vergehen."
+                ],
+                "sentence": "Neben Regans spöttischem Blick wirft Cornwall das Urteil in die Luft. Ich flüstere den Wächtern des Schicksals zu: Das Wort „bestrafen“ darf nicht vergehen.",
+                "sentenceTranslation": "Рядом с насмешливым взглядом Реганы Корнуолл бросает приговор в воздух. Я шепчу стражам судьбы: слово «карать» не должно исчезнуть."
+            },
+            {
+                "word": "züchtigen",
+                "translation": "наказывать",
+                "parts": [
+                    "Am Werkzeugtisch der Garde prüft Cornwall die scharfen Nägel.",
+                    "Ich presse das Wort „züchtigen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Am Werkzeugtisch der Garde prüft Cornwall die scharfen Nägel. Ich presse das Wort „züchtigen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У верстака стражи Корнуолл проверяет острые гвозди. Я стискиваю слово «наказывать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "demütigen",
+                "translation": "унижать",
+                "parts": [
+                    "Vor den verschreckten Dienern lächelt Cornwall über das Flehen um Gnade.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „demütigen“ darf nicht vergehen."
+                ],
+                "sentence": "Vor den verschreckten Dienern lächelt Cornwall über das Flehen um Gnade. Ich flüstere den Wächtern des Schicksals zu: Das Wort „demütigen“ darf nicht vergehen.",
+                "sentenceTranslation": "Перед перепуганными слугами Корнуолл улыбается мольбам о пощаде. Я шепчу стражам судьбы: слово «унижать» не должно исчезнуть."
+            },
+            {
+                "word": "erniedrigen",
+                "translation": "унижать",
+                "parts": [
+                    "Unter Donnerhall befiehlt Cornwall das Opfer in den Regen zu stellen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „erniedrigen“ mein Nordstern."
+                ],
+                "sentence": "Unter Donnerhall befiehlt Cornwall das Opfer in den Regen zu stellen. Selbst wenn die Welt zerfällt, bleibt das Wort „erniedrigen“ mein Nordstern.",
+                "sentenceTranslation": "Под раскаты грома Корнуолл приказывает поставить жертву под дождь. Даже если мир распадается, слово «унижать» остаётся моим северным светом."
+            },
+            {
+                "word": "quälen",
+                "translation": "мучить",
+                "parts": [
+                    "Auf dem Steinboden hinterlässt Cornwall Spuren von Blut und Wasser.",
+                    "Ich halte das Wort „quälen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Auf dem Steinboden hinterlässt Cornwall Spuren von Blut und Wasser. Ich halte das Wort „quälen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На каменном полу Корнуолл оставляет следы крови и воды. Я держу слово «мучить» как факел у сердца."
+            }
+        ]
     },
     "torturer": {
         "title": "Мучитель",
         "description": "Акт III: Ослепляет Глостера",
         "words": [
             {
+                "wordId": "",
                 "word": "die Folter",
                 "translation": "пытка",
                 "transcription": "[ди ФОЛЬ-тер]",
@@ -2505,9 +3160,14 @@
                     "Die Folter ist meine Unterhaltung. — Пытка - моё развлечение.",
                     "Die Folter ist mein liebstes Werkzeug. — Пытка - мой любимый инструмент.",
                     "Die Folter ist grausam und erbarmungslos. — Пытка жестока и беспощадна."
+                ],
+                "sentenceParts": [
+                    "Im düsteren Saal bindet Cornwall den Grafen an den eichenen Stuhl.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Folter“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Sadismus",
                 "translation": "садизм",
                 "transcription": "[дер за-ДИС-мус]",
@@ -2532,9 +3192,14 @@
                 "collocations": [
                     "Mein Sadismus findet Befriedigung. — Мой садизм находит удовлетворение.",
                     "Mein Sadismus kennt keine Grenzen. — Мой садизм не знает границ."
+                ],
+                "sentenceParts": [
+                    "Neben knirschenden Seilen entfachen Regans Diener das Feuer, während Cornwall zuschaut.",
+                    "Ich zeichne das Wort „der Sadismus“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Blut",
                 "translation": "кровь",
                 "transcription": "[дас БЛУТ]",
@@ -2555,9 +3220,14 @@
                 "collocations": [
                     "Der Narr spottet, sobald das Blut erwähnt wird. — Шут насмехается, едва кто-то произносит «кровь».",
                     "Das Blut des Grafen befleckt meine Hände. — Кровь графа пятнает мои руки."
+                ],
+                "sentenceParts": [
+                    "Vor der versammelten Ritterschaft lässt Cornwall die Dolche bereitlegen.",
+                    "Ich zeichne das Wort „das Blut“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "foltern",
                 "translation": "пытать",
                 "transcription": "[ФОЛЬ-терн]",
@@ -2583,9 +3253,14 @@
                 "collocations": [
                     "Ich foltere ihn mit kalten Worten. — Я пытаю его холодными словами.",
                     "Mit Lust foltere ich den alten Mann. — С наслаждением я пытаю старика."
+                ],
+                "sentenceParts": [
+                    "Am blutbefleckten Boden tritt Cornwall das Geständnis aus dem Gefangenen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „foltern“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verstümmeln",
                 "translation": "калечить",
                 "transcription": "[фер-ШТЮМ-мельн]",
@@ -2607,9 +3282,14 @@
                 ],
                 "collocations": [
                     "Ich verstümmle ihn ohne Erbarmen. — Я калечу его без милосердия."
+                ],
+                "sentenceParts": [
+                    "Zwischen aufschreienden Dienern bleibt Cornwall eiskalt und unbewegt.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „verstümmeln“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "blenden",
                 "translation": "ослеплять",
                 "transcription": "[БЛЕН-ден]",
@@ -2633,9 +3313,14 @@
                     "Wir blenden den treuen Grafen Gloucester. — Мы ослепляем верного графа Глостера.",
                     "Eigenhändig blende ich Gloucester. — Собственноручно я ослепляю Глостера.",
                     "Sie blenden mich für meinen Verrat. — Они ослепляют меня за мою измену."
+                ],
+                "sentenceParts": [
+                    "Unter Regans Jubel reißt Cornwall das grausame Werk zu Ende.",
+                    "Mein Atem zeichnet das Wort „blenden“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ausstechen",
                 "translation": "выкалывать",
                 "transcription": "[АУС-ште-хен]",
@@ -2660,9 +3345,14 @@
                 "collocations": [
                     "Stecht ihm beide Augen aus! — Выколите ему оба глаза!",
                     "Seine Augen steche ich mit Freude aus. — Его глаза я выкалываю с радостью."
+                ],
+                "sentenceParts": [
+                    "Vor den entsetzten Augen des Hofes wischt Cornwall das Blut vom Stiefel.",
+                    "Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Qual",
                 "translation": "мука",
                 "transcription": "[ди КВАЛЬ]",
@@ -2689,6 +3379,10 @@
                 "collocations": [
                     "Die Qual des Giftes zerreißt mich. — Мучение от яда разрывает меня.",
                     "Seine Qual bereitet mir Vergnügen. — Его мука доставляет мне удовольствие."
+                ],
+                "sentenceParts": [
+                    "Im Nachhall der Schreie richtet Cornwall den Mantel und wendet sich zur Tür.",
+                    "Ich umarme das Wort „die Qual“, als wäre es mein einziger Verbündeter."
                 ]
             }
         ],
@@ -2696,91 +3390,174 @@
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "кровь",
                     "садизм",
-                    "пытка",
-                    "пытать"
+                    "кровь",
+                    "пытать",
+                    "пытка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
                     "пытать",
                     "садизм",
-                    "пытка",
-                    "кровь"
+                    "кровь",
+                    "пытка"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Blut»?",
                 "choices": [
+                    "калечить",
                     "выкалывать",
-                    "пытка",
                     "кровь",
-                    "мука"
+                    "пытка"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
-                    "пытать",
-                    "кровь",
-                    "садизм",
-                    "ослеплять"
+                    "выкалывать",
+                    "ослеплять",
+                    "мука",
+                    "пытать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verstümmeln»?",
                 "choices": [
-                    "ослеплять",
+                    "выкалывать",
                     "пытка",
-                    "мука",
-                    "калечить"
+                    "калечить",
+                    "ослеплять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "калечить",
+                    "пытка",
+                    "кровь",
                     "ослеплять",
-                    "пытать",
-                    "пытка"
+                    "пытать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
+                    "пытка",
                     "ослеплять",
-                    "пытать",
-                    "садизм",
-                    "выкалывать"
+                    "выкалывать",
+                    "мука"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
-                    "садизм",
-                    "пытка",
                     "пытать",
-                    "мука"
+                    "мука",
+                    "пытка",
+                    "выкалывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Folter",
+                "translation": "пытка",
+                "parts": [
+                    "Im düsteren Saal bindet Cornwall den Grafen an den eichenen Stuhl.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Folter“ wird heute nicht verraten."
+                ],
+                "sentence": "Im düsteren Saal bindet Cornwall den Grafen an den eichenen Stuhl. Mit fester Stimme schwöre ich mir: Das Wort „die Folter“ wird heute nicht verraten.",
+                "sentenceTranslation": "В мрачном зале Корнуолл приковывает графа к дубовому креслу. Твёрдым голосом я клянусь себе: слово «пытка» сегодня не будет предано."
+            },
+            {
+                "word": "der Sadismus",
+                "translation": "садизм",
+                "parts": [
+                    "Neben knirschenden Seilen entfachen Regans Diener das Feuer, während Cornwall zuschaut.",
+                    "Ich zeichne das Wort „der Sadismus“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Neben knirschenden Seilen entfachen Regans Diener das Feuer, während Cornwall zuschaut. Ich zeichne das Wort „der Sadismus“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под скрип канатов слуги Реганы раздувают огонь, пока Корнуолл наблюдает. Я черчу слово «садизм» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "das Blut",
+                "translation": "кровь",
+                "parts": [
+                    "Vor der versammelten Ritterschaft lässt Cornwall die Dolche bereitlegen.",
+                    "Ich zeichne das Wort „das Blut“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Vor der versammelten Ritterschaft lässt Cornwall die Dolche bereitlegen. Ich zeichne das Wort „das Blut“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед собравшимся рыцарством Корнуолл велит приготовить кинжалы. Я черчу слово «кровь» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "foltern",
+                "translation": "пытать",
+                "parts": [
+                    "Am blutbefleckten Boden tritt Cornwall das Geständnis aus dem Gefangenen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „foltern“ bleibt lebendig."
+                ],
+                "sentence": "Am blutbefleckten Boden tritt Cornwall das Geständnis aus dem Gefangenen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „foltern“ bleibt lebendig.",
+                "sentenceTranslation": "На забрызганном кровью полу Корнуолл выбивает признание из пленника. Каждой клеткой тела я обещаю: слово «пытать» останется живым."
+            },
+            {
+                "word": "verstümmeln",
+                "translation": "калечить",
+                "parts": [
+                    "Zwischen aufschreienden Dienern bleibt Cornwall eiskalt und unbewegt.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „verstümmeln“ mein Nordstern."
+                ],
+                "sentence": "Zwischen aufschreienden Dienern bleibt Cornwall eiskalt und unbewegt. Selbst wenn die Welt zerfällt, bleibt das Wort „verstümmeln“ mein Nordstern.",
+                "sentenceTranslation": "Среди вскрикивающих слуг Корнуолл остаётся ледяным и неподвижным. Даже если мир распадается, слово «калечить» остаётся моим северным светом."
+            },
+            {
+                "word": "blenden",
+                "translation": "ослеплять",
+                "parts": [
+                    "Unter Regans Jubel reißt Cornwall das grausame Werk zu Ende.",
+                    "Mein Atem zeichnet das Wort „blenden“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Unter Regans Jubel reißt Cornwall das grausame Werk zu Ende. Mein Atem zeichnet das Wort „blenden“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Под ликование Реганы Корнуолл довершает жестокую работу. Моё дыхание рисует слово «ослеплять» в холодном воздухе между нами."
+            },
+            {
+                "word": "ausstechen",
+                "translation": "выкалывать",
+                "parts": [
+                    "Vor den entsetzten Augen des Hofes wischt Cornwall das Blut vom Stiefel.",
+                    "Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus."
+                ],
+                "sentence": "Vor den entsetzten Augen des Hofes wischt Cornwall das Blut vom Stiefel. Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus.",
+                "sentenceTranslation": "Перед ужаснувшимися придворными Корнуолл стирает кровь с сапога. Я глубоко вдыхаю и выпускаю только слово «выкалывать»."
+            },
+            {
+                "word": "die Qual",
+                "translation": "мука",
+                "parts": [
+                    "Im Nachhall der Schreie richtet Cornwall den Mantel und wendet sich zur Tür.",
+                    "Ich umarme das Wort „die Qual“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Im Nachhall der Schreie richtet Cornwall den Mantel und wendet sich zur Tür. Ich umarme das Wort „die Qual“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В отзвуках криков Корнуолл поправляет плащ и разворачивается к двери. Я обнимаю слово «мука», будто это единственный союзник."
+            }
+        ]
     },
     "wounded": {
         "title": "Раненый",
         "description": "Акт III: Ранен слугой",
         "words": [
             {
+                "wordId": "",
                 "word": "die Wunde",
                 "translation": "рана",
                 "transcription": "[ди ВУН-де]",
@@ -2802,9 +3579,14 @@
                 ],
                 "collocations": [
                     "Die Wunde brennt wie Feuer in meinem Leib. — Рана горит как огонь в моём теле."
+                ],
+                "sentenceParts": [
+                    "Im dunklen Korridor presst Cornwall die Hand gegen die frische Wunde.",
+                    "Ich atme tief ein und lasse nur das Wort „die Wunde“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Schmerz",
                 "translation": "боль",
                 "transcription": "[дер ШМЕРЦ]",
@@ -2826,9 +3608,14 @@
                     "Während des Sturms wirkt der Schmerz noch bedrückender. — Во время бури само «боль» звучит ещё тяжелее.",
                     "Der Schmerz durchbohrt meinen Körper. — Боль пронзает моё тело.",
                     "Der Schmerz durchbohrt meine Seele. — Боль пронзает мою душу."
+                ],
+                "sentenceParts": [
+                    "Auf der Treppe taumelt Cornwall, während das Blut den Stein färbt.",
+                    "Das kalte Licht lässt das Wort „der Schmerz“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Überraschung",
                 "translation": "удивление",
                 "transcription": "[ди ю-бер-РА-шунг]",
@@ -2850,9 +3637,14 @@
                 ],
                 "collocations": [
                     "Die Überraschung des Angriffs schockiert mich. — Неожиданность нападения шокирует меня."
+                ],
+                "sentenceParts": [
+                    "Neben Regans erschrockener Stimme sucht Cornwall Halt am Geländer.",
+                    "Ich zeichne das Wort „die Überraschung“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "bluten",
                 "translation": "кровоточить",
                 "transcription": "[БЛУ-тен]",
@@ -2874,9 +3666,14 @@
                 ],
                 "collocations": [
                     "Ich blute wie ein geschlachtetes Schwein. — Я кровоточу как зарезанная свинья."
+                ],
+                "sentenceParts": [
+                    "Im Stall greift Cornwall nach einem Sattel, doch die Kräfte schwinden.",
+                    "Ich umarme das Wort „bluten“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verwundet",
                 "translation": "раненый",
                 "transcription": "[фер-ВУН-дет]",
@@ -2898,9 +3695,14 @@
                 ],
                 "collocations": [
                     "Schwer verwundet sinke ich zu Boden. — Тяжело раненый я падаю на землю."
+                ],
+                "sentenceParts": [
+                    "Vor dem Tor der Burg hinterlässt Cornwall eine Spur aus rotem Staub.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „verwundet“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "schwächen",
                 "translation": "ослаблять",
                 "transcription": "[ШВЕ-хен]",
@@ -2922,9 +3724,14 @@
                 ],
                 "collocations": [
                     "Die Verletzung schwächt meinen starken Körper. — Ранение ослабляет моё сильное тело."
+                ],
+                "sentenceParts": [
+                    "Auf dem Hof sinkt Cornwall zwischen erschrockenen Wachen zusammen.",
+                    "Wie ein stilles Gebet legt sich das Wort „schwächen“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "leiden",
                 "translation": "страдать",
                 "transcription": "[ЛАЙ-ден]",
@@ -2949,6 +3756,10 @@
                     "Er muss furchtbar leiden ohne mich. — Он должно быть ужасно страдает без меня.",
                     "Ich leide furchtbare Qualen. — Я страдаю от ужасных мук.",
                     "Zum ersten Mal leide ich selbst. — Впервые я сам страдаю."
+                ],
+                "sentenceParts": [
+                    "Unter dem bleiernen Himmel schwört Cornwall Rache mit letzter Kraft.",
+                    "Das kalte Licht lässt das Wort „leiden“ wie geschmolzenes Gold erscheinen."
                 ]
             }
         ],
@@ -2956,39 +3767,39 @@
             {
                 "question": "Что означает немецкое слово «die Wunde»?",
                 "choices": [
+                    "рана",
                     "боль",
-                    "кровоточить",
                     "удивление",
-                    "рана"
+                    "кровоточить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
-                    "удивление",
-                    "рана",
                     "кровоточить",
-                    "боль"
+                    "боль",
+                    "удивление",
+                    "рана"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Überraschung»?",
                 "choices": [
-                    "кровоточить",
+                    "раненый",
                     "удивление",
-                    "страдать",
-                    "рана"
+                    "рана",
+                    "страдать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bluten»?",
                 "choices": [
-                    "раненый",
+                    "ослаблять",
                     "страдать",
-                    "рана",
+                    "удивление",
                     "кровоточить"
                 ],
                 "correctIndex": 3
@@ -2996,41 +3807,114 @@
             {
                 "question": "Что означает немецкое слово «verwundet»?",
                 "choices": [
+                    "ослаблять",
+                    "рана",
+                    "раненый",
+                    "страдать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «schwächen»?",
+                "choices": [
+                    "ослаблять",
                     "раненый",
                     "рана",
-                    "страдать",
                     "удивление"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «schwächen»?",
-                "choices": [
-                    "страдать",
-                    "рана",
-                    "боль",
-                    "ослаблять"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
+                    "ослаблять",
+                    "раненый",
                     "удивление",
-                    "рана",
-                    "страдать",
-                    "кровоточить"
+                    "страдать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Wunde",
+                "translation": "рана",
+                "parts": [
+                    "Im dunklen Korridor presst Cornwall die Hand gegen die frische Wunde.",
+                    "Ich atme tief ein und lasse nur das Wort „die Wunde“ wieder hinaus."
+                ],
+                "sentence": "Im dunklen Korridor presst Cornwall die Hand gegen die frische Wunde. Ich atme tief ein und lasse nur das Wort „die Wunde“ wieder hinaus.",
+                "sentenceTranslation": "В тёмном коридоре Корнуолл прижимает руку к свежей ране. Я глубоко вдыхаю и выпускаю только слово «рана»."
+            },
+            {
+                "word": "der Schmerz",
+                "translation": "боль",
+                "parts": [
+                    "Auf der Treppe taumelt Cornwall, während das Blut den Stein färbt.",
+                    "Das kalte Licht lässt das Wort „der Schmerz“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Auf der Treppe taumelt Cornwall, während das Blut den Stein färbt. Das kalte Licht lässt das Wort „der Schmerz“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На лестнице Корнуолл пошатывается, окрашивая камень кровью. Холодный свет заставляет слово «боль» сиять словно расплавленное золото."
+            },
+            {
+                "word": "die Überraschung",
+                "translation": "удивление",
+                "parts": [
+                    "Neben Regans erschrockener Stimme sucht Cornwall Halt am Geländer.",
+                    "Ich zeichne das Wort „die Überraschung“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Neben Regans erschrockener Stimme sucht Cornwall Halt am Geländer. Ich zeichne das Wort „die Überraschung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Рядом с испуганным голосом Реганы Корнуолл ищет опоры в перилах. Я вывожу слово «удивление» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "bluten",
+                "translation": "кровоточить",
+                "parts": [
+                    "Im Stall greift Cornwall nach einem Sattel, doch die Kräfte schwinden.",
+                    "Ich umarme das Wort „bluten“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Im Stall greift Cornwall nach einem Sattel, doch die Kräfte schwinden. Ich umarme das Wort „bluten“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В конюшне Корнуолл тянется к седлу, но силы уходят. Я обнимаю слово «кровоточить», будто это единственный союзник."
+            },
+            {
+                "word": "verwundet",
+                "translation": "раненый",
+                "parts": [
+                    "Vor dem Tor der Burg hinterlässt Cornwall eine Spur aus rotem Staub.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „verwundet“ mein Nordstern."
+                ],
+                "sentence": "Vor dem Tor der Burg hinterlässt Cornwall eine Spur aus rotem Staub. Selbst wenn die Welt zerfällt, bleibt das Wort „verwundet“ mein Nordstern.",
+                "sentenceTranslation": "Перед воротами замка Корнуолл оставляет след из красной пыли. Даже если мир распадается, слово «раненый» остаётся моим северным светом."
+            },
+            {
+                "word": "schwächen",
+                "translation": "ослаблять",
+                "parts": [
+                    "Auf dem Hof sinkt Cornwall zwischen erschrockenen Wachen zusammen.",
+                    "Wie ein stilles Gebet legt sich das Wort „schwächen“ auf meine Lippen."
+                ],
+                "sentence": "Auf dem Hof sinkt Cornwall zwischen erschrockenen Wachen zusammen. Wie ein stilles Gebet legt sich das Wort „schwächen“ auf meine Lippen.",
+                "sentenceTranslation": "На дворе Корнуолл падает среди испуганных стражников. Как тихая молитва слово «ослаблять» ложится на мои губы."
+            },
+            {
+                "word": "leiden",
+                "translation": "страдать",
+                "parts": [
+                    "Unter dem bleiernen Himmel schwört Cornwall Rache mit letzter Kraft.",
+                    "Das kalte Licht lässt das Wort „leiden“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Unter dem bleiernen Himmel schwört Cornwall Rache mit letzter Kraft. Das kalte Licht lässt das Wort „leiden“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Под свинцовым небом Корнуолл клянётся в мести из последних сил. Холодный свет заставляет слово «страдать» сиять словно расплавленное золото."
+            }
+        ]
     },
     "death": {
         "title": "Смерть тирана",
         "description": "Акт III: Умирает от раны",
         "words": [
             {
+                "wordId": "",
                 "word": "der Tod",
                 "translation": "смерть",
                 "transcription": "[дер ТОД]",
@@ -3055,9 +3939,14 @@
                     "Der Tod trennt uns nur für kurze Zeit. — Смерть разлучает нас лишь ненадолго.",
                     "Bis zum Tod bleibe ich an seiner Seite. — До смерти я остаюсь рядом с ним.",
                     "Der Tod kommt für mich zu früh. — Смерть приходит ко мне слишком рано."
+                ],
+                "sentenceParts": [
+                    "Im Treppenhaus der Burg bricht Cornwall auf das kalte Steinpodest.",
+                    "Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Vergeltung",
                 "translation": "возмездие",
                 "transcription": "[ди фер-ГЕЛЬ-тунг]",
@@ -3079,9 +3968,14 @@
                 ],
                 "collocations": [
                     "Die Vergeltung ereilt mich unerwartet. — Возмездие настигает меня неожиданно."
+                ],
+                "sentenceParts": [
+                    "Zwischen zerbrochenen Waffen liegt Cornwall und ringt nach Atem.",
+                    "Das kalte Licht lässt das Wort „die Vergeltung“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Ende",
                 "translation": "конец",
                 "transcription": "[дас ЕН-де]",
@@ -3105,9 +3999,14 @@
                     "Das Ende kommt schnell und gerecht. — Конец приходит быстро и справедливо.",
                     "Dies ist nicht das Ende, nur ein Übergang. — Это не конец, только переход.",
                     "Mein Ende kommt durch eines Dieners Hand. — Мой конец приходит от руки слуги."
+                ],
+                "sentenceParts": [
+                    "Vor Regans entsetztem Blick verliert Cornwall den Griff um das eigene Blut.",
+                    "Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "sterben",
                 "translation": "умирать",
                 "transcription": "[ШТЕР-бен]",
@@ -3132,9 +4031,14 @@
                     "Ich sterbe ohne Reue für meine Taten. — Я умираю без раскаяния за свои дела.",
                     "Ich sterbe vor Freude und Kummer. — Я умираю от радости и горя.",
                     "Ich sterbe durch meine eigene Hand. — Я умираю от своей собственной руки."
+                ],
+                "sentenceParts": [
+                    "Am Fuß der Treppe murmelt Cornwall die letzten Befehle.",
+                    "Ich umarme das Wort „sterben“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verenden",
                 "translation": "издыхать",
                 "transcription": "[фер-ЕН-ден]",
@@ -3159,9 +4063,14 @@
                 ],
                 "collocations": [
                     "Wie ein Tier verende ich elend. — Как зверь я издыхаю жалко."
+                ],
+                "sentenceParts": [
+                    "Auf der kalten Flaggenkiste sinkt Cornwall schwer zusammen.",
+                    "Mein Atem zeichnet das Wort „verenden“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verfluchen",
                 "translation": "проклинать",
                 "transcription": "[фер-ФЛУ-хен]",
@@ -3186,9 +4095,14 @@
                     "Ich verfluche dich bei allen Sternen! — Я проклинаю тебя всеми звёздами!",
                     "Sterbend verfluche ich meine Mörder. — Умирая, я проклинаю своих убийц.",
                     "Im Zorn verfluche ich Edgar. — В гневе я проклинаю Эдгара."
+                ],
+                "sentenceParts": [
+                    "Neben zerborstenen Fenstern haucht Cornwall den letzten Fluch aus.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „verfluchen“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "röcheln",
                 "translation": "хрипеть",
                 "transcription": "[РЁ-хельн]",
@@ -3210,9 +4124,14 @@
                 ],
                 "collocations": [
                     "Röchelnd hauche ich mein Leben aus. — Хрипя, я испускаю дух."
+                ],
+                "sentenceParts": [
+                    "Unter dem prasselnden Regen verglimmt Cornwalls Leben rasch.",
+                    "Ich halte das Wort „röcheln“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Strafe",
                 "translation": "кара",
                 "transcription": "[ди ШТРА-фе]",
@@ -3238,6 +4157,11 @@
                     "Diese Strafe erdulde ich für meinen König. — Это наказание я терплю ради короля.",
                     "Die Strafe für Widerspruch ist hart. — Наказание за возражение сурово.",
                     "Dies ist die gerechte Strafe für meine Grausamkeit. — Это справедливая кара за мою жестокость."
+                ],
+                "sentenceParts": [
+                    "Im Staub des Hofes starrt Cornwall zum grauen Himmel,",
+                    "bevor die Augen erlöschen.",
+                    "Ich atme tief ein und lasse nur das Wort „die Strafe“ wieder hinaus."
                 ]
             }
         ],
@@ -3245,19 +4169,19 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "смерть",
-                    "возмездие",
+                    "умирать",
                     "конец",
-                    "умирать"
+                    "возмездие",
+                    "смерть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Vergeltung»?",
                 "choices": [
-                    "смерть",
-                    "конец",
                     "умирать",
+                    "конец",
+                    "смерть",
                     "возмездие"
                 ],
                 "correctIndex": 3
@@ -3265,65 +4189,148 @@
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "проклинать",
-                    "конец",
-                    "кара",
-                    "издыхать"
+                    "издыхать",
+                    "смерть",
+                    "возмездие",
+                    "конец"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "проклинать",
+                    "смерть",
+                    "конец",
                     "хрипеть",
-                    "умирать",
-                    "конец"
+                    "умирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
-                    "издыхать",
+                    "кара",
+                    "конец",
                     "хрипеть",
-                    "возмездие",
-                    "умирать"
+                    "издыхать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
                     "смерть",
-                    "возмездие",
+                    "проклинать",
                     "кара",
-                    "проклинать"
+                    "возмездие"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «röcheln»?",
                 "choices": [
-                    "издыхать",
-                    "кара",
+                    "смерть",
                     "умирать",
-                    "хрипеть"
+                    "хрипеть",
+                    "возмездие"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "издыхать",
-                    "смерть",
+                    "проклинать",
                     "кара",
-                    "умирать"
+                    "возмездие",
+                    "издыхать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Tod",
+                "translation": "смерть",
+                "parts": [
+                    "Im Treppenhaus der Burg bricht Cornwall auf das kalte Steinpodest.",
+                    "Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im Treppenhaus der Burg bricht Cornwall auf das kalte Steinpodest. Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На лестнице замка Корнуолл рушится на холодную площадку. Моё дыхание рисует слово «смерть» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Vergeltung",
+                "translation": "возмездие",
+                "parts": [
+                    "Zwischen zerbrochenen Waffen liegt Cornwall und ringt nach Atem.",
+                    "Das kalte Licht lässt das Wort „die Vergeltung“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Zwischen zerbrochenen Waffen liegt Cornwall und ringt nach Atem. Das kalte Licht lässt das Wort „die Vergeltung“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Среди разбитого оружия Корнуолл лежит, хватая воздух. Холодный свет заставляет слово «возмездие» сиять словно расплавленное золото."
+            },
+            {
+                "word": "das Ende",
+                "translation": "конец",
+                "parts": [
+                    "Vor Regans entsetztem Blick verliert Cornwall den Griff um das eigene Blut.",
+                    "Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Vor Regans entsetztem Blick verliert Cornwall den Griff um das eigene Blut. Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед ужаснувшимся взглядом Реганы Корнуолл теряет хватку на собственной ране. Я держу слово «конец» как факел у сердца."
+            },
+            {
+                "word": "sterben",
+                "translation": "умирать",
+                "parts": [
+                    "Am Fuß der Treppe murmelt Cornwall die letzten Befehle.",
+                    "Ich umarme das Wort „sterben“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Am Fuß der Treppe murmelt Cornwall die letzten Befehle. Ich umarme das Wort „sterben“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "У подножия лестницы Корнуолл бормочет последние приказы. Я обнимаю слово «умирать», будто это единственный союзник."
+            },
+            {
+                "word": "verenden",
+                "translation": "издыхать",
+                "parts": [
+                    "Auf der kalten Flaggenkiste sinkt Cornwall schwer zusammen.",
+                    "Mein Atem zeichnet das Wort „verenden“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Auf der kalten Flaggenkiste sinkt Cornwall schwer zusammen. Mein Atem zeichnet das Wort „verenden“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На холодном сундуке со знамёнами Корнуолл тяжело оседает. Моё дыхание рисует слово «издыхать» в холодном воздухе между нами."
+            },
+            {
+                "word": "verfluchen",
+                "translation": "проклинать",
+                "parts": [
+                    "Neben zerborstenen Fenstern haucht Cornwall den letzten Fluch aus.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „verfluchen“ wird heute nicht verraten."
+                ],
+                "sentence": "Neben zerborstenen Fenstern haucht Cornwall den letzten Fluch aus. Mit fester Stimme schwöre ich mir: Das Wort „verfluchen“ wird heute nicht verraten.",
+                "sentenceTranslation": "У разбитых окон Корнуолл выдыхает последний проклятый звук. Твёрдым голосом я клянусь себе: слово «проклинать» сегодня не будет предано."
+            },
+            {
+                "word": "röcheln",
+                "translation": "хрипеть",
+                "parts": [
+                    "Unter dem prasselnden Regen verglimmt Cornwalls Leben rasch.",
+                    "Ich halte das Wort „röcheln“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Unter dem prasselnden Regen verglimmt Cornwalls Leben rasch. Ich halte das Wort „röcheln“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Под проливным дождём жизнь Корнуолл быстро гаснет. Я держу слово «хрипеть» как факел у сердца."
+            },
+            {
+                "word": "die Strafe",
+                "translation": "кара",
+                "parts": [
+                    "Im Staub des Hofes starrt Cornwall zum grauen Himmel,",
+                    "bevor die Augen erlöschen.",
+                    "Ich atme tief ein und lasse nur das Wort „die Strafe“ wieder hinaus."
+                ],
+                "sentence": "Im Staub des Hofes starrt Cornwall zum grauen Himmel, bevor die Augen erlöschen. Ich atme tief ein und lasse nur das Wort „die Strafe“ wieder hinaus.",
+                "sentenceTranslation": "В пыли двора Корнуолл смотрит в серое небо, прежде чем глаза угасают. Я глубоко вдыхаю и выпускаю только слово «кара»."
+            }
+        ]
     }
 };
 
@@ -3339,6 +4346,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3775,6 +5130,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -3843,6 +5515,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -3851,13 +5526,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4768,6 +6491,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/journeys/edgar.html
+++ b/output/journeys/edgar.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="throne">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="goneril">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="regan">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="storm">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="hut">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="dover">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="prison">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["наследник", "доверять", "знать", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["доверять", "наследник", "знать", "королевство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["наследник", "королевство", "знать", "граф"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["законный", "знать", "честь", "доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["законный", "наследник", "честь", "граф"], "correct_index": 2}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["наследник", "честь", "законный", "ничего не подозревающий"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["граф", "честь", "наследник", "знать"], "correct_index": 0}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["граф", "законный", "честь", "ничего не подозревающий"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["преследовать", "предательство", "опасность", "бежать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["бежать", "опасность", "предательство", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["бежать", "преследовать", "прятаться", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["обман", "изгнать", "бежать", "преследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["изгнать", "прятаться", "интрига", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["изгнать", "интрига", "преследовать", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["изгнать", "обман", "бежать", "прятаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["бежать", "изгнать", "обман", "предательство"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["нищий", "голый", "маскировка", "безумие"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["маскировка", "безумие", "голый", "нищий"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["дрожать", "маскировка", "голый", "нищета"], "correct_index": 1}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["дрожать", "безумие", "маскировка", "голый"], "correct_index": 3}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["бормотать", "нищий", "дрожать", "безумие"], "correct_index": 0}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["безумный", "дрожать", "нищета", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["дрожать", "голый", "нищета", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["дрожать", "безумный", "бормотать", "нищий"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["мёрзнуть", "хижина", "страдать", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["страдать", "мёрзнуть", "хижина", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["защищать", "страдать", "гром", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["хижина", "сопровождать", "буря", "гром"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["защищать", "страдать", "хижина", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["защищать", "сопровождать", "хижина", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["молния", "гром", "буря", "хижина"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["гром", "страдать", "мёрзнуть", "молния"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["вести", "слепой", "утёс", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «führen»?", "choices": ["утёс", "обманывать", "вести", "слепой"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["утёс", "спасать", "вести", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["слепой", "вести", "обманывать", "утёс"], "correct_index": 2}, {"question": "Что означает немецкое слово «retten»?", "choices": ["спасать", "утешать", "вести", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["слепой", "отчаяние", "хитрость", "утешать"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["обманывать", "утешать", "утёс", "слепой"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["спасать", "отчаяние", "вести", "обманывать"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["разоблачать", "бой", "месть", "дуэль"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["разоблачать", "бой", "дуэль", "месть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "разоблачать", "дуэль", "меч"], "correct_index": 0}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["справедливость", "разоблачать", "меч", "брат"], "correct_index": 1}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["побеждать", "брат", "дуэль", "бой"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["побеждать", "меч", "дуэль", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["брат", "бой", "меч", "дуэль"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["разоблачать", "брат", "месть", "меч"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["выживать", "будущее", "наследовать", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «erben»?", "choices": ["править", "наследовать", "будущее", "выживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["выживать", "мудрость", "будущее", "ответственность"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["править", "мудрость", "выживать", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["порядок", "наследовать", "мудрость", "выживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["порядок", "будущее", "наследовать", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["порядок", "ответственность", "будущее", "выживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «neu»?", "choices": ["наследовать", "новый", "будущее", "порядок"], "correct_index": 1}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["королевство", "знать", "доверять", "наследник"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["королевство", "знать", "доверять", "наследник"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["знать", "ничего не подозревающий", "королевство", "граф"], "correct_index": 2}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["наследник", "доверять", "законный", "честь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["доверять", "ничего не подозревающий", "граф", "честь"], "correct_index": 3}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["честь", "граф", "законный", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["ничего не подозревающий", "наследник", "законный", "граф"], "correct_index": 3}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["ничего не подозревающий", "граф", "законный", "доверять"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["преследовать", "опасность", "бежать", "предательство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["опасность", "преследовать", "предательство", "бежать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["бежать", "опасность", "прятаться", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["предательство", "преследовать", "изгнать", "прятаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["бежать", "прятаться", "интрига", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["обман", "опасность", "интрига", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["обман", "прятаться", "бежать", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["опасность", "обман", "предательство", "изгнать"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["голый", "нищий", "маскировка", "безумие"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["нищий", "безумие", "маскировка", "голый"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["маскировка", "безумие", "бормотать", "безумный"], "correct_index": 0}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["маскировка", "голый", "нищий", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["нищий", "маскировка", "бормотать", "безумный"], "correct_index": 2}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["нищета", "дрожать", "бормотать", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищета", "бормотать", "нищий", "дрожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["безумный", "безумие", "дрожать", "нищий"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["мёрзнуть", "страдать", "буря", "хижина"], "correct_index": 2}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["хижина", "страдать", "буря", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["защищать", "мёрзнуть", "буря", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["гром", "мёрзнуть", "хижина", "сопровождать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["защищать", "сопровождать", "мёрзнуть", "гром"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["мёрзнуть", "буря", "сопровождать", "хижина"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["страдать", "гром", "мёрзнуть", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["молния", "защищать", "гром", "мёрзнуть"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["вести", "слепой", "обманывать", "утёс"], "correct_index": 1}, {"question": "Что означает немецкое слово «führen»?", "choices": ["обманывать", "слепой", "утёс", "вести"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["утешать", "вести", "обманывать", "утёс"], "correct_index": 3}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["утёс", "обманывать", "хитрость", "спасать"], "correct_index": 1}, {"question": "Что означает немецкое слово «retten»?", "choices": ["слепой", "отчаяние", "утешать", "спасать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die List»?", "choices": ["отчаяние", "утёс", "обманывать", "хитрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["хитрость", "отчаяние", "утешать", "спасать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["спасать", "отчаяние", "вести", "утёс"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["разоблачать", "месть", "дуэль", "бой"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["бой", "разоблачать", "дуэль", "месть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["брат", "справедливость", "побеждать", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["дуэль", "бой", "побеждать", "разоблачать"], "correct_index": 3}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["справедливость", "бой", "побеждать", "брат"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["меч", "побеждать", "дуэль", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["брат", "разоблачать", "меч", "месть"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["брат", "справедливость", "бой", "месть"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["править", "будущее", "выживать", "наследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erben»?", "choices": ["править", "выживать", "будущее", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["выживать", "новый", "будущее", "порядок"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["будущее", "править", "мудрость", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["ответственность", "наследовать", "править", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["будущее", "ответственность", "наследовать", "порядок"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["новый", "ответственность", "порядок", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «neu»?", "choices": ["править", "ответственность", "выживать", "новый"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный сын</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,81 +661,81 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Erbe»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ничего не подозревающий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Erbe»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ничего не подозревающий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -549,45 +745,45 @@
                         <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ничего не подозревающий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ничего не подозревающий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,17 +796,17 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «fliehen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -620,45 +816,45 @@
                         <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прятаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -668,7 +864,7 @@
                         <div class="quiz-question">Что означает немецкое слово «verstecken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">прятаться</button>
                             
@@ -680,49 +876,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прятаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгнать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -739,9 +935,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
                             
@@ -751,43 +947,11 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
@@ -799,17 +963,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бормотать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -819,11 +1015,11 @@
                         <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
@@ -831,31 +1027,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бормотать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «wahnsinnig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
@@ -870,65 +1066,65 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -940,27 +1136,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -970,29 +1166,29 @@
                         <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1013,51 +1209,35 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утёс</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «führen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Klippe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
                             
@@ -1069,49 +1249,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утёс</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1127,7 +1323,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утёс</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1140,77 +1336,13 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">меч</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">брат</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
@@ -1220,13 +1352,77 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">брат</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
                     <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">меч</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
@@ -1242,27 +1438,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Bruder»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">меч</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1275,33 +1471,33 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «überleben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1313,25 +1509,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ответственность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                             
@@ -1339,33 +1535,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ответственность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1375,29 +1571,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">порядок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «neu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1421,6 +1617,7 @@
         "description": "Акт I: Законный наследник",
         "words": [
             {
+                "wordId": "",
                 "word": "der Adel",
                 "translation": "знать",
                 "transcription": "[дер А-дель]",
@@ -1445,9 +1642,14 @@
                     "Lears Herz wird schwer, wenn der Adel zur Sprache kommt. — Сердце Лира тяжелеет: «дворянство» звучит слишком близко.",
                     "Der Adel erwartet von mir ehrenhaftes Verhalten. — Знать ожидает от меня достойного поведения.",
                     "Als Adel diene ich meinem König treu. — Как знать я верно служу своему королю."
+                ],
+                "sentenceParts": [
+                    "Edgar steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Adel“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Erbe",
                 "translation": "наследник",
                 "transcription": "[дер ЕР-бе]",
@@ -1468,9 +1670,14 @@
                 "collocations": [
                     "Im Thronsaal verstummen die Gespräche über der Erbe nie. — В тронном зале постоянно звучит слово «наследник».",
                     "Als rechtmäßiger Erbe habe ich Pflichten. — Как законный наследник, у меня есть обязанности."
+                ],
+                "sentenceParts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Edgar über Lears schweren Tisch.",
+                    "Mein Atem zeichnet das Wort „der Erbe“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Königreich",
                 "translation": "королевство",
                 "transcription": "[дас КЁ-ниг-райх]",
@@ -1492,9 +1699,14 @@
                     "Lears Herz wird schwer, wenn das Königreich zur Sprache kommt. — Сердце Лира тяжелеет: «королевство» звучит слишком близко.",
                     "Mein Königreich teile ich unter meinen Töchtern. — Моё королевство я делю между дочерьми.",
                     "Ich diene dem Königreich mit Ehre. — Я служу королевству с честью."
+                ],
+                "sentenceParts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Edgar die Hände hinter dem Rücken.",
+                    "Wie ein stilles Gebet legt sich das Wort „das Königreich“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vertrauen",
                 "translation": "доверять",
                 "transcription": "[фер-ТРАУ-ен]",
@@ -1518,9 +1730,14 @@
                     "Im Sturm zeigt sich, wie wichtig das Vertrauen ist. — Во время бури становится понятно, насколько важно доверять.",
                     "Mein Vater vertraut mir vollkommen. — Мой отец полностью мне доверяет.",
                     "Ich vertraue beiden Söhnen gleich. — Я доверяю обоим сыновьям одинаково."
+                ],
+                "sentenceParts": [
+                    "Zwischen flüsternden Höflingen gleitet Edgar über den kalten Marmorboden.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vertrauen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Ehre",
                 "translation": "честь",
                 "transcription": "[ди Э-ре]",
@@ -1543,9 +1760,14 @@
                     "Die Ehre der Familie liegt in meinen Händen. — Честь семьи в моих руках.",
                     "Unsere Ehre bleibt unbefleckt. — Наша честь остаётся незапятнанной.",
                     "Meine Ehre ist mein höchstes Gut. — Моя честь - моё высшее благо."
+                ],
+                "sentenceParts": [
+                    "Am Rand des purpurnen Teppichs wartet Edgar auf ein Zeichen des Königs.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Ehre“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "legitim",
                 "translation": "законный",
                 "transcription": "[ле-ги-ТИМ]",
@@ -1567,9 +1789,14 @@
                 ],
                 "collocations": [
                     "Ich bin der legitime Sohn des Grafen. — Я законный сын графа."
+                ],
+                "sentenceParts": [
+                    "Unter wehenden Standarten der Schwestern senkt Edgar kurz den Blick.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „legitim“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Graf",
                 "translation": "граф",
                 "transcription": "[дер ГРАФ]",
@@ -1591,9 +1818,14 @@
                     "Im Thronsaal verstummen die Gespräche über der Graf nie. — В тронном зале постоянно звучит слово «граф».",
                     "Mein Vater, der Graf, ist ein edler Mann. — Мой отец, граф, благородный человек.",
                     "Als Graf habe ich große Verantwortung. — Как граф я несу большую ответственность."
+                ],
+                "sentenceParts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Edgar das gespannte Antlitz des Hofes.",
+                    "Das kalte Licht lässt das Wort „der Graf“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ahnungslos",
                 "translation": "ничего не подозревающий",
                 "transcription": "[А-нунгс-лос]",
@@ -1618,6 +1850,10 @@
                 ],
                 "collocations": [
                     "Ahnungslos vertraue ich meinem Bruder. — Ничего не подозревая, я доверяю брату."
+                ],
+                "sentenceParts": [
+                    "Im Schein der offenen Feuerbecken erhebt Edgar langsam die Stimme.",
+                    "Ich presse das Wort „ahnungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             }
         ],
@@ -1625,91 +1861,174 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
-                    "наследник",
-                    "доверять",
+                    "королевство",
                     "знать",
-                    "королевство"
+                    "доверять",
+                    "наследник"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Erbe»?",
                 "choices": [
-                    "доверять",
-                    "наследник",
-                    "знать",
-                    "королевство"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «das Königreich»?",
-                "choices": [
-                    "наследник",
                     "королевство",
                     "знать",
-                    "граф"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «vertrauen»?",
-                "choices": [
-                    "законный",
-                    "знать",
-                    "честь",
-                    "доверять"
+                    "доверять",
+                    "наследник"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Ehre»?",
+                "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
-                    "законный",
-                    "наследник",
-                    "честь",
+                    "знать",
+                    "ничего не подозревающий",
+                    "королевство",
                     "граф"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «legitim»?",
+                "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
                     "наследник",
-                    "честь",
+                    "доверять",
                     "законный",
-                    "ничего не подозревающий"
+                    "честь"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Ehre»?",
+                "choices": [
+                    "доверять",
+                    "ничего не подозревающий",
+                    "граф",
+                    "честь"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «legitim»?",
+                "choices": [
+                    "честь",
+                    "граф",
+                    "законный",
+                    "королевство"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
-                    "граф",
-                    "честь",
+                    "ничего не подозревающий",
                     "наследник",
-                    "знать"
+                    "законный",
+                    "граф"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ahnungslos»?",
                 "choices": [
+                    "ничего не подозревающий",
                     "граф",
                     "законный",
-                    "честь",
-                    "ничего не подозревающий"
+                    "доверять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Adel",
+                "translation": "знать",
+                "parts": [
+                    "Edgar steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Adel“ bleibt lebendig."
+                ],
+                "sentence": "Edgar steht unter dem glühenden Kronleuchter des Thronsaals. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Adel“ bleibt lebendig.",
+                "sentenceTranslation": "Эдгар стоит под пылающей люстрой тронного зала. Каждой клеткой тела я обещаю: слово «знать» останется живым."
+            },
+            {
+                "word": "der Erbe",
+                "translation": "наследник",
+                "parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Edgar über Lears schweren Tisch.",
+                    "Mein Atem zeichnet das Wort „der Erbe“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Edgar über Lears schweren Tisch. Mein Atem zeichnet das Wort „der Erbe“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У развернутой карты королевства Эдгар склоняется над тяжёлым столом Лира. Моё дыхание рисует слово «наследник» в холодном воздухе между нами."
+            },
+            {
+                "word": "das Königreich",
+                "translation": "королевство",
+                "parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Edgar die Hände hinter dem Rücken.",
+                    "Wie ein stilles Gebet legt sich das Wort „das Königreich“ auf meine Lippen."
+                ],
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Edgar die Hände hinter dem Rücken. Wie ein stilles Gebet legt sich das Wort „das Königreich“ auf meine Lippen.",
+                "sentenceTranslation": "Перед каменными статуями предков Эдгар сцепляет руки за спиной. Как тихая молитва слово «королевство» ложится на мои губы."
+            },
+            {
+                "word": "vertrauen",
+                "translation": "доверять",
+                "parts": [
+                    "Zwischen flüsternden Höflingen gleitet Edgar über den kalten Marmorboden.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vertrauen“ gehört mir."
+                ],
+                "sentence": "Zwischen flüsternden Höflingen gleitet Edgar über den kalten Marmorboden. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vertrauen“ gehört mir.",
+                "sentenceTranslation": "Между шепчущимися придворными Эдгар скользит по холодному мраморному полу. Буря за окнами усиливает клятву: слово «доверять» принадлежит мне."
+            },
+            {
+                "word": "die Ehre",
+                "translation": "честь",
+                "parts": [
+                    "Am Rand des purpurnen Teppichs wartet Edgar auf ein Zeichen des Königs.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Ehre“ auf meine Lippen."
+                ],
+                "sentence": "Am Rand des purpurnen Teppichs wartet Edgar auf ein Zeichen des Königs. Wie ein stilles Gebet legt sich das Wort „die Ehre“ auf meine Lippen.",
+                "sentenceTranslation": "На краю пурпурного ковра Эдгар ждёт знака от короля. Как тихая молитва слово «честь» ложится на мои губы."
+            },
+            {
+                "word": "legitim",
+                "translation": "законный",
+                "parts": [
+                    "Unter wehenden Standarten der Schwestern senkt Edgar kurz den Blick.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „legitim“ bleibt lebendig."
+                ],
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Edgar kurz den Blick. Mit jeder Faser meines Körpers verspreche ich: Das Wort „legitim“ bleibt lebendig.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Эдгар на миг опускает взгляд. Каждой клеткой тела я обещаю: слово «законный» останется живым."
+            },
+            {
+                "word": "der Graf",
+                "translation": "граф",
+                "parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Edgar das gespannte Antlitz des Hofes.",
+                    "Das kalte Licht lässt das Wort „der Graf“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Edgar das gespannte Antlitz des Hofes. Das kalte Licht lässt das Wort „der Graf“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "За позолоченной балюстрадой Эдгар наблюдает за напряжёнными лицами двора. Холодный свет заставляет слово «граф» сиять словно расплавленное золото."
+            },
+            {
+                "word": "ahnungslos",
+                "translation": "ничего не подозревающий",
+                "parts": [
+                    "Im Schein der offenen Feuerbecken erhebt Edgar langsam die Stimme.",
+                    "Ich presse das Wort „ahnungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Edgar langsam die Stimme. Ich presse das Wort „ahnungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В отблесках открытых жаровен Эдгар медленно поднимает голос. Я стискиваю слово «ничего не подозревающий» зубами, чтобы не вырвалось сомнение."
+            }
+        ]
     },
     "goneril": {
         "title": "Бегство",
         "description": "Акт II: Предательство Эдмунда",
         "words": [
             {
+                "wordId": "",
                 "word": "fliehen",
                 "translation": "бежать",
                 "transcription": "[ФЛИ-ен]",
@@ -1731,9 +2050,14 @@
                 "collocations": [
                     "Der Narr spürt, wie das Fliehen alle verändert. — Шут чувствует, как умение бежать меняет всех.",
                     "Ich muss vor falschen Anschuldigungen fliehen. — Я должен бежать от ложных обвинений."
+                ],
+                "sentenceParts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Edgar zwischen gepackten Kisten.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „fliehen“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Verrat",
                 "translation": "предательство",
                 "transcription": "[дер фер-РАТ]",
@@ -1757,9 +2081,14 @@
                     "Der Verrat ist mein tägliches Geschäft. — Предательство - моё ежедневное дело.",
                     "Der Verrat meines Bruders zerstört mein Leben. — Предательство моего брата разрушает мою жизнь.",
                     "Meine Hilfe gilt als Verrat. — Моя помощь считается изменой."
+                ],
+                "sentenceParts": [
+                    "Auf der windigen Freitreppe blickt Edgar zum schweigenden Hof hinunter.",
+                    "Ich umarme das Wort „der Verrat“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Gefahr",
                 "translation": "опасность",
                 "transcription": "[ди ге-ФАР]",
@@ -1782,9 +2111,14 @@
                     "Die Gefahr lauert überall um mich herum. — Опасность подстерегает меня повсюду.",
                     "Trotz Gefahr bleibe ich beim König. — Несмотря на опасность, я остаюсь с королём.",
                     "Die Gefahr der Entdeckung ist groß. — Опасность разоблачения велика."
+                ],
+                "sentenceParts": [
+                    "Zwischen zurückgelassenen Dienern schließt Edgar den Reisemantel enger.",
+                    "Ich zeichne das Wort „die Gefahr“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verfolgen",
                 "translation": "преследовать",
                 "transcription": "[фер-ФОЛЬ-ген]",
@@ -1806,9 +2140,14 @@
                     "Der Narr spürt, wie das Verfolgen alle verändert. — Шут чувствует, как умение преследовать меняет всех.",
                     "Gnadenlos verfolge ich den alten Mann. — Безжалостно я преследую старика.",
                     "Die Soldaten verfolgen mich wie einen Verbrecher. — Солдаты преследуют меня как преступника."
+                ],
+                "sentenceParts": [
+                    "Am dunklen Pferdestall streicht Edgar einem nervösen Tier über die Mähne.",
+                    "Ich zeichne das Wort „verfolgen“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verstecken",
                 "translation": "прятаться",
                 "transcription": "[фер-ШТЕ-кен]",
@@ -1830,9 +2169,14 @@
                 "collocations": [
                     "Das Verstecken fällt Lear unerwartet schwer. — Лиру неожиданно тяжело прятать.",
                     "Ich muss mich in den Wäldern verstecken. — Я должен прятаться в лесах."
+                ],
+                "sentenceParts": [
+                    "Vor dem knarrenden Fallgatter tastet Edgar ein letztes Mal nach dem Haustor.",
+                    "Das kalte Licht lässt das Wort „verstecken“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Intrige",
                 "translation": "интрига",
                 "transcription": "[ди ин-ТРИ-ге]",
@@ -1856,9 +2200,14 @@
                     "Jede Intrige spinne ich mit Freude. — Каждую интригу я плету с радостью.",
                     "Edmunds Intrige hat mich zum Geächteten gemacht. — Интрига Эдмунда сделала меня изгоем.",
                     "Meine Intrige wird sie vernichten. — Моя интрига уничтожит её."
+                ],
+                "sentenceParts": [
+                    "Zwischen verstreuten Schriftrollen dreht Edgar den Ring an der Hand.",
+                    "Mein Atem zeichnet das Wort „die Intrige“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Betrug",
                 "translation": "обман",
                 "transcription": "[дер бе-ТРУГ]",
@@ -1881,9 +2230,14 @@
                     "Cordelia merkt sich genau, wie der Betrug verteilt wird. — Корделия внимательно следит, кому достанется «обман».",
                     "Dieser Betrug wird eines Tages aufgedeckt. — Этот обман однажды раскроется.",
                     "Ich erkenne den Betrug nicht. — Я не распознаю обман."
+                ],
+                "sentenceParts": [
+                    "Am leeren Bankettisch zählt Edgar die verlöschenden Kerzen.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Betrug“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verbannen",
                 "translation": "изгнать",
                 "transcription": "[фер-БАН-нен]",
@@ -1907,6 +2261,10 @@
                 "collocations": [
                     "Cordelia zeigt, dass das Verbannen auch ohne Stolz möglich ist. — Корделия показывает, что изгонять можно и без гордыни.",
                     "Mein Vater will mich aus dem Land verbannen. — Мой отец хочет изгнать меня из страны."
+                ],
+                "sentenceParts": [
+                    "Zwischen schweigenden Wachen geht Edgar auf den kalten Hof hinaus.",
+                    "Ich atme tief ein und lasse nur das Wort „verbannen“ wieder hinaus."
                 ]
             }
         ],
@@ -1915,19 +2273,19 @@
                 "question": "Что означает немецкое слово «fliehen»?",
                 "choices": [
                     "преследовать",
-                    "предательство",
                     "опасность",
-                    "бежать"
+                    "бежать",
+                    "предательство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "бежать",
                     "опасность",
+                    "преследовать",
                     "предательство",
-                    "преследовать"
+                    "бежать"
                 ],
                 "correctIndex": 2
             },
@@ -1935,26 +2293,26 @@
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
                     "бежать",
-                    "преследовать",
+                    "опасность",
                     "прятаться",
-                    "опасность"
+                    "предательство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
-                    "обман",
+                    "предательство",
+                    "преследовать",
                     "изгнать",
-                    "бежать",
-                    "преследовать"
+                    "прятаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verstecken»?",
                 "choices": [
-                    "изгнать",
+                    "бежать",
                     "прятаться",
                     "интрига",
                     "обман"
@@ -1964,41 +2322,124 @@
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "изгнать",
+                    "обман",
+                    "опасность",
                     "интрига",
-                    "преследовать",
-                    "предательство"
+                    "преследовать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
-                    "изгнать",
                     "обман",
+                    "прятаться",
                     "бежать",
-                    "прятаться"
+                    "опасность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verbannen»?",
                 "choices": [
-                    "бежать",
-                    "изгнать",
+                    "опасность",
                     "обман",
-                    "предательство"
+                    "предательство",
+                    "изгнать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "fliehen",
+                "translation": "бежать",
+                "parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Edgar zwischen gepackten Kisten.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „fliehen“ mein Nordstern."
+                ],
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Edgar zwischen gepackten Kisten. Selbst wenn die Welt zerfällt, bleibt das Wort „fliehen“ mein Nordstern.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Эдгар замирает среди нагруженных ящиков. Даже если мир распадается, слово «бежать» остаётся моим северным светом."
+            },
+            {
+                "word": "der Verrat",
+                "translation": "предательство",
+                "parts": [
+                    "Auf der windigen Freitreppe blickt Edgar zum schweigenden Hof hinunter.",
+                    "Ich umarme das Wort „der Verrat“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Auf der windigen Freitreppe blickt Edgar zum schweigenden Hof hinunter. Ich umarme das Wort „der Verrat“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Эдгар смотрит вниз на молчаливый двор. Я обнимаю слово «предательство», будто это единственный союзник."
+            },
+            {
+                "word": "die Gefahr",
+                "translation": "опасность",
+                "parts": [
+                    "Zwischen zurückgelassenen Dienern schließt Edgar den Reisemantel enger.",
+                    "Ich zeichne das Wort „die Gefahr“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Edgar den Reisemantel enger. Ich zeichne das Wort „die Gefahr“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Среди оставленных слуг Эдгар плотнее запахивает дорожный плащ. Я вывожу слово «опасность» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "verfolgen",
+                "translation": "преследовать",
+                "parts": [
+                    "Am dunklen Pferdestall streicht Edgar einem nervösen Tier über die Mähne.",
+                    "Ich zeichne das Wort „verfolgen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Am dunklen Pferdestall streicht Edgar einem nervösen Tier über die Mähne. Ich zeichne das Wort „verfolgen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Эдгар гладит гриву нервного коня. Я вывожу слово «преследовать» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "verstecken",
+                "translation": "прятаться",
+                "parts": [
+                    "Vor dem knarrenden Fallgatter tastet Edgar ein letztes Mal nach dem Haustor.",
+                    "Das kalte Licht lässt das Wort „verstecken“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Vor dem knarrenden Fallgatter tastet Edgar ein letztes Mal nach dem Haustor. Das kalte Licht lässt das Wort „verstecken“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Эдгар в последний раз касается родной двери. Холодный свет заставляет слово «прятаться» сиять словно расплавленное золото."
+            },
+            {
+                "word": "die Intrige",
+                "translation": "интрига",
+                "parts": [
+                    "Zwischen verstreuten Schriftrollen dreht Edgar den Ring an der Hand.",
+                    "Mein Atem zeichnet das Wort „die Intrige“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Edgar den Ring an der Hand. Mein Atem zeichnet das Wort „die Intrige“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Среди разбросанных свитков Эдгар вертит кольцо на пальце. Моё дыхание рисует слово «интрига» в холодном воздухе между нами."
+            },
+            {
+                "word": "der Betrug",
+                "translation": "обман",
+                "parts": [
+                    "Am leeren Bankettisch zählt Edgar die verlöschenden Kerzen.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Betrug“ auf meine Lippen."
+                ],
+                "sentence": "Am leeren Bankettisch zählt Edgar die verlöschenden Kerzen. Wie ein stilles Gebet legt sich das Wort „der Betrug“ auf meine Lippen.",
+                "sentenceTranslation": "У пустого банкетного стола Эдгар пересчитывает гаснущие свечи. Как тихая молитва слово «обман» ложится на мои губы."
+            },
+            {
+                "word": "verbannen",
+                "translation": "изгнать",
+                "parts": [
+                    "Zwischen schweigenden Wachen geht Edgar auf den kalten Hof hinaus.",
+                    "Ich atme tief ein und lasse nur das Wort „verbannen“ wieder hinaus."
+                ],
+                "sentence": "Zwischen schweigenden Wachen geht Edgar auf den kalten Hof hinaus. Ich atme tief ein und lasse nur das Wort „verbannen“ wieder hinaus.",
+                "sentenceTranslation": "Между молчаливыми стражниками Эдгар выходит на холодный двор. Я глубоко вдыхаю и выпускаю только слово «изгнать»."
+            }
+        ]
     },
     "regan": {
         "title": "Том из Бедлама",
         "description": "Акт III: Превращение в безумца",
         "words": [
             {
+                "wordId": "",
                 "word": "der Wahnsinn",
                 "translation": "безумие",
                 "transcription": "[дер ВАН-зин]",
@@ -2021,9 +2462,14 @@
                     "Der Wahnsinn ist gnädiger als die Vernunft! — Безумие милосерднее разума!",
                     "Ich spiele den Wahnsinn, um zu überleben. — Я играю безумие, чтобы выжить.",
                     "Im Wahnsinn finden wir uns als Brüder. — В безумии мы находим друг друга как братья."
+                ],
+                "sentenceParts": [
+                    "Im zugigen Seitenflügel lauscht Edgar dem Heulen der Küstenwinde.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „der Wahnsinn“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Bettler",
                 "translation": "нищий",
                 "transcription": "[дер БЕТ-лер]",
@@ -2048,9 +2494,14 @@
                 "collocations": [
                     "Dieser Bettler ist glücklicher als ich, der König! — Этот нищий счастливее меня, короля!",
                     "Als Bettler bin ich unsichtbar für meine Feinde. — Как нищий, я невидим для врагов."
+                ],
+                "sentenceParts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Edgar einen zerknitterten Brief.",
+                    "Ich halte das Wort „der Bettler“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Verkleidung",
                 "translation": "маскировка",
                 "transcription": "[ди фер-КЛАЙ-дунг]",
@@ -2077,9 +2528,14 @@
                 "collocations": [
                     "Diese Verkleidung ist meine einzige Rettung. — Эта маскировка - моё единственное спасение.",
                     "In Verkleidung diene ich meinem König weiter. — В переодевании я продолжаю служить королю."
+                ],
+                "sentenceParts": [
+                    "Unter farblosen Wandteppichen schreitet Edgar rastlos auf und ab.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Verkleidung“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "nackt",
                 "translation": "голый",
                 "transcription": "[НАКТ]",
@@ -2105,9 +2561,14 @@
                 "collocations": [
                     "Nackt kam ich auf die Welt, nackt gehe ich! — Голым я пришёл в мир, голым и уйду!",
                     "Fast nackt wandere ich durch die Wildnis. — Почти голый, я брожу по дикой местности."
+                ],
+                "sentenceParts": [
+                    "An der schmalen Fensterluke zählt Edgar die Fackeln auf dem Hof.",
+                    "Ich presse das Wort „nackt“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "murmeln",
                 "translation": "бормотать",
                 "transcription": "[МУР-мельн]",
@@ -2129,9 +2590,14 @@
                 ],
                 "collocations": [
                     "Ich murmle Unsinn, um verrückt zu wirken. — Я бормочу чепуху, чтобы казаться сумасшедшим."
+                ],
+                "sentenceParts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Edgar nach frischen Botschaften.",
+                    "Ich halte das Wort „murmeln“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "zittern",
                 "translation": "дрожать",
                 "transcription": "[ЦИ-терн]",
@@ -2153,9 +2619,14 @@
                     "Der Narr spürt, wie das Zittern alle verändert. — Шут чувствует, как умение дрожать меняет всех.",
                     "Vor Kälte und Angst zittere ich ständig. — От холода и страха я постоянно дрожу.",
                     "Vor Kälte zittern wir wie Espenlaub. — От холода мы дрожим как осиновый лист."
+                ],
+                "sentenceParts": [
+                    "Im stillen Kapellenraum kniet Edgar vor der kalten Steinfigur.",
+                    "Ich presse das Wort „zittern“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Elend",
                 "translation": "нищета",
                 "transcription": "[дас Э-ленд]",
@@ -2177,9 +2648,15 @@
                     "Im Thronsaal verstummen die Gespräche über das Elend nie. — В тронном зале постоянно звучит слово «нищета».",
                     "Im Elend erkenne ich die Wahrheit der Welt. — В нищете я познаю истину мира.",
                     "Im Elend lerne ich die wahre Natur des Menschen. — В нищете я познаю истинную природу человека."
+                ],
+                "sentenceParts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Edgar die Laterne fest.",
+                    "Ich presse das Wort „das Elend“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "wahnsinnig",
                 "translation": "безумный",
                 "transcription": "[ВАН-зи-ниг]",
@@ -2201,6 +2678,10 @@
                 ],
                 "collocations": [
                     "Ich gebe vor, wahnsinnig zu sein. — Я притворяюсь безумным."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der hohen Burgmauern schreibt Edgar eine fiebrige Antwort.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „wahnsinnig“ bleibt lebendig."
                 ]
             }
         ],
@@ -2208,8 +2689,8 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "нищий",
                     "голый",
+                    "нищий",
                     "маскировка",
                     "безумие"
                 ],
@@ -2218,49 +2699,49 @@
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
-                    "маскировка",
-                    "безумие",
-                    "голый",
-                    "нищий"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Verkleidung»?",
-                "choices": [
-                    "дрожать",
-                    "маскировка",
-                    "голый",
-                    "нищета"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «nackt»?",
-                "choices": [
-                    "дрожать",
+                    "нищий",
                     "безумие",
                     "маскировка",
                     "голый"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «murmeln»?",
+                "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
+                    "маскировка",
+                    "безумие",
                     "бормотать",
-                    "нищий",
-                    "дрожать",
-                    "безумие"
+                    "безумный"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «nackt»?",
+                "choices": [
+                    "маскировка",
+                    "голый",
+                    "нищий",
+                    "безумие"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «murmeln»?",
+                "choices": [
+                    "нищий",
+                    "маскировка",
+                    "бормотать",
+                    "безумный"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
-                    "безумный",
-                    "дрожать",
                     "нищета",
+                    "дрожать",
+                    "бормотать",
                     "нищий"
                 ],
                 "correctIndex": 1
@@ -2268,31 +2749,115 @@
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
-                    "дрожать",
-                    "голый",
                     "нищета",
-                    "безумие"
+                    "бормотать",
+                    "нищий",
+                    "дрожать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «wahnsinnig»?",
                 "choices": [
-                    "дрожать",
                     "безумный",
-                    "бормотать",
+                    "безумие",
+                    "дрожать",
                     "нищий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Wahnsinn",
+                "translation": "безумие",
+                "parts": [
+                    "Im zugigen Seitenflügel lauscht Edgar dem Heulen der Küstenwinde.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „der Wahnsinn“ wird heute nicht verraten."
+                ],
+                "sentence": "Im zugigen Seitenflügel lauscht Edgar dem Heulen der Küstenwinde. Mit fester Stimme schwöre ich mir: Das Wort „der Wahnsinn“ wird heute nicht verraten.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Эдгар слушает вой прибрежного ветра. Твёрдым голосом я клянусь себе: слово «безумие» сегодня не будет предано."
+            },
+            {
+                "word": "der Bettler",
+                "translation": "нищий",
+                "parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Edgar einen zerknitterten Brief.",
+                    "Ich halte das Wort „der Bettler“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Edgar einen zerknitterten Brief. Ich halte das Wort „der Bettler“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед дымным камином замка Эдгар складывает измятый лист. Я держу слово «нищий» как факел у сердца."
+            },
+            {
+                "word": "die Verkleidung",
+                "translation": "маскировка",
+                "parts": [
+                    "Unter farblosen Wandteppichen schreitet Edgar rastlos auf und ab.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Verkleidung“ wird heute nicht verraten."
+                ],
+                "sentence": "Unter farblosen Wandteppichen schreitet Edgar rastlos auf und ab. Mit fester Stimme schwöre ich mir: Das Wort „die Verkleidung“ wird heute nicht verraten.",
+                "sentenceTranslation": "Под выцветшими гобеленами Эдгар беспокойно меряет шагами зал. Твёрдым голосом я клянусь себе: слово «маскировка» сегодня не будет предано."
+            },
+            {
+                "word": "nackt",
+                "translation": "голый",
+                "parts": [
+                    "An der schmalen Fensterluke zählt Edgar die Fackeln auf dem Hof.",
+                    "Ich presse das Wort „nackt“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "An der schmalen Fensterluke zählt Edgar die Fackeln auf dem Hof. Ich presse das Wort „nackt“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У узкой бойницы Эдгар считает факелы на дворе. Я стискиваю слово «голый» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "murmeln",
+                "translation": "бормотать",
+                "parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Edgar nach frischen Botschaften.",
+                    "Ich halte das Wort „murmeln“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Edgar nach frischen Botschaften. Ich halte das Wort „murmeln“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Эдгар ищет свежие вести. Я держу слово «бормотать» как факел у сердца."
+            },
+            {
+                "word": "zittern",
+                "translation": "дрожать",
+                "parts": [
+                    "Im stillen Kapellenraum kniet Edgar vor der kalten Steinfigur.",
+                    "Ich presse das Wort „zittern“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Im stillen Kapellenraum kniet Edgar vor der kalten Steinfigur. Ich presse das Wort „zittern“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В тихой капелле Эдгар преклоняет колени перед холодной каменной фигурой. Я стискиваю слово «дрожать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "das Elend",
+                "translation": "нищета",
+                "parts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Edgar die Laterne fest.",
+                    "Ich presse das Wort „das Elend“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Edgar die Laterne fest. Ich presse das Wort „das Elend“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Эдгар крепко держит фонарь. Я стискиваю слово «нищета» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "wahnsinnig",
+                "translation": "безумный",
+                "parts": [
+                    "Im Schatten der hohen Burgmauern schreibt Edgar eine fiebrige Antwort.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „wahnsinnig“ bleibt lebendig."
+                ],
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Edgar eine fiebrige Antwort. Mit jeder Faser meines Körpers verspreche ich: Das Wort „wahnsinnig“ bleibt lebendig.",
+                "sentenceTranslation": "В тени высоких стен Эдгар пишет лихорадочный ответ. Каждой клеткой тела я обещаю: слово «безумный» останется живым."
+            }
+        ]
     },
     "storm": {
         "title": "В буре",
         "description": "Акт III: Встреча с Лиром",
         "words": [
             {
+                "wordId": "",
                 "word": "der Sturm",
                 "translation": "буря",
                 "transcription": "[дер ШТУРМ]",
@@ -2316,9 +2881,14 @@
                     "Der Sturm tobt über unseren Köpfen. — Буря бушует над нашими головами.",
                     "Im Sturm bleibe ich bei meinem König. — В буре я остаюсь с моим королём.",
                     "Der Sturm soll sein neues Zuhause sein. — Буря пусть будет его новым домом."
+                ],
+                "sentenceParts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edgar gegen den Wind.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "frieren",
                 "translation": "мёрзнуть",
                 "transcription": "[ФРИ-рен]",
@@ -2347,9 +2917,14 @@
                     "Wir alle frieren in dieser kalten Welt. — Мы все мёрзнем в этом холодном мире.",
                     "Wir frieren gemeinsam in dieser kalten Nacht. — Мы мёрзнем вместе в эту холодную ночь.",
                     "Wir frieren gemeinsam in der kalten Nacht. — Мы мёрзнем вместе в холодную ночь."
+                ],
+                "sentenceParts": [
+                    "Unter einem zerrissenen Banner schützt Edgar die Augen vor den Blitzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „frieren“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "leiden",
                 "translation": "страдать",
                 "transcription": "[ЛАЙ-ден]",
@@ -2374,9 +2949,14 @@
                     "Er muss furchtbar leiden ohne mich. — Он должно быть ужасно страдает без меня.",
                     "Ich leide furchtbare Qualen. — Я страдаю от ужасных мук.",
                     "Zum ersten Mal leide ich selbst. — Впервые я сам страдаю."
+                ],
+                "sentenceParts": [
+                    "Am Rand eines umgestürzten Baumes sucht Edgar Deckung vor dem Donner.",
+                    "Ich atme tief ein und lasse nur das Wort „leiden“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Hütte",
                 "translation": "хижина",
                 "transcription": "[ди ХЮ-те]",
@@ -2402,9 +2982,14 @@
                 "collocations": [
                     "Diese Hütte ist ein Palast für die Verlassenen. — Эта хижина - дворец для покинутых.",
                     "In dieser armseligen Hütte finden wir Zuflucht. — В этой жалкой хижине мы находим убежище."
+                ],
+                "sentenceParts": [
+                    "Zwischen schäumenden Wassergräben stolpert Edgar durch den Schlamm.",
+                    "Ich umarme das Wort „die Hütte“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "beschützen",
                 "translation": "защищать",
                 "transcription": "[бе-ШЮ-цен]",
@@ -2429,9 +3014,14 @@
                     "Die Unschuldigen will ich beschützen. — Невинных я хочу защитить.",
                     "Heimlich beschütze ich den wahnsinnigen König. — Тайно я защищаю безумного короля.",
                     "Ich kann ihn aus der Ferne nicht beschützen. — Я не могу защитить его издалека."
+                ],
+                "sentenceParts": [
+                    "Vor einem zuckenden Himmel hebt Edgar die Arme trotzig an.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „beschützen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "begleiten",
                 "translation": "сопровождать",
                 "transcription": "[бе-ГЛАЙ-тен]",
@@ -2459,9 +3049,14 @@
                     "Als Tom begleite ich Lear durch seine dunkelste Stunde. — Как Том, я сопровождаю Лира в его самый тёмный час.",
                     "Ich begleite ihn durch Wind und Regen. — Я сопровождаю его сквозь ветер и дождь.",
                     "Treu begleite ich meinen verrückten König. — Верно я сопровождаю своего безумного короля."
+                ],
+                "sentenceParts": [
+                    "Unter dem durchtränkten Umhang presst Edgar den Atem gegen die Kälte.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „begleiten“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Donner",
                 "translation": "гром",
                 "transcription": "[дер ДО-нер]",
@@ -2483,9 +3078,14 @@
                     "Für die Höflinge bleibt der Donner ein ständiges Thema. — Для придворных «гром» — постоянная тема.",
                     "Der Donner ist die Stimme der Götter! — Гром - это голос богов!",
                     "Der Donner übertönt unsere Schreie. — Гром заглушает наши крики."
+                ],
+                "sentenceParts": [
+                    "Am kläglichen Feuerrest wärmt Edgar zitternde Finger.",
+                    "Ich zeichne das Wort „der Donner“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Blitz",
                 "translation": "молния",
                 "transcription": "[дер БЛИЦ]",
@@ -2507,6 +3107,10 @@
                     "Für die Höflinge bleibt der Blitz ein ständiges Thema. — Для придворных «молния» — постоянная тема.",
                     "Die Blitze sollen meine weißen Haare verbrennen! — Пусть молнии сожгут мои седые волосы!",
                     "Die Blitze erhellen unser Elend. — Молнии освещают нашу нищету."
+                ],
+                "sentenceParts": [
+                    "Zwischen heulenden Hunden ruft Edgar gegen den tosenden Sturm an.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Blitz“ darf nicht vergehen."
                 ]
             }
         ],
@@ -2515,90 +3119,173 @@
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
                     "мёрзнуть",
-                    "хижина",
                     "страдать",
-                    "буря"
+                    "буря",
+                    "хижина"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "страдать",
-                    "мёрзнуть",
                     "хижина",
-                    "буря"
+                    "страдать",
+                    "буря",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
                     "защищать",
-                    "страдать",
-                    "гром",
-                    "буря"
+                    "мёрзнуть",
+                    "буря",
+                    "страдать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
+                    "гром",
+                    "мёрзнуть",
                     "хижина",
-                    "сопровождать",
-                    "буря",
-                    "гром"
+                    "сопровождать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
                     "защищать",
-                    "страдать",
-                    "хижина",
-                    "буря"
+                    "сопровождать",
+                    "мёрзнуть",
+                    "гром"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "защищать",
+                    "мёрзнуть",
+                    "буря",
                     "сопровождать",
-                    "хижина",
-                    "страдать"
+                    "хижина"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Donner»?",
                 "choices": [
-                    "молния",
+                    "страдать",
                     "гром",
-                    "буря",
-                    "хижина"
+                    "мёрзнуть",
+                    "защищать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Blitz»?",
                 "choices": [
+                    "молния",
+                    "защищать",
                     "гром",
-                    "страдать",
-                    "мёрзнуть",
-                    "молния"
+                    "мёрзнуть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Sturm",
+                "translation": "буря",
+                "parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edgar gegen den Wind.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen."
+                ],
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edgar gegen den Wind. Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Эдгар упирается в ветер. Как тихая молитва слово «буря» ложится на мои губы."
+            },
+            {
+                "word": "frieren",
+                "translation": "мёрзнуть",
+                "parts": [
+                    "Unter einem zerrissenen Banner schützt Edgar die Augen vor den Blitzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „frieren“ bleibt lebendig."
+                ],
+                "sentence": "Unter einem zerrissenen Banner schützt Edgar die Augen vor den Blitzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „frieren“ bleibt lebendig.",
+                "sentenceTranslation": "Под разорванным знаменем Эдгар прикрывает глаза от молний. Каждой клеткой тела я обещаю: слово «мёрзнуть» останется живым."
+            },
+            {
+                "word": "leiden",
+                "translation": "страдать",
+                "parts": [
+                    "Am Rand eines umgestürzten Baumes sucht Edgar Deckung vor dem Donner.",
+                    "Ich atme tief ein und lasse nur das Wort „leiden“ wieder hinaus."
+                ],
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Edgar Deckung vor dem Donner. Ich atme tief ein und lasse nur das Wort „leiden“ wieder hinaus.",
+                "sentenceTranslation": "У поваленного дерева Эдгар ищет укрытия от грома. Я глубоко вдыхаю и выпускаю только слово «страдать»."
+            },
+            {
+                "word": "die Hütte",
+                "translation": "хижина",
+                "parts": [
+                    "Zwischen schäumenden Wassergräben stolpert Edgar durch den Schlamm.",
+                    "Ich umarme das Wort „die Hütte“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Edgar durch den Schlamm. Ich umarme das Wort „die Hütte“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Между пенящимися лужами Эдгар пробирается через грязь. Я обнимаю слово «хижина», будто это единственный союзник."
+            },
+            {
+                "word": "beschützen",
+                "translation": "защищать",
+                "parts": [
+                    "Vor einem zuckenden Himmel hebt Edgar die Arme trotzig an.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „beschützen“ bleibt lebendig."
+                ],
+                "sentence": "Vor einem zuckenden Himmel hebt Edgar die Arme trotzig an. Mit jeder Faser meines Körpers verspreche ich: Das Wort „beschützen“ bleibt lebendig.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Эдгар упрямо поднимает руки. Каждой клеткой тела я обещаю: слово «защищать» останется живым."
+            },
+            {
+                "word": "begleiten",
+                "translation": "сопровождать",
+                "parts": [
+                    "Unter dem durchtränkten Umhang presst Edgar den Atem gegen die Kälte.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „begleiten“ bleibt lebendig."
+                ],
+                "sentence": "Unter dem durchtränkten Umhang presst Edgar den Atem gegen die Kälte. Mit jeder Faser meines Körpers verspreche ich: Das Wort „begleiten“ bleibt lebendig.",
+                "sentenceTranslation": "Под промокшим плащом Эдгар прижимает дыхание к груди, спасаясь от холода. Каждой клеткой тела я обещаю: слово «сопровождать» останется живым."
+            },
+            {
+                "word": "der Donner",
+                "translation": "гром",
+                "parts": [
+                    "Am kläglichen Feuerrest wärmt Edgar zitternde Finger.",
+                    "Ich zeichne das Wort „der Donner“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Am kläglichen Feuerrest wärmt Edgar zitternde Finger. Ich zeichne das Wort „der Donner“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У жалких огненных углей Эдгар греет дрожащие пальцы. Я черчу слово «гром» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "der Blitz",
+                "translation": "молния",
+                "parts": [
+                    "Zwischen heulenden Hunden ruft Edgar gegen den tosenden Sturm an.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Blitz“ darf nicht vergehen."
+                ],
+                "sentence": "Zwischen heulenden Hunden ruft Edgar gegen den tosenden Sturm an. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Blitz“ darf nicht vergehen.",
+                "sentenceTranslation": "Среди воющих псов Эдгар перекрикивает беснующуюся бурю. Я шепчу стражам судьбы: слово «молния» не должно исчезнуть."
+            }
+        ]
     },
     "hut": {
         "title": "Проводник слепого",
         "description": "Акт IV: Спасение отца",
         "words": [
             {
+                "wordId": "",
                 "word": "blind",
                 "translation": "слепой",
                 "transcription": "[БЛИНД]",
@@ -2624,9 +3311,14 @@
                 "collocations": [
                     "Mein blinder Vater erkennt mich nicht. — Мой слепой отец не узнаёт меня.",
                     "Ich bin blind für die Wahrheit. — Я слеп к правде."
+                ],
+                "sentenceParts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Edgar bei der flackernden Kerze.",
+                    "Ich atme tief ein und lasse nur das Wort „blind“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "führen",
                 "translation": "вести",
                 "transcription": "[ФЮ-рен]",
@@ -2648,9 +3340,14 @@
                 "collocations": [
                     "Der Narr spürt, wie das Führen alle verändert. — Шут чувствует, как умение вести меняет всех.",
                     "Ich führe ihn sicher durch die Dunkelheit. — Я веду его безопасно сквозь тьму."
+                ],
+                "sentenceParts": [
+                    "Zwischen zerbeulten Rüstungen streicht Edgar über ein altes Wappen.",
+                    "Ich atme tief ein und lasse nur das Wort „führen“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Klippe",
                 "translation": "утёс",
                 "transcription": "[ди КЛИ-пе]",
@@ -2672,9 +3369,14 @@
                 ],
                 "collocations": [
                     "Er glaubt, wir stehen am Rand der Klippe. — Он думает, мы стоим на краю утёса."
+                ],
+                "sentenceParts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Edgar fast den Kopf.",
+                    "Ich halte das Wort „die Klippe“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "täuschen",
                 "translation": "обманывать",
                 "transcription": "[ТОЙ-шен]",
@@ -2699,9 +3401,14 @@
                     "Ich täusche ihn, um sein Leben zu retten. — Я обманываю его, чтобы спасти его жизнь.",
                     "Edmund täuscht mich mit falschen Beweisen. — Эдмунд обманывает меня ложными доказательствами.",
                     "Ich täusche meinen alten Vater leicht. — Я легко обманываю старого отца."
+                ],
+                "sentenceParts": [
+                    "Neben der schlafenden Wache flüstert Edgar in die schwere Nacht.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "retten",
                 "translation": "спасать",
                 "transcription": "[РЕ-тен]",
@@ -2723,9 +3430,14 @@
                     "Der Narr spürt, wie das Retten alle verändert. — Шут чувствует, как умение спасать меняет всех.",
                     "Mit List will ich meinen Vater retten. — Хитростью я хочу спасти отца.",
                     "Ich muss meinen Vater vor seinen grausamen Töchtern retten. — Я должна спасти отца от его жестоких дочерей."
+                ],
+                "sentenceParts": [
+                    "Vor dem einfachen Feldbett betrachtet Edgar die Narben vergangener Schlachten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „retten“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die List",
                 "translation": "хитрость",
                 "transcription": "[ди ЛИСТ]",
@@ -2755,9 +3467,14 @@
                     "Meine List bewahrt ihn vor dem Selbstmord. — Моя хитрость спасает его от самоубийства.",
                     "Mit List gewinne ich sein Vertrauen. — Хитростью я завоёвываю его доверие.",
                     "Mit List kehre ich an den Hof zurück. — Хитростью я возвращаюсь ко двору."
+                ],
+                "sentenceParts": [
+                    "Im Geruch von feuchtem Stroh legt Edgar den Mantel zur Seite.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "trösten",
                 "translation": "утешать",
                 "transcription": "[ТРЁС-тен]",
@@ -2780,9 +3497,14 @@
                     "Als Fremder tröste ich meinen eigenen Vater. — Как чужой, я утешаю собственного отца.",
                     "Lass mich dich trösten in dieser dunklen Stunde. — Позволь мне утешить тебя в этот тёмный час.",
                     "Mit Worten tröste ich den wahnsinnigen König. — Словами я утешаю безумного короля."
+                ],
+                "sentenceParts": [
+                    "Auf dem wackligen Holztisch ordnet Edgar zerlesene Briefe.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „trösten“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Verzweiflung",
                 "translation": "отчаяние",
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
@@ -2806,6 +3528,10 @@
                     "Seine Verzweiflung bricht mir das Herz. — Его отчаяние разбивает мне сердце.",
                     "Die Verzweiflung treibt mich zum Abgrund. — Отчаяние гонит меня к пропасти.",
                     "Die Verzweiflung führt mich zum Tod. — Отчаяние ведёт меня к смерти."
+                ],
+                "sentenceParts": [
+                    "Am Eingang der Hütte späht Edgar nach einem vertrauten Schatten.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Verzweiflung“ gehört mir."
                 ]
             }
         ],
@@ -2815,70 +3541,70 @@
                 "choices": [
                     "вести",
                     "слепой",
-                    "утёс",
-                    "обманывать"
+                    "обманывать",
+                    "утёс"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «führen»?",
                 "choices": [
-                    "утёс",
                     "обманывать",
-                    "вести",
-                    "слепой"
+                    "слепой",
+                    "утёс",
+                    "вести"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Klippe»?",
                 "choices": [
-                    "утёс",
-                    "спасать",
-                    "вести",
-                    "утешать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «täuschen»?",
-                "choices": [
-                    "слепой",
+                    "утешать",
                     "вести",
                     "обманывать",
                     "утёс"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «täuschen»?",
+                "choices": [
+                    "утёс",
+                    "обманывать",
+                    "хитрость",
+                    "спасать"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
-                    "спасать",
+                    "слепой",
+                    "отчаяние",
                     "утешать",
-                    "вести",
-                    "отчаяние"
+                    "спасать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "слепой",
                     "отчаяние",
-                    "хитрость",
-                    "утешать"
+                    "утёс",
+                    "обманывать",
+                    "хитрость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "обманывать",
+                    "хитрость",
+                    "отчаяние",
                     "утешать",
-                    "утёс",
-                    "слепой"
+                    "спасать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
@@ -2886,18 +3612,101 @@
                     "спасать",
                     "отчаяние",
                     "вести",
-                    "обманывать"
+                    "утёс"
                 ],
                 "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "blind",
+                "translation": "слепой",
+                "parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Edgar bei der flackernden Kerze.",
+                    "Ich atme tief ein und lasse nur das Wort „blind“ wieder hinaus."
+                ],
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Edgar bei der flackernden Kerze. Ich atme tief ein und lasse nur das Wort „blind“ wieder hinaus.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Эдгар сидит у мерцающей свечи. Я глубоко вдыхаю и выпускаю только слово «слепой»."
+            },
+            {
+                "word": "führen",
+                "translation": "вести",
+                "parts": [
+                    "Zwischen zerbeulten Rüstungen streicht Edgar über ein altes Wappen.",
+                    "Ich atme tief ein und lasse nur das Wort „führen“ wieder hinaus."
+                ],
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Edgar über ein altes Wappen. Ich atme tief ein und lasse nur das Wort „führen“ wieder hinaus.",
+                "sentenceTranslation": "Среди помятых доспехов Эдгар гладит старый герб. Я глубоко вдыхаю и выпускаю только слово «вести»."
+            },
+            {
+                "word": "die Klippe",
+                "translation": "утёс",
+                "parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Edgar fast den Kopf.",
+                    "Ich halte das Wort „die Klippe“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Edgar fast den Kopf. Ich halte das Wort „die Klippe“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "О низкую балку хижины Эдгар едва не ударяется головой. Я держу слово «утёс» как факел у сердца."
+            },
+            {
+                "word": "täuschen",
+                "translation": "обманывать",
+                "parts": [
+                    "Neben der schlafenden Wache flüstert Edgar in die schwere Nacht.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir."
+                ],
+                "sentence": "Neben der schlafenden Wache flüstert Edgar in die schwere Nacht. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir.",
+                "sentenceTranslation": "Рядом со спящим стражем Эдгар шепчет в тяжёлую ночь. Буря за окнами усиливает клятву: слово «обманывать» принадлежит мне."
+            },
+            {
+                "word": "retten",
+                "translation": "спасать",
+                "parts": [
+                    "Vor dem einfachen Feldbett betrachtet Edgar die Narben vergangener Schlachten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „retten“ wird heute nicht verraten."
+                ],
+                "sentence": "Vor dem einfachen Feldbett betrachtet Edgar die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „retten“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед грубой походной койкой Эдгар разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «спасать» сегодня не будет предано."
+            },
+            {
+                "word": "die List",
+                "translation": "хитрость",
+                "parts": [
+                    "Im Geruch von feuchtem Stroh legt Edgar den Mantel zur Seite.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern."
+                ],
+                "sentence": "Im Geruch von feuchtem Stroh legt Edgar den Mantel zur Seite. Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern.",
+                "sentenceTranslation": "В запахе влажной соломы Эдгар откладывает плащ в сторону. Даже если мир распадается, слово «хитрость» остаётся моим северным светом."
+            },
+            {
+                "word": "trösten",
+                "translation": "утешать",
+                "parts": [
+                    "Auf dem wackligen Holztisch ordnet Edgar zerlesene Briefe.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „trösten“ darf nicht vergehen."
+                ],
+                "sentence": "Auf dem wackligen Holztisch ordnet Edgar zerlesene Briefe. Ich flüstere den Wächtern des Schicksals zu: Das Wort „trösten“ darf nicht vergehen.",
+                "sentenceTranslation": "На шатком деревянном столе Эдгар раскладывает зачитанные письма. Я шепчу стражам судьбы: слово «утешать» не должно исчезнуть."
+            },
+            {
+                "word": "die Verzweiflung",
+                "translation": "отчаяние",
+                "parts": [
+                    "Am Eingang der Hütte späht Edgar nach einem vertrauten Schatten.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Verzweiflung“ gehört mir."
+                ],
+                "sentence": "Am Eingang der Hütte späht Edgar nach einem vertrauten Schatten. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Verzweiflung“ gehört mir.",
+                "sentenceTranslation": "У входа в хижину Эдгар высматривает знакомую тень. Буря за окнами усиливает клятву: слово «отчаяние» принадлежит мне."
+            }
+        ]
     },
     "dover": {
         "title": "Дуэль",
         "description": "Акт V: Поединок с Эдмундом",
         "words": [
             {
+                "wordId": "",
                 "word": "der Kampf",
                 "translation": "бой",
                 "transcription": "[дер КАМПФ]",
@@ -2921,9 +3730,14 @@
                     "Der Kampf für das Recht beginnt jetzt. — Борьба за право начинается сейчас.",
                     "Der Kampf gegen meinen Bruder ist unvermeidlich. — Бой с моим братом неизбежен.",
                     "Dieser Kampf ist für die Ehre meines Vaters. — Эта борьба за честь моего отца."
+                ],
+                "sentenceParts": [
+                    "Auf den weißen Klippen von Dover blickt Edgar in den aufgewühlten Kanal.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Kampf“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Duell",
                 "translation": "дуэль",
                 "transcription": "[дас ду-ЭЛЬ]",
@@ -2945,9 +3759,14 @@
                     "Für die Höflinge bleibt das Duell ein ständiges Thema. — Для придворных «дуэль» — постоянная тема.",
                     "Das Duell mit Edgar ist mein Ende. — Дуэль с Эдгаром - мой конец.",
                     "In diesem Duell kämpfe ich für die Gerechtigkeit. — В этой дуэли я сражаюсь за справедливость."
+                ],
+                "sentenceParts": [
+                    "Zwischen flatternden Feldzeichen richtet Edgar den Helm.",
+                    "Ich atme tief ein und lasse nur das Wort „das Duell“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Rache",
                 "translation": "месть",
                 "transcription": "[ди РА-хе]",
@@ -2971,9 +3790,15 @@
                     "Nicht Rache, sondern Gerechtigkeit leitet meine Klinge. — Не месть, а справедливость ведёт мой клинок.",
                     "Dies ist ihre Rache für meine Treue. — Это их месть за мою верность.",
                     "Die Rache für Jahre der Unterwerfung. — Месть за годы подчинения."
+                ],
+                "sentenceParts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Edgar Marschrouten in den Sand.",
+                    "Ich presse das Wort „die Rache“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "enthüllen",
                 "translation": "разоблачать",
                 "transcription": "[энт-ХЮ-лен]",
@@ -2999,9 +3824,14 @@
                 "collocations": [
                     "Ich enthülle meine wahre Identität. — Я разоблачаю свою истинную личность.",
                     "Spielerisch enthülle ich seine Fehler. — Играючи я раскрываю его ошибки."
+                ],
+                "sentenceParts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Edgar das Siegel.",
+                    "Ich halte das Wort „enthüllen“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "siegen",
                 "translation": "побеждать",
                 "transcription": "[ЗИ-ген]",
@@ -3023,9 +3853,14 @@
                     "Der Narr spürt, wie das Siegen alle verändert. — Шут чувствует, как умение побеждать меняет всех.",
                     "Die Wahrheit wird über die Lüge siegen. — Правда победит ложь.",
                     "Die Liebe wird über den Hass siegen. — Любовь победит ненависть."
+                ],
+                "sentenceParts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Edgar dem dumpfen Meer.",
+                    "Mein Atem zeichnet das Wort „siegen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Gerechtigkeit",
                 "translation": "справедливость",
                 "transcription": "[ди ге-РЕХ-тиг-кайт]",
@@ -3048,9 +3883,14 @@
                     "Für Gerechtigkeit will ich kämpfen. — За справедливость я хочу бороться.",
                     "Die Gerechtigkeit fordert diesen Kampf. — Справедливость требует этого боя.",
                     "Die Gerechtigkeit führt meine Klinge. — Справедливость ведёт мой клинок."
+                ],
+                "sentenceParts": [
+                    "Auf dem sandigen Trainingsplatz übt Edgar das Ziehen des Schwerts.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Gerechtigkeit“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Schwert",
                 "translation": "меч",
                 "transcription": "[дас ШВЕРТ]",
@@ -3071,9 +3911,14 @@
                 "collocations": [
                     "Während des Sturms wirkt das Schwert noch bedrückender. — Во время бури само «меч» звучит ещё тяжелее.",
                     "Mein Schwert ist die Waffe der Wahrheit. — Мой меч - оружие правды."
+                ],
+                "sentenceParts": [
+                    "Zwischen pochenden Trommeln hebt Edgar das Banner der Hoffnung.",
+                    "Ich zeichne das Wort „das Schwert“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Bruder",
                 "translation": "брат",
                 "transcription": "[дер БРУ-дер]",
@@ -3094,6 +3939,10 @@
                 "collocations": [
                     "Der Narr spottet, sobald der Bruder erwähnt wird. — Шут насмехается, едва кто-то произносит «брат».",
                     "Mein Bruder muss für seine Verbrechen büßen. — Мой брат должен поплатиться за свои преступления."
+                ],
+                "sentenceParts": [
+                    "Am Morgennebel der Küste legt Edgar die Hand auf das pochende Herz.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Bruder“ auf meine Lippen."
                 ]
             }
         ],
@@ -3102,17 +3951,17 @@
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
                     "разоблачать",
-                    "бой",
                     "месть",
-                    "дуэль"
+                    "дуэль",
+                    "бой"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Duell»?",
                 "choices": [
-                    "разоблачать",
                     "бой",
+                    "разоблачать",
                     "дуэль",
                     "месть"
                 ],
@@ -3121,38 +3970,38 @@
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "месть",
-                    "разоблачать",
-                    "дуэль",
-                    "меч"
+                    "брат",
+                    "справедливость",
+                    "побеждать",
+                    "месть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «enthüllen»?",
                 "choices": [
-                    "справедливость",
-                    "разоблачать",
-                    "меч",
-                    "брат"
+                    "дуэль",
+                    "бой",
+                    "побеждать",
+                    "разоблачать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
+                    "справедливость",
+                    "бой",
                     "побеждать",
-                    "брат",
-                    "дуэль",
-                    "бой"
+                    "брат"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "побеждать",
                     "меч",
+                    "побеждать",
                     "дуэль",
                     "справедливость"
                 ],
@@ -3162,30 +4011,114 @@
                 "question": "Что означает немецкое слово «das Schwert»?",
                 "choices": [
                     "брат",
-                    "бой",
+                    "разоблачать",
                     "меч",
-                    "дуэль"
+                    "месть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Bruder»?",
                 "choices": [
-                    "разоблачать",
                     "брат",
-                    "месть",
-                    "меч"
+                    "справедливость",
+                    "бой",
+                    "месть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Kampf",
+                "translation": "бой",
+                "parts": [
+                    "Auf den weißen Klippen von Dover blickt Edgar in den aufgewühlten Kanal.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Kampf“ mein Nordstern."
+                ],
+                "sentence": "Auf den weißen Klippen von Dover blickt Edgar in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „der Kampf“ mein Nordstern.",
+                "sentenceTranslation": "На белых скалах Дувра Эдгар смотрит в вздыбленный пролив. Даже если мир распадается, слово «бой» остаётся моим северным светом."
+            },
+            {
+                "word": "das Duell",
+                "translation": "дуэль",
+                "parts": [
+                    "Zwischen flatternden Feldzeichen richtet Edgar den Helm.",
+                    "Ich atme tief ein und lasse nur das Wort „das Duell“ wieder hinaus."
+                ],
+                "sentence": "Zwischen flatternden Feldzeichen richtet Edgar den Helm. Ich atme tief ein und lasse nur das Wort „das Duell“ wieder hinaus.",
+                "sentenceTranslation": "Среди хлопающих штандартов Эдгар поправляет шлем. Я глубоко вдыхаю и выпускаю только слово «дуэль»."
+            },
+            {
+                "word": "die Rache",
+                "translation": "месть",
+                "parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Edgar Marschrouten in den Sand.",
+                    "Ich presse das Wort „die Rache“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Edgar Marschrouten in den Sand. Ich presse das Wort „die Rache“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У французского костра Эдгар рисует в песке путь марша. Я стискиваю слово «месть» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "enthüllen",
+                "translation": "разоблачать",
+                "parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Edgar das Siegel.",
+                    "Ich halte das Wort „enthüllen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Edgar das Siegel. Ich halte das Wort „enthüllen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Эдгар проверяет печати. Я держу слово «разоблачать» как факел у сердца."
+            },
+            {
+                "word": "siegen",
+                "translation": "побеждать",
+                "parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Edgar dem dumpfen Meer.",
+                    "Mein Atem zeichnet das Wort „siegen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Edgar dem dumpfen Meer. Mein Atem zeichnet das Wort „siegen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Эдгар слушает глухой шум моря. Моё дыхание рисует слово «побеждать» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Gerechtigkeit",
+                "translation": "справедливость",
+                "parts": [
+                    "Auf dem sandigen Trainingsplatz übt Edgar das Ziehen des Schwerts.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Gerechtigkeit“ darf nicht vergehen."
+                ],
+                "sentence": "Auf dem sandigen Trainingsplatz übt Edgar das Ziehen des Schwerts. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Gerechtigkeit“ darf nicht vergehen.",
+                "sentenceTranslation": "На песчаном плацу Эдгар отрабатывает выхват меча. Я шепчу стражам судьбы: слово «справедливость» не должно исчезнуть."
+            },
+            {
+                "word": "das Schwert",
+                "translation": "меч",
+                "parts": [
+                    "Zwischen pochenden Trommeln hebt Edgar das Banner der Hoffnung.",
+                    "Ich zeichne das Wort „das Schwert“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Zwischen pochenden Trommeln hebt Edgar das Banner der Hoffnung. Ich zeichne das Wort „das Schwert“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под гул барабанов Эдгар поднимает знамя надежды. Я вывожу слово «меч» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "der Bruder",
+                "translation": "брат",
+                "parts": [
+                    "Am Morgennebel der Küste legt Edgar die Hand auf das pochende Herz.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Bruder“ auf meine Lippen."
+                ],
+                "sentence": "Am Morgennebel der Küste legt Edgar die Hand auf das pochende Herz. Wie ein stilles Gebet legt sich das Wort „der Bruder“ auf meine Lippen.",
+                "sentenceTranslation": "В утреннем тумане побережья Эдгар кладёт ладонь на бьющееся сердце. Как тихая молитва слово «брат» ложится на мои губы."
+            }
+        ]
     },
     "prison": {
         "title": "Наследник",
         "description": "Акт V: Новый граф",
         "words": [
             {
+                "wordId": "",
                 "word": "überleben",
                 "translation": "выживать",
                 "transcription": "[ю-бер-ЛЕ-бен]",
@@ -3206,9 +4139,14 @@
                 "collocations": [
                     "Cordelia zeigt, dass das Überleben auch ohne Stolz möglich ist. — Корделия показывает, что выживать можно и без гордыни.",
                     "Ich habe alle Prüfungen überlebt. — Я пережил все испытания."
+                ],
+                "sentenceParts": [
+                    "Im feuchten Kerker stützt Edgar sich an den tropfenden Stein.",
+                    "Ich halte das Wort „überleben“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erben",
                 "translation": "наследовать",
                 "transcription": "[ЭР-бен]",
@@ -3230,9 +4168,14 @@
                     "Der Narr spürt, wie das Erben alle verändert. — Шут чувствует, как умение наследовать меняет всех.",
                     "Nun erbe ich alles, was Edgar zustand. — Теперь я наследую всё, что полагалось Эдгару.",
                     "Nun erbe ich Titel und Verantwortung. — Теперь я наследую титул и ответственность."
+                ],
+                "sentenceParts": [
+                    "Unter der trüben Laterne zählt Edgar die eisernen Ringe der Kette.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „erben“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Zukunft",
                 "translation": "будущее",
                 "transcription": "[ди ЦУ-кунфт]",
@@ -3253,9 +4196,14 @@
                 "collocations": [
                     "Cordelia merkt sich genau, wie die Zukunft verteilt wird. — Корделия внимательно следит, кому достанется «будущее».",
                     "Die Zukunft des Königreichs liegt in unseren Händen. — Будущее королевства в наших руках."
+                ],
+                "sentenceParts": [
+                    "Neben der schweren Holztür horcht Edgar auf entferntes Schluchzen.",
+                    "Das Echo des Wortes „die Zukunft“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "regieren",
                 "translation": "править",
                 "transcription": "[ре-ГИ-рен]",
@@ -3279,9 +4227,14 @@
                     "Der Narr spürt, wie das Regieren alle verändert. — Шут чувствует, как умение управлять меняет всех.",
                     "Mit Weisheit werde ich regieren. — С мудростью я буду править.",
                     "Ich werde mit eiserner Hand regieren. — Я буду управлять железной рукой."
+                ],
+                "sentenceParts": [
+                    "Auf der kalten Steinbank zieht Edgar den Mantel enger um die Schultern.",
+                    "Ich atme tief ein und lasse nur das Wort „regieren“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Weisheit",
                 "translation": "мудрость",
                 "transcription": "[ди ВАЙС-хайт]",
@@ -3313,9 +4266,14 @@
                     "Die Weisheit kommt zu spät zu mir. — Мудрость приходит ко мне слишком поздно.",
                     "Durch Leiden habe ich Weisheit erlangt. — Через страдания я обрёл мудрость.",
                     "Hinter meinen Späßen verbirgt sich Weisheit. — За моими шутками скрывается мудрость."
+                ],
+                "sentenceParts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Edgar das Gesicht zum Licht.",
+                    "Ich halte das Wort „die Weisheit“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Ordnung",
                 "translation": "порядок",
                 "transcription": "[ди ОРД-нунг]",
@@ -3337,9 +4295,14 @@
                 ],
                 "collocations": [
                     "Neue Ordnung muss aus dem Chaos entstehen. — Новый порядок должен возникнуть из хаоса."
+                ],
+                "sentenceParts": [
+                    "Am rostigen Wassereimer spiegelt Edgar kurz die eigenen Augen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ordnung“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Verantwortung",
                 "translation": "ответственность",
                 "transcription": "[ди фер-АНТ-вор-тунг]",
@@ -3361,9 +4324,14 @@
                 ],
                 "collocations": [
                     "Die Verantwortung für alle wiegt schwer. — Ответственность за всех тяжела."
+                ],
+                "sentenceParts": [
+                    "Im dumpfen Hall der Schritte zählt Edgar den Rhythmus der Wachen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Verantwortung“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "neu",
                 "translation": "новый",
                 "transcription": "[НОЙ]",
@@ -3385,6 +4353,10 @@
                 ],
                 "collocations": [
                     "Eine neue Ära beginnt für unser Land. — Новая эра начинается для нашей страны."
+                ],
+                "sentenceParts": [
+                    "Vor dem verriegelten Fenster zeichnet Edgar Kreise in den Staub.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „neu“ wird heute nicht verraten."
                 ]
             }
         ],
@@ -3392,85 +4364,167 @@
             {
                 "question": "Что означает немецкое слово «überleben»?",
                 "choices": [
-                    "выживать",
+                    "править",
                     "будущее",
-                    "наследовать",
-                    "править"
+                    "выживать",
+                    "наследовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
                     "править",
-                    "наследовать",
+                    "выживать",
                     "будущее",
-                    "выживать"
+                    "наследовать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Zukunft»?",
                 "choices": [
                     "выживать",
-                    "мудрость",
+                    "новый",
                     "будущее",
-                    "ответственность"
+                    "порядок"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
+                    "будущее",
                     "править",
                     "мудрость",
-                    "выживать",
                     "наследовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "порядок",
+                    "ответственность",
                     "наследовать",
-                    "мудрость",
-                    "выживать"
+                    "править",
+                    "мудрость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ordnung»?",
                 "choices": [
-                    "порядок",
                     "будущее",
+                    "ответственность",
                     "наследовать",
-                    "мудрость"
+                    "порядок"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Verantwortung»?",
                 "choices": [
-                    "порядок",
+                    "новый",
                     "ответственность",
-                    "будущее",
-                    "выживать"
+                    "порядок",
+                    "мудрость"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «neu»?",
                 "choices": [
-                    "наследовать",
-                    "новый",
-                    "будущее",
-                    "порядок"
+                    "править",
+                    "ответственность",
+                    "выживать",
+                    "новый"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "überleben",
+                "translation": "выживать",
+                "parts": [
+                    "Im feuchten Kerker stützt Edgar sich an den tropfenden Stein.",
+                    "Ich halte das Wort „überleben“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Im feuchten Kerker stützt Edgar sich an den tropfenden Stein. Ich halte das Wort „überleben“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В сыром подземелье Эдгар опирается на сочащийся камень. Я держу слово «выживать» как факел у сердца."
+            },
+            {
+                "word": "erben",
+                "translation": "наследовать",
+                "parts": [
+                    "Unter der trüben Laterne zählt Edgar die eisernen Ringe der Kette.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „erben“ wird heute nicht verraten."
+                ],
+                "sentence": "Unter der trüben Laterne zählt Edgar die eisernen Ringe der Kette. Mit fester Stimme schwöre ich mir: Das Wort „erben“ wird heute nicht verraten.",
+                "sentenceTranslation": "Под мутным фонарём Эдгар пересчитывает железные кольца цепи. Твёрдым голосом я клянусь себе: слово «наследовать» сегодня не будет предано."
+            },
+            {
+                "word": "die Zukunft",
+                "translation": "будущее",
+                "parts": [
+                    "Neben der schweren Holztür horcht Edgar auf entferntes Schluchzen.",
+                    "Das Echo des Wortes „die Zukunft“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Neben der schweren Holztür horcht Edgar auf entferntes Schluchzen. Das Echo des Wortes „die Zukunft“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У тяжёлой двери Эдгар прислушивается к далёким рыданиям. Эхо слова «будущее» заглушает шёпот придворных."
+            },
+            {
+                "word": "regieren",
+                "translation": "править",
+                "parts": [
+                    "Auf der kalten Steinbank zieht Edgar den Mantel enger um die Schultern.",
+                    "Ich atme tief ein und lasse nur das Wort „regieren“ wieder hinaus."
+                ],
+                "sentence": "Auf der kalten Steinbank zieht Edgar den Mantel enger um die Schultern. Ich atme tief ein und lasse nur das Wort „regieren“ wieder hinaus.",
+                "sentenceTranslation": "На холодной каменной скамье Эдгар плотнее кутается в плащ. Я глубоко вдыхаю и выпускаю только слово «править»."
+            },
+            {
+                "word": "die Weisheit",
+                "translation": "мудрость",
+                "parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Edgar das Gesicht zum Licht.",
+                    "Ich halte das Wort „die Weisheit“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Edgar das Gesicht zum Licht. Ich halte das Wort „die Weisheit“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Между тенями решёток Эдгар поднимает лицо к свету. Я держу слово «мудрость» как факел у сердца."
+            },
+            {
+                "word": "die Ordnung",
+                "translation": "порядок",
+                "parts": [
+                    "Am rostigen Wassereimer spiegelt Edgar kurz die eigenen Augen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ordnung“ bleibt lebendig."
+                ],
+                "sentence": "Am rostigen Wassereimer spiegelt Edgar kurz die eigenen Augen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ordnung“ bleibt lebendig.",
+                "sentenceTranslation": "У ржавого ведра с водой Эдгар на мгновение видит отражение глаз. Каждой клеткой тела я обещаю: слово «порядок» останется живым."
+            },
+            {
+                "word": "die Verantwortung",
+                "translation": "ответственность",
+                "parts": [
+                    "Im dumpfen Hall der Schritte zählt Edgar den Rhythmus der Wachen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Verantwortung“ darf nicht vergehen."
+                ],
+                "sentence": "Im dumpfen Hall der Schritte zählt Edgar den Rhythmus der Wachen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Verantwortung“ darf nicht vergehen.",
+                "sentenceTranslation": "В глухом эхе шагов Эдгар отсчитывает ритм часовых. Я шепчу стражам судьбы: слово «ответственность» не должно исчезнуть."
+            },
+            {
+                "word": "neu",
+                "translation": "новый",
+                "parts": [
+                    "Vor dem verriegelten Fenster zeichnet Edgar Kreise in den Staub.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „neu“ wird heute nicht verraten."
+                ],
+                "sentence": "Vor dem verriegelten Fenster zeichnet Edgar Kreise in den Staub. Mit fester Stimme schwöre ich mir: Das Wort „neu“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед заколоченным окном Эдгар чертит круги в пыли. Твёрдым голосом я клянусь себе: слово «новый» сегодня не будет предано."
+            }
+        ]
     }
 };
 
@@ -3486,6 +4540,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3922,6 +5324,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -3990,6 +5709,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -3998,13 +5720,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4915,6 +6685,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/journeys/edmund.html
+++ b/output/journeys/edmund.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="throne">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="goneril">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="regan">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="storm">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="hut">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="dover">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="prison">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["обделённый", "амбиция", "зависть", "бастард"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["зависть", "обделённый", "амбиция", "бастард"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["природа", "амбиция", "возвышаться", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["обделённый", "амбиция", "месть", "природа"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["природа", "возвышаться", "месть", "внебрачный"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["внебрачный", "обделённый", "возвышаться", "бастард"], "correct_index": 2}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["природа", "внебрачный", "возвышаться", "зависть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["амбиция", "зависть", "природа", "внебрачный"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["подделывать", "обвинять", "план", "интриговать"], "correct_index": 0}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["обвинять", "подделывать", "план", "интриговать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["план", "обвинять", "письмо", "манипулировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["план", "подделывать", "интриговать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["манипулировать", "интриговать", "обвинять", "план"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["лгать", "обман", "письмо", "подделывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["лгать", "манипулировать", "обвинять", "план"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["лгать", "обман", "манипулировать", "обвинять"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["торжествовать", "изгонять", "наследовать", "успех"], "correct_index": 1}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["наследовать", "успех", "изгонять", "торжествовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "вытеснять", "победа", "успех"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["успех", "победа", "торжествовать", "выигрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["успех", "вытеснять", "торжествовать", "выигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["успех", "изгонять", "награда", "вытеснять"], "correct_index": 2}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["наследовать", "торжествовать", "победа", "вытеснять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["успех", "торжествовать", "победа", "выигрывать"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["объединяться", "союз", "власть", "завоёвывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["союз", "завоёвывать", "власть", "объединяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоевание", "соблазнять", "завоёвывать", "господствовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["соблазнять", "господствовать", "союз", "завоёвывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["соблазнять", "власть", "объединяться", "альянс"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["господствовать", "завоевание", "альянс", "объединяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["завоевание", "господствовать", "союз", "альянс"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["завоёвывать", "альянс", "союз", "господствовать"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["предавать", "ослеплять", "жестокость", "доносить"], "correct_index": 0}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "жестокость", "предавать", "доносить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["ослеплять", "выдавать", "жестокость", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["предавать", "доносить", "выдавать", "беспощадный"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["выдавать", "пытка", "доносить", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["выдавать", "жертвовать", "пытка", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["выдавать", "ослеплять", "беспощадный", "жертвовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["жестокость", "предавать", "жертвовать", "беспощадный"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["соперничество", "завлекать", "играть", "любовная связь"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["завлекать", "играть", "соперничество", "любовная связь"], "correct_index": 2}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["похоть", "использовать", "играть", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["похоть", "интрига", "играть", "завлекать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["жонглировать", "похоть", "играть", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["жонглировать", "играть", "завлекать", "использовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["похоть", "жонглировать", "использовать", "завлекать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["использовать", "интрига", "завлекать", "похоть"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["падать", "дуэль", "сожалеть", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "дуэль", "поражение", "сожалеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["дуэль", "сожалеть", "признаваться", "проигрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["поражение", "дуэль", "проигрывать", "признаваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["дуэль", "поражение", "проигрывать", "признаваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["проигрывать", "падать", "падение", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["сожалеть", "проигрывать", "дуэль", "признаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["поражение", "конец", "падение", "проигрывать"], "correct_index": 1}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["бастард", "амбиция", "зависть", "обделённый"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["бастард", "зависть", "обделённый", "амбиция"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["обделённый", "природа", "месть", "амбиция"], "correct_index": 3}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["месть", "внебрачный", "возвышаться", "обделённый"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["зависть", "обделённый", "амбиция", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["амбиция", "внебрачный", "месть", "возвышаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["внебрачный", "обделённый", "возвышаться", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["природа", "внебрачный", "обделённый", "возвышаться"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["подделывать", "план", "интриговать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["подделывать", "интриговать", "план", "обвинять"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["обман", "лгать", "обвинять", "манипулировать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["манипулировать", "план", "подделывать", "письмо"], "correct_index": 1}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["подделывать", "обман", "письмо", "манипулировать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["подделывать", "интриговать", "план", "письмо"], "correct_index": 3}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["письмо", "интриговать", "обвинять", "лгать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["письмо", "план", "обман", "манипулировать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["изгонять", "наследовать", "успех", "торжествовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["изгонять", "успех", "наследовать", "торжествовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erben»?", "choices": ["вытеснять", "награда", "победа", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["торжествовать", "успех", "победа", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["выигрывать", "торжествовать", "изгонять", "награда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["успех", "победа", "наследовать", "награда"], "correct_index": 3}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["торжествовать", "выигрывать", "вытеснять", "успех"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["изгонять", "торжествовать", "победа", "награда"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["власть", "объединяться", "завоёвывать", "союз"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["объединяться", "власть", "союз", "завоёвывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоёвывать", "объединяться", "власть", "союз"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["соблазнять", "власть", "союз", "завоёвывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["альянс", "господствовать", "завоевание", "соблазнять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["завоевание", "господствовать", "объединяться", "завоёвывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["объединяться", "завоевание", "завоёвывать", "господствовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["объединяться", "альянс", "господствовать", "соблазнять"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["доносить", "ослеплять", "жестокость", "предавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "жестокость", "предавать", "доносить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["доносить", "ослеплять", "беспощадный", "жестокость"], "correct_index": 3}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["беспощадный", "ослеплять", "предавать", "доносить"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["ослеплять", "пытка", "выдавать", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["жестокость", "предавать", "жертвовать", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["выдавать", "жертвовать", "пытка", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["жертвовать", "жестокость", "предавать", "беспощадный"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["соперничество", "играть", "завлекать", "любовная связь"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["завлекать", "соперничество", "играть", "любовная связь"], "correct_index": 1}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["соперничество", "похоть", "играть", "любовная связь"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["похоть", "завлекать", "соперничество", "использовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["похоть", "соперничество", "завлекать", "играть"], "correct_index": 0}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["интрига", "похоть", "соперничество", "использовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["любовная связь", "играть", "жонглировать", "похоть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["соперничество", "использовать", "интрига", "жонглировать"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["сожалеть", "дуэль", "падать", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "сожалеть", "дуэль", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["поражение", "признаваться", "сожалеть", "проигрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["дуэль", "признаваться", "поражение", "проигрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["падение", "конец", "сожалеть", "проигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["признаваться", "падать", "поражение", "падение"], "correct_index": 3}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["поражение", "конец", "признаваться", "проигрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["падение", "конец", "поражение", "признаваться"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Незаконнорождённый</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,24 +661,72 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Bastard»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Neid»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">зависть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">природа</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «benachteiligt»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
@@ -491,19 +735,35 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">возвышаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">внебрачный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
                             
@@ -513,81 +773,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «benachteiligt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвышаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">внебрачный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Natur»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">зависть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Natur»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">зависть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">природа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">возвышаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -606,55 +802,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «intrigieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «beschuldigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">манипулировать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
                             
@@ -664,65 +812,113 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «intrigieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">интриговать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «beschuldigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">лгать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">манипулировать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">манипулировать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">интриговать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «lügen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">манипулировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интриговать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">лгать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">манипулировать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,17 +931,17 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">торжествовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -755,11 +951,11 @@
                         <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">торжествовать</button>
                             
@@ -767,81 +963,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вытеснять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Erfolg»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">награда</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">награда</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">награда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вытеснять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -851,13 +1047,13 @@
                         <div class="quiz-question">Что означает немецкое слово «der Sieg»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">награда</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -870,15 +1066,31 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verbünden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">объединяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
                             
@@ -886,33 +1098,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">объединяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -924,7 +1120,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                             
@@ -934,49 +1130,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">альянс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Eroberung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">господствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">альянс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоевание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -986,13 +1182,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Allianz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">альянс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">господствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1005,17 +1201,17 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1037,47 +1233,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
@@ -1085,8 +1249,56 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертвовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «opfern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
@@ -1095,23 +1307,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «opfern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1121,11 +1317,11 @@
                         <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
                             
@@ -1146,9 +1342,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
                             
@@ -1156,15 +1352,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
                             
@@ -1176,45 +1372,45 @@
                         <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verlocken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verlocken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">использовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1224,11 +1420,11 @@
                         <div class="quiz-question">Что означает немецкое слово «ausnutzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">использовать</button>
                             
@@ -1236,33 +1432,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «jonglieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">использовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Affäre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1279,11 +1475,11 @@
                         <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
@@ -1297,23 +1493,87 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">падение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">признаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">признаваться</button>
                             
@@ -1323,81 +1583,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">падение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">падение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">падение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1421,6 +1617,7 @@
         "description": "Акт I: Зависть бастарда",
         "words": [
             {
+                "wordId": "",
                 "word": "der Bastard",
                 "translation": "бастард",
                 "transcription": "[дер БАС-тард]",
@@ -1441,9 +1638,14 @@
                 "collocations": [
                     "Im Thronsaal verstummen die Gespräche über der Bastard nie. — В тронном зале постоянно звучит слово «бастард».",
                     "Als Bastard habe ich keine Rechte. — Как бастард я не имею прав."
+                ],
+                "sentenceParts": [
+                    "Edmund steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mein Atem zeichnet das Wort „der Bastard“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Neid",
                 "translation": "зависть",
                 "transcription": "[дер НАЙД]",
@@ -1465,9 +1667,14 @@
                 ],
                 "collocations": [
                     "Der Neid auf Edgar verzehrt mich. — Зависть к Эдгару пожирает меня."
+                ],
+                "sentenceParts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Edmund über Lears schweren Tisch.",
+                    "Ich umarme das Wort „der Neid“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Ambition",
                 "translation": "амбиция",
                 "transcription": "[ди ам-би-ЦИ-он]",
@@ -1489,9 +1696,14 @@
                 ],
                 "collocations": [
                     "Meine Ambition kennt keine Grenzen. — Моя амбиция не знает границ."
+                ],
+                "sentenceParts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Edmund die Hände hinter dem Rücken.",
+                    "Das Echo des Wortes „die Ambition“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "benachteiligt",
                 "translation": "обделённый",
                 "transcription": "[бе-НАХ-тай-лигт]",
@@ -1513,9 +1725,14 @@
                 ],
                 "collocations": [
                     "Ich bin von Geburt an benachteiligt. — Я обделён с рождения."
+                ],
+                "sentenceParts": [
+                    "Zwischen flüsternden Höflingen gleitet Edmund über den kalten Marmorboden.",
+                    "Ich zeichne das Wort „benachteiligt“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Rache",
                 "translation": "месть",
                 "transcription": "[ди РА-хе]",
@@ -1539,9 +1756,14 @@
                     "Nicht Rache, sondern Gerechtigkeit leitet meine Klinge. — Не месть, а справедливость ведёт мой клинок.",
                     "Dies ist ihre Rache für meine Treue. — Это их месть за мою верность.",
                     "Die Rache für Jahre der Unterwerfung. — Месть за годы подчинения."
+                ],
+                "sentenceParts": [
+                    "Am Rand des purpurnen Teppichs wartet Edmund auf ein Zeichen des Königs.",
+                    "Mein Atem zeichnet das Wort „die Rache“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "aufsteigen",
                 "translation": "возвышаться",
                 "transcription": "[АУФ-штай-ген]",
@@ -1563,9 +1785,14 @@
                 ],
                 "collocations": [
                     "Ich will über alle aufsteigen. — Я хочу возвыситься над всеми."
+                ],
+                "sentenceParts": [
+                    "Unter wehenden Standarten der Schwestern senkt Edmund kurz den Blick.",
+                    "Ich zeichne das Wort „aufsteigen“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "unehelich",
                 "translation": "внебрачный",
                 "transcription": "[УН-э-е-лих]",
@@ -1587,9 +1814,14 @@
                 ],
                 "collocations": [
                     "Meine uneheliche Geburt ist mein Fluch. — Моё внебрачное рождение - мой проклятие."
+                ],
+                "sentenceParts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Edmund das gespannte Antlitz des Hofes.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unehelich“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Natur",
                 "translation": "природа",
                 "transcription": "[ди на-ТУР]",
@@ -1611,6 +1843,10 @@
                 "collocations": [
                     "Im Thronsaal verstummen die Gespräche über die Natur nie. — В тронном зале постоянно звучит слово «природа».",
                     "Die Natur ist meine Göttin, nicht das Gesetz. — Природа - моя богиня, не закон."
+                ],
+                "sentenceParts": [
+                    "Im Schein der offenen Feuerbecken erhebt Edmund langsam die Stimme.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Natur“ darf nicht vergehen."
                 ]
             }
         ],
@@ -1618,91 +1854,174 @@
             {
                 "question": "Что означает немецкое слово «der Bastard»?",
                 "choices": [
-                    "обделённый",
+                    "бастард",
                     "амбиция",
                     "зависть",
-                    "бастард"
+                    "обделённый"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Neid»?",
                 "choices": [
+                    "бастард",
                     "зависть",
                     "обделённый",
-                    "амбиция",
-                    "бастард"
+                    "амбиция"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ambition»?",
                 "choices": [
+                    "обделённый",
                     "природа",
-                    "амбиция",
-                    "возвышаться",
-                    "месть"
+                    "месть",
+                    "амбиция"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «benachteiligt»?",
                 "choices": [
-                    "обделённый",
-                    "амбиция",
                     "месть",
-                    "природа"
+                    "внебрачный",
+                    "возвышаться",
+                    "обделённый"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "природа",
-                    "возвышаться",
-                    "месть",
-                    "внебрачный"
+                    "зависть",
+                    "обделённый",
+                    "амбиция",
+                    "месть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «aufsteigen»?",
                 "choices": [
+                    "амбиция",
                     "внебрачный",
-                    "обделённый",
-                    "возвышаться",
-                    "бастард"
+                    "месть",
+                    "возвышаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «unehelich»?",
                 "choices": [
-                    "природа",
                     "внебрачный",
+                    "обделённый",
                     "возвышаться",
-                    "зависть"
+                    "месть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Natur»?",
                 "choices": [
-                    "амбиция",
-                    "зависть",
                     "природа",
-                    "внебрачный"
+                    "внебрачный",
+                    "обделённый",
+                    "возвышаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Bastard",
+                "translation": "бастард",
+                "parts": [
+                    "Edmund steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mein Atem zeichnet das Wort „der Bastard“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Edmund steht unter dem glühenden Kronleuchter des Thronsaals. Mein Atem zeichnet das Wort „der Bastard“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Эдмунд стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «бастард» в холодном воздухе между нами."
+            },
+            {
+                "word": "der Neid",
+                "translation": "зависть",
+                "parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Edmund über Lears schweren Tisch.",
+                    "Ich umarme das Wort „der Neid“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Edmund über Lears schweren Tisch. Ich umarme das Wort „der Neid“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "У развернутой карты королевства Эдмунд склоняется над тяжёлым столом Лира. Я обнимаю слово «зависть», будто это единственный союзник."
+            },
+            {
+                "word": "die Ambition",
+                "translation": "амбиция",
+                "parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Edmund die Hände hinter dem Rücken.",
+                    "Das Echo des Wortes „die Ambition“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Edmund die Hände hinter dem Rücken. Das Echo des Wortes „die Ambition“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Перед каменными статуями предков Эдмунд сцепляет руки за спиной. Эхо слова «амбиция» заглушает шёпот придворных."
+            },
+            {
+                "word": "benachteiligt",
+                "translation": "обделённый",
+                "parts": [
+                    "Zwischen flüsternden Höflingen gleitet Edmund über den kalten Marmorboden.",
+                    "Ich zeichne das Wort „benachteiligt“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Zwischen flüsternden Höflingen gleitet Edmund über den kalten Marmorboden. Ich zeichne das Wort „benachteiligt“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Между шепчущимися придворными Эдмунд скользит по холодному мраморному полу. Я черчу слово «обделённый» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "die Rache",
+                "translation": "месть",
+                "parts": [
+                    "Am Rand des purpurnen Teppichs wartet Edmund auf ein Zeichen des Königs.",
+                    "Mein Atem zeichnet das Wort „die Rache“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Am Rand des purpurnen Teppichs wartet Edmund auf ein Zeichen des Königs. Mein Atem zeichnet das Wort „die Rache“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На краю пурпурного ковра Эдмунд ждёт знака от короля. Моё дыхание рисует слово «месть» в холодном воздухе между нами."
+            },
+            {
+                "word": "aufsteigen",
+                "translation": "возвышаться",
+                "parts": [
+                    "Unter wehenden Standarten der Schwestern senkt Edmund kurz den Blick.",
+                    "Ich zeichne das Wort „aufsteigen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Edmund kurz den Blick. Ich zeichne das Wort „aufsteigen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Эдмунд на миг опускает взгляд. Я вывожу слово «возвышаться» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "unehelich",
+                "translation": "внебрачный",
+                "parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Edmund das gespannte Antlitz des Hofes.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unehelich“ gehört mir."
+                ],
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Edmund das gespannte Antlitz des Hofes. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unehelich“ gehört mir.",
+                "sentenceTranslation": "За позолоченной балюстрадой Эдмунд наблюдает за напряжёнными лицами двора. Буря за окнами усиливает клятву: слово «внебрачный» принадлежит мне."
+            },
+            {
+                "word": "die Natur",
+                "translation": "природа",
+                "parts": [
+                    "Im Schein der offenen Feuerbecken erhebt Edmund langsam die Stimme.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Natur“ darf nicht vergehen."
+                ],
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Edmund langsam die Stimme. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Natur“ darf nicht vergehen.",
+                "sentenceTranslation": "В отблесках открытых жаровен Эдмунд медленно поднимает голос. Я шепчу стражам судьбы: слово «природа» не должно исчезнуть."
+            }
+        ]
     },
     "goneril": {
         "title": "Интрига с письмом",
         "description": "Акт I: Обман отца",
         "words": [
             {
+                "wordId": "",
                 "word": "fälschen",
                 "translation": "подделывать",
                 "transcription": "[ФЕЛЬ-шен]",
@@ -1724,9 +2043,14 @@
                 ],
                 "collocations": [
                     "Ich fälsche Edgars Brief perfekt. — Я идеально подделываю письмо Эдгара."
+                ],
+                "sentenceParts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Edmund zwischen gepackten Kisten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „fälschen“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "intrigieren",
                 "translation": "интриговать",
                 "transcription": "[ин-три-ГИ-рен]",
@@ -1748,9 +2072,14 @@
                 ],
                 "collocations": [
                     "Ich intrigiere gegen meinen Bruder. — Я интригую против брата."
+                ],
+                "sentenceParts": [
+                    "Auf der windigen Freitreppe blickt Edmund zum schweigenden Hof hinunter.",
+                    "Ich zeichne das Wort „intrigieren“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "beschuldigen",
                 "translation": "обвинять",
                 "transcription": "[бе-ШУЛЬ-ди-ген]",
@@ -1774,9 +2103,14 @@
                 ],
                 "collocations": [
                     "Ich beschuldige Edgar des Verrats. — Я обвиняю Эдгара в предательстве."
+                ],
+                "sentenceParts": [
+                    "Zwischen zurückgelassenen Dienern schließt Edmund den Reisemantel enger.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „beschuldigen“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Plan",
                 "translation": "план",
                 "transcription": "[дер ПЛАН]",
@@ -1802,9 +2136,15 @@
                 "collocations": [
                     "Mein hinterhältiger Plan wird funktionieren. — Мой коварный план сработает.",
                     "Mein Plan wird perfekt ausgeführt. — Мой план выполняется идеально."
+                ],
+                "sentenceParts": [
+                    "Am dunklen Pferdestall streicht Edmund einem nervösen Tier über die Mähne.",
+                    "Ich presse das Wort „der Plan“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "manipulieren",
                 "translation": "манипулировать",
                 "transcription": "[ма-ни-пу-ЛИ-рен]",
@@ -1826,9 +2166,14 @@
                 ],
                 "collocations": [
                     "Ich manipuliere meinen Vater geschickt. — Я ловко манипулирую отцом."
+                ],
+                "sentenceParts": [
+                    "Vor dem knarrenden Fallgatter tastet Edmund ein letztes Mal nach dem Haustor.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „manipulieren“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Brief",
                 "translation": "письмо",
                 "transcription": "[дер БРИФ]",
@@ -1850,9 +2195,14 @@
                     "Im Thronsaal verstummen die Gespräche über der Brief nie. — В тронном зале постоянно звучит слово «письмо».",
                     "Der gefälschte Brief ist mein Beweis. — Поддельное письмо - моё доказательство.",
                     "Dieser Brief beweist Edgars Verrat. — Это письмо доказывает предательство Эдгара."
+                ],
+                "sentenceParts": [
+                    "Zwischen verstreuten Schriftrollen dreht Edmund den Ring an der Hand.",
+                    "Ich umarme das Wort „der Brief“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "lügen",
                 "translation": "лгать",
                 "transcription": "[ЛЮ-ген]",
@@ -1874,9 +2224,14 @@
                 "collocations": [
                     "Der Narr spürt, wie das Lügen alle verändert. — Шут чувствует, как умение лгать меняет всех.",
                     "Ich lüge ohne mit der Wimper zu zucken. — Я лгу не моргнув глазом."
+                ],
+                "sentenceParts": [
+                    "Am leeren Bankettisch zählt Edmund die verlöschenden Kerzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „lügen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Täuschung",
                 "translation": "обман",
                 "transcription": "[ди ТОЙ-шунг]",
@@ -1903,6 +2258,10 @@
                 "collocations": [
                     "Die Täuschung ist vollkommen. — Обман совершенен.",
                     "Edgars liebevolle Täuschung rettet mich. — Любящий обман Эдгара спасает меня."
+                ],
+                "sentenceParts": [
+                    "Zwischen schweigenden Wachen geht Edmund auf den kalten Hof hinaus.",
+                    "Das Echo des Wortes „die Täuschung“ übertönt das Flüstern der Höflinge."
                 ]
             }
         ],
@@ -1911,90 +2270,174 @@
                 "question": "Что означает немецкое слово «fälschen»?",
                 "choices": [
                     "подделывать",
-                    "обвинять",
                     "план",
-                    "интриговать"
+                    "интриговать",
+                    "обвинять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «intrigieren»?",
                 "choices": [
-                    "обвинять",
                     "подделывать",
+                    "интриговать",
                     "план",
-                    "интриговать"
+                    "обвинять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beschuldigen»?",
                 "choices": [
-                    "план",
-                    "обвинять",
-                    "письмо",
-                    "манипулировать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Plan»?",
-                "choices": [
-                    "план",
-                    "подделывать",
-                    "интриговать",
-                    "обвинять"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «manipulieren»?",
-                "choices": [
-                    "манипулировать",
-                    "интриговать",
-                    "обвинять",
-                    "план"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Brief»?",
-                "choices": [
-                    "лгать",
                     "обман",
-                    "письмо",
-                    "подделывать"
+                    "лгать",
+                    "обвинять",
+                    "манипулировать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «der Plan»?",
+                "choices": [
+                    "манипулировать",
+                    "план",
+                    "подделывать",
+                    "письмо"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «manipulieren»?",
+                "choices": [
+                    "подделывать",
+                    "обман",
+                    "письмо",
+                    "манипулировать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Brief»?",
+                "choices": [
+                    "подделывать",
+                    "интриговать",
+                    "план",
+                    "письмо"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «lügen»?",
                 "choices": [
-                    "лгать",
-                    "манипулировать",
+                    "письмо",
+                    "интриговать",
                     "обвинять",
-                    "план"
+                    "лгать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
-                    "лгать",
+                    "письмо",
+                    "план",
                     "обман",
-                    "манипулировать",
-                    "обвинять"
+                    "манипулировать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "fälschen",
+                "translation": "подделывать",
+                "parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Edmund zwischen gepackten Kisten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „fälschen“ wird heute nicht verraten."
+                ],
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Edmund zwischen gepackten Kisten. Mit fester Stimme schwöre ich mir: Das Wort „fälschen“ wird heute nicht verraten.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Эдмунд замирает среди нагруженных ящиков. Твёрдым голосом я клянусь себе: слово «подделывать» сегодня не будет предано."
+            },
+            {
+                "word": "intrigieren",
+                "translation": "интриговать",
+                "parts": [
+                    "Auf der windigen Freitreppe blickt Edmund zum schweigenden Hof hinunter.",
+                    "Ich zeichne das Wort „intrigieren“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Auf der windigen Freitreppe blickt Edmund zum schweigenden Hof hinunter. Ich zeichne das Wort „intrigieren“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Эдмунд смотрит вниз на молчаливый двор. Я вывожу слово «интриговать» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "beschuldigen",
+                "translation": "обвинять",
+                "parts": [
+                    "Zwischen zurückgelassenen Dienern schließt Edmund den Reisemantel enger.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „beschuldigen“ darf nicht vergehen."
+                ],
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Edmund den Reisemantel enger. Ich flüstere den Wächtern des Schicksals zu: Das Wort „beschuldigen“ darf nicht vergehen.",
+                "sentenceTranslation": "Среди оставленных слуг Эдмунд плотнее запахивает дорожный плащ. Я шепчу стражам судьбы: слово «обвинять» не должно исчезнуть."
+            },
+            {
+                "word": "der Plan",
+                "translation": "план",
+                "parts": [
+                    "Am dunklen Pferdestall streicht Edmund einem nervösen Tier über die Mähne.",
+                    "Ich presse das Wort „der Plan“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Am dunklen Pferdestall streicht Edmund einem nervösen Tier über die Mähne. Ich presse das Wort „der Plan“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Эдмунд гладит гриву нервного коня. Я стискиваю слово «план» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "manipulieren",
+                "translation": "манипулировать",
+                "parts": [
+                    "Vor dem knarrenden Fallgatter tastet Edmund ein letztes Mal nach dem Haustor.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „manipulieren“ wird heute nicht verraten."
+                ],
+                "sentence": "Vor dem knarrenden Fallgatter tastet Edmund ein letztes Mal nach dem Haustor. Mit fester Stimme schwöre ich mir: Das Wort „manipulieren“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Эдмунд в последний раз касается родной двери. Твёрдым голосом я клянусь себе: слово «манипулировать» сегодня не будет предано."
+            },
+            {
+                "word": "der Brief",
+                "translation": "письмо",
+                "parts": [
+                    "Zwischen verstreuten Schriftrollen dreht Edmund den Ring an der Hand.",
+                    "Ich umarme das Wort „der Brief“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Edmund den Ring an der Hand. Ich umarme das Wort „der Brief“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Среди разбросанных свитков Эдмунд вертит кольцо на пальце. Я обнимаю слово «письмо», будто это единственный союзник."
+            },
+            {
+                "word": "lügen",
+                "translation": "лгать",
+                "parts": [
+                    "Am leeren Bankettisch zählt Edmund die verlöschenden Kerzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „lügen“ bleibt lebendig."
+                ],
+                "sentence": "Am leeren Bankettisch zählt Edmund die verlöschenden Kerzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „lügen“ bleibt lebendig.",
+                "sentenceTranslation": "У пустого банкетного стола Эдмунд пересчитывает гаснущие свечи. Каждой клеткой тела я обещаю: слово «лгать» останется живым."
+            },
+            {
+                "word": "die Täuschung",
+                "translation": "обман",
+                "parts": [
+                    "Zwischen schweigenden Wachen geht Edmund auf den kalten Hof hinaus.",
+                    "Das Echo des Wortes „die Täuschung“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Zwischen schweigenden Wachen geht Edmund auf den kalten Hof hinaus. Das Echo des Wortes „die Täuschung“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Между молчаливыми стражниками Эдмунд выходит на холодный двор. Эхо слова «обман» заглушает шёпот придворных."
+            }
+        ]
     },
     "regan": {
         "title": "Изгнание Эдгара",
         "description": "Акт II: Победа интриги",
         "words": [
             {
+                "wordId": "",
                 "word": "vertreiben",
                 "translation": "изгонять",
                 "transcription": "[фер-ТРАЙ-бен]",
@@ -2020,9 +2463,14 @@
                     "Aus meinem eigenen Haus will sie mich vertreiben! — Из моего собственного дома она хочет меня изгнать!",
                     "Ich vertreibe Edgar aus seinem Erbe. — Я изгоняю Эдгара из его наследства.",
                     "Ich vertreibe ihn aus meinem Haus. — Я изгоняю его из моего дома."
+                ],
+                "sentenceParts": [
+                    "Im zugigen Seitenflügel lauscht Edmund dem Heulen der Küstenwinde.",
+                    "Das Echo des Wortes „vertreiben“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "triumphieren",
                 "translation": "торжествовать",
                 "transcription": "[три-ум-ФИ-рен]",
@@ -2044,9 +2492,14 @@
                 ],
                 "collocations": [
                     "Ich triumphiere über meinen Bruder. — Я торжествую над братом."
+                ],
+                "sentenceParts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Edmund einen zerknitterten Brief.",
+                    "Ich halte das Wort „triumphieren“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erben",
                 "translation": "наследовать",
                 "transcription": "[ЭР-бен]",
@@ -2068,9 +2521,14 @@
                     "Der Narr spürt, wie das Erben alle verändert. — Шут чувствует, как умение наследовать меняет всех.",
                     "Nun erbe ich alles, was Edgar zustand. — Теперь я наследую всё, что полагалось Эдгару.",
                     "Nun erbe ich Titel und Verantwortung. — Теперь я наследую титул и ответственность."
+                ],
+                "sentenceParts": [
+                    "Unter farblosen Wandteppichen schreitet Edmund rastlos auf und ab.",
+                    "Ich zeichne das Wort „erben“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Erfolg",
                 "translation": "успех",
                 "transcription": "[дер эр-ФОЛЬГ]",
@@ -2092,9 +2550,14 @@
                 ],
                 "collocations": [
                     "Mein Erfolg ist vollkommen. — Мой успех полный."
+                ],
+                "sentenceParts": [
+                    "An der schmalen Fensterluke zählt Edmund die Fackeln auf dem Hof.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Erfolg“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "gewinnen",
                 "translation": "выигрывать",
                 "transcription": "[ге-ВИН-нен]",
@@ -2115,9 +2578,14 @@
                 "collocations": [
                     "Der Narr spürt, wie das Gewinnen alle verändert. — Шут чувствует, как умение выигрывать меняет всех.",
                     "Ich gewinne alles durch List. — Я выигрываю всё хитростью."
+                ],
+                "sentenceParts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Edmund nach frischen Botschaften.",
+                    "Ich umarme das Wort „gewinnen“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Belohnung",
                 "translation": "награда",
                 "transcription": "[ди бе-ЛО-нунг]",
@@ -2139,9 +2607,14 @@
                 ],
                 "collocations": [
                     "Die Belohnung für meine Intrige ist groß. — Награда за мою интригу велика."
+                ],
+                "sentenceParts": [
+                    "Im stillen Kapellenraum kniet Edmund vor der kalten Steinfigur.",
+                    "Ich zeichne das Wort „die Belohnung“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verdrängen",
                 "translation": "вытеснять",
                 "transcription": "[фер-ДРЕН-ген]",
@@ -2163,9 +2636,14 @@
                 ],
                 "collocations": [
                     "Ich verdränge den rechtmäßigen Erben. — Я вытесняю законного наследника."
+                ],
+                "sentenceParts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Edmund die Laterne fest.",
+                    "Das kalte Licht lässt das Wort „verdrängen“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Sieg",
                 "translation": "победа",
                 "transcription": "[дер ЗИГ]",
@@ -2187,6 +2665,10 @@
                 ],
                 "collocations": [
                     "Der Sieg über Edgar ist süß. — Победа над Эдгаром сладка."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der hohen Burgmauern schreibt Edmund eine fiebrige Antwort.",
+                    "Ich zeichne das Wort „der Sieg“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             }
         ],
@@ -2194,19 +2676,19 @@
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "торжествовать",
                     "изгонять",
                     "наследовать",
-                    "успех"
+                    "успех",
+                    "торжествовать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «triumphieren»?",
                 "choices": [
-                    "наследовать",
-                    "успех",
                     "изгонять",
+                    "успех",
+                    "наследовать",
                     "торжествовать"
                 ],
                 "correctIndex": 3
@@ -2214,71 +2696,154 @@
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
-                    "наследовать",
                     "вытеснять",
+                    "награда",
                     "победа",
-                    "успех"
+                    "наследовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Erfolg»?",
                 "choices": [
+                    "торжествовать",
                     "успех",
                     "победа",
-                    "торжествовать",
-                    "выигрывать"
+                    "наследовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «gewinnen»?",
                 "choices": [
-                    "успех",
-                    "вытеснять",
+                    "выигрывать",
                     "торжествовать",
-                    "выигрывать"
+                    "изгонять",
+                    "награда"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Belohnung»?",
                 "choices": [
                     "успех",
-                    "изгонять",
-                    "награда",
-                    "вытеснять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «verdrängen»?",
-                "choices": [
-                    "наследовать",
-                    "торжествовать",
                     "победа",
-                    "вытеснять"
+                    "наследовать",
+                    "награда"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «verdrängen»?",
+                "choices": [
+                    "торжествовать",
+                    "выигрывать",
+                    "вытеснять",
+                    "успех"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «der Sieg»?",
                 "choices": [
-                    "успех",
+                    "изгонять",
                     "торжествовать",
                     "победа",
-                    "выигрывать"
+                    "награда"
                 ],
                 "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "vertreiben",
+                "translation": "изгонять",
+                "parts": [
+                    "Im zugigen Seitenflügel lauscht Edmund dem Heulen der Küstenwinde.",
+                    "Das Echo des Wortes „vertreiben“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Im zugigen Seitenflügel lauscht Edmund dem Heulen der Küstenwinde. Das Echo des Wortes „vertreiben“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Эдмунд слушает вой прибрежного ветра. Эхо слова «изгонять» заглушает шёпот придворных."
+            },
+            {
+                "word": "triumphieren",
+                "translation": "торжествовать",
+                "parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Edmund einen zerknitterten Brief.",
+                    "Ich halte das Wort „triumphieren“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Edmund einen zerknitterten Brief. Ich halte das Wort „triumphieren“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед дымным камином замка Эдмунд складывает измятый лист. Я держу слово «торжествовать» как факел у сердца."
+            },
+            {
+                "word": "erben",
+                "translation": "наследовать",
+                "parts": [
+                    "Unter farblosen Wandteppichen schreitet Edmund rastlos auf und ab.",
+                    "Ich zeichne das Wort „erben“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Unter farblosen Wandteppichen schreitet Edmund rastlos auf und ab. Ich zeichne das Wort „erben“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под выцветшими гобеленами Эдмунд беспокойно меряет шагами зал. Я черчу слово «наследовать» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "der Erfolg",
+                "translation": "успех",
+                "parts": [
+                    "An der schmalen Fensterluke zählt Edmund die Fackeln auf dem Hof.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Erfolg“ auf meine Lippen."
+                ],
+                "sentence": "An der schmalen Fensterluke zählt Edmund die Fackeln auf dem Hof. Wie ein stilles Gebet legt sich das Wort „der Erfolg“ auf meine Lippen.",
+                "sentenceTranslation": "У узкой бойницы Эдмунд считает факелы на дворе. Как тихая молитва слово «успех» ложится на мои губы."
+            },
+            {
+                "word": "gewinnen",
+                "translation": "выигрывать",
+                "parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Edmund nach frischen Botschaften.",
+                    "Ich umarme das Wort „gewinnen“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Edmund nach frischen Botschaften. Ich umarme das Wort „gewinnen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Эдмунд ищет свежие вести. Я обнимаю слово «выигрывать», будто это единственный союзник."
+            },
+            {
+                "word": "die Belohnung",
+                "translation": "награда",
+                "parts": [
+                    "Im stillen Kapellenraum kniet Edmund vor der kalten Steinfigur.",
+                    "Ich zeichne das Wort „die Belohnung“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Im stillen Kapellenraum kniet Edmund vor der kalten Steinfigur. Ich zeichne das Wort „die Belohnung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В тихой капелле Эдмунд преклоняет колени перед холодной каменной фигурой. Я вывожу слово «награда» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "verdrängen",
+                "translation": "вытеснять",
+                "parts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Edmund die Laterne fest.",
+                    "Das kalte Licht lässt das Wort „verdrängen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Edmund die Laterne fest. Das kalte Licht lässt das Wort „verdrängen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Эдмунд крепко держит фонарь. Холодный свет заставляет слово «вытеснять» сиять словно расплавленное золото."
+            },
+            {
+                "word": "der Sieg",
+                "translation": "победа",
+                "parts": [
+                    "Im Schatten der hohen Burgmauern schreibt Edmund eine fiebrige Antwort.",
+                    "Ich zeichne das Wort „der Sieg“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Edmund eine fiebrige Antwort. Ich zeichne das Wort „der Sieg“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В тени высоких стен Эдмунд пишет лихорадочный ответ. Я вывожу слово «победа» невидимыми чернилами на ладони."
+            }
+        ]
     },
     "storm": {
         "title": "Союз с сёстрами",
         "description": "Акт III: Альянс со злом",
         "words": [
             {
+                "wordId": "",
                 "word": "verbünden",
                 "translation": "объединяться",
                 "transcription": "[фер-БЮН-ден]",
@@ -2300,9 +2865,14 @@
                 ],
                 "collocations": [
                     "Ich verbünde mich mit den bösen Schwestern. — Я объединяюсь со злыми сёстрами."
+                ],
+                "sentenceParts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edmund gegen den Wind.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbünden“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Macht",
                 "translation": "власть",
                 "transcription": "[ди МАХТ]",
@@ -2326,9 +2896,14 @@
                     "Die Macht über das Königreich ist nah. — Власть над королевством близка.",
                     "Die Macht bedeutet nichts ohne wahre Liebe. — Власть ничего не значит без истинной любви.",
                     "Die Macht über das halbe Königreich ist mein. — Власть над половиной королевства моя."
+                ],
+                "sentenceParts": [
+                    "Unter einem zerrissenen Banner schützt Edmund die Augen vor den Blitzen.",
+                    "Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erobern",
                 "translation": "завоёвывать",
                 "transcription": "[эр-О-берн]",
@@ -2351,9 +2926,14 @@
                     "Der Narr spürt, wie das Erobern alle verändert. — Шут чувствует, как умение завоевывать меняет всех.",
                     "Wir erobern das Reich gemeinsam. — Мы завоёвываем королевство вместе.",
                     "Ich erobere, was mir zusteht. — Я завоёвываю то, что мне положено."
+                ],
+                "sentenceParts": [
+                    "Am Rand eines umgestürzten Baumes sucht Edmund Deckung vor dem Donner.",
+                    "Das kalte Licht lässt das Wort „erobern“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Bündnis",
                 "translation": "союз",
                 "transcription": "[дас БЮНД-нис]",
@@ -2379,9 +2959,14 @@
                 "collocations": [
                     "Unser Bündnis ist stark und grausam. — Наш союз силён и жесток.",
                     "Ein Bündnis mit Goneril gegen unseren Vater. — Союз с Гонерильей против нашего отца."
+                ],
+                "sentenceParts": [
+                    "Zwischen schäumenden Wassergräben stolpert Edmund durch den Schlamm.",
+                    "Das kalte Licht lässt das Wort „das Bündnis“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verführen",
                 "translation": "соблазнять",
                 "transcription": "[фер-ФЮ-рен]",
@@ -2407,9 +2992,14 @@
                 "collocations": [
                     "Ich verführe beide Schwestern gleichzeitig. — Я соблазняю обеих сестёр одновременно.",
                     "Ich will Edmund verführen und besitzen. — Я хочу соблазнить и завладеть Эдмундом."
+                ],
+                "sentenceParts": [
+                    "Vor einem zuckenden Himmel hebt Edmund die Arme trotzig an.",
+                    "Ich umarme das Wort „verführen“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Eroberung",
                 "translation": "завоевание",
                 "transcription": "[ди эр-О-бе-рунг]",
@@ -2431,9 +3021,14 @@
                 ],
                 "collocations": [
                     "Die Eroberung des Throns ist mein Ziel. — Завоевание трона - моя цель."
+                ],
+                "sentenceParts": [
+                    "Unter dem durchtränkten Umhang presst Edmund den Atem gegen die Kälte.",
+                    "Ich halte das Wort „die Eroberung“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "beherrschen",
                 "translation": "господствовать",
                 "transcription": "[бе-ХЕР-шен]",
@@ -2455,9 +3050,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Beherrschen ist. — Во время бури становится понятно, насколько важно владеть.",
                     "Ich beherrsche das Spiel der Macht. — Я господствую в игре власти."
+                ],
+                "sentenceParts": [
+                    "Am kläglichen Feuerrest wärmt Edmund zitternde Finger.",
+                    "Ich presse das Wort „beherrschen“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Allianz",
                 "translation": "альянс",
                 "transcription": "[ди а-ли-АНЦС]",
@@ -2479,6 +3079,11 @@
                 ],
                 "collocations": [
                     "Unsere Allianz wird alle Feinde vernichten. — Наш альянс уничтожит всех врагов."
+                ],
+                "sentenceParts": [
+                    "Zwischen heulenden Hunden ruft Edmund gegen den tosenden Sturm an.",
+                    "Ich presse das Wort „die Allianz“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             }
         ],
@@ -2486,38 +3091,38 @@
             {
                 "question": "Что означает немецкое слово «verbünden»?",
                 "choices": [
-                    "объединяться",
-                    "союз",
                     "власть",
-                    "завоёвывать"
+                    "объединяться",
+                    "завоёвывать",
+                    "союз"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "союз",
-                    "завоёвывать",
+                    "объединяться",
                     "власть",
-                    "объединяться"
+                    "союз",
+                    "завоёвывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
-                    "завоевание",
-                    "соблазнять",
                     "завоёвывать",
-                    "господствовать"
+                    "объединяться",
+                    "власть",
+                    "союз"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
                     "соблазнять",
-                    "господствовать",
+                    "власть",
                     "союз",
                     "завоёвывать"
                 ],
@@ -2526,51 +3131,135 @@
             {
                 "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
-                    "соблазнять",
-                    "власть",
-                    "объединяться",
-                    "альянс"
+                    "альянс",
+                    "господствовать",
+                    "завоевание",
+                    "соблазнять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Eroberung»?",
                 "choices": [
-                    "господствовать",
                     "завоевание",
-                    "альянс",
-                    "объединяться"
+                    "господствовать",
+                    "объединяться",
+                    "завоёвывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beherrschen»?",
                 "choices": [
+                    "объединяться",
                     "завоевание",
-                    "господствовать",
-                    "союз",
-                    "альянс"
+                    "завоёвывать",
+                    "господствовать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Allianz»?",
                 "choices": [
-                    "завоёвывать",
+                    "объединяться",
                     "альянс",
-                    "союз",
-                    "господствовать"
+                    "господствовать",
+                    "соблазнять"
                 ],
                 "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "verbünden",
+                "translation": "объединяться",
+                "parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edmund gegen den Wind.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbünden“ gehört mir."
+                ],
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edmund gegen den Wind. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbünden“ gehört mir.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Эдмунд упирается в ветер. Буря за окнами усиливает клятву: слово «объединяться» принадлежит мне."
+            },
+            {
+                "word": "die Macht",
+                "translation": "власть",
+                "parts": [
+                    "Unter einem zerrissenen Banner schützt Edmund die Augen vor den Blitzen.",
+                    "Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Unter einem zerrissenen Banner schützt Edmund die Augen vor den Blitzen. Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Под разорванным знаменем Эдмунд прикрывает глаза от молний. Я обнимаю слово «власть», будто это единственный союзник."
+            },
+            {
+                "word": "erobern",
+                "translation": "завоёвывать",
+                "parts": [
+                    "Am Rand eines umgestürzten Baumes sucht Edmund Deckung vor dem Donner.",
+                    "Das kalte Licht lässt das Wort „erobern“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Edmund Deckung vor dem Donner. Das kalte Licht lässt das Wort „erobern“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "У поваленного дерева Эдмунд ищет укрытия от грома. Холодный свет заставляет слово «завоёвывать» сиять словно расплавленное золото."
+            },
+            {
+                "word": "das Bündnis",
+                "translation": "союз",
+                "parts": [
+                    "Zwischen schäumenden Wassergräben stolpert Edmund durch den Schlamm.",
+                    "Das kalte Licht lässt das Wort „das Bündnis“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Edmund durch den Schlamm. Das kalte Licht lässt das Wort „das Bündnis“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Между пенящимися лужами Эдмунд пробирается через грязь. Холодный свет заставляет слово «союз» сиять словно расплавленное золото."
+            },
+            {
+                "word": "verführen",
+                "translation": "соблазнять",
+                "parts": [
+                    "Vor einem zuckenden Himmel hebt Edmund die Arme trotzig an.",
+                    "Ich umarme das Wort „verführen“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Vor einem zuckenden Himmel hebt Edmund die Arme trotzig an. Ich umarme das Wort „verführen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Эдмунд упрямо поднимает руки. Я обнимаю слово «соблазнять», будто это единственный союзник."
+            },
+            {
+                "word": "die Eroberung",
+                "translation": "завоевание",
+                "parts": [
+                    "Unter dem durchtränkten Umhang presst Edmund den Atem gegen die Kälte.",
+                    "Ich halte das Wort „die Eroberung“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Unter dem durchtränkten Umhang presst Edmund den Atem gegen die Kälte. Ich halte das Wort „die Eroberung“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Под промокшим плащом Эдмунд прижимает дыхание к груди, спасаясь от холода. Я держу слово «завоевание» как факел у сердца."
+            },
+            {
+                "word": "beherrschen",
+                "translation": "господствовать",
+                "parts": [
+                    "Am kläglichen Feuerrest wärmt Edmund zitternde Finger.",
+                    "Ich presse das Wort „beherrschen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Am kläglichen Feuerrest wärmt Edmund zitternde Finger. Ich presse das Wort „beherrschen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У жалких огненных углей Эдмунд греет дрожащие пальцы. Я стискиваю слово «господствовать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Allianz",
+                "translation": "альянс",
+                "parts": [
+                    "Zwischen heulenden Hunden ruft Edmund gegen den tosenden Sturm an.",
+                    "Ich presse das Wort „die Allianz“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Zwischen heulenden Hunden ruft Edmund gegen den tosenden Sturm an. Ich presse das Wort „die Allianz“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди воющих псов Эдмунд перекрикивает беснующуюся бурю. Я стискиваю слово «альянс» зубами, чтобы не вырвалось сомнение."
+            }
+        ]
     },
     "hut": {
         "title": "Предательство отца",
         "description": "Акт III-IV: Ослепление Глостера",
         "words": [
             {
+                "wordId": "",
                 "word": "verraten",
                 "translation": "предавать",
                 "transcription": "[фер-РА-тен]",
@@ -2596,9 +3285,14 @@
                     "Ich verrate jeden an meine Herrin. — Я выдаю каждого своей госпоже.",
                     "Ich verrate meinen eigenen Vater. — Я предаю собственного отца.",
                     "Ich verrate meinen Mann für Edmund. — Я предаю мужа ради Эдмунда."
+                ],
+                "sentenceParts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Edmund bei der flackernden Kerze.",
+                    "Mein Atem zeichnet das Wort „verraten“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "blenden",
                 "translation": "ослеплять",
                 "transcription": "[БЛЕН-ден]",
@@ -2622,9 +3316,14 @@
                     "Wir blenden den treuen Grafen Gloucester. — Мы ослепляем верного графа Глостера.",
                     "Eigenhändig blende ich Gloucester. — Собственноручно я ослепляю Глостера.",
                     "Sie blenden mich für meinen Verrat. — Они ослепляют меня за мою измену."
+                ],
+                "sentenceParts": [
+                    "Zwischen zerbeulten Rüstungen streicht Edmund über ein altes Wappen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Grausamkeit",
                 "translation": "жестокость",
                 "transcription": "[ди ГРАУ-зам-кайт]",
@@ -2657,9 +3356,14 @@
                     "Meine Grausamkeit kennt keine Grenzen. — Моя жестокость не знает границ.",
                     "Meine Grausamkeit übertrifft die meiner Schwester. — Моя жестокость превосходит жестокость сестры.",
                     "Die Grausamkeit meiner Frau gefällt mir. — Жестокость моей жены мне нравится."
+                ],
+                "sentenceParts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Edmund fast den Kopf.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Grausamkeit“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "denunzieren",
                 "translation": "доносить",
                 "transcription": "[де-нун-ЦИ-рен]",
@@ -2681,9 +3385,14 @@
                 ],
                 "collocations": [
                     "Ich denunziere meinen Vater als Verräter. — Я доношу на отца как на предателя."
+                ],
+                "sentenceParts": [
+                    "Neben der schlafenden Wache flüstert Edmund in die schwere Nacht.",
+                    "Ich presse das Wort „denunzieren“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ausliefern",
                 "translation": "выдавать",
                 "transcription": "[АУС-ли-ферн]",
@@ -2707,9 +3416,14 @@
                 ],
                 "collocations": [
                     "Ich liefere ihn seinen Feinden aus. — Я выдаю его врагам."
+                ],
+                "sentenceParts": [
+                    "Vor dem einfachen Feldbett betrachtet Edmund die Narben vergangener Schlachten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „ausliefern“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Folter",
                 "translation": "пытка",
                 "transcription": "[ди ФОЛЬ-тер]",
@@ -2739,9 +3453,14 @@
                     "Die Folter ist meine Unterhaltung. — Пытка - моё развлечение.",
                     "Die Folter ist mein liebstes Werkzeug. — Пытка - мой любимый инструмент.",
                     "Die Folter ist grausam und erbarmungslos. — Пытка жестока и беспощадна."
+                ],
+                "sentenceParts": [
+                    "Im Geruch von feuchtem Stroh legt Edmund den Mantel zur Seite.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Folter“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "opfern",
                 "translation": "жертвовать",
                 "transcription": "[ОП-ферн]",
@@ -2763,9 +3482,14 @@
                 ],
                 "collocations": [
                     "Ich opfere ihn für meine Ambitionen. — Я жертвую им ради своих амбиций."
+                ],
+                "sentenceParts": [
+                    "Auf dem wackligen Holztisch ordnet Edmund zerlesene Briefe.",
+                    "Das kalte Licht lässt das Wort „opfern“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erbarmungslos",
                 "translation": "беспощадный",
                 "transcription": "[эр-БАР-мунгс-лос]",
@@ -2794,6 +3518,10 @@
                     "Erbarmungslos verfolge ich mein Ziel. — Беспощадно я преследую свою цель.",
                     "Ich bin erbarmungslos in meiner Rache. — Я беспощадна в своей мести.",
                     "Erbarmungslos werfe ich ihn hinaus. — Беспощадно я выбрасываю его."
+                ],
+                "sentenceParts": [
+                    "Am Eingang der Hütte späht Edmund nach einem vertrauten Schatten.",
+                    "Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             }
         ],
@@ -2801,12 +3529,12 @@
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "предавать",
+                    "доносить",
                     "ослеплять",
                     "жестокость",
-                    "доносить"
+                    "предавать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «blenden»?",
@@ -2821,71 +3549,154 @@
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
+                    "доносить",
                     "ослеплять",
+                    "беспощадный",
+                    "жестокость"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «denunzieren»?",
+                "choices": [
+                    "беспощадный",
+                    "ослеплять",
+                    "предавать",
+                    "доносить"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «ausliefern»?",
+                "choices": [
+                    "ослеплять",
+                    "пытка",
                     "выдавать",
-                    "жестокость",
                     "предавать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «denunzieren»?",
-                "choices": [
-                    "предавать",
-                    "доносить",
-                    "выдавать",
-                    "беспощадный"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «ausliefern»?",
-                "choices": [
-                    "выдавать",
-                    "пытка",
-                    "доносить",
-                    "жестокость"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "выдавать",
+                    "жестокость",
+                    "предавать",
                     "жертвовать",
-                    "пытка",
-                    "жестокость"
+                    "пытка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «opfern»?",
                 "choices": [
                     "выдавать",
-                    "ослеплять",
-                    "беспощадный",
-                    "жертвовать"
+                    "жертвовать",
+                    "пытка",
+                    "ослеплять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
+                    "жертвовать",
                     "жестокость",
                     "предавать",
-                    "жертвовать",
                     "беспощадный"
                 ],
                 "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "verraten",
+                "translation": "предавать",
+                "parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Edmund bei der flackernden Kerze.",
+                    "Mein Atem zeichnet das Wort „verraten“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Edmund bei der flackernden Kerze. Mein Atem zeichnet das Wort „verraten“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Эдмунд сидит у мерцающей свечи. Моё дыхание рисует слово «предавать» в холодном воздухе между нами."
+            },
+            {
+                "word": "blenden",
+                "translation": "ослеплять",
+                "parts": [
+                    "Zwischen zerbeulten Rüstungen streicht Edmund über ein altes Wappen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen."
+                ],
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Edmund über ein altes Wappen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen.",
+                "sentenceTranslation": "Среди помятых доспехов Эдмунд гладит старый герб. Я шепчу стражам судьбы: слово «ослеплять» не должно исчезнуть."
+            },
+            {
+                "word": "die Grausamkeit",
+                "translation": "жестокость",
+                "parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Edmund fast den Kopf.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Grausamkeit“ gehört mir."
+                ],
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Edmund fast den Kopf. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Grausamkeit“ gehört mir.",
+                "sentenceTranslation": "О низкую балку хижины Эдмунд едва не ударяется головой. Буря за окнами усиливает клятву: слово «жестокость» принадлежит мне."
+            },
+            {
+                "word": "denunzieren",
+                "translation": "доносить",
+                "parts": [
+                    "Neben der schlafenden Wache flüstert Edmund in die schwere Nacht.",
+                    "Ich presse das Wort „denunzieren“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Neben der schlafenden Wache flüstert Edmund in die schwere Nacht. Ich presse das Wort „denunzieren“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Рядом со спящим стражем Эдмунд шепчет в тяжёлую ночь. Я стискиваю слово «доносить» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "ausliefern",
+                "translation": "выдавать",
+                "parts": [
+                    "Vor dem einfachen Feldbett betrachtet Edmund die Narben vergangener Schlachten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „ausliefern“ wird heute nicht verraten."
+                ],
+                "sentence": "Vor dem einfachen Feldbett betrachtet Edmund die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „ausliefern“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед грубой походной койкой Эдмунд разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «выдавать» сегодня не будет предано."
+            },
+            {
+                "word": "die Folter",
+                "translation": "пытка",
+                "parts": [
+                    "Im Geruch von feuchtem Stroh legt Edmund den Mantel zur Seite.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Folter“ bleibt lebendig."
+                ],
+                "sentence": "Im Geruch von feuchtem Stroh legt Edmund den Mantel zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Folter“ bleibt lebendig.",
+                "sentenceTranslation": "В запахе влажной соломы Эдмунд откладывает плащ в сторону. Каждой клеткой тела я обещаю: слово «пытка» останется живым."
+            },
+            {
+                "word": "opfern",
+                "translation": "жертвовать",
+                "parts": [
+                    "Auf dem wackligen Holztisch ordnet Edmund zerlesene Briefe.",
+                    "Das kalte Licht lässt das Wort „opfern“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Auf dem wackligen Holztisch ordnet Edmund zerlesene Briefe. Das kalte Licht lässt das Wort „opfern“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На шатком деревянном столе Эдмунд раскладывает зачитанные письма. Холодный свет заставляет слово «жертвовать» сиять словно расплавленное золото."
+            },
+            {
+                "word": "erbarmungslos",
+                "translation": "беспощадный",
+                "parts": [
+                    "Am Eingang der Hütte späht Edmund nach einem vertrauten Schatten.",
+                    "Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Am Eingang der Hütte späht Edmund nach einem vertrauten Schatten. Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У входа в хижину Эдмунд высматривает знакомую тень. Я стискиваю слово «беспощадный» зубами, чтобы не вырвалось сомнение."
+            }
+        ]
     },
     "dover": {
         "title": "Любовный треугольник",
         "description": "Акт IV-V: Между двух сестёр",
         "words": [
             {
+                "wordId": "",
                 "word": "die Liebschaft",
                 "translation": "любовная связь",
                 "transcription": "[ди ЛИБ-шафт]",
@@ -2908,9 +3719,14 @@
                 ],
                 "collocations": [
                     "Meine Liebschaft mit beiden Schwestern ist gefährlich. — Моя любовная связь с обеими сёстрами опасна."
+                ],
+                "sentenceParts": [
+                    "Auf den weißen Klippen von Dover blickt Edmund in den aufgewühlten Kanal.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Liebschaft“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Rivalität",
                 "translation": "соперничество",
                 "transcription": "[ди ри-ва-ли-ТЕТ]",
@@ -2936,9 +3752,14 @@
                 "collocations": [
                     "Ihre Rivalität spielt mir in die Hände. — Их соперничество играет мне на руку.",
                     "Unsere Rivalität wird tödlich enden. — Наше соперничество закончится смертью."
+                ],
+                "sentenceParts": [
+                    "Zwischen flatternden Feldzeichen richtet Edmund den Helm.",
+                    "Ich halte das Wort „die Rivalität“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "spielen",
                 "translation": "играть",
                 "transcription": "[ШПИ-лен]",
@@ -2959,9 +3780,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Spielen ist. — Во время бури становится понятно, насколько важно играть.",
                     "Ich spiele mit ihren Gefühlen. — Я играю с их чувствами."
+                ],
+                "sentenceParts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Edmund Marschrouten in den Sand.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „spielen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verlocken",
                 "translation": "завлекать",
                 "transcription": "[фер-ЛО-кен]",
@@ -2983,9 +3809,14 @@
                 ],
                 "collocations": [
                     "Ich verlocke sie mit falschen Versprechen. — Я завлекаю их ложными обещаниями."
+                ],
+                "sentenceParts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Edmund das Siegel.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „verlocken“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Lust",
                 "translation": "похоть",
                 "transcription": "[ди ЛУСТ]",
@@ -3011,9 +3842,15 @@
                 "collocations": [
                     "Ihre Lust macht sie blind. — Их похоть делает их слепыми.",
                     "Die Lust macht mich blind für Gefahr. — Похоть делает меня слепой к опасности."
+                ],
+                "sentenceParts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Edmund dem dumpfen Meer.",
+                    "Ich presse das Wort „die Lust“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ausnutzen",
                 "translation": "использовать",
                 "transcription": "[АУС-нут-цен]",
@@ -3035,9 +3872,14 @@
                 ],
                 "collocations": [
                     "Ich nutze ihre Leidenschaft aus. — Я использую их страсть."
+                ],
+                "sentenceParts": [
+                    "Auf dem sandigen Trainingsplatz übt Edmund das Ziehen des Schwerts.",
+                    "Ich atme tief ein und lasse nur das Wort „ausnutzen“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "jonglieren",
                 "translation": "жонглировать",
                 "transcription": "[жон-ГЛИ-рен]",
@@ -3059,9 +3901,14 @@
                 ],
                 "collocations": [
                     "Ich jongliere mit zwei gefährlichen Frauen. — Я жонглирую двумя опасными женщинами."
+                ],
+                "sentenceParts": [
+                    "Zwischen pochenden Trommeln hebt Edmund das Banner der Hoffnung.",
+                    "Das kalte Licht lässt das Wort „jonglieren“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Affäre",
                 "translation": "интрига",
                 "transcription": "[ди а-ФЕ-ре]",
@@ -3084,6 +3931,10 @@
                 ],
                 "collocations": [
                     "Diese Affäre wird tödlich enden. — Эта интрига закончится смертью."
+                ],
+                "sentenceParts": [
+                    "Am Morgennebel der Küste legt Edmund die Hand auf das pochende Herz.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Affäre“ darf nicht vergehen."
                 ]
             }
         ],
@@ -3092,8 +3943,8 @@
                 "question": "Что означает немецкое слово «die Liebschaft»?",
                 "choices": [
                     "соперничество",
-                    "завлекать",
                     "играть",
+                    "завлекать",
                     "любовная связь"
                 ],
                 "correctIndex": 3
@@ -3102,19 +3953,19 @@
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
                     "завлекать",
-                    "играть",
                     "соперничество",
+                    "играть",
                     "любовная связь"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «spielen»?",
                 "choices": [
+                    "соперничество",
                     "похоть",
-                    "использовать",
                     "играть",
-                    "интрига"
+                    "любовная связь"
                 ],
                 "correctIndex": 2
             },
@@ -3122,28 +3973,28 @@
                 "question": "Что означает немецкое слово «verlocken»?",
                 "choices": [
                     "похоть",
-                    "интрига",
-                    "играть",
-                    "завлекать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Lust»?",
-                "choices": [
-                    "жонглировать",
-                    "похоть",
-                    "играть",
-                    "соперничество"
+                    "завлекать",
+                    "соперничество",
+                    "использовать"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «die Lust»?",
+                "choices": [
+                    "похоть",
+                    "соперничество",
+                    "завлекать",
+                    "играть"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «ausnutzen»?",
                 "choices": [
-                    "жонглировать",
-                    "играть",
-                    "завлекать",
+                    "интрига",
+                    "похоть",
+                    "соперничество",
                     "использовать"
                 ],
                 "correctIndex": 3
@@ -3151,31 +4002,115 @@
             {
                 "question": "Что означает немецкое слово «jonglieren»?",
                 "choices": [
-                    "похоть",
+                    "любовная связь",
+                    "играть",
                     "жонглировать",
-                    "использовать",
-                    "завлекать"
+                    "похоть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Affäre»?",
                 "choices": [
+                    "соперничество",
                     "использовать",
                     "интрига",
-                    "завлекать",
-                    "похоть"
+                    "жонглировать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Liebschaft",
+                "translation": "любовная связь",
+                "parts": [
+                    "Auf den weißen Klippen von Dover blickt Edmund in den aufgewühlten Kanal.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Liebschaft“ gehört mir."
+                ],
+                "sentence": "Auf den weißen Klippen von Dover blickt Edmund in den aufgewühlten Kanal. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Liebschaft“ gehört mir.",
+                "sentenceTranslation": "На белых скалах Дувра Эдмунд смотрит в вздыбленный пролив. Буря за окнами усиливает клятву: слово «любовная связь» принадлежит мне."
+            },
+            {
+                "word": "die Rivalität",
+                "translation": "соперничество",
+                "parts": [
+                    "Zwischen flatternden Feldzeichen richtet Edmund den Helm.",
+                    "Ich halte das Wort „die Rivalität“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Zwischen flatternden Feldzeichen richtet Edmund den Helm. Ich halte das Wort „die Rivalität“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Среди хлопающих штандартов Эдмунд поправляет шлем. Я держу слово «соперничество» как факел у сердца."
+            },
+            {
+                "word": "spielen",
+                "translation": "играть",
+                "parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Edmund Marschrouten in den Sand.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „spielen“ gehört mir."
+                ],
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Edmund Marschrouten in den Sand. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „spielen“ gehört mir.",
+                "sentenceTranslation": "У французского костра Эдмунд рисует в песке путь марша. Буря за окнами усиливает клятву: слово «играть» принадлежит мне."
+            },
+            {
+                "word": "verlocken",
+                "translation": "завлекать",
+                "parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Edmund das Siegel.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „verlocken“ darf nicht vergehen."
+                ],
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Edmund das Siegel. Ich flüstere den Wächtern des Schicksals zu: Das Wort „verlocken“ darf nicht vergehen.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Эдмунд проверяет печати. Я шепчу стражам судьбы: слово «завлекать» не должно исчезнуть."
+            },
+            {
+                "word": "die Lust",
+                "translation": "похоть",
+                "parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Edmund dem dumpfen Meer.",
+                    "Ich presse das Wort „die Lust“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Edmund dem dumpfen Meer. Ich presse das Wort „die Lust“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Эдмунд слушает глухой шум моря. Я стискиваю слово «похоть» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "ausnutzen",
+                "translation": "использовать",
+                "parts": [
+                    "Auf dem sandigen Trainingsplatz übt Edmund das Ziehen des Schwerts.",
+                    "Ich atme tief ein und lasse nur das Wort „ausnutzen“ wieder hinaus."
+                ],
+                "sentence": "Auf dem sandigen Trainingsplatz übt Edmund das Ziehen des Schwerts. Ich atme tief ein und lasse nur das Wort „ausnutzen“ wieder hinaus.",
+                "sentenceTranslation": "На песчаном плацу Эдмунд отрабатывает выхват меча. Я глубоко вдыхаю и выпускаю только слово «использовать»."
+            },
+            {
+                "word": "jonglieren",
+                "translation": "жонглировать",
+                "parts": [
+                    "Zwischen pochenden Trommeln hebt Edmund das Banner der Hoffnung.",
+                    "Das kalte Licht lässt das Wort „jonglieren“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Zwischen pochenden Trommeln hebt Edmund das Banner der Hoffnung. Das kalte Licht lässt das Wort „jonglieren“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Под гул барабанов Эдмунд поднимает знамя надежды. Холодный свет заставляет слово «жонглировать» сиять словно расплавленное золото."
+            },
+            {
+                "word": "die Affäre",
+                "translation": "интрига",
+                "parts": [
+                    "Am Morgennebel der Küste legt Edmund die Hand auf das pochende Herz.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Affäre“ darf nicht vergehen."
+                ],
+                "sentence": "Am Morgennebel der Küste legt Edmund die Hand auf das pochende Herz. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Affäre“ darf nicht vergehen.",
+                "sentenceTranslation": "В утреннем тумане побережья Эдмунд кладёт ладонь на бьющееся сердце. Я шепчу стражам судьбы: слово «интрига» не должно исчезнуть."
+            }
+        ]
     },
     "prison": {
         "title": "Дуэль и смерть",
         "description": "Акт V: Поражение и раскаяние",
         "words": [
             {
+                "wordId": "",
                 "word": "das Duell",
                 "translation": "дуэль",
                 "transcription": "[дас ду-ЭЛЬ]",
@@ -3197,9 +4132,14 @@
                     "Für die Höflinge bleibt das Duell ein ständiges Thema. — Для придворных «дуэль» — постоянная тема.",
                     "Das Duell mit Edgar ist mein Ende. — Дуэль с Эдгаром - мой конец.",
                     "In diesem Duell kämpfe ich für die Gerechtigkeit. — В этой дуэли я сражаюсь за справедливость."
+                ],
+                "sentenceParts": [
+                    "Im feuchten Kerker stützt Edmund sich an den tropfenden Stein.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Duell“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "fallen",
                 "translation": "падать",
                 "transcription": "[ФАЛ-лен]",
@@ -3222,9 +4162,14 @@
                     "Der Narr spürt, wie das Fallen alle verändert. — Шут чувствует, как умение падать меняет всех.",
                     "Ich falle wie der Feigling, der ich bin. — Я падаю как трус, которым являюсь.",
                     "Ich falle von seinem gerechten Schwert. — Я падаю от его справедливого меча."
+                ],
+                "sentenceParts": [
+                    "Unter der trüben Laterne zählt Edmund die eisernen Ringe der Kette.",
+                    "Ich zeichne das Wort „fallen“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "bereuen",
                 "translation": "сожалеть",
                 "transcription": "[бе-РОЙ-ен]",
@@ -3248,9 +4193,14 @@
                     "Am Ende bereue ich meine Taten. — В конце я сожалею о своих делах.",
                     "Später werde ich diese Tat bitter bereuen. — Позже я горько пожалею об этом поступке.",
                     "Zu spät bereue ich meine Taten. — Слишком поздно я сожалею о своих делах."
+                ],
+                "sentenceParts": [
+                    "Neben der schweren Holztür horcht Edmund auf entferntes Schluchzen.",
+                    "Das Echo des Wortes „bereuen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Niederlage",
                 "translation": "поражение",
                 "transcription": "[ди НИ-дер-ла-ге]",
@@ -3276,9 +4226,14 @@
                 "collocations": [
                     "Die Niederlage ist mein letztes Schicksal. — Поражение - моя последняя судьба.",
                     "Die Niederlage ist vollkommen. — Поражение полное."
+                ],
+                "sentenceParts": [
+                    "Auf der kalten Steinbank zieht Edmund den Mantel enger um die Schultern.",
+                    "Ich zeichne das Wort „die Niederlage“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verlieren",
                 "translation": "проигрывать",
                 "transcription": "[фер-ЛИ-рен]",
@@ -3301,9 +4256,14 @@
                 "collocations": [
                     "Der Narr spürt, wie das Verlieren alle verändert. — Шут чувствует, как умение терять меняет всех.",
                     "Ich verliere alles, was ich gewann. — Я проигрываю всё, что выиграл."
+                ],
+                "sentenceParts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Edmund das Gesicht zum Licht.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „verlieren“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Untergang",
                 "translation": "падение",
                 "transcription": "[дер УН-тер-ганг]",
@@ -3325,9 +4285,14 @@
                 ],
                 "collocations": [
                     "Mein Untergang ist gerecht. — Моё падение справедливо."
+                ],
+                "sentenceParts": [
+                    "Am rostigen Wassereimer spiegelt Edmund kurz die eigenen Augen.",
+                    "Ich halte das Wort „der Untergang“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "gestehen",
                 "translation": "признаваться",
                 "transcription": "[ге-ШТЕ-ен]",
@@ -3348,9 +4313,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Gestehen ist. — Во время бури становится понятно, насколько важно признаваться.",
                     "Ich gestehe alle meine Verbrechen. — Я признаюсь во всех преступлениях."
+                ],
+                "sentenceParts": [
+                    "Im dumpfen Hall der Schritte zählt Edmund den Rhythmus der Wachen.",
+                    "Das Echo des Wortes „gestehen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Ende",
                 "translation": "конец",
                 "transcription": "[дас ЭН-де]",
@@ -3374,6 +4344,10 @@
                     "Das Ende kommt schnell und gerecht. — Конец приходит быстро и справедливо.",
                     "Dies ist nicht das Ende, nur ein Übergang. — Это не конец, только переход.",
                     "Mein Ende kommt durch eines Dieners Hand. — Мой конец приходит от руки слуги."
+                ],
+                "sentenceParts": [
+                    "Vor dem verriegelten Fenster zeichnet Edmund Kreise in den Staub.",
+                    "Ich atme tief ein und lasse nur das Wort „das Ende“ wieder hinaus."
                 ]
             }
         ],
@@ -3381,9 +4355,9 @@
             {
                 "question": "Что означает немецкое слово «das Duell»?",
                 "choices": [
-                    "падать",
-                    "дуэль",
                     "сожалеть",
+                    "дуэль",
+                    "падать",
                     "поражение"
                 ],
                 "correctIndex": 1
@@ -3392,74 +4366,156 @@
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
                     "падать",
+                    "сожалеть",
                     "дуэль",
-                    "поражение",
-                    "сожалеть"
+                    "поражение"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "дуэль",
-                    "сожалеть",
+                    "поражение",
                     "признаваться",
+                    "сожалеть",
                     "проигрывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "поражение",
                     "дуэль",
-                    "проигрывать",
-                    "признаваться"
+                    "признаваться",
+                    "поражение",
+                    "проигрывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verlieren»?",
                 "choices": [
-                    "дуэль",
-                    "поражение",
-                    "проигрывать",
-                    "признаваться"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Untergang»?",
-                "choices": [
-                    "проигрывать",
-                    "падать",
                     "падение",
-                    "сожалеть"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «gestehen»?",
-                "choices": [
+                    "конец",
                     "сожалеть",
-                    "проигрывать",
-                    "дуэль",
-                    "признаваться"
+                    "проигрывать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «das Ende»?",
+                "question": "Что означает немецкое слово «der Untergang»?",
+                "choices": [
+                    "признаваться",
+                    "падать",
+                    "поражение",
+                    "падение"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «gestehen»?",
                 "choices": [
                     "поражение",
                     "конец",
-                    "падение",
+                    "признаваться",
                     "проигрывать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «das Ende»?",
+                "choices": [
+                    "падение",
+                    "конец",
+                    "поражение",
+                    "признаваться"
                 ],
                 "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "das Duell",
+                "translation": "дуэль",
+                "parts": [
+                    "Im feuchten Kerker stützt Edmund sich an den tropfenden Stein.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Duell“ gehört mir."
+                ],
+                "sentence": "Im feuchten Kerker stützt Edmund sich an den tropfenden Stein. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Duell“ gehört mir.",
+                "sentenceTranslation": "В сыром подземелье Эдмунд опирается на сочащийся камень. Буря за окнами усиливает клятву: слово «дуэль» принадлежит мне."
+            },
+            {
+                "word": "fallen",
+                "translation": "падать",
+                "parts": [
+                    "Unter der trüben Laterne zählt Edmund die eisernen Ringe der Kette.",
+                    "Ich zeichne das Wort „fallen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Unter der trüben Laterne zählt Edmund die eisernen Ringe der Kette. Ich zeichne das Wort „fallen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под мутным фонарём Эдмунд пересчитывает железные кольца цепи. Я черчу слово «падать» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "bereuen",
+                "translation": "сожалеть",
+                "parts": [
+                    "Neben der schweren Holztür horcht Edmund auf entferntes Schluchzen.",
+                    "Das Echo des Wortes „bereuen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Neben der schweren Holztür horcht Edmund auf entferntes Schluchzen. Das Echo des Wortes „bereuen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У тяжёлой двери Эдмунд прислушивается к далёким рыданиям. Эхо слова «сожалеть» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Niederlage",
+                "translation": "поражение",
+                "parts": [
+                    "Auf der kalten Steinbank zieht Edmund den Mantel enger um die Schultern.",
+                    "Ich zeichne das Wort „die Niederlage“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Auf der kalten Steinbank zieht Edmund den Mantel enger um die Schultern. Ich zeichne das Wort „die Niederlage“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На холодной каменной скамье Эдмунд плотнее кутается в плащ. Я черчу слово «поражение» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "verlieren",
+                "translation": "проигрывать",
+                "parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Edmund das Gesicht zum Licht.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „verlieren“ wird heute nicht verraten."
+                ],
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Edmund das Gesicht zum Licht. Mit fester Stimme schwöre ich mir: Das Wort „verlieren“ wird heute nicht verraten.",
+                "sentenceTranslation": "Между тенями решёток Эдмунд поднимает лицо к свету. Твёрдым голосом я клянусь себе: слово «проигрывать» сегодня не будет предано."
+            },
+            {
+                "word": "der Untergang",
+                "translation": "падение",
+                "parts": [
+                    "Am rostigen Wassereimer spiegelt Edmund kurz die eigenen Augen.",
+                    "Ich halte das Wort „der Untergang“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Am rostigen Wassereimer spiegelt Edmund kurz die eigenen Augen. Ich halte das Wort „der Untergang“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У ржавого ведра с водой Эдмунд на мгновение видит отражение глаз. Я держу слово «падение» как факел у сердца."
+            },
+            {
+                "word": "gestehen",
+                "translation": "признаваться",
+                "parts": [
+                    "Im dumpfen Hall der Schritte zählt Edmund den Rhythmus der Wachen.",
+                    "Das Echo des Wortes „gestehen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Im dumpfen Hall der Schritte zählt Edmund den Rhythmus der Wachen. Das Echo des Wortes „gestehen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В глухом эхе шагов Эдмунд отсчитывает ритм часовых. Эхо слова «признаваться» заглушает шёпот придворных."
+            },
+            {
+                "word": "das Ende",
+                "translation": "конец",
+                "parts": [
+                    "Vor dem verriegelten Fenster zeichnet Edmund Kreise in den Staub.",
+                    "Ich atme tief ein und lasse nur das Wort „das Ende“ wieder hinaus."
+                ],
+                "sentence": "Vor dem verriegelten Fenster zeichnet Edmund Kreise in den Staub. Ich atme tief ein und lasse nur das Wort „das Ende“ wieder hinaus.",
+                "sentenceTranslation": "Перед заколоченным окном Эдмунд чертит круги в пыли. Я глубоко вдыхаю и выпускаю только слово «конец»."
+            }
+        ]
     }
 };
 
@@ -3475,6 +4531,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3911,6 +5315,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -3979,6 +5700,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -3987,13 +5711,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4904,6 +6676,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/journeys/fool.html
+++ b/output/journeys/fool.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="jester">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="bitter_truths">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="prophecies">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="mad_companion">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="songs">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="wisdom">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="vanishing">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["мудрость", "шутить", "шут", "печаль"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["шутить", "печаль", "шут", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["печаль", "шут", "остроумие", "забава"], "correct_index": 0}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["забава", "шут", "шутить", "остроумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["шут", "шутить", "забава", "мудрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «klug»?", "choices": ["скучать", "остроумие", "умный", "мудрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["шут", "скучать", "шутить", "остроумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["умный", "шут", "остроумие", "скучать"], "correct_index": 2}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "шутка", "горький", "предупреждение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["правда", "шутка", "предупреждение", "горький"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["предупреждение", "правда", "шутка", "горький"], "correct_index": 0}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["шутка", "горький", "предупреждение", "насмехаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["правда", "шутка", "насмехаться", "дразнить"], "correct_index": 2}, {"question": "Что означает немецкое слово «necken»?", "choices": ["правда", "дразнить", "шутка", "предупреждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["раскрывать", "горький", "дразнить", "шутка"], "correct_index": 0}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["предсказывать", "пророчество", "предчувствие", "загадка"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["загадка", "предсказывать", "пророчество", "предчувствие"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["загадка", "предчувствие", "толковать", "загадочный"], "correct_index": 1}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["предсказывать", "толковать", "загадка", "пророчество"], "correct_index": 0}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["загадка", "пророчество", "толковать", "знамение"], "correct_index": 2}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["загадка", "предчувствовать", "толковать", "пророчество"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["загадка", "предчувствовать", "знамение", "толковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадочный", "предчувствие", "предсказывать", "пророчество"], "correct_index": 0}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["сопровождать", "безумие", "мёрзнуть", "дружба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["дружба", "сопровождать", "безумие", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["сопровождать", "верный", "дрожать", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "дрожать", "безумие", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «singen»?", "choices": ["петь", "сопровождать", "верный", "дрожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["верный", "сопровождать", "дрожать", "дружба"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["безумие", "сопровождать", "верный", "дружба"], "correct_index": 2}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["напевать", "песня", "ирония", "утешение"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["утешение", "песня", "напевать", "ирония"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["ирония", "мелодия", "напевать", "звучать"], "correct_index": 0}, {"question": "Что означает немецкое слово «summen»?", "choices": ["мелодия", "напевать", "утешение", "рифма"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["мелодия", "звучать", "утешение", "свистеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["звучать", "свистеть", "напевать", "песня"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["ирония", "мелодия", "рифма", "утешение"], "correct_index": 2}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["мелодия", "рифма", "напевать", "звучать"], "correct_index": 3}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["философия", "размышлять", "судьба", "бренность"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["философия", "судьба", "бренность", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["преходящий", "философия", "смысл", "бренность"], "correct_index": 3}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["бренность", "познавать", "преходящий", "размышлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["познавать", "преходящий", "размышлять", "философия"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["размышлять", "бренность", "познавать", "смысл"], "correct_index": 3}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["философия", "преходящий", "судьба", "бренность"], "correct_index": 1}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["растворяться", "пустота", "исчезать", "тайна"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["тайна", "пустота", "растворяться", "исчезать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["исчезать", "пустота", "бесследно", "уходить"], "correct_index": 1}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["растворяться", "уходить", "тайна", "исчезать"], "correct_index": 0}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["тайна", "туман", "исчезать", "бесследно"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["бесследно", "туман", "пустота", "уходить"], "correct_index": 1}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["пустота", "исчезать", "загадочный", "бесследно"], "correct_index": 2}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["уходить", "тайна", "растворяться", "исчезать"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["шутить", "шут", "печаль", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["шутить", "шут", "мудрость", "печаль"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["забава", "печаль", "умный", "остроумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["шутить", "скучать", "шут", "забава"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["остроумие", "забава", "мудрость", "шут"], "correct_index": 1}, {"question": "Что означает немецкое слово «klug»?", "choices": ["шутить", "умный", "забава", "остроумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["забава", "шутить", "шут", "скучать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["печаль", "шутить", "остроумие", "мудрость"], "correct_index": 2}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["горький", "правда", "шутка", "предупреждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["правда", "шутка", "горький", "предупреждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["горький", "дразнить", "предупреждение", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["горький", "шутка", "предупреждение", "раскрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["предупреждение", "насмехаться", "правда", "горький"], "correct_index": 1}, {"question": "Что означает немецкое слово «necken»?", "choices": ["раскрывать", "шутка", "насмехаться", "дразнить"], "correct_index": 3}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["дразнить", "предупреждение", "раскрывать", "шутка"], "correct_index": 2}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["пророчество", "предсказывать", "загадка", "предчувствие"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["предсказывать", "пророчество", "загадка", "предчувствие"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["загадочный", "предсказывать", "предчувствие", "знамение"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["предсказывать", "предчувствовать", "знамение", "толковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["предсказывать", "загадочный", "предчувствовать", "толковать"], "correct_index": 3}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["предчувствовать", "загадочный", "толковать", "пророчество"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["предсказывать", "загадка", "знамение", "загадочный"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадка", "загадочный", "предсказывать", "знамение"], "correct_index": 1}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["мёрзнуть", "безумие", "сопровождать", "дружба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["безумие", "дружба", "мёрзнуть", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["безумие", "дрожать", "сопровождать", "дружба"], "correct_index": 2}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["дрожать", "петь", "мёрзнуть", "дружба"], "correct_index": 2}, {"question": "Что означает немецкое слово «singen»?", "choices": ["мёрзнуть", "верный", "сопровождать", "петь"], "correct_index": 3}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["дрожать", "верный", "сопровождать", "дружба"], "correct_index": 0}, {"question": "Что означает немецкое слово «treu»?", "choices": ["дружба", "верный", "мёрзнуть", "сопровождать"], "correct_index": 1}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["ирония", "напевать", "песня", "утешение"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["напевать", "утешение", "ирония", "песня"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["ирония", "рифма", "свистеть", "напевать"], "correct_index": 0}, {"question": "Что означает немецкое слово «summen»?", "choices": ["напевать", "звучать", "утешение", "песня"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["свистеть", "звучать", "мелодия", "ирония"], "correct_index": 2}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["ирония", "напевать", "свистеть", "рифма"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["рифма", "свистеть", "ирония", "напевать"], "correct_index": 0}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["мелодия", "звучать", "свистеть", "ирония"], "correct_index": 1}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["размышлять", "философия", "судьба", "бренность"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["судьба", "бренность", "философия", "размышлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["преходящий", "познавать", "философия", "бренность"], "correct_index": 3}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["размышлять", "судьба", "смысл", "преходящий"], "correct_index": 0}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["размышлять", "смысл", "познавать", "философия"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["преходящий", "судьба", "философия", "смысл"], "correct_index": 3}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["философия", "судьба", "бренность", "преходящий"], "correct_index": 3}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["тайна", "исчезать", "растворяться", "пустота"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["растворяться", "пустота", "тайна", "исчезать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["пустота", "бесследно", "уходить", "тайна"], "correct_index": 0}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["туман", "загадочный", "растворяться", "исчезать"], "correct_index": 2}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["исчезать", "пустота", "бесследно", "туман"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["загадочный", "бесследно", "уходить", "туман"], "correct_index": 3}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["пустота", "тайна", "загадочный", "бесследно"], "correct_index": 2}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["туман", "пустота", "тайна", "уходить"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Королевский шут</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,15 +661,31 @@
             <div class="quiz-phase-container active" data-phase="jester">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
                             
@@ -481,31 +693,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">забава</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «scherzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
                             
@@ -513,65 +725,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «scherzen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">остроумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «klug»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">умный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «vermissen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">забава</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «klug»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vermissen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скучать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -581,13 +777,13 @@
                         <div class="quiz-question">Что означает немецкое слово «der Witz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">остроумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">скучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,15 +796,15 @@
             <div class="quiz-phase-container" data-phase="bitter_truths">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
                             
@@ -624,23 +820,55 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дразнить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскрывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
                             
@@ -648,27 +876,11 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «necken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
                             
@@ -680,31 +892,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «necken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дразнить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дразнить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
                             
@@ -719,31 +915,15 @@
             <div class="quiz-phase-container" data-phase="prophecies">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Prophezeiung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Rätsel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
                             
@@ -751,17 +931,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Rätsel»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Vorahnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -773,39 +969,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">знамение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «ahnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
                             
@@ -819,29 +1015,29 @@
                         <div class="quiz-question">Что означает немецкое слово «das Omen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">знамение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -858,9 +1054,57 @@
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
@@ -870,79 +1114,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «singen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «singen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">петь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">петь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
                             
@@ -950,17 +1146,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,15 +1169,15 @@
             <div class="quiz-phase-container" data-phase="songs">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Lied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">песня</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
                             
@@ -989,17 +1185,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Trost»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1011,57 +1207,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">свистеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">напевать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «summen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мелодия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рифма</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">свистеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">звучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
                             
@@ -1069,33 +1233,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">свистеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">рифма</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">напевать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «klingen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мелодия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">свистеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,13 +1304,13 @@
             <div class="quiz-phase-container" data-phase="wisdom">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Philosophie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
                             
@@ -1124,15 +1320,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
@@ -1146,9 +1342,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">преходящий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">познавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
                             
@@ -1156,31 +1352,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">познавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преходящий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преходящий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преходящий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смысл</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">философия</button>
                             
@@ -1192,11 +1388,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преходящий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смысл</button>
                             
@@ -1204,17 +1400,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vergänglich»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преходящий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преходящий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,61 +1423,29 @@
             <div class="quiz-phase-container" data-phase="vanishing">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verschwinden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">уходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
                             
@@ -1291,33 +1455,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бесследно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">туман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бесследно</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1329,7 +1525,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
                             
@@ -1339,17 +1535,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «fortgehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">туман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1373,6 +1569,7 @@
         "description": "Акт I: При дворе, грустит о Корделии",
         "words": [
             {
+                "wordId": "",
                 "word": "der Narr",
                 "translation": "шут",
                 "transcription": "[дер НАР]",
@@ -1394,9 +1591,15 @@
                     "Im Thronsaal verstummen die Gespräche über der Narr nie. — В тронном зале постоянно звучит слово «шут».",
                     "Mein Narr ist weiser als ich je war. — Мой шут мудрее, чем я когда-либо был.",
                     "Als Narr sage ich die Wahrheit durch Scherze. — Как шут я говорю правду через шутки."
+                ],
+                "sentenceParts": [
+                    "Im grellen Licht des Thronsaals schlägt Fool die Laute an.",
+                    "Ich presse das Wort „der Narr“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Weisheit",
                 "translation": "мудрость",
                 "transcription": "[ди ВАЙС-хайт]",
@@ -1428,9 +1631,14 @@
                     "Die Weisheit kommt zu spät zu mir. — Мудрость приходит ко мне слишком поздно.",
                     "Durch Leiden habe ich Weisheit erlangt. — Через страдания я обрёл мудрость.",
                     "Hinter meinen Späßen verbirgt sich Weisheit. — За моими шутками скрывается мудрость."
+                ],
+                "sentenceParts": [
+                    "Neben Lears Krone balanciert Fool auf einem Fuß.",
+                    "Ich atme tief ein und lasse nur das Wort „die Weisheit“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Trauer",
                 "translation": "печаль",
                 "transcription": "[ди ТРАУ-ер]",
@@ -1454,9 +1662,14 @@
                     "Die Trauer überwältigt meine Seele. — Скорбь переполняет мою душу.",
                     "Die Trauer ist zu schwer zu ertragen. — Скорбь слишком тяжела, чтобы вынести.",
                     "Die Trauer um Корделия macht mich stumm. — Печаль о Корделии делает меня немым."
+                ],
+                "sentenceParts": [
+                    "Zwischen Hofdamen und Rittern wirbelt Fool mit flatterndem Schellenkleid.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Trauer“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "scherzen",
                 "translation": "шутить",
                 "transcription": "[ШЕР-цен]",
@@ -1478,9 +1691,14 @@
                 ],
                 "collocations": [
                     "Ich scherze, um den Schmerz zu verbergen. — Я шучу, чтобы скрыть боль."
+                ],
+                "sentenceParts": [
+                    "Vor dem königlichen Podest verzieht Fool die Maske zum Spott.",
+                    "Ich zeichne das Wort „scherzen“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Spaß",
                 "translation": "забава",
                 "transcription": "[дер ШПАС]",
@@ -1502,9 +1720,14 @@
                 ],
                 "collocations": [
                     "Der Spaß ist meine Maske vor der Welt. — Забава - моя маска перед миром."
+                ],
+                "sentenceParts": [
+                    "Am Bankettisch jongliert Fool mit goldenen Pokalen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Spaß“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "klug",
                 "translation": "умный",
                 "transcription": "[КЛУГ]",
@@ -1526,9 +1749,14 @@
                 ],
                 "collocations": [
                     "Ich bin klüger als alle bei Hofe. — Я умнее всех при дворе."
+                ],
+                "sentenceParts": [
+                    "Zwischen Lachern und Seufzern zeichnet Fool Grimassen in die Luft.",
+                    "Das kalte Licht lässt das Wort „klug“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vermissen",
                 "translation": "скучать",
                 "transcription": "[фер-МИ-сен]",
@@ -1550,9 +1778,14 @@
                 ],
                 "collocations": [
                     "Ich vermisse die süße Корделия sehr. — Я очень скучаю по милой Корделии."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der Säulen lauscht Fool den leisen Worten Cordelias.",
+                    "Mein Atem zeichnet das Wort „vermissen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Witz",
                 "translation": "остроумие",
                 "transcription": "[дер ВИТЦ]",
@@ -1574,6 +1807,10 @@
                 ],
                 "collocations": [
                     "Mein Witz ist scharf wie ein Schwert. — Моё остроумие остро как меч."
+                ],
+                "sentenceParts": [
+                    "Auf der Marmorstufe lässt Fool ein Glöckchen über den Boden tanzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Witz“ bleibt lebendig."
                 ]
             }
         ],
@@ -1581,91 +1818,175 @@
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "мудрость",
                     "шутить",
                     "шут",
-                    "печаль"
+                    "печаль",
+                    "мудрость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
                     "шутить",
-                    "печаль",
                     "шут",
-                    "мудрость"
+                    "мудрость",
+                    "печаль"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
+                    "забава",
                     "печаль",
-                    "шут",
-                    "остроумие",
-                    "забава"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «scherzen»?",
-                "choices": [
-                    "забава",
-                    "шут",
-                    "шутить",
-                    "остроумие"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Spaß»?",
-                "choices": [
-                    "шут",
-                    "шутить",
-                    "забава",
-                    "мудрость"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «klug»?",
-                "choices": [
-                    "скучать",
-                    "остроумие",
                     "умный",
-                    "мудрость"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «vermissen»?",
-                "choices": [
-                    "шут",
-                    "скучать",
-                    "шутить",
                     "остроумие"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «scherzen»?",
+                "choices": [
+                    "шутить",
+                    "скучать",
+                    "шут",
+                    "забава"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «der Spaß»?",
+                "choices": [
+                    "остроумие",
+                    "забава",
+                    "мудрость",
+                    "шут"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «klug»?",
+                "choices": [
+                    "шутить",
+                    "умный",
+                    "забава",
+                    "остроумие"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «vermissen»?",
+                "choices": [
+                    "забава",
+                    "шутить",
+                    "шут",
+                    "скучать"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «der Witz»?",
                 "choices": [
-                    "умный",
-                    "шут",
+                    "печаль",
+                    "шутить",
                     "остроумие",
-                    "скучать"
+                    "мудрость"
                 ],
                 "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Narr",
+                "translation": "шут",
+                "parts": [
+                    "Im grellen Licht des Thronsaals schlägt Fool die Laute an.",
+                    "Ich presse das Wort „der Narr“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Im grellen Licht des Thronsaals schlägt Fool die Laute an. Ich presse das Wort „der Narr“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В ярком свете тронного зала Шут ударяет по струнам лютни. Я стискиваю слово «шут» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Weisheit",
+                "translation": "мудрость",
+                "parts": [
+                    "Neben Lears Krone balanciert Fool auf einem Fuß.",
+                    "Ich atme tief ein und lasse nur das Wort „die Weisheit“ wieder hinaus."
+                ],
+                "sentence": "Neben Lears Krone balanciert Fool auf einem Fuß. Ich atme tief ein und lasse nur das Wort „die Weisheit“ wieder hinaus.",
+                "sentenceTranslation": "Рядом с короной Лира Шут балансирует на одной ноге. Я глубоко вдыхаю и выпускаю только слово «мудрость»."
+            },
+            {
+                "word": "die Trauer",
+                "translation": "печаль",
+                "parts": [
+                    "Zwischen Hofdamen und Rittern wirbelt Fool mit flatterndem Schellenkleid.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Trauer“ bleibt lebendig."
+                ],
+                "sentence": "Zwischen Hofdamen und Rittern wirbelt Fool mit flatterndem Schellenkleid. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Trauer“ bleibt lebendig.",
+                "sentenceTranslation": "Между дамами двора и рыцарями Шут кружится в звенящем костюме. Каждой клеткой тела я обещаю: слово «печаль» останется живым."
+            },
+            {
+                "word": "scherzen",
+                "translation": "шутить",
+                "parts": [
+                    "Vor dem königlichen Podest verzieht Fool die Maske zum Spott.",
+                    "Ich zeichne das Wort „scherzen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Vor dem königlichen Podest verzieht Fool die Maske zum Spott. Ich zeichne das Wort „scherzen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед королевским помостом Шут кривит маску насмешки. Я черчу слово «шутить» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "der Spaß",
+                "translation": "забава",
+                "parts": [
+                    "Am Bankettisch jongliert Fool mit goldenen Pokalen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Spaß“ mein Nordstern."
+                ],
+                "sentence": "Am Bankettisch jongliert Fool mit goldenen Pokalen. Selbst wenn die Welt zerfällt, bleibt das Wort „der Spaß“ mein Nordstern.",
+                "sentenceTranslation": "У банкетного стола Шут жонглирует золотыми кубками. Даже если мир распадается, слово «забава» остаётся моим северным светом."
+            },
+            {
+                "word": "klug",
+                "translation": "умный",
+                "parts": [
+                    "Zwischen Lachern und Seufzern zeichnet Fool Grimassen in die Luft.",
+                    "Das kalte Licht lässt das Wort „klug“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Zwischen Lachern und Seufzern zeichnet Fool Grimassen in die Luft. Das kalte Licht lässt das Wort „klug“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Среди смеха и вздохов Шут рисует в воздухе гримасы. Холодный свет заставляет слово «умный» сиять словно расплавленное золото."
+            },
+            {
+                "word": "vermissen",
+                "translation": "скучать",
+                "parts": [
+                    "Im Schatten der Säulen lauscht Fool den leisen Worten Cordelias.",
+                    "Mein Atem zeichnet das Wort „vermissen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im Schatten der Säulen lauscht Fool den leisen Worten Cordelias. Mein Atem zeichnet das Wort „vermissen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тени колонн Шут прислушивается к тихим словам Корделии. Моё дыхание рисует слово «скучать» в холодном воздухе между нами."
+            },
+            {
+                "word": "der Witz",
+                "translation": "остроумие",
+                "parts": [
+                    "Auf der Marmorstufe lässt Fool ein Glöckchen über den Boden tanzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Witz“ bleibt lebendig."
+                ],
+                "sentence": "Auf der Marmorstufe lässt Fool ein Glöckchen über den Boden tanzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Witz“ bleibt lebendig.",
+                "sentenceTranslation": "На мраморной ступени Шут пускает колокольчик плясать по полу. Каждой клеткой тела я обещаю: слово «остроумие» останется живым."
+            }
+        ]
     },
     "bitter_truths": {
         "title": "Горькие истины",
         "description": "Акт I: Говорит правду через шутки",
         "words": [
             {
+                "wordId": "",
                 "word": "die Wahrheit",
                 "translation": "правда",
                 "transcription": "[ди ВАР-хайт]",
@@ -1688,9 +2009,14 @@
                     "Die Wahrheit war immer in deinen Worten, Kind. — Правда всегда была в твоих словах, дитя.",
                     "Die Wahrheit war vor meinen Augen verborgen. — Правда была скрыта от моих глаз.",
                     "Die Wahrheit verpacke ich in lustige Lieder. — Правду я заворачиваю в весёлые песни."
+                ],
+                "sentenceParts": [
+                    "Vor Lears Ohr flüstert Fool mit funkelndem Blick die spöttische Wahrheit.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Wahrheit“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Scherz",
                 "translation": "шутка",
                 "transcription": "[дер ШЕРЦ]",
@@ -1712,9 +2038,15 @@
                 ],
                 "collocations": [
                     "Jeder Scherz enthält eine bittere Lehre. — Каждая шутка содержит горький урок."
+                ],
+                "sentenceParts": [
+                    "Auf dem Hofbalkon zeigt Fool mit der Laute auf die heuchlerischen Schwestern.",
+                    "Ich presse das Wort „der Scherz“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Warnung",
                 "translation": "предупреждение",
                 "transcription": "[ди ВАР-нунг]",
@@ -1736,9 +2068,14 @@
                 ],
                 "collocations": [
                     "Meine Warnung kommt als Rätsel verkleidet. — Моё предупреждение приходит замаскированным под загадку."
+                ],
+                "sentenceParts": [
+                    "Zwischen umgestoßenen Bechern sammelt Fool die Lügen wie Perlen auf.",
+                    "Ich zeichne das Wort „die Warnung“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "bitter",
                 "translation": "горький",
                 "transcription": "[БИ-тер]",
@@ -1760,9 +2097,14 @@
                 ],
                 "collocations": [
                     "Die Wahrheit schmeckt bitter wie Galle. — Правда горька как желчь."
+                ],
+                "sentenceParts": [
+                    "An Lears Seite zeichnet Fool mit Kreide eine Krone auf den Boden.",
+                    "Wie ein stilles Gebet legt sich das Wort „bitter“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "spotten",
                 "translation": "насмехаться",
                 "transcription": "[ШПО-тен]",
@@ -1785,9 +2127,14 @@
                 ],
                 "collocations": [
                     "Ich spotte über die Torheit der Mächtigen. — Я насмехаюсь над глупостью сильных."
+                ],
+                "sentenceParts": [
+                    "Im Gedränge der Höflinge spielt Fool eine schrille Warnmelodie.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „spotten“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "necken",
                 "translation": "дразнить",
                 "transcription": "[НЕ-кен]",
@@ -1809,9 +2156,14 @@
                 ],
                 "collocations": [
                     "Ich necke den König mit der Wahrheit. — Я дразню короля правдой."
+                ],
+                "sentenceParts": [
+                    "Auf den Stufen zum Thron zieht Fool die Stirn in tiefe Falten.",
+                    "Ich presse das Wort „necken“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "enthüllen",
                 "translation": "раскрывать",
                 "transcription": "[энт-ХЮ-лен]",
@@ -1837,6 +2189,10 @@
                 "collocations": [
                     "Ich enthülle meine wahre Identität. — Я разоблачаю свою истинную личность.",
                     "Spielerisch enthülle ich seine Fehler. — Играючи я раскрываю его ошибки."
+                ],
+                "sentenceParts": [
+                    "Neben dem Tränenstrom des Königs wischt Fool die Schminke vom Gesicht.",
+                    "Ich zeichne das Wort „enthüllen“ in Gedanken über die Linien des Schicksals."
                 ]
             }
         ],
@@ -1844,81 +2200,155 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
+                    "горький",
                     "правда",
                     "шутка",
-                    "горький",
                     "предупреждение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Scherz»?",
                 "choices": [
                     "правда",
                     "шутка",
-                    "предупреждение",
-                    "горький"
+                    "горький",
+                    "предупреждение"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Warnung»?",
                 "choices": [
-                    "предупреждение",
-                    "правда",
-                    "шутка",
-                    "горький"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «bitter»?",
-                "choices": [
-                    "шутка",
                     "горький",
+                    "дразнить",
                     "предупреждение",
-                    "насмехаться"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «spotten»?",
-                "choices": [
-                    "правда",
-                    "шутка",
-                    "насмехаться",
-                    "дразнить"
+                    "правда"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «necken»?",
+                "question": "Что означает немецкое слово «bitter»?",
                 "choices": [
-                    "правда",
-                    "дразнить",
+                    "горький",
                     "шутка",
-                    "предупреждение"
+                    "предупреждение",
+                    "раскрывать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «spotten»?",
+                "choices": [
+                    "предупреждение",
+                    "насмехаться",
+                    "правда",
+                    "горький"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «enthüllen»?",
+                "question": "Что означает немецкое слово «necken»?",
                 "choices": [
                     "раскрывать",
-                    "горький",
+                    "шутка",
+                    "насмехаться",
+                    "дразнить"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «enthüllen»?",
+                "choices": [
                     "дразнить",
+                    "предупреждение",
+                    "раскрывать",
                     "шутка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Wahrheit",
+                "translation": "правда",
+                "parts": [
+                    "Vor Lears Ohr flüstert Fool mit funkelndem Blick die spöttische Wahrheit.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Wahrheit“ wird heute nicht verraten."
+                ],
+                "sentence": "Vor Lears Ohr flüstert Fool mit funkelndem Blick die spöttische Wahrheit. Mit fester Stimme schwöre ich mir: Das Wort „die Wahrheit“ wird heute nicht verraten.",
+                "sentenceTranslation": "У самого уха Лира Шут с блеском в глазах шепчет язвительную правду. Твёрдым голосом я клянусь себе: слово «правда» сегодня не будет предано."
+            },
+            {
+                "word": "der Scherz",
+                "translation": "шутка",
+                "parts": [
+                    "Auf dem Hofbalkon zeigt Fool mit der Laute auf die heuchlerischen Schwestern.",
+                    "Ich presse das Wort „der Scherz“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Auf dem Hofbalkon zeigt Fool mit der Laute auf die heuchlerischen Schwestern. Ich presse das Wort „der Scherz“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На дворцовом балконе Шут указывает лютней на лицемерных сестёр. Я стискиваю слово «шутка» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Warnung",
+                "translation": "предупреждение",
+                "parts": [
+                    "Zwischen umgestoßenen Bechern sammelt Fool die Lügen wie Perlen auf.",
+                    "Ich zeichne das Wort „die Warnung“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Zwischen umgestoßenen Bechern sammelt Fool die Lügen wie Perlen auf. Ich zeichne das Wort „die Warnung“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Среди опрокинутых кубков Шут собирает ложь словно жемчуг. Я черчу слово «предупреждение» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "bitter",
+                "translation": "горький",
+                "parts": [
+                    "An Lears Seite zeichnet Fool mit Kreide eine Krone auf den Boden.",
+                    "Wie ein stilles Gebet legt sich das Wort „bitter“ auf meine Lippen."
+                ],
+                "sentence": "An Lears Seite zeichnet Fool mit Kreide eine Krone auf den Boden. Wie ein stilles Gebet legt sich das Wort „bitter“ auf meine Lippen.",
+                "sentenceTranslation": "Рядом с Лиром Шут мелом рисует корону на полу. Как тихая молитва слово «горький» ложится на мои губы."
+            },
+            {
+                "word": "spotten",
+                "translation": "насмехаться",
+                "parts": [
+                    "Im Gedränge der Höflinge spielt Fool eine schrille Warnmelodie.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „spotten“ wird heute nicht verraten."
+                ],
+                "sentence": "Im Gedränge der Höflinge spielt Fool eine schrille Warnmelodie. Mit fester Stimme schwöre ich mir: Das Wort „spotten“ wird heute nicht verraten.",
+                "sentenceTranslation": "В толчее придворных Шут играет пронзительную мелодию предупреждения. Твёрдым голосом я клянусь себе: слово «насмехаться» сегодня не будет предано."
+            },
+            {
+                "word": "necken",
+                "translation": "дразнить",
+                "parts": [
+                    "Auf den Stufen zum Thron zieht Fool die Stirn in tiefe Falten.",
+                    "Ich presse das Wort „necken“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Auf den Stufen zum Thron zieht Fool die Stirn in tiefe Falten. Ich presse das Wort „necken“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На ступенях, ведущих к трону, Шут морщит лоб глубокими складками. Я стискиваю слово «дразнить» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "enthüllen",
+                "translation": "раскрывать",
+                "parts": [
+                    "Neben dem Tränenstrom des Königs wischt Fool die Schminke vom Gesicht.",
+                    "Ich zeichne das Wort „enthüllen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Neben dem Tränenstrom des Königs wischt Fool die Schminke vom Gesicht. Ich zeichne das Wort „enthüllen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Рядом с потоками слёз короля Шут стирает грим с лица. Я черчу слово «раскрывать» в мыслях поверх линий судьбы."
+            }
+        ]
     },
     "prophecies": {
         "title": "Пророчества",
         "description": "Акт II: Предсказывает беды",
         "words": [
             {
+                "wordId": "",
                 "word": "die Prophezeiung",
                 "translation": "пророчество",
                 "transcription": "[ди про-фе-ЦАЙ-унг]",
@@ -1940,9 +2370,14 @@
                 ],
                 "collocations": [
                     "Meine Prophezeiung wird wahr werden. — Моё пророчество сбудется."
+                ],
+                "sentenceParts": [
+                    "Unter dem Sternenzelt deutet Fool mit dem Stab die funkelnden Zeichen.",
+                    "Das kalte Licht lässt das Wort „die Prophezeiung“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Rätsel",
                 "translation": "загадка",
                 "transcription": "[дас РЕТ-зель]",
@@ -1964,9 +2399,14 @@
                 ],
                 "collocations": [
                     "In Rätseln spreche ich von der Zukunft. — В загадках я говорю о будущем."
+                ],
+                "sentenceParts": [
+                    "Auf den Mauern des Schlosses rezitiert Fool Verse von kommenden Stürmen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Rätsel“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Vorahnung",
                 "translation": "предчувствие",
                 "transcription": "[ди ФОР-а-нунг]",
@@ -1988,9 +2428,14 @@
                 ],
                 "collocations": [
                     "Eine dunkle Vorahnung erfüllt mein Herz. — Тёмное предчувствие наполняет моё сердце."
+                ],
+                "sentenceParts": [
+                    "Zwischen Rauch und Kerzenduft schleudert Fool rätselhafte Reime.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Vorahnung“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vorhersagen",
                 "translation": "предсказывать",
                 "transcription": "[ФОР-хер-за-ген]",
@@ -2012,9 +2457,14 @@
                 ],
                 "collocations": [
                     "Ich sage das kommende Unheil vorher. — Я предсказываю грядущую беду."
+                ],
+                "sentenceParts": [
+                    "Am Brunnen des Hofes wirft Fool Kiesel, um die Zukunft zu spiegeln.",
+                    "Ich atme tief ein und lasse nur das Wort „vorhersagen“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "deuten",
                 "translation": "толковать",
                 "transcription": "[ДОЙ-тен]",
@@ -2036,9 +2486,14 @@
                 ],
                 "collocations": [
                     "Die Zeichen deute ich besser als alle. — Знаки я толкую лучше всех."
+                ],
+                "sentenceParts": [
+                    "Vor erstaunten Dienern zeichnet Fool Kreise in den Staub.",
+                    "Ich presse das Wort „deuten“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ahnen",
                 "translation": "предчувствовать",
                 "transcription": "[А-нен]",
@@ -2060,9 +2515,14 @@
                 ],
                 "collocations": [
                     "Ich ahne das schlimme Ende voraus. — Я предчувствую плохой конец."
+                ],
+                "sentenceParts": [
+                    "Auf der Markttreppe singt Fool von Königen, die zu Bettlern werden.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „ahnen“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Omen",
                 "translation": "знамение",
                 "transcription": "[дас О-мен]",
@@ -2084,9 +2544,14 @@
                 ],
                 "collocations": [
                     "Jedes Omen zeigt auf Untergang. — Каждое знамение указывает на гибель."
+                ],
+                "sentenceParts": [
+                    "Neben einem reisenden Pilger deutet Fool in den flammenden Himmel.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „das Omen“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "rätselhaft",
                 "translation": "загадочный",
                 "transcription": "[РЕТ-зель-хафт]",
@@ -2112,6 +2577,10 @@
                 "collocations": [
                     "Meine Worte bleiben rätselhaft und wahr. — Мои слова остаются загадочными и правдивыми.",
                     "Mein Ende bleibt rätselhaft und stumm. — Мой конец остаётся загадочным и немым."
+                ],
+                "sentenceParts": [
+                    "Im Gewitterlicht zählt Fool die Schläge, die die Zukunft ankündigen.",
+                    "Ich zeichne das Wort „rätselhaft“ in Gedanken über die Linien des Schicksals."
                 ]
             }
         ],
@@ -2119,91 +2588,174 @@
             {
                 "question": "Что означает немецкое слово «die Prophezeiung»?",
                 "choices": [
-                    "предсказывать",
                     "пророчество",
-                    "предчувствие",
-                    "загадка"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «das Rätsel»?",
-                "choices": [
+                    "предсказывать",
                     "загадка",
-                    "предсказывать",
-                    "пророчество",
                     "предчувствие"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «das Rätsel»?",
+                "choices": [
+                    "предсказывать",
+                    "пророчество",
+                    "загадка",
+                    "предчувствие"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Vorahnung»?",
                 "choices": [
-                    "загадка",
+                    "загадочный",
+                    "предсказывать",
                     "предчувствие",
-                    "толковать",
-                    "загадочный"
+                    "знамение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vorhersagen»?",
                 "choices": [
                     "предсказывать",
-                    "толковать",
-                    "загадка",
-                    "пророчество"
+                    "предчувствовать",
+                    "знамение",
+                    "толковать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «deuten»?",
                 "choices": [
-                    "загадка",
-                    "пророчество",
-                    "толковать",
-                    "знамение"
+                    "предсказывать",
+                    "загадочный",
+                    "предчувствовать",
+                    "толковать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ahnen»?",
                 "choices": [
-                    "загадка",
                     "предчувствовать",
+                    "загадочный",
                     "толковать",
                     "пророчество"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Omen»?",
                 "choices": [
+                    "предсказывать",
                     "загадка",
-                    "предчувствовать",
                     "знамение",
-                    "толковать"
+                    "загадочный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
+                    "загадка",
                     "загадочный",
-                    "предчувствие",
                     "предсказывать",
-                    "пророчество"
+                    "знамение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Prophezeiung",
+                "translation": "пророчество",
+                "parts": [
+                    "Unter dem Sternenzelt deutet Fool mit dem Stab die funkelnden Zeichen.",
+                    "Das kalte Licht lässt das Wort „die Prophezeiung“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Unter dem Sternenzelt deutet Fool mit dem Stab die funkelnden Zeichen. Das kalte Licht lässt das Wort „die Prophezeiung“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Под звёздным шатром Шут посохом указывает на мерцающие знаки. Холодный свет заставляет слово «пророчество» сиять словно расплавленное золото."
+            },
+            {
+                "word": "das Rätsel",
+                "translation": "загадка",
+                "parts": [
+                    "Auf den Mauern des Schlosses rezitiert Fool Verse von kommenden Stürmen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Rätsel“ darf nicht vergehen."
+                ],
+                "sentence": "Auf den Mauern des Schlosses rezitiert Fool Verse von kommenden Stürmen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Rätsel“ darf nicht vergehen.",
+                "sentenceTranslation": "На стенах замка Шут декламирует стихи о грядущих бурях. Я шепчу стражам судьбы: слово «загадка» не должно исчезнуть."
+            },
+            {
+                "word": "die Vorahnung",
+                "translation": "предчувствие",
+                "parts": [
+                    "Zwischen Rauch und Kerzenduft schleudert Fool rätselhafte Reime.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Vorahnung“ wird heute nicht verraten."
+                ],
+                "sentence": "Zwischen Rauch und Kerzenduft schleudert Fool rätselhafte Reime. Mit fester Stimme schwöre ich mir: Das Wort „die Vorahnung“ wird heute nicht verraten.",
+                "sentenceTranslation": "Среди дыма и аромата свечей Шут бросает загадочные рифмы. Твёрдым голосом я клянусь себе: слово «предчувствие» сегодня не будет предано."
+            },
+            {
+                "word": "vorhersagen",
+                "translation": "предсказывать",
+                "parts": [
+                    "Am Brunnen des Hofes wirft Fool Kiesel, um die Zukunft zu spiegeln.",
+                    "Ich atme tief ein und lasse nur das Wort „vorhersagen“ wieder hinaus."
+                ],
+                "sentence": "Am Brunnen des Hofes wirft Fool Kiesel, um die Zukunft zu spiegeln. Ich atme tief ein und lasse nur das Wort „vorhersagen“ wieder hinaus.",
+                "sentenceTranslation": "У дворцового фонтана Шут бросает гальку, чтобы отразить будущее. Я глубоко вдыхаю и выпускаю только слово «предсказывать»."
+            },
+            {
+                "word": "deuten",
+                "translation": "толковать",
+                "parts": [
+                    "Vor erstaunten Dienern zeichnet Fool Kreise in den Staub.",
+                    "Ich presse das Wort „deuten“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Vor erstaunten Dienern zeichnet Fool Kreise in den Staub. Ich presse das Wort „deuten“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Перед поражёнными слугами Шут чертит круги в пыли. Я стискиваю слово «толковать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "ahnen",
+                "translation": "предчувствовать",
+                "parts": [
+                    "Auf der Markttreppe singt Fool von Königen, die zu Bettlern werden.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „ahnen“ wird heute nicht verraten."
+                ],
+                "sentence": "Auf der Markttreppe singt Fool von Königen, die zu Bettlern werden. Mit fester Stimme schwöre ich mir: Das Wort „ahnen“ wird heute nicht verraten.",
+                "sentenceTranslation": "На рыночной лестнице Шут поёт о королях, становящихся нищими. Твёрдым голосом я клянусь себе: слово «предчувствовать» сегодня не будет предано."
+            },
+            {
+                "word": "das Omen",
+                "translation": "знамение",
+                "parts": [
+                    "Neben einem reisenden Pilger deutet Fool in den flammenden Himmel.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „das Omen“ wird heute nicht verraten."
+                ],
+                "sentence": "Neben einem reisenden Pilger deutet Fool in den flammenden Himmel. Mit fester Stimme schwöre ich mir: Das Wort „das Omen“ wird heute nicht verraten.",
+                "sentenceTranslation": "Рядом со странствующим пилигримом Шут указывает на пылающее небо. Твёрдым голосом я клянусь себе: слово «знамение» сегодня не будет предано."
+            },
+            {
+                "word": "rätselhaft",
+                "translation": "загадочный",
+                "parts": [
+                    "Im Gewitterlicht zählt Fool die Schläge, die die Zukunft ankündigen.",
+                    "Ich zeichne das Wort „rätselhaft“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Im Gewitterlicht zählt Fool die Schläge, die die Zukunft ankündigen. Ich zeichne das Wort „rätselhaft“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В свете грозы Шут отсчитывает удары, возвещающие будущее. Я черчу слово «загадочный» в мыслях поверх линий судьбы."
+            }
+        ]
     },
     "mad_companion": {
         "title": "Спутник безумия",
         "description": "Акт III: Единственный друг в буре",
         "words": [
             {
+                "wordId": "",
                 "word": "der Wahnsinn",
                 "translation": "безумие",
                 "transcription": "[дер ВАН-зин]",
@@ -2226,9 +2778,14 @@
                     "Der Wahnsinn ist gnädiger als die Vernunft! — Безумие милосерднее разума!",
                     "Ich spiele den Wahnsinn, um zu überleben. — Я играю безумие, чтобы выжить.",
                     "Im Wahnsinn finden wir uns als Brüder. — В безумии мы находим друг друга как братья."
+                ],
+                "sentenceParts": [
+                    "In der sturmgepeitschten Heide drückt Fool Lear die klammen Hände.",
+                    "Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Freundschaft",
                 "translation": "дружба",
                 "transcription": "[ди ФРОЙНД-шафт]",
@@ -2250,9 +2807,14 @@
                 ],
                 "collocations": [
                     "Unsere Freundschaft überdauert den Sturm. — Наша дружба переживёт бурю."
+                ],
+                "sentenceParts": [
+                    "Zwischen zerrissenen Zelten singt Fool ein trostloses Wiegenlied.",
+                    "Ich umarme das Wort „die Freundschaft“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "begleiten",
                 "translation": "сопровождать",
                 "transcription": "[бе-ГЛАЙ-тен]",
@@ -2280,9 +2842,14 @@
                     "Als Tom begleite ich Lear durch seine dunkelste Stunde. — Как Том, я сопровождаю Лира в его самый тёмный час.",
                     "Ich begleite ihn durch Wind und Regen. — Я сопровождаю его сквозь ветер и дождь.",
                     "Treu begleite ich meinen verrückten König. — Верно я сопровождаю своего безумного короля."
+                ],
+                "sentenceParts": [
+                    "Am umgestürzten Wagen schirmt Fool den König vor der Peitsche des Regens.",
+                    "Ich presse das Wort „begleiten“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "frieren",
                 "translation": "мёрзнуть",
                 "transcription": "[ФРИ-рен]",
@@ -2311,9 +2878,14 @@
                     "Wir alle frieren in dieser kalten Welt. — Мы все мёрзнем в этом холодном мире.",
                     "Wir frieren gemeinsam in dieser kalten Nacht. — Мы мёрзнем вместе в эту холодную ночь.",
                     "Wir frieren gemeinsam in der kalten Nacht. — Мы мёрзнем вместе в холодную ночь."
+                ],
+                "sentenceParts": [
+                    "Unter dem knarzenden Dach der Hütte sitzt Fool dicht an Lear gedrängt.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „frieren“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "singen",
                 "translation": "петь",
                 "transcription": "[ЗИН-ген]",
@@ -2334,9 +2906,14 @@
                 "collocations": [
                     "Das Singen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело петь.",
                     "Ich singe, um seine Angst zu lindern. — Я пою, чтобы облегчить его страх."
+                ],
+                "sentenceParts": [
+                    "Vor der tobenden Nacht schreit Fool seine Possen gegen den Wind.",
+                    "Ich zeichne das Wort „singen“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "zittern",
                 "translation": "дрожать",
                 "transcription": "[ЦИ-терн]",
@@ -2358,9 +2935,14 @@
                     "Der Narr spürt, wie das Zittern alle verändert. — Шут чувствует, как умение дрожать меняет всех.",
                     "Vor Kälte und Angst zittere ich ständig. — От холода и страха я постоянно дрожу.",
                     "Vor Kälte zittern wir wie Espenlaub. — От холода мы дрожим как осиновый лист."
+                ],
+                "sentenceParts": [
+                    "Am aufgeweichten Boden zeichnet Fool mit Stock und Witz ein Schutzschild.",
+                    "Ich atme tief ein und lasse nur das Wort „zittern“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "treu",
                 "translation": "верный",
                 "transcription": "[ТРОЙ]",
@@ -2386,6 +2968,10 @@
                 "collocations": [
                     "Treu bleibe ich trotz der Verkleidung. — Верным остаюсь несмотря на переодевание.",
                     "Ich bleibe treu, wenn alle anderen fliehen. — Я остаюсь верным, когда все остальные бегут."
+                ],
+                "sentenceParts": [
+                    "In der Finsternis des Waldes zündet Fool einen letzten Funken Mut an.",
+                    "Ich umarme das Wort „treu“, als wäre es mein einziger Verbündeter."
                 ]
             }
         ],
@@ -2393,9 +2979,9 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "сопровождать",
-                    "безумие",
                     "мёрзнуть",
+                    "безумие",
+                    "сопровождать",
                     "дружба"
                 ],
                 "correctIndex": 1
@@ -2403,71 +2989,144 @@
             {
                 "question": "Что означает немецкое слово «die Freundschaft»?",
                 "choices": [
-                    "дружба",
-                    "сопровождать",
                     "безумие",
-                    "мёрзнуть"
+                    "дружба",
+                    "мёрзнуть",
+                    "сопровождать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "сопровождать",
-                    "верный",
+                    "безумие",
                     "дрожать",
-                    "мёрзнуть"
+                    "сопровождать",
+                    "дружба"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "мёрзнуть",
                     "дрожать",
-                    "безумие",
-                    "сопровождать"
+                    "петь",
+                    "мёрзнуть",
+                    "дружба"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «singen»?",
                 "choices": [
-                    "петь",
-                    "сопровождать",
+                    "мёрзнуть",
                     "верный",
-                    "дрожать"
+                    "сопровождать",
+                    "петь"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
+                    "дрожать",
                     "верный",
                     "сопровождать",
-                    "дрожать",
                     "дружба"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
-                    "безумие",
-                    "сопровождать",
+                    "дружба",
                     "верный",
-                    "дружба"
+                    "мёрзнуть",
+                    "сопровождать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Wahnsinn",
+                "translation": "безумие",
+                "parts": [
+                    "In der sturmgepeitschten Heide drückt Fool Lear die klammen Hände.",
+                    "Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "In der sturmgepeitschten Heide drückt Fool Lear die klammen Hände. Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На залитой бурей пустоши Шут сжимает озябшие руки Лира. Моё дыхание рисует слово «безумие» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Freundschaft",
+                "translation": "дружба",
+                "parts": [
+                    "Zwischen zerrissenen Zelten singt Fool ein trostloses Wiegenlied.",
+                    "Ich umarme das Wort „die Freundschaft“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Zwischen zerrissenen Zelten singt Fool ein trostloses Wiegenlied. Ich umarme das Wort „die Freundschaft“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Среди разорванных шатров Шут поёт безутешную колыбельную. Я обнимаю слово «дружба», будто это единственный союзник."
+            },
+            {
+                "word": "begleiten",
+                "translation": "сопровождать",
+                "parts": [
+                    "Am umgestürzten Wagen schirmt Fool den König vor der Peitsche des Regens.",
+                    "Ich presse das Wort „begleiten“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Am umgestürzten Wagen schirmt Fool den König vor der Peitsche des Regens. Ich presse das Wort „begleiten“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У перевёрнутой повозки Шут заслоняет короля от кнута дождя. Я стискиваю слово «сопровождать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "frieren",
+                "translation": "мёрзнуть",
+                "parts": [
+                    "Unter dem knarzenden Dach der Hütte sitzt Fool dicht an Lear gedrängt.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „frieren“ darf nicht vergehen."
+                ],
+                "sentence": "Unter dem knarzenden Dach der Hütte sitzt Fool dicht an Lear gedrängt. Ich flüstere den Wächtern des Schicksals zu: Das Wort „frieren“ darf nicht vergehen.",
+                "sentenceTranslation": "Под скрипучей крышей хижины Шут сидит вплотную к Лиру. Я шепчу стражам судьбы: слово «мёрзнуть» не должно исчезнуть."
+            },
+            {
+                "word": "singen",
+                "translation": "петь",
+                "parts": [
+                    "Vor der tobenden Nacht schreit Fool seine Possen gegen den Wind.",
+                    "Ich zeichne das Wort „singen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Vor der tobenden Nacht schreit Fool seine Possen gegen den Wind. Ich zeichne das Wort „singen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Перед бушующей ночью Шут выкрикивает свои шутки наперекор ветру. Я вывожу слово «петь» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "zittern",
+                "translation": "дрожать",
+                "parts": [
+                    "Am aufgeweichten Boden zeichnet Fool mit Stock und Witz ein Schutzschild.",
+                    "Ich atme tief ein und lasse nur das Wort „zittern“ wieder hinaus."
+                ],
+                "sentence": "Am aufgeweichten Boden zeichnet Fool mit Stock und Witz ein Schutzschild. Ich atme tief ein und lasse nur das Wort „zittern“ wieder hinaus.",
+                "sentenceTranslation": "На размокшей земле Шут рисует палкой и шутками защитный круг. Я глубоко вдыхаю и выпускаю только слово «дрожать»."
+            },
+            {
+                "word": "treu",
+                "translation": "верный",
+                "parts": [
+                    "In der Finsternis des Waldes zündet Fool einen letzten Funken Mut an.",
+                    "Ich umarme das Wort „treu“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "In der Finsternis des Waldes zündet Fool einen letzten Funken Mut an. Ich umarme das Wort „treu“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В темноте леса Шут зажигает последний огонёк мужества. Я обнимаю слово «верный», будто это единственный союзник."
+            }
+        ]
     },
     "songs": {
         "title": "Песни в хижине",
         "description": "Акт III: Поёт и утешает",
         "words": [
             {
+                "wordId": "",
                 "word": "das Lied",
                 "translation": "песня",
                 "transcription": "[дас ЛИД]",
@@ -2489,9 +3148,14 @@
                 ],
                 "collocations": [
                     "Mein Lied erzählt von vergangenen Tagen. — Моя песня рассказывает о прошлых днях."
+                ],
+                "sentenceParts": [
+                    "Im warmen Schein der Hütte summt Fool eine Melodie über verlorene Kronen.",
+                    "Mein Atem zeichnet das Wort „das Lied“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Trost",
                 "translation": "утешение",
                 "transcription": "[дер ТРОСТ]",
@@ -2513,9 +3177,14 @@
                 ],
                 "collocations": [
                     "Mit Liedern bringe ich kleinen Trost. — Песнями я приношу малое утешение."
+                ],
+                "sentenceParts": [
+                    "Neben Lear legt Fool den Kopf auf die Knie und schaukelt im Takt.",
+                    "Ich zeichne das Wort „der Trost“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Ironie",
                 "translation": "ирония",
                 "transcription": "[ди и-ро-НИ]",
@@ -2537,9 +3206,14 @@
                 ],
                 "collocations": [
                     "Die Ironie ist meine letzte Waffe. — Ирония - моё последнее оружие."
+                ],
+                "sentenceParts": [
+                    "Vor der knisternden Feuerstelle klatscht Fool den Rhythmus in die Hände.",
+                    "Ich atme tief ein und lasse nur das Wort „die Ironie“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "summen",
                 "translation": "напевать",
                 "transcription": "[ЗУ-мен]",
@@ -2561,9 +3235,14 @@
                 ],
                 "collocations": [
                     "Leise summe ich alte Melodien. — Тихо я напеваю старые мелодии."
+                ],
+                "sentenceParts": [
+                    "Auf dem Holzbalken sitzt Fool und schwingt die Beine zur Melodie.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „summen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Melodie",
                 "translation": "мелодия",
                 "transcription": "[ди ме-ло-ДИ]",
@@ -2585,9 +3264,14 @@
                 ],
                 "collocations": [
                     "Die Melodie erinnert an bessere Zeiten. — Мелодия напоминает о лучших временах."
+                ],
+                "sentenceParts": [
+                    "Zwischen Schlafenden senkt Fool die Stimme zu einem flüsternden Refrain.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Melodie“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "pfeifen",
                 "translation": "свистеть",
                 "transcription": "[ПФАЙ-фен]",
@@ -2609,9 +3293,14 @@
                 ],
                 "collocations": [
                     "Ich pfeife gegen die Dunkelheit an. — Я свищу против темноты."
+                ],
+                "sentenceParts": [
+                    "Am offenen Feld singt Fool gegen das Heulen der Nacht.",
+                    "Ich umarme das Wort „pfeifen“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Reim",
                 "translation": "рифма",
                 "transcription": "[дер РАЙМ]",
@@ -2633,9 +3322,14 @@
                 ],
                 "collocations": [
                     "Jeder Reim verbirgt eine tiefe Wahrheit. — Каждая рифма скрывает глубокую правду."
+                ],
+                "sentenceParts": [
+                    "In der Morgendämmerung stimmt Fool ein hoffnungsvolles Lied an.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Reim“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "klingen",
                 "translation": "звучать",
                 "transcription": "[КЛИН-ген]",
@@ -2657,6 +3351,10 @@
                 ],
                 "collocations": [
                     "Meine Worte klingen lustig, doch sind traurig. — Мои слова звучат весело, но печальны."
+                ],
+                "sentenceParts": [
+                    "Über Lear gebeugt beendet Fool das Lied mit einem sanften Kuss auf die Stirn.",
+                    "Ich presse das Wort „klingen“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             }
         ],
@@ -2664,91 +3362,174 @@
             {
                 "question": "Что означает немецкое слово «das Lied»?",
                 "choices": [
+                    "ирония",
                     "напевать",
                     "песня",
-                    "ирония",
                     "утешение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Trost»?",
                 "choices": [
-                    "утешение",
-                    "песня",
                     "напевать",
-                    "ирония"
+                    "утешение",
+                    "ирония",
+                    "песня"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ironie»?",
                 "choices": [
                     "ирония",
-                    "мелодия",
-                    "напевать",
-                    "звучать"
+                    "рифма",
+                    "свистеть",
+                    "напевать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «summen»?",
                 "choices": [
-                    "мелодия",
                     "напевать",
-                    "утешение",
-                    "рифма"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Melodie»?",
-                "choices": [
-                    "мелодия",
                     "звучать",
                     "утешение",
-                    "свистеть"
+                    "песня"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Melodie»?",
+                "choices": [
+                    "свистеть",
+                    "звучать",
+                    "мелодия",
+                    "ирония"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «pfeifen»?",
                 "choices": [
-                    "звучать",
-                    "свистеть",
+                    "ирония",
                     "напевать",
-                    "песня"
+                    "свистеть",
+                    "рифма"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Reim»?",
                 "choices": [
-                    "ирония",
-                    "мелодия",
                     "рифма",
-                    "утешение"
+                    "свистеть",
+                    "ирония",
+                    "напевать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «klingen»?",
                 "choices": [
                     "мелодия",
-                    "рифма",
-                    "напевать",
-                    "звучать"
+                    "звучать",
+                    "свистеть",
+                    "ирония"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "das Lied",
+                "translation": "песня",
+                "parts": [
+                    "Im warmen Schein der Hütte summt Fool eine Melodie über verlorene Kronen.",
+                    "Mein Atem zeichnet das Wort „das Lied“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im warmen Schein der Hütte summt Fool eine Melodie über verlorene Kronen. Mein Atem zeichnet das Wort „das Lied“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тёплом свете хижины Шут напевает мелодию о потерянных коронах. Моё дыхание рисует слово «песня» в холодном воздухе между нами."
+            },
+            {
+                "word": "der Trost",
+                "translation": "утешение",
+                "parts": [
+                    "Neben Lear legt Fool den Kopf auf die Knie und schaukelt im Takt.",
+                    "Ich zeichne das Wort „der Trost“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Neben Lear legt Fool den Kopf auf die Knie und schaukelt im Takt. Ich zeichne das Wort „der Trost“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Рядом с Лиром Шут кладёт голову на колени и покачивается в такт. Я черчу слово «утешение» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "die Ironie",
+                "translation": "ирония",
+                "parts": [
+                    "Vor der knisternden Feuerstelle klatscht Fool den Rhythmus in die Hände.",
+                    "Ich atme tief ein und lasse nur das Wort „die Ironie“ wieder hinaus."
+                ],
+                "sentence": "Vor der knisternden Feuerstelle klatscht Fool den Rhythmus in die Hände. Ich atme tief ein und lasse nur das Wort „die Ironie“ wieder hinaus.",
+                "sentenceTranslation": "Перед потрескивающим огнём Шут отбивает ритм ладонями. Я глубоко вдыхаю и выпускаю только слово «ирония»."
+            },
+            {
+                "word": "summen",
+                "translation": "напевать",
+                "parts": [
+                    "Auf dem Holzbalken sitzt Fool und schwingt die Beine zur Melodie.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „summen“ gehört mir."
+                ],
+                "sentence": "Auf dem Holzbalken sitzt Fool und schwingt die Beine zur Melodie. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „summen“ gehört mir.",
+                "sentenceTranslation": "На деревянной балке Шут сидит и качает ногами в такт песне. Буря за окнами усиливает клятву: слово «напевать» принадлежит мне."
+            },
+            {
+                "word": "die Melodie",
+                "translation": "мелодия",
+                "parts": [
+                    "Zwischen Schlafenden senkt Fool die Stimme zu einem flüsternden Refrain.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Melodie“ auf meine Lippen."
+                ],
+                "sentence": "Zwischen Schlafenden senkt Fool die Stimme zu einem flüsternden Refrain. Wie ein stilles Gebet legt sich das Wort „die Melodie“ auf meine Lippen.",
+                "sentenceTranslation": "Среди спящих Шут понижает голос до шёпотного припева. Как тихая молитва слово «мелодия» ложится на мои губы."
+            },
+            {
+                "word": "pfeifen",
+                "translation": "свистеть",
+                "parts": [
+                    "Am offenen Feld singt Fool gegen das Heulen der Nacht.",
+                    "Ich umarme das Wort „pfeifen“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Am offenen Feld singt Fool gegen das Heulen der Nacht. Ich umarme das Wort „pfeifen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "На открытом поле Шут поёт наперекор вою ночи. Я обнимаю слово «свистеть», будто это единственный союзник."
+            },
+            {
+                "word": "der Reim",
+                "translation": "рифма",
+                "parts": [
+                    "In der Morgendämmerung stimmt Fool ein hoffnungsvolles Lied an.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Reim“ mein Nordstern."
+                ],
+                "sentence": "In der Morgendämmerung stimmt Fool ein hoffnungsvolles Lied an. Selbst wenn die Welt zerfällt, bleibt das Wort „der Reim“ mein Nordstern.",
+                "sentenceTranslation": "На рассвете Шут заводит песню надежды. Даже если мир распадается, слово «рифма» остаётся моим северным светом."
+            },
+            {
+                "word": "klingen",
+                "translation": "звучать",
+                "parts": [
+                    "Über Lear gebeugt beendet Fool das Lied mit einem sanften Kuss auf die Stirn.",
+                    "Ich presse das Wort „klingen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Über Lear gebeugt beendet Fool das Lied mit einem sanften Kuss auf die Stirn. Ich presse das Wort „klingen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Наклонившись над Лиром, Шут завершает песню мягким поцелуем в лоб. Я стискиваю слово «звучать» зубами, чтобы не вырвалось сомнение."
+            }
+        ]
     },
     "wisdom": {
         "title": "Последняя мудрость",
         "description": "Акт III-IV: Философские размышления",
         "words": [
             {
+                "wordId": "",
                 "word": "die Philosophie",
                 "translation": "философия",
                 "transcription": "[ди фи-ло-зо-ФИ]",
@@ -2770,9 +3551,14 @@
                 ],
                 "collocations": [
                     "Meine Philosophie ist einfach: Alles ist Narretei. — Моя философия проста: всё - глупость."
+                ],
+                "sentenceParts": [
+                    "Im verlassenen Hof sitzt Fool auf einem leeren Fass und denkt laut nach.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Philosophie“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Schicksal",
                 "translation": "судьба",
                 "transcription": "[дас ШИК-заль]",
@@ -2794,9 +3580,14 @@
                     "Der Narr spottet, sobald das Schicksal erwähnt wird. — Шут насмехается, едва кто-то произносит «судьба».",
                     "Unser Schicksal ist miteinander verwoben. — Наши судьбы переплетены.",
                     "Das Schicksal macht Narren aus uns allen. — Судьба делает дураков из всех нас."
+                ],
+                "sentenceParts": [
+                    "Unter einer nackten Eiche zählt Fool die Fehler der Mächtigen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Schicksal“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Vergänglichkeit",
                 "translation": "бренность",
                 "transcription": "[ди фер-ГЕНГ-лих-кайт]",
@@ -2818,9 +3609,14 @@
                 ],
                 "collocations": [
                     "Die Vergänglichkeit der Macht ist offenbar. — Бренность власти очевидна."
+                ],
+                "sentenceParts": [
+                    "Am stillen Bachlauf wirft Fool Steine, um die Zeit zu messen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Vergänglichkeit“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "nachdenken",
                 "translation": "размышлять",
                 "transcription": "[НАХ-ден-кен]",
@@ -2844,9 +3640,14 @@
                 ],
                 "collocations": [
                     "Ich denke nach über des Lebens Sinn. — Я размышляю о смысле жизни."
+                ],
+                "sentenceParts": [
+                    "Neben einer verlassenen Bühne probt Fool Zeilen über Narrheit und Macht.",
+                    "Das kalte Licht lässt das Wort „nachdenken“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erkennen",
                 "translation": "познавать",
                 "transcription": "[ер-КЕН-нен]",
@@ -2873,9 +3674,14 @@
                     "Erkennst du mich, dein Kind Cordelia? — Узнаёшь ли ты меня, твоё дитя Корделия?",
                     "Endlich erkenne ich meinen treuen Edgar. — Наконец я узнаю моего верного Эдгара.",
                     "Ich erkenne die Wahrheit hinter dem Schein. — Я познаю правду за видимостью."
+                ],
+                "sentenceParts": [
+                    "Auf dem Dachboden der Burg sortiert Fool Erinnerungen wie alte Kostüme.",
+                    "Ich atme tief ein und lasse nur das Wort „erkennen“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Sinn",
                 "translation": "смысл",
                 "transcription": "[дер ЗИН]",
@@ -2897,9 +3703,14 @@
                 ],
                 "collocations": [
                     "Der Sinn des Lebens ist ein schlechter Witz. — Смысл жизни - плохая шутка."
+                ],
+                "sentenceParts": [
+                    "Vor einem Spiegel ohne Glas betrachtet Fool das eigene müde Gesicht.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Sinn“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vergänglich",
                 "translation": "преходящий",
                 "transcription": "[фер-ГЕНГ-лих]",
@@ -2921,6 +3732,10 @@
                 ],
                 "collocations": [
                     "Alles ist vergänglich, nur die Torheit bleibt. — Всё преходяще, только глупость остаётся."
+                ],
+                "sentenceParts": [
+                    "Im ersten Morgenlicht schreibt Fool letzte Sprüche auf Pergament.",
+                    "Ich atme tief ein und lasse nur das Wort „vergänglich“ wieder hinaus."
                 ]
             }
         ],
@@ -2928,29 +3743,29 @@
             {
                 "question": "Что означает немецкое слово «die Philosophie»?",
                 "choices": [
-                    "философия",
                     "размышлять",
+                    "философия",
                     "судьба",
                     "бренность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
-                    "философия",
                     "судьба",
                     "бренность",
+                    "философия",
                     "размышлять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Vergänglichkeit»?",
                 "choices": [
                     "преходящий",
+                    "познавать",
                     "философия",
-                    "смысл",
                     "бренность"
                 ],
                 "correctIndex": 3
@@ -2958,29 +3773,29 @@
             {
                 "question": "Что означает немецкое слово «nachdenken»?",
                 "choices": [
-                    "бренность",
-                    "познавать",
-                    "преходящий",
-                    "размышлять"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «erkennen»?",
-                "choices": [
-                    "познавать",
-                    "преходящий",
                     "размышлять",
-                    "философия"
+                    "судьба",
+                    "смысл",
+                    "преходящий"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Sinn»?",
+                "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
                     "размышлять",
-                    "бренность",
+                    "смысл",
                     "познавать",
+                    "философия"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Sinn»?",
+                "choices": [
+                    "преходящий",
+                    "судьба",
+                    "философия",
                     "смысл"
                 ],
                 "correctIndex": 3
@@ -2989,20 +3804,93 @@
                 "question": "Что означает немецкое слово «vergänglich»?",
                 "choices": [
                     "философия",
-                    "преходящий",
                     "судьба",
-                    "бренность"
+                    "бренность",
+                    "преходящий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Philosophie",
+                "translation": "философия",
+                "parts": [
+                    "Im verlassenen Hof sitzt Fool auf einem leeren Fass und denkt laut nach.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Philosophie“ mein Nordstern."
+                ],
+                "sentence": "Im verlassenen Hof sitzt Fool auf einem leeren Fass und denkt laut nach. Selbst wenn die Welt zerfällt, bleibt das Wort „die Philosophie“ mein Nordstern.",
+                "sentenceTranslation": "На пустынном дворе Шут сидит на пустой бочке и размышляет вслух. Даже если мир распадается, слово «философия» остаётся моим северным светом."
+            },
+            {
+                "word": "das Schicksal",
+                "translation": "судьба",
+                "parts": [
+                    "Unter einer nackten Eiche zählt Fool die Fehler der Mächtigen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Schicksal“ darf nicht vergehen."
+                ],
+                "sentence": "Unter einer nackten Eiche zählt Fool die Fehler der Mächtigen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Schicksal“ darf nicht vergehen.",
+                "sentenceTranslation": "Под обнажённым дубом Шут пересчитывает ошибки власть имущих. Я шепчу стражам судьбы: слово «судьба» не должно исчезнуть."
+            },
+            {
+                "word": "die Vergänglichkeit",
+                "translation": "бренность",
+                "parts": [
+                    "Am stillen Bachlauf wirft Fool Steine, um die Zeit zu messen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Vergänglichkeit“ gehört mir."
+                ],
+                "sentence": "Am stillen Bachlauf wirft Fool Steine, um die Zeit zu messen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Vergänglichkeit“ gehört mir.",
+                "sentenceTranslation": "У тихого ручья Шут бросает камни, чтобы измерить время. Буря за окнами усиливает клятву: слово «бренность» принадлежит мне."
+            },
+            {
+                "word": "nachdenken",
+                "translation": "размышлять",
+                "parts": [
+                    "Neben einer verlassenen Bühne probt Fool Zeilen über Narrheit und Macht.",
+                    "Das kalte Licht lässt das Wort „nachdenken“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Neben einer verlassenen Bühne probt Fool Zeilen über Narrheit und Macht. Das kalte Licht lässt das Wort „nachdenken“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "У заброшенной сцены Шут репетирует строки о глупости и власти. Холодный свет заставляет слово «размышлять» сиять словно расплавленное золото."
+            },
+            {
+                "word": "erkennen",
+                "translation": "познавать",
+                "parts": [
+                    "Auf dem Dachboden der Burg sortiert Fool Erinnerungen wie alte Kostüme.",
+                    "Ich atme tief ein und lasse nur das Wort „erkennen“ wieder hinaus."
+                ],
+                "sentence": "Auf dem Dachboden der Burg sortiert Fool Erinnerungen wie alte Kostüme. Ich atme tief ein und lasse nur das Wort „erkennen“ wieder hinaus.",
+                "sentenceTranslation": "На чердаке замка Шут раскладывает воспоминания как старые костюмы. Я глубоко вдыхаю и выпускаю только слово «познавать»."
+            },
+            {
+                "word": "der Sinn",
+                "translation": "смысл",
+                "parts": [
+                    "Vor einem Spiegel ohne Glas betrachtet Fool das eigene müde Gesicht.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Sinn“ mein Nordstern."
+                ],
+                "sentence": "Vor einem Spiegel ohne Glas betrachtet Fool das eigene müde Gesicht. Selbst wenn die Welt zerfällt, bleibt das Wort „der Sinn“ mein Nordstern.",
+                "sentenceTranslation": "Перед зеркалом без стекла Шут разглядывает собственное усталое лицо. Даже если мир распадается, слово «смысл» остаётся моим северным светом."
+            },
+            {
+                "word": "vergänglich",
+                "translation": "преходящий",
+                "parts": [
+                    "Im ersten Morgenlicht schreibt Fool letzte Sprüche auf Pergament.",
+                    "Ich atme tief ein und lasse nur das Wort „vergänglich“ wieder hinaus."
+                ],
+                "sentence": "Im ersten Morgenlicht schreibt Fool letzte Sprüche auf Pergament. Ich atme tief ein und lasse nur das Wort „vergänglich“ wieder hinaus.",
+                "sentenceTranslation": "В первом утреннем свете Шут записывает последние остроты на пергамент. Я глубоко вдыхаю и выпускаю только слово «преходящий»."
+            }
+        ]
     },
     "vanishing": {
         "title": "Исчезновение",
         "description": "Акт III: Таинственно исчезает",
         "words": [
             {
+                "wordId": "",
                 "word": "verschwinden",
                 "translation": "исчезать",
                 "transcription": "[фер-ШВИН-ден]",
@@ -3023,9 +3911,14 @@
                 "collocations": [
                     "Das Verschwinden fällt Lear unerwartet schwer. — Лиру неожиданно тяжело исчезать.",
                     "Ich verschwinde wie ein Traum im Morgen. — Я исчезаю как сон поутру."
+                ],
+                "sentenceParts": [
+                    "Im Nebel des Morgens löst sich Fool zwischen den Zelten der Armee auf.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verschwinden“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Geheimnis",
                 "translation": "тайна",
                 "transcription": "[дас ге-ХАЙМ-нис]",
@@ -3046,9 +3939,15 @@
                 "collocations": [
                     "Cordelia merkt sich genau, wie das Geheimnis verteilt wird. — Корделия внимательно следит, кому достанется «тайна».",
                     "Mein Verschwinden bleibt ein ewiges Geheimnis. — Моё исчезновение остаётся вечной тайной."
+                ],
+                "sentenceParts": [
+                    "Auf dem verlassenen Pfad lässt Fool nur ein Glöckchen zurück.",
+                    "Ich presse das Wort „das Geheimnis“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Leere",
                 "translation": "пустота",
                 "transcription": "[ди ЛЕ-ре]",
@@ -3070,9 +3969,14 @@
                 ],
                 "collocations": [
                     "Ich hinterlasse nur Leere und Erinnerung. — Я оставляю только пустоту и воспоминание."
+                ],
+                "sentenceParts": [
+                    "Zwischen verstreuten Karten verschwindet Fool hinter einem Wandteppich.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leere“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "sich auflösen",
                 "translation": "растворяться",
                 "transcription": "[зих АУФ-лё-зен]",
@@ -3094,9 +3998,14 @@
                 ],
                 "collocations": [
                     "Ich löse mich auf wie Nebel im Wind. — Я растворяюсь как туман на ветру."
+                ],
+                "sentenceParts": [
+                    "Am Rand des Schlachtfelds weht Fools bunter Schal davon.",
+                    "Ich zeichne das Wort „sich auflösen“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "spurlos",
                 "translation": "бесследно",
                 "transcription": "[ШПУР-лос]",
@@ -3118,9 +4027,14 @@
                 ],
                 "collocations": [
                     "Spurlos gehe ich aus dieser Welt. — Бесследно я ухожу из этого мира."
+                ],
+                "sentenceParts": [
+                    "Unter den Blicken der Soldaten verbeugt sich Fool und geht ohne Abschied.",
+                    "Ich umarme das Wort „spurlos“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Nebel",
                 "translation": "туман",
                 "transcription": "[дер НЕ-бель]",
@@ -3142,9 +4056,14 @@
                 ],
                 "collocations": [
                     "Im Nebel verliere ich mich für immer. — В тумане я теряюсь навсегда."
+                ],
+                "sentenceParts": [
+                    "Auf der Treppe der Burg bleibt Fools Schellenstab einsam liegen.",
+                    "Ich atme tief ein und lasse nur das Wort „der Nebel“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "rätselhaft",
                 "translation": "загадочный",
                 "transcription": "[РЕТ-зель-хафт]",
@@ -3170,9 +4089,14 @@
                 "collocations": [
                     "Meine Worte bleiben rätselhaft und wahr. — Мои слова остаются загадочными и правдивыми.",
                     "Mein Ende bleibt rätselhaft und stumm. — Мой конец остаётся загадочным и немым."
+                ],
+                "sentenceParts": [
+                    "Im Rauschen des Meeres verliert sich Fools Stimme wie ein ferner Traum.",
+                    "Ich umarme das Wort „rätselhaft“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "fortgehen",
                 "translation": "уходить",
                 "transcription": "[ФОРТ-ге-ен]",
@@ -3194,6 +4118,10 @@
                 ],
                 "collocations": [
                     "Ich gehe fort, wenn keiner es bemerkt. — Я ухожу, когда никто не замечает."
+                ],
+                "sentenceParts": [
+                    "Vor der aufgehenden Sonne wirft Fool einen letzten Schatten und verblasst.",
+                    "Ich zeichne das Wort „fortgehen“ in Gedanken über die Linien des Schicksals."
                 ]
             }
         ],
@@ -3201,68 +4129,68 @@
             {
                 "question": "Что означает немецкое слово «verschwinden»?",
                 "choices": [
-                    "растворяться",
-                    "пустота",
+                    "тайна",
                     "исчезать",
-                    "тайна"
+                    "растворяться",
+                    "пустота"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Geheimnis»?",
                 "choices": [
-                    "тайна",
-                    "пустота",
                     "растворяться",
+                    "пустота",
+                    "тайна",
                     "исчезать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Leere»?",
                 "choices": [
-                    "исчезать",
                     "пустота",
                     "бесследно",
-                    "уходить"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «sich auflösen»?",
-                "choices": [
-                    "растворяться",
                     "уходить",
-                    "тайна",
-                    "исчезать"
+                    "тайна"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «sich auflösen»?",
+                "choices": [
+                    "туман",
+                    "загадочный",
+                    "растворяться",
+                    "исчезать"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «spurlos»?",
                 "choices": [
-                    "тайна",
-                    "туман",
                     "исчезать",
-                    "бесследно"
+                    "пустота",
+                    "бесследно",
+                    "туман"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Nebel»?",
                 "choices": [
+                    "загадочный",
                     "бесследно",
-                    "туман",
-                    "пустота",
-                    "уходить"
+                    "уходить",
+                    "туман"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
                     "пустота",
-                    "исчезать",
+                    "тайна",
                     "загадочный",
                     "бесследно"
                 ],
@@ -3271,15 +4199,98 @@
             {
                 "question": "Что означает немецкое слово «fortgehen»?",
                 "choices": [
-                    "уходить",
+                    "туман",
+                    "пустота",
                     "тайна",
-                    "растворяться",
-                    "исчезать"
+                    "уходить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "verschwinden",
+                "translation": "исчезать",
+                "parts": [
+                    "Im Nebel des Morgens löst sich Fool zwischen den Zelten der Armee auf.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verschwinden“ gehört mir."
+                ],
+                "sentence": "Im Nebel des Morgens löst sich Fool zwischen den Zelten der Armee auf. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verschwinden“ gehört mir.",
+                "sentenceTranslation": "В утреннем тумане Шут растворяется между шатрами армии. Буря за окнами усиливает клятву: слово «исчезать» принадлежит мне."
+            },
+            {
+                "word": "das Geheimnis",
+                "translation": "тайна",
+                "parts": [
+                    "Auf dem verlassenen Pfad lässt Fool nur ein Glöckchen zurück.",
+                    "Ich presse das Wort „das Geheimnis“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Auf dem verlassenen Pfad lässt Fool nur ein Glöckchen zurück. Ich presse das Wort „das Geheimnis“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На пустой тропе Шут оставляет лишь один колокольчик. Я стискиваю слово «тайна» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Leere",
+                "translation": "пустота",
+                "parts": [
+                    "Zwischen verstreuten Karten verschwindet Fool hinter einem Wandteppich.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leere“ bleibt lebendig."
+                ],
+                "sentence": "Zwischen verstreuten Karten verschwindet Fool hinter einem Wandteppich. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leere“ bleibt lebendig.",
+                "sentenceTranslation": "Среди разбросанных карт Шут исчезает за гобеленом. Каждой клеткой тела я обещаю: слово «пустота» останется живым."
+            },
+            {
+                "word": "sich auflösen",
+                "translation": "растворяться",
+                "parts": [
+                    "Am Rand des Schlachtfelds weht Fools bunter Schal davon.",
+                    "Ich zeichne das Wort „sich auflösen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Am Rand des Schlachtfelds weht Fools bunter Schal davon. Ich zeichne das Wort „sich auflösen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На краю поля битвы уносит пёстрый шарф Шут. Я вывожу слово «растворяться» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "spurlos",
+                "translation": "бесследно",
+                "parts": [
+                    "Unter den Blicken der Soldaten verbeugt sich Fool und geht ohne Abschied.",
+                    "Ich umarme das Wort „spurlos“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Unter den Blicken der Soldaten verbeugt sich Fool und geht ohne Abschied. Ich umarme das Wort „spurlos“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Под взглядами солдат Шут кланяется и уходит без прощания. Я обнимаю слово «бесследно», будто это единственный союзник."
+            },
+            {
+                "word": "der Nebel",
+                "translation": "туман",
+                "parts": [
+                    "Auf der Treppe der Burg bleibt Fools Schellenstab einsam liegen.",
+                    "Ich atme tief ein und lasse nur das Wort „der Nebel“ wieder hinaus."
+                ],
+                "sentence": "Auf der Treppe der Burg bleibt Fools Schellenstab einsam liegen. Ich atme tief ein und lasse nur das Wort „der Nebel“ wieder hinaus.",
+                "sentenceTranslation": "На лестнице замка одиноко остаётся жезл с бубенчиками Шут. Я глубоко вдыхаю и выпускаю только слово «туман»."
+            },
+            {
+                "word": "rätselhaft",
+                "translation": "загадочный",
+                "parts": [
+                    "Im Rauschen des Meeres verliert sich Fools Stimme wie ein ferner Traum.",
+                    "Ich umarme das Wort „rätselhaft“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Im Rauschen des Meeres verliert sich Fools Stimme wie ein ferner Traum. Ich umarme das Wort „rätselhaft“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В шуме моря голос Шут растворяется как далёкий сон. Я обнимаю слово «загадочный», будто это единственный союзник."
+            },
+            {
+                "word": "fortgehen",
+                "translation": "уходить",
+                "parts": [
+                    "Vor der aufgehenden Sonne wirft Fool einen letzten Schatten und verblasst.",
+                    "Ich zeichne das Wort „fortgehen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Vor der aufgehenden Sonne wirft Fool einen letzten Schatten und verblasst. Ich zeichne das Wort „fortgehen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед восходящим солнцем Шут бросает последнюю тень и растворяется. Я черчу слово «уходить» в мыслях поверх линий судьбы."
+            }
+        ]
     }
 };
 
@@ -3295,6 +4306,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3731,6 +5090,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -3799,6 +5475,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -3807,13 +5486,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4724,6 +6451,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/journeys/gloucester.html
+++ b/output/journeys/gloucester.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="throne">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="goneril">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="regan">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="storm">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="hut">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="dover">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="prison">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["знать", "доверять", "граф", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["доверять", "служить", "граф", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["граф", "доверять", "праведный", "долг"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["граф", "знать", "долг", "честь"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["честь", "доверять", "праведный", "знать"], "correct_index": 0}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["граф", "праведный", "честь", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["честь", "долг", "уважать", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «achten»?", "choices": ["доверять", "уважать", "праведный", "служить"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["письмо", "обман", "верить", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["верить", "обман", "обманывать", "письмо"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["простодушный", "письмо", "обманывать", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["обман", "письмо", "верить", "простодушный"], "correct_index": 0}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["обман", "подозревать", "ловушка", "простодушный"], "correct_index": 3}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["ловушка", "легковерный", "письмо", "подозревать"], "correct_index": 3}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["простодушный", "обман", "легковерный", "письмо"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["письмо", "обман", "ловушка", "простодушный"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["проклинать", "заблуждение", "изгонять", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["заблуждение", "проклинать", "изгонять", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "заблуждение", "гнать", "слепой"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["слепой", "гнать", "изгонять", "заблуждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «blind»?", "choices": ["несправедливость", "слепой", "сожалеть", "заблуждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["гнать", "сожалеть", "проклинать", "слепой"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["заблуждение", "сожалеть", "проклинать", "несправедливость"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["сострадание", "помогать", "опасность", "рисковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["рисковать", "опасность", "помогать", "сострадание"], "correct_index": 3}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["защищать", "измена", "рисковать", "помогать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["рисковать", "измена", "осмеливаться", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["тайно", "осмеливаться", "рисковать", "помогать"], "correct_index": 0}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["защищать", "опасность", "тайно", "измена"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["тайно", "измена", "рисковать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["осмеливаться", "опасность", "измена", "защищать"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["темнота", "пытка", "ослеплять", "боль"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["темнота", "боль", "ослеплять", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["боль", "слепнуть", "ослеплять", "темнота"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["пытка", "месть", "темнота", "кричать"], "correct_index": 2}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["месть", "кричать", "пытка", "темнота"], "correct_index": 1}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["кричать", "слепнуть", "темнота", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "боль", "ослеплять", "пытка"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["обман", "прыгать", "отчаяние", "пропасть"], "correct_index": 2}, {"question": "Что означает немецкое слово «springen»?", "choices": ["обман", "прыгать", "пропасть", "отчаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["падать", "прыгать", "избавлять", "обман"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["избавлять", "пропасть", "сдаваться", "безнадёжность"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["пропасть", "отчаяние", "безнадёжность", "сдаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["сдаваться", "прыгать", "отчаяние", "безнадёжность"], "correct_index": 3}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["падать", "сдаваться", "обман", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["избавлять", "безнадёжность", "обман", "прыгать"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "умирать", "прощать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "умирать", "осознание", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["раскаяние", "сердце", "умирать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["осознание", "умирать", "узнавать", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "сердце", "узнавать", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["сердце", "обнимать", "прощать", "раскаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["сердце", "осознание", "примирение", "прощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["узнавать", "прощать", "сердце", "обнимать"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["граф", "знать", "доверять", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["служить", "знать", "доверять", "граф"], "correct_index": 0}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["долг", "доверять", "честь", "уважать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["служить", "долг", "граф", "знать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["доверять", "честь", "уважать", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["знать", "граф", "честь", "праведный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["знать", "уважать", "долг", "служить"], "correct_index": 2}, {"question": "Что означает немецкое слово «achten»?", "choices": ["праведный", "служить", "честь", "уважать"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["обман", "обманывать", "письмо", "верить"], "correct_index": 2}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["обманывать", "верить", "письмо", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["легковерный", "обманывать", "обман", "верить"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["подозревать", "обман", "легковерный", "верить"], "correct_index": 1}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["подозревать", "легковерный", "простодушный", "ловушка"], "correct_index": 2}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["легковерный", "ловушка", "подозревать", "верить"], "correct_index": 2}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["простодушный", "легковерный", "верить", "письмо"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["простодушный", "обман", "обманывать", "ловушка"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["проклинать", "изгонять", "заблуждение", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["заблуждение", "сожалеть", "проклинать", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "несправедливость", "проклинать", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["гнать", "проклинать", "изгонять", "заблуждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «blind»?", "choices": ["слепой", "гнать", "сожалеть", "несправедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["гнать", "заблуждение", "слепой", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["гнать", "проклинать", "изгонять", "несправедливость"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["сострадание", "рисковать", "опасность", "помогать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["опасность", "сострадание", "помогать", "рисковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["рисковать", "осмеливаться", "сострадание", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["осмеливаться", "сострадание", "опасность", "помогать"], "correct_index": 2}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["опасность", "тайно", "помогать", "осмеливаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["осмеливаться", "защищать", "помогать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["сострадание", "опасность", "измена", "осмеливаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["измена", "опасность", "сострадание", "осмеливаться"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["пытка", "темнота", "ослеплять", "боль"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["ослеплять", "темнота", "боль", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["кричать", "месть", "пытка", "боль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["темнота", "ослеплять", "боль", "кричать"], "correct_index": 0}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["кричать", "пытка", "месть", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["месть", "кричать", "ослеплять", "слепнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["темнота", "пытка", "месть", "боль"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["пропасть", "отчаяние", "прыгать", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «springen»?", "choices": ["прыгать", "пропасть", "обман", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["прыгать", "безнадёжность", "обман", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["избавлять", "пропасть", "обман", "сдаваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["избавлять", "безнадёжность", "отчаяние", "сдаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["безнадёжность", "прыгать", "сдаваться", "пропасть"], "correct_index": 0}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["избавлять", "падать", "отчаяние", "сдаваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["избавлять", "отчаяние", "обман", "безнадёжность"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["прощать", "умирать", "узнавать", "осознание"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["умирать", "осознание", "узнавать", "прощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["обнимать", "сердце", "прощать", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["осознание", "умирать", "сердце", "обнимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "прощать", "осознание", "сердце"], "correct_index": 0}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["раскаяние", "прощать", "умирать", "обнимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["узнавать", "раскаяние", "обнимать", "примирение"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["прощать", "обнимать", "сердце", "примирение"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный граф</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,15 +661,15 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                             
@@ -481,17 +677,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -501,73 +697,41 @@
                         <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
                             
@@ -577,17 +741,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «achten»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «achten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,47 +796,31 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «glauben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
@@ -648,63 +828,79 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">легковерный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «arglos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">легковерный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">простодушный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">легковерный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «leichtgläubig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">легковерный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                             
@@ -712,17 +908,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -735,15 +931,15 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
@@ -751,17 +947,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -773,11 +969,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -787,9 +983,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
@@ -799,17 +995,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «blind»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -821,11 +1017,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -835,11 +1031,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
@@ -854,15 +1050,31 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «helfen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
                             
@@ -870,63 +1082,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «riskieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">осмеливаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «heimlich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">осмеливаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
                             
@@ -934,31 +1114,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «schützen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «heimlich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">измена</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «schützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
@@ -966,17 +1146,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «wagen»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">измена</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «wagen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">измена</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -993,9 +1189,9 @@
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
@@ -1009,11 +1205,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
@@ -1021,31 +1217,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Dunkelheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
                             
@@ -1053,49 +1249,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erblinden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erblinden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,31 +1304,31 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «springen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
@@ -1140,17 +1336,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">избавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1164,9 +1360,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1176,11 +1372,11 @@
                         <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безнадёжность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
                             
@@ -1188,33 +1384,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Hoffnungslosigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безнадёжность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1226,11 +1422,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1243,15 +1439,15 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
                             
@@ -1259,33 +1455,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1299,9 +1495,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1313,43 +1509,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">примирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1359,13 +1555,13 @@
                         <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1389,6 +1585,7 @@
         "description": "Акт I: При дворе короля",
         "words": [
             {
+                "wordId": "",
                 "word": "der Adel",
                 "translation": "знать",
                 "transcription": "[дер А-дель]",
@@ -1413,9 +1610,14 @@
                     "Lears Herz wird schwer, wenn der Adel zur Sprache kommt. — Сердце Лира тяжелеет: «дворянство» звучит слишком близко.",
                     "Der Adel erwartet von mir ehrenhaftes Verhalten. — Знать ожидает от меня достойного поведения.",
                     "Als Adel diene ich meinem König treu. — Как знать я верно служу своему королю."
+                ],
+                "sentenceParts": [
+                    "Gloucester steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Adel“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "dienen",
                 "translation": "служить",
                 "transcription": "[ДИ-нен]",
@@ -1437,9 +1639,14 @@
                     "Im Sturm zeigt sich, wie wichtig das Dienen ist. — Во время бури становится понятно, насколько важно служить.",
                     "Ich diene ohne Gewissen oder Ehre. — Я служу без совести и чести.",
                     "Ich diene dem König seit vielen Jahren. — Я служу королю много лет."
+                ],
+                "sentenceParts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Gloucester über Lears schweren Tisch.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „dienen“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vertrauen",
                 "translation": "доверять",
                 "transcription": "[фер-ТРАУ-ен]",
@@ -1463,9 +1670,14 @@
                     "Im Sturm zeigt sich, wie wichtig das Vertrauen ist. — Во время бури становится понятно, насколько важно доверять.",
                     "Mein Vater vertraut mir vollkommen. — Мой отец полностью мне доверяет.",
                     "Ich vertraue beiden Söhnen gleich. — Я доверяю обоим сыновьям одинаково."
+                ],
+                "sentenceParts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Gloucester die Hände hinter dem Rücken.",
+                    "Ich atme tief ein und lasse nur das Wort „vertrauen“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Graf",
                 "translation": "граф",
                 "transcription": "[дер ГРАФ]",
@@ -1487,9 +1699,14 @@
                     "Im Thronsaal verstummen die Gespräche über der Graf nie. — В тронном зале постоянно звучит слово «граф».",
                     "Mein Vater, der Graf, ist ein edler Mann. — Мой отец, граф, благородный человек.",
                     "Als Graf habe ich große Verantwortung. — Как граф я несу большую ответственность."
+                ],
+                "sentenceParts": [
+                    "Zwischen flüsternden Höflingen gleitet Gloucester über den kalten Marmorboden.",
+                    "Ich zeichne das Wort „der Graf“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Ehre",
                 "translation": "честь",
                 "transcription": "[ди Э-ре]",
@@ -1512,9 +1729,14 @@
                     "Die Ehre der Familie liegt in meinen Händen. — Честь семьи в моих руках.",
                     "Unsere Ehre bleibt unbefleckt. — Наша честь остаётся незапятнанной.",
                     "Meine Ehre ist mein höchstes Gut. — Моя честь - моё высшее благо."
+                ],
+                "sentenceParts": [
+                    "Am Rand des purpurnen Teppichs wartet Gloucester auf ein Zeichen des Königs.",
+                    "Ich zeichne das Wort „die Ehre“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "rechtschaffen",
                 "translation": "праведный",
                 "transcription": "[РЕХТ-ша-фен]",
@@ -1540,9 +1762,14 @@
                 "collocations": [
                     "Ich will rechtschaffen leben und handeln. — Я хочу жить и действовать праведно.",
                     "Ich bin ein rechtschaffener Mann. — Я праведный человек."
+                ],
+                "sentenceParts": [
+                    "Unter wehenden Standarten der Schwestern senkt Gloucester kurz den Blick.",
+                    "Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Pflicht",
                 "translation": "долг",
                 "transcription": "[ди ПФЛИХТ]",
@@ -1564,9 +1791,14 @@
                     "Cordelia merkt sich genau, wie die Pflicht verteilt wird. — Корделия внимательно следит, кому достанется «долг».",
                     "Meine Pflicht ist es, ehrlich zu sein. — Мой долг - быть честной.",
                     "Meine Pflicht ruft mich zum König. — Мой долг зовёт меня к королю."
+                ],
+                "sentenceParts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Gloucester das gespannte Antlitz des Hofes.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Pflicht“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "achten",
                 "translation": "уважать",
                 "transcription": "[АХ-тен]",
@@ -1588,6 +1820,10 @@
                 ],
                 "collocations": [
                     "Ich achte beide Söhne, Edgar und Edmund. — Я уважаю обоих сыновей, Эдгара и Эдмунда."
+                ],
+                "sentenceParts": [
+                    "Im Schein der offenen Feuerbecken erhebt Gloucester langsam die Stimme.",
+                    "Ich zeichne das Wort „achten“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             }
         ],
@@ -1595,91 +1831,174 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
+                    "граф",
                     "знать",
                     "доверять",
-                    "граф",
                     "служить"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «dienen»?",
-                "choices": [
-                    "доверять",
-                    "служить",
-                    "граф",
-                    "знать"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «dienen»?",
+                "choices": [
+                    "служить",
+                    "знать",
+                    "доверять",
+                    "граф"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
-                    "граф",
+                    "долг",
                     "доверять",
-                    "праведный",
-                    "долг"
+                    "честь",
+                    "уважать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
-                    "граф",
-                    "знать",
+                    "служить",
                     "долг",
-                    "честь"
+                    "граф",
+                    "знать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "честь",
                     "доверять",
-                    "праведный",
-                    "знать"
+                    "честь",
+                    "уважать",
+                    "служить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
+                    "знать",
                     "граф",
-                    "праведный",
                     "честь",
-                    "знать"
+                    "праведный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
-                    "честь",
-                    "долг",
+                    "знать",
                     "уважать",
+                    "долг",
                     "служить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «achten»?",
                 "choices": [
-                    "доверять",
-                    "уважать",
                     "праведный",
-                    "служить"
+                    "служить",
+                    "честь",
+                    "уважать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Adel",
+                "translation": "знать",
+                "parts": [
+                    "Gloucester steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Adel“ mein Nordstern."
+                ],
+                "sentence": "Gloucester steht unter dem glühenden Kronleuchter des Thronsaals. Selbst wenn die Welt zerfällt, bleibt das Wort „der Adel“ mein Nordstern.",
+                "sentenceTranslation": "Глостер стоит под пылающей люстрой тронного зала. Даже если мир распадается, слово «знать» остаётся моим северным светом."
+            },
+            {
+                "word": "dienen",
+                "translation": "служить",
+                "parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Gloucester über Lears schweren Tisch.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „dienen“ wird heute nicht verraten."
+                ],
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Gloucester über Lears schweren Tisch. Mit fester Stimme schwöre ich mir: Das Wort „dienen“ wird heute nicht verraten.",
+                "sentenceTranslation": "У развернутой карты королевства Глостер склоняется над тяжёлым столом Лира. Твёрдым голосом я клянусь себе: слово «служить» сегодня не будет предано."
+            },
+            {
+                "word": "vertrauen",
+                "translation": "доверять",
+                "parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Gloucester die Hände hinter dem Rücken.",
+                    "Ich atme tief ein und lasse nur das Wort „vertrauen“ wieder hinaus."
+                ],
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Gloucester die Hände hinter dem Rücken. Ich atme tief ein und lasse nur das Wort „vertrauen“ wieder hinaus.",
+                "sentenceTranslation": "Перед каменными статуями предков Глостер сцепляет руки за спиной. Я глубоко вдыхаю и выпускаю только слово «доверять»."
+            },
+            {
+                "word": "der Graf",
+                "translation": "граф",
+                "parts": [
+                    "Zwischen flüsternden Höflingen gleitet Gloucester über den kalten Marmorboden.",
+                    "Ich zeichne das Wort „der Graf“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Zwischen flüsternden Höflingen gleitet Gloucester über den kalten Marmorboden. Ich zeichne das Wort „der Graf“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Между шепчущимися придворными Глостер скользит по холодному мраморному полу. Я вывожу слово «граф» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "die Ehre",
+                "translation": "честь",
+                "parts": [
+                    "Am Rand des purpurnen Teppichs wartet Gloucester auf ein Zeichen des Königs.",
+                    "Ich zeichne das Wort „die Ehre“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Am Rand des purpurnen Teppichs wartet Gloucester auf ein Zeichen des Königs. Ich zeichne das Wort „die Ehre“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На краю пурпурного ковра Глостер ждёт знака от короля. Я вывожу слово «честь» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "rechtschaffen",
+                "translation": "праведный",
+                "parts": [
+                    "Unter wehenden Standarten der Schwestern senkt Gloucester kurz den Blick.",
+                    "Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Gloucester kurz den Blick. Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Глостер на миг опускает взгляд. Я стискиваю слово «праведный» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Pflicht",
+                "translation": "долг",
+                "parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Gloucester das gespannte Antlitz des Hofes.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Pflicht“ gehört mir."
+                ],
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Gloucester das gespannte Antlitz des Hofes. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Pflicht“ gehört mir.",
+                "sentenceTranslation": "За позолоченной балюстрадой Глостер наблюдает за напряжёнными лицами двора. Буря за окнами усиливает клятву: слово «долг» принадлежит мне."
+            },
+            {
+                "word": "achten",
+                "translation": "уважать",
+                "parts": [
+                    "Im Schein der offenen Feuerbecken erhebt Gloucester langsam die Stimme.",
+                    "Ich zeichne das Wort „achten“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Gloucester langsam die Stimme. Ich zeichne das Wort „achten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В отблесках открытых жаровен Глостер медленно поднимает голос. Я вывожу слово «уважать» невидимыми чернилами на ладони."
+            }
+        ]
     },
     "goneril": {
         "title": "Обман Эдмунда",
         "description": "Акт I: Поддельное письмо",
         "words": [
             {
+                "wordId": "",
                 "word": "der Brief",
                 "translation": "письмо",
                 "transcription": "[дер БРИФ]",
@@ -1701,9 +2020,14 @@
                     "Im Thronsaal verstummen die Gespräche über der Brief nie. — В тронном зале постоянно звучит слово «письмо».",
                     "Der gefälschte Brief ist mein Beweis. — Поддельное письмо - моё доказательство.",
                     "Dieser Brief beweist Edgars Verrat. — Это письмо доказывает предательство Эдгара."
+                ],
+                "sentenceParts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Gloucester zwischen gepackten Kisten.",
+                    "Das kalte Licht lässt das Wort „der Brief“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "glauben",
                 "translation": "верить",
                 "transcription": "[ГЛАУ-бен]",
@@ -1724,9 +2048,14 @@
                 "collocations": [
                     "Das Glauben fällt Lear unerwartet schwer. — Лиру неожиданно тяжело верить.",
                     "Ich glaube Edmunds Lügen sofort. — Я сразу верю лжи Эдмунда."
+                ],
+                "sentenceParts": [
+                    "Auf der windigen Freitreppe blickt Gloucester zum schweigenden Hof hinunter.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „glauben“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "täuschen",
                 "translation": "обманывать",
                 "transcription": "[ТОЙ-шен]",
@@ -1751,9 +2080,14 @@
                     "Ich täusche ihn, um sein Leben zu retten. — Я обманываю его, чтобы спасти его жизнь.",
                     "Edmund täuscht mich mit falschen Beweisen. — Эдмунд обманывает меня ложными доказательствами.",
                     "Ich täusche meinen alten Vater leicht. — Я легко обманываю старого отца."
+                ],
+                "sentenceParts": [
+                    "Zwischen zurückgelassenen Dienern schließt Gloucester den Reisemantel enger.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Betrug",
                 "translation": "обман",
                 "transcription": "[дер бе-ТРУГ]",
@@ -1776,9 +2110,14 @@
                     "Cordelia merkt sich genau, wie der Betrug verteilt wird. — Корделия внимательно следит, кому достанется «обман».",
                     "Dieser Betrug wird eines Tages aufgedeckt. — Этот обман однажды раскроется.",
                     "Ich erkenne den Betrug nicht. — Я не распознаю обман."
+                ],
+                "sentenceParts": [
+                    "Am dunklen Pferdestall streicht Gloucester einem nervösen Tier über die Mähne.",
+                    "Ich zeichne das Wort „der Betrug“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "arglos",
                 "translation": "простодушный",
                 "transcription": "[АРГ-лос]",
@@ -1800,9 +2139,14 @@
                 ],
                 "collocations": [
                     "Ich bin zu arglos für solche Intrigen. — Я слишком простодушен для таких интриг."
+                ],
+                "sentenceParts": [
+                    "Vor dem knarrenden Fallgatter tastet Gloucester ein letztes Mal nach dem Haustor.",
+                    "Ich zeichne das Wort „arglos“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verdächtigen",
                 "translation": "подозревать",
                 "transcription": "[фер-ДЕХ-ти-ген]",
@@ -1824,9 +2168,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Verdächtigen ist. — Во время бури становится понятно, насколько важно подозревать.",
                     "Ich verdächtige meinen guten Sohn Edgar. — Я подозреваю моего доброго сына Эдгара."
+                ],
+                "sentenceParts": [
+                    "Zwischen verstreuten Schriftrollen dreht Gloucester den Ring an der Hand.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „verdächtigen“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "leichtgläubig",
                 "translation": "легковерный",
                 "transcription": "[ЛАЙХТ-глой-биг]",
@@ -1848,9 +2197,14 @@
                 ],
                 "collocations": [
                     "Ich bin zu leichtgläubig für diese Welt. — Я слишком легковерен для этого мира."
+                ],
+                "sentenceParts": [
+                    "Am leeren Bankettisch zählt Gloucester die verlöschenden Kerzen.",
+                    "Mein Atem zeichnet das Wort „leichtgläubig“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Falle",
                 "translation": "ловушка",
                 "transcription": "[ди ФА-ле]",
@@ -1876,6 +2230,11 @@
                 "collocations": [
                     "Ich stelle Fallen für die Ahnungslosen. — Я ставлю ловушки для ничего не подозревающих.",
                     "Ich tappe blind in Edmunds Falle. — Я слепо попадаю в ловушку Эдмунда."
+                ],
+                "sentenceParts": [
+                    "Zwischen schweigenden Wachen geht Gloucester auf den kalten Hof hinaus.",
+                    "Ich presse das Wort „die Falle“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             }
         ],
@@ -1883,91 +2242,175 @@
             {
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
-                    "письмо",
-                    "обман",
-                    "верить",
-                    "обманывать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «glauben»?",
-                "choices": [
-                    "верить",
                     "обман",
                     "обманывать",
-                    "письмо"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «täuschen»?",
-                "choices": [
-                    "простодушный",
                     "письмо",
-                    "обманывать",
-                    "обман"
+                    "верить"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «glauben»?",
+                "choices": [
+                    "обманывать",
+                    "верить",
+                    "письмо",
+                    "обман"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «täuschen»?",
+                "choices": [
+                    "легковерный",
+                    "обманывать",
+                    "обман",
+                    "верить"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
+                    "подозревать",
                     "обман",
-                    "письмо",
-                    "верить",
-                    "простодушный"
+                    "легковерный",
+                    "верить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «arglos»?",
                 "choices": [
-                    "обман",
                     "подозревать",
-                    "ловушка",
-                    "простодушный"
+                    "легковерный",
+                    "простодушный",
+                    "ловушка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verdächtigen»?",
                 "choices": [
-                    "ловушка",
                     "легковерный",
-                    "письмо",
-                    "подозревать"
+                    "ловушка",
+                    "подозревать",
+                    "верить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «leichtgläubig»?",
                 "choices": [
                     "простодушный",
-                    "обман",
                     "легковерный",
+                    "верить",
                     "письмо"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
-                    "письмо",
+                    "простодушный",
                     "обман",
-                    "ловушка",
-                    "простодушный"
+                    "обманывать",
+                    "ловушка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Brief",
+                "translation": "письмо",
+                "parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Gloucester zwischen gepackten Kisten.",
+                    "Das kalte Licht lässt das Wort „der Brief“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Gloucester zwischen gepackten Kisten. Das kalte Licht lässt das Wort „der Brief“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Глостер замирает среди нагруженных ящиков. Холодный свет заставляет слово «письмо» сиять словно расплавленное золото."
+            },
+            {
+                "word": "glauben",
+                "translation": "верить",
+                "parts": [
+                    "Auf der windigen Freitreppe blickt Gloucester zum schweigenden Hof hinunter.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „glauben“ gehört mir."
+                ],
+                "sentence": "Auf der windigen Freitreppe blickt Gloucester zum schweigenden Hof hinunter. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „glauben“ gehört mir.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Глостер смотрит вниз на молчаливый двор. Буря за окнами усиливает клятву: слово «верить» принадлежит мне."
+            },
+            {
+                "word": "täuschen",
+                "translation": "обманывать",
+                "parts": [
+                    "Zwischen zurückgelassenen Dienern schließt Gloucester den Reisemantel enger.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir."
+                ],
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Gloucester den Reisemantel enger. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir.",
+                "sentenceTranslation": "Среди оставленных слуг Глостер плотнее запахивает дорожный плащ. Буря за окнами усиливает клятву: слово «обманывать» принадлежит мне."
+            },
+            {
+                "word": "der Betrug",
+                "translation": "обман",
+                "parts": [
+                    "Am dunklen Pferdestall streicht Gloucester einem nervösen Tier über die Mähne.",
+                    "Ich zeichne das Wort „der Betrug“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Am dunklen Pferdestall streicht Gloucester einem nervösen Tier über die Mähne. Ich zeichne das Wort „der Betrug“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Глостер гладит гриву нервного коня. Я черчу слово «обман» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "arglos",
+                "translation": "простодушный",
+                "parts": [
+                    "Vor dem knarrenden Fallgatter tastet Gloucester ein letztes Mal nach dem Haustor.",
+                    "Ich zeichne das Wort „arglos“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Vor dem knarrenden Fallgatter tastet Gloucester ein letztes Mal nach dem Haustor. Ich zeichne das Wort „arglos“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Глостер в последний раз касается родной двери. Я вывожу слово «простодушный» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "verdächtigen",
+                "translation": "подозревать",
+                "parts": [
+                    "Zwischen verstreuten Schriftrollen dreht Gloucester den Ring an der Hand.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „verdächtigen“ mein Nordstern."
+                ],
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Gloucester den Ring an der Hand. Selbst wenn die Welt zerfällt, bleibt das Wort „verdächtigen“ mein Nordstern.",
+                "sentenceTranslation": "Среди разбросанных свитков Глостер вертит кольцо на пальце. Даже если мир распадается, слово «подозревать» остаётся моим северным светом."
+            },
+            {
+                "word": "leichtgläubig",
+                "translation": "легковерный",
+                "parts": [
+                    "Am leeren Bankettisch zählt Gloucester die verlöschenden Kerzen.",
+                    "Mein Atem zeichnet das Wort „leichtgläubig“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Am leeren Bankettisch zählt Gloucester die verlöschenden Kerzen. Mein Atem zeichnet das Wort „leichtgläubig“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У пустого банкетного стола Глостер пересчитывает гаснущие свечи. Моё дыхание рисует слово «легковерный» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Falle",
+                "translation": "ловушка",
+                "parts": [
+                    "Zwischen schweigenden Wachen geht Gloucester auf den kalten Hof hinaus.",
+                    "Ich presse das Wort „die Falle“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Zwischen schweigenden Wachen geht Gloucester auf den kalten Hof hinaus. Ich presse das Wort „die Falle“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Между молчаливыми стражниками Глостер выходит на холодный двор. Я стискиваю слово «ловушка» зубами, чтобы не вырвалось сомнение."
+            }
+        ]
     },
     "regan": {
         "title": "Изгнание Эдгара",
         "description": "Акт II: Изгнание сына",
         "words": [
             {
+                "wordId": "",
                 "word": "verstoßen",
                 "translation": "изгонять",
                 "transcription": "[фер-ШТО-сен]",
@@ -1995,9 +2438,14 @@
                     "Der König verstößt mich aus seinem Herzen. — Король изгоняет меня из своего сердца.",
                     "Ich verstoße meinen unschuldigen Sohn. — Я изгоняю своего невинного сына.",
                     "Ich verstoße meinen Vater in die Nacht. — Я отвергаю отца в ночь."
+                ],
+                "sentenceParts": [
+                    "Im zugigen Seitenflügel lauscht Gloucester dem Heulen der Küstenwinde.",
+                    "Ich umarme das Wort „verstoßen“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verfluchen",
                 "translation": "проклинать",
                 "transcription": "[фер-ФЛУ-хен]",
@@ -2022,9 +2470,14 @@
                     "Ich verfluche dich bei allen Sternen! — Я проклинаю тебя всеми звёздами!",
                     "Sterbend verfluche ich meine Mörder. — Умирая, я проклинаю своих убийц.",
                     "Im Zorn verfluche ich Edgar. — В гневе я проклинаю Эдгара."
+                ],
+                "sentenceParts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Gloucester einen zerknitterten Brief.",
+                    "Ich zeichne das Wort „verfluchen“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "bereuen",
                 "translation": "сожалеть",
                 "transcription": "[бе-РОЙ-ен]",
@@ -2048,9 +2501,14 @@
                     "Am Ende bereue ich meine Taten. — В конце я сожалею о своих делах.",
                     "Später werde ich diese Tat bitter bereuen. — Позже я горько пожалею об этом поступке.",
                     "Zu spät bereue ich meine Taten. — Слишком поздно я сожалею о своих делах."
+                ],
+                "sentenceParts": [
+                    "Unter farblosen Wandteppichen schreitet Gloucester rastlos auf und ab.",
+                    "Das kalte Licht lässt das Wort „bereuen“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Irrtum",
                 "translation": "заблуждение",
                 "transcription": "[дер ИР-тум]",
@@ -2072,9 +2530,14 @@
                 "collocations": [
                     "Der Narr spottet, sobald der Irrtum erwähnt wird. — Шут насмехается, едва кто-то произносит «ошибка».",
                     "Mein Irrtum zerstört meine Familie. — Моё заблуждение разрушает мою семью."
+                ],
+                "sentenceParts": [
+                    "An der schmalen Fensterluke zählt Gloucester die Fackeln auf dem Hof.",
+                    "Ich halte das Wort „der Irrtum“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "blind",
                 "translation": "слепой",
                 "transcription": "[БЛИНД]",
@@ -2100,9 +2563,14 @@
                 "collocations": [
                     "Mein blinder Vater erkennt mich nicht. — Мой слепой отец не узнаёт меня.",
                     "Ich bin blind für die Wahrheit. — Я слеп к правде."
+                ],
+                "sentenceParts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Gloucester nach frischen Botschaften.",
+                    "Wie ein stilles Gebet legt sich das Wort „blind“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "jagen",
                 "translation": "гнать",
                 "transcription": "[Я-ген]",
@@ -2129,9 +2597,14 @@
                 "collocations": [
                     "Wie ein Hund jage ich meine Beute. — Как собака я гонюсь за добычей.",
                     "Ich jage meinen Sohn fort wie einen Verbrecher. — Я гоню сына прочь как преступника."
+                ],
+                "sentenceParts": [
+                    "Im stillen Kapellenraum kniet Gloucester vor der kalten Steinfigur.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „jagen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Ungerechtigkeit",
                 "translation": "несправедливость",
                 "transcription": "[ди УН-ге-рех-тиг-кайт]",
@@ -2157,6 +2630,10 @@
                 "collocations": [
                     "Diese Ungerechtigkeit werde ich nicht akzeptieren. — Эту несправедливость я не приму.",
                     "Ich begehe große Ungerechtigkeit. — Я совершаю большую несправедливость."
+                ],
+                "sentenceParts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Gloucester die Laterne fest.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ungerechtigkeit“ bleibt lebendig."
                 ]
             }
         ],
@@ -2165,37 +2642,37 @@
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
                     "проклинать",
-                    "заблуждение",
                     "изгонять",
-                    "сожалеть"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «verfluchen»?",
-                "choices": [
                     "заблуждение",
-                    "проклинать",
-                    "изгонять",
                     "сожалеть"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «verfluchen»?",
+                "choices": [
+                    "заблуждение",
+                    "сожалеть",
+                    "проклинать",
+                    "изгонять"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
                     "сожалеть",
-                    "заблуждение",
-                    "гнать",
-                    "слепой"
+                    "несправедливость",
+                    "проклинать",
+                    "изгонять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Irrtum»?",
                 "choices": [
-                    "слепой",
                     "гнать",
+                    "проклинать",
                     "изгонять",
                     "заблуждение"
                 ],
@@ -2204,41 +2681,114 @@
             {
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
-                    "несправедливость",
                     "слепой",
+                    "гнать",
                     "сожалеть",
-                    "заблуждение"
+                    "несправедливость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
                     "гнать",
-                    "сожалеть",
-                    "проклинать",
-                    "слепой"
+                    "заблуждение",
+                    "слепой",
+                    "изгонять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
-                    "заблуждение",
-                    "сожалеть",
+                    "гнать",
                     "проклинать",
+                    "изгонять",
                     "несправедливость"
                 ],
                 "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "verstoßen",
+                "translation": "изгонять",
+                "parts": [
+                    "Im zugigen Seitenflügel lauscht Gloucester dem Heulen der Küstenwinde.",
+                    "Ich umarme das Wort „verstoßen“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Im zugigen Seitenflügel lauscht Gloucester dem Heulen der Küstenwinde. Ich umarme das Wort „verstoßen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Глостер слушает вой прибрежного ветра. Я обнимаю слово «изгонять», будто это единственный союзник."
+            },
+            {
+                "word": "verfluchen",
+                "translation": "проклинать",
+                "parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Gloucester einen zerknitterten Brief.",
+                    "Ich zeichne das Wort „verfluchen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Gloucester einen zerknitterten Brief. Ich zeichne das Wort „verfluchen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед дымным камином замка Глостер складывает измятый лист. Я черчу слово «проклинать» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "bereuen",
+                "translation": "сожалеть",
+                "parts": [
+                    "Unter farblosen Wandteppichen schreitet Gloucester rastlos auf und ab.",
+                    "Das kalte Licht lässt das Wort „bereuen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Unter farblosen Wandteppichen schreitet Gloucester rastlos auf und ab. Das kalte Licht lässt das Wort „bereuen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Под выцветшими гобеленами Глостер беспокойно меряет шагами зал. Холодный свет заставляет слово «сожалеть» сиять словно расплавленное золото."
+            },
+            {
+                "word": "der Irrtum",
+                "translation": "заблуждение",
+                "parts": [
+                    "An der schmalen Fensterluke zählt Gloucester die Fackeln auf dem Hof.",
+                    "Ich halte das Wort „der Irrtum“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "An der schmalen Fensterluke zählt Gloucester die Fackeln auf dem Hof. Ich halte das Wort „der Irrtum“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У узкой бойницы Глостер считает факелы на дворе. Я держу слово «заблуждение» как факел у сердца."
+            },
+            {
+                "word": "blind",
+                "translation": "слепой",
+                "parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Gloucester nach frischen Botschaften.",
+                    "Wie ein stilles Gebet legt sich das Wort „blind“ auf meine Lippen."
+                ],
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Gloucester nach frischen Botschaften. Wie ein stilles Gebet legt sich das Wort „blind“ auf meine Lippen.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Глостер ищет свежие вести. Как тихая молитва слово «слепой» ложится на мои губы."
+            },
+            {
+                "word": "jagen",
+                "translation": "гнать",
+                "parts": [
+                    "Im stillen Kapellenraum kniet Gloucester vor der kalten Steinfigur.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „jagen“ bleibt lebendig."
+                ],
+                "sentence": "Im stillen Kapellenraum kniet Gloucester vor der kalten Steinfigur. Mit jeder Faser meines Körpers verspreche ich: Das Wort „jagen“ bleibt lebendig.",
+                "sentenceTranslation": "В тихой капелле Глостер преклоняет колени перед холодной каменной фигурой. Каждой клеткой тела я обещаю: слово «гнать» останется живым."
+            },
+            {
+                "word": "die Ungerechtigkeit",
+                "translation": "несправедливость",
+                "parts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Gloucester die Laterne fest.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ungerechtigkeit“ bleibt lebendig."
+                ],
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Gloucester die Laterne fest. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ungerechtigkeit“ bleibt lebendig.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Глостер крепко держит фонарь. Каждой клеткой тела я обещаю: слово «несправедливость» останется живым."
+            }
+        ]
     },
     "storm": {
         "title": "Помощь Лиру",
         "description": "Акт III: Тайная помощь",
         "words": [
             {
+                "wordId": "",
                 "word": "helfen",
                 "translation": "помогать",
                 "transcription": "[ХЕЛЬ-фен]",
@@ -2259,9 +2809,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Helfen ist. — Во время бури становится понятно, насколько важно помогать.",
                     "Heimlich helfe ich dem verstoßenen König. — Тайно я помогаю изгнанному королю."
+                ],
+                "sentenceParts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Gloucester gegen den Wind.",
+                    "Das Echo des Wortes „helfen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Mitleid",
                 "translation": "сострадание",
                 "transcription": "[дас МИТ-лайд]",
@@ -2282,9 +2837,14 @@
                 "collocations": [
                     "Während des Sturms wirkt das Mitleid noch bedrückender. — Во время бури само «сострадание» звучит ещё тяжелее.",
                     "Mitleid erfüllt mein Herz für Lear. — Сострадание наполняет моё сердце к Лиру."
+                ],
+                "sentenceParts": [
+                    "Unter einem zerrissenen Banner schützt Gloucester die Augen vor den Blitzen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „das Mitleid“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "riskieren",
                 "translation": "рисковать",
                 "transcription": "[рис-КИ-рен]",
@@ -2306,9 +2866,14 @@
                 ],
                 "collocations": [
                     "Ich riskiere alles für den alten König. — Я рискую всем ради старого короля."
+                ],
+                "sentenceParts": [
+                    "Am Rand eines umgestürzten Baumes sucht Gloucester Deckung vor dem Donner.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „riskieren“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Gefahr",
                 "translation": "опасность",
                 "transcription": "[ди ге-ФАР]",
@@ -2331,9 +2896,14 @@
                     "Die Gefahr lauert überall um mich herum. — Опасность подстерегает меня повсюду.",
                     "Trotz Gefahr bleibe ich beim König. — Несмотря на опасность, я остаюсь с королём.",
                     "Die Gefahr der Entdeckung ist groß. — Опасность разоблачения велика."
+                ],
+                "sentenceParts": [
+                    "Zwischen schäumenden Wassergräben stolpert Gloucester durch den Schlamm.",
+                    "Das kalte Licht lässt das Wort „die Gefahr“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "heimlich",
                 "translation": "тайно",
                 "transcription": "[ХАЙМ-лих]",
@@ -2355,9 +2925,14 @@
                 ],
                 "collocations": [
                     "Ich handle heimlich gegen die neuen Herrscher. — Я действую тайно против новых правителей."
+                ],
+                "sentenceParts": [
+                    "Vor einem zuckenden Himmel hebt Gloucester die Arme trotzig an.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „heimlich“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "schützen",
                 "translation": "защищать",
                 "transcription": "[ШЮ-цен]",
@@ -2381,9 +2956,14 @@
                 ],
                 "collocations": [
                     "Ich will den wahnsinnigen König schützen. — Я хочу защитить безумного короля."
+                ],
+                "sentenceParts": [
+                    "Unter dem durchtränkten Umhang presst Gloucester den Atem gegen die Kälte.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „schützen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Verrat",
                 "translation": "измена",
                 "transcription": "[дер фер-РАТ]",
@@ -2407,9 +2987,14 @@
                     "Der Verrat ist mein tägliches Geschäft. — Предательство - моё ежедневное дело.",
                     "Der Verrat meines Bruders zerstört mein Leben. — Предательство моего брата разрушает мою жизнь.",
                     "Meine Hilfe gilt als Verrat. — Моя помощь считается изменой."
+                ],
+                "sentenceParts": [
+                    "Am kläglichen Feuerrest wärmt Gloucester zitternde Finger.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Verrat“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "wagen",
                 "translation": "осмеливаться",
                 "transcription": "[ВА-ген]",
@@ -2430,6 +3015,10 @@
                 "collocations": [
                     "Cordelia zeigt, dass das Wagen auch ohne Stolz möglich ist. — Корделия показывает, что осмеливаться можно и без гордыни.",
                     "Ich wage es, gegen die Töchter zu handeln. — Я осмеливаюсь действовать против дочерей."
+                ],
+                "sentenceParts": [
+                    "Zwischen heulenden Hunden ruft Gloucester gegen den tosenden Sturm an.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „wagen“ gehört mir."
                 ]
             }
         ],
@@ -2438,90 +3027,173 @@
                 "question": "Что означает немецкое слово «helfen»?",
                 "choices": [
                     "сострадание",
-                    "помогать",
+                    "рисковать",
                     "опасность",
+                    "помогать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «das Mitleid»?",
+                "choices": [
+                    "опасность",
+                    "сострадание",
+                    "помогать",
                     "рисковать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «das Mitleid»?",
-                "choices": [
-                    "рисковать",
-                    "опасность",
-                    "помогать",
-                    "сострадание"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «riskieren»?",
                 "choices": [
-                    "защищать",
-                    "измена",
                     "рисковать",
+                    "осмеливаться",
+                    "сострадание",
+                    "защищать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Gefahr»?",
+                "choices": [
+                    "осмеливаться",
+                    "сострадание",
+                    "опасность",
                     "помогать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Gefahr»?",
-                "choices": [
-                    "рисковать",
-                    "измена",
-                    "осмеливаться",
-                    "опасность"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «heimlich»?",
                 "choices": [
+                    "опасность",
                     "тайно",
-                    "осмеливаться",
-                    "рисковать",
-                    "помогать"
+                    "помогать",
+                    "осмеливаться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schützen»?",
                 "choices": [
+                    "осмеливаться",
                     "защищать",
-                    "опасность",
-                    "тайно",
-                    "измена"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Verrat»?",
-                "choices": [
-                    "тайно",
-                    "измена",
-                    "рисковать",
+                    "помогать",
                     "опасность"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «wagen»?",
+                "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "осмеливаться",
+                    "сострадание",
                     "опасность",
                     "измена",
-                    "защищать"
+                    "осмеливаться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «wagen»?",
+                "choices": [
+                    "измена",
+                    "опасность",
+                    "сострадание",
+                    "осмеливаться"
+                ],
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "helfen",
+                "translation": "помогать",
+                "parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Gloucester gegen den Wind.",
+                    "Das Echo des Wortes „helfen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Gloucester gegen den Wind. Das Echo des Wortes „helfen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Глостер упирается в ветер. Эхо слова «помогать» заглушает шёпот придворных."
+            },
+            {
+                "word": "das Mitleid",
+                "translation": "сострадание",
+                "parts": [
+                    "Unter einem zerrissenen Banner schützt Gloucester die Augen vor den Blitzen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „das Mitleid“ mein Nordstern."
+                ],
+                "sentence": "Unter einem zerrissenen Banner schützt Gloucester die Augen vor den Blitzen. Selbst wenn die Welt zerfällt, bleibt das Wort „das Mitleid“ mein Nordstern.",
+                "sentenceTranslation": "Под разорванным знаменем Глостер прикрывает глаза от молний. Даже если мир распадается, слово «сострадание» остаётся моим северным светом."
+            },
+            {
+                "word": "riskieren",
+                "translation": "рисковать",
+                "parts": [
+                    "Am Rand eines umgestürzten Baumes sucht Gloucester Deckung vor dem Donner.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „riskieren“ mein Nordstern."
+                ],
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Gloucester Deckung vor dem Donner. Selbst wenn die Welt zerfällt, bleibt das Wort „riskieren“ mein Nordstern.",
+                "sentenceTranslation": "У поваленного дерева Глостер ищет укрытия от грома. Даже если мир распадается, слово «рисковать» остаётся моим северным светом."
+            },
+            {
+                "word": "die Gefahr",
+                "translation": "опасность",
+                "parts": [
+                    "Zwischen schäumenden Wassergräben stolpert Gloucester durch den Schlamm.",
+                    "Das kalte Licht lässt das Wort „die Gefahr“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Gloucester durch den Schlamm. Das kalte Licht lässt das Wort „die Gefahr“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Между пенящимися лужами Глостер пробирается через грязь. Холодный свет заставляет слово «опасность» сиять словно расплавленное золото."
+            },
+            {
+                "word": "heimlich",
+                "translation": "тайно",
+                "parts": [
+                    "Vor einem zuckenden Himmel hebt Gloucester die Arme trotzig an.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „heimlich“ gehört mir."
+                ],
+                "sentence": "Vor einem zuckenden Himmel hebt Gloucester die Arme trotzig an. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „heimlich“ gehört mir.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Глостер упрямо поднимает руки. Буря за окнами усиливает клятву: слово «тайно» принадлежит мне."
+            },
+            {
+                "word": "schützen",
+                "translation": "защищать",
+                "parts": [
+                    "Unter dem durchtränkten Umhang presst Gloucester den Atem gegen die Kälte.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „schützen“ bleibt lebendig."
+                ],
+                "sentence": "Unter dem durchtränkten Umhang presst Gloucester den Atem gegen die Kälte. Mit jeder Faser meines Körpers verspreche ich: Das Wort „schützen“ bleibt lebendig.",
+                "sentenceTranslation": "Под промокшим плащом Глостер прижимает дыхание к груди, спасаясь от холода. Каждой клеткой тела я обещаю: слово «защищать» останется живым."
+            },
+            {
+                "word": "der Verrat",
+                "translation": "измена",
+                "parts": [
+                    "Am kläglichen Feuerrest wärmt Gloucester zitternde Finger.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Verrat“ gehört mir."
+                ],
+                "sentence": "Am kläglichen Feuerrest wärmt Gloucester zitternde Finger. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Verrat“ gehört mir.",
+                "sentenceTranslation": "У жалких огненных углей Глостер греет дрожащие пальцы. Буря за окнами усиливает клятву: слово «измена» принадлежит мне."
+            },
+            {
+                "word": "wagen",
+                "translation": "осмеливаться",
+                "parts": [
+                    "Zwischen heulenden Hunden ruft Gloucester gegen den tosenden Sturm an.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „wagen“ gehört mir."
+                ],
+                "sentence": "Zwischen heulenden Hunden ruft Gloucester gegen den tosenden Sturm an. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „wagen“ gehört mir.",
+                "sentenceTranslation": "Среди воющих псов Глостер перекрикивает беснующуюся бурю. Буря за окнами усиливает клятву: слово «осмеливаться» принадлежит мне."
+            }
+        ]
     },
     "hut": {
         "title": "Ослепление",
         "description": "Акт III: Потеря глаз",
         "words": [
             {
+                "wordId": "",
                 "word": "blenden",
                 "translation": "ослеплять",
                 "transcription": "[БЛЕН-ден]",
@@ -2545,9 +3217,14 @@
                     "Wir blenden den treuen Grafen Gloucester. — Мы ослепляем верного графа Глостера.",
                     "Eigenhändig blende ich Gloucester. — Собственноручно я ослепляю Глостера.",
                     "Sie blenden mich für meinen Verrat. — Они ослепляют меня за мою измену."
+                ],
+                "sentenceParts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Gloucester bei der flackernden Kerze.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „blenden“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Folter",
                 "translation": "пытка",
                 "transcription": "[ди ФОЛЬ-тер]",
@@ -2577,9 +3254,15 @@
                     "Die Folter ist meine Unterhaltung. — Пытка - моё развлечение.",
                     "Die Folter ist mein liebstes Werkzeug. — Пытка - мой любимый инструмент.",
                     "Die Folter ist grausam und erbarmungslos. — Пытка жестока и беспощадна."
+                ],
+                "sentenceParts": [
+                    "Zwischen zerbeulten Rüstungen streicht Gloucester über ein altes Wappen.",
+                    "Ich presse das Wort „die Folter“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Schmerz",
                 "translation": "боль",
                 "transcription": "[дер ШМЕРЦ]",
@@ -2601,9 +3284,14 @@
                     "Während des Sturms wirkt der Schmerz noch bedrückender. — Во время бури само «боль» звучит ещё тяжелее.",
                     "Der Schmerz durchbohrt meinen Körper. — Боль пронзает моё тело.",
                     "Der Schmerz durchbohrt meine Seele. — Боль пронзает мою душу."
+                ],
+                "sentenceParts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Gloucester fast den Kopf.",
+                    "Ich umarme das Wort „der Schmerz“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Dunkelheit",
                 "translation": "темнота",
                 "transcription": "[ди ДУН-кель-хайт]",
@@ -2624,9 +3312,15 @@
                 "collocations": [
                     "Lears Herz wird schwer, wenn die Dunkelheit zur Sprache kommt. — Сердце Лира тяжелеет: «темнота» звучит слишком близко.",
                     "Ewige Dunkelheit umgibt mich nun. — Вечная темнота окружает меня теперь."
+                ],
+                "sentenceParts": [
+                    "Neben der schlafenden Wache flüstert Gloucester in die schwere Nacht.",
+                    "Ich presse das Wort „die Dunkelheit“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "schreien",
                 "translation": "кричать",
                 "transcription": "[ШРАЙ-ен]",
@@ -2652,9 +3346,14 @@
                 "collocations": [
                     "Ich schreie in den Wind meine Wut hinaus! — Я кричу в ветер свою ярость!",
                     "Ich schreie vor unerträglichem Schmerz. — Я кричу от невыносимой боли."
+                ],
+                "sentenceParts": [
+                    "Vor dem einfachen Feldbett betrachtet Gloucester die Narben vergangener Schlachten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „schreien“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erblinden",
                 "translation": "слепнуть",
                 "transcription": "[ер-БЛИН-ден]",
@@ -2675,9 +3374,14 @@
                 "collocations": [
                     "Das Erblinden fällt Lear unerwartet schwer. — Лиру неожиданно тяжело слепнуть.",
                     "Ich erblinde durch ihre Grausamkeit. — Я слепну от их жестокости."
+                ],
+                "sentenceParts": [
+                    "Im Geruch von feuchtem Stroh legt Gloucester den Mantel zur Seite.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „erblinden“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Rache",
                 "translation": "месть",
                 "transcription": "[ди РА-хе]",
@@ -2701,6 +3405,10 @@
                     "Nicht Rache, sondern Gerechtigkeit leitet meine Klinge. — Не месть, а справедливость ведёт мой клинок.",
                     "Dies ist ihre Rache für meine Treue. — Это их месть за мою верность.",
                     "Die Rache für Jahre der Unterwerfung. — Месть за годы подчинения."
+                ],
+                "sentenceParts": [
+                    "Auf dem wackligen Holztisch ordnet Gloucester zerlesene Briefe.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Rache“ auf meine Lippen."
                 ]
             }
         ],
@@ -2708,8 +3416,8 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "темнота",
                     "пытка",
+                    "темнота",
                     "ослеплять",
                     "боль"
                 ],
@@ -2718,9 +3426,9 @@
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
+                    "ослеплять",
                     "темнота",
                     "боль",
-                    "ослеплять",
                     "пытка"
                 ],
                 "correctIndex": 3
@@ -2728,61 +3436,136 @@
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
-                    "боль",
-                    "слепнуть",
-                    "ослеплять",
-                    "темнота"
+                    "кричать",
+                    "месть",
+                    "пытка",
+                    "боль"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Dunkelheit»?",
                 "choices": [
-                    "пытка",
-                    "месть",
                     "темнота",
+                    "ослеплять",
+                    "боль",
                     "кричать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
-                    "месть",
                     "кричать",
                     "пытка",
-                    "темнота"
+                    "месть",
+                    "ослеплять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erblinden»?",
                 "choices": [
+                    "месть",
                     "кричать",
-                    "слепнуть",
-                    "темнота",
-                    "пытка"
+                    "ослеплять",
+                    "слепнуть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
+                    "темнота",
+                    "пытка",
                     "месть",
-                    "боль",
-                    "ослеплять",
-                    "пытка"
+                    "боль"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "blenden",
+                "translation": "ослеплять",
+                "parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Gloucester bei der flackernden Kerze.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „blenden“ gehört mir."
+                ],
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Gloucester bei der flackernden Kerze. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „blenden“ gehört mir.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Глостер сидит у мерцающей свечи. Буря за окнами усиливает клятву: слово «ослеплять» принадлежит мне."
+            },
+            {
+                "word": "die Folter",
+                "translation": "пытка",
+                "parts": [
+                    "Zwischen zerbeulten Rüstungen streicht Gloucester über ein altes Wappen.",
+                    "Ich presse das Wort „die Folter“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Gloucester über ein altes Wappen. Ich presse das Wort „die Folter“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди помятых доспехов Глостер гладит старый герб. Я стискиваю слово «пытка» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "der Schmerz",
+                "translation": "боль",
+                "parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Gloucester fast den Kopf.",
+                    "Ich umarme das Wort „der Schmerz“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Gloucester fast den Kopf. Ich umarme das Wort „der Schmerz“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "О низкую балку хижины Глостер едва не ударяется головой. Я обнимаю слово «боль», будто это единственный союзник."
+            },
+            {
+                "word": "die Dunkelheit",
+                "translation": "темнота",
+                "parts": [
+                    "Neben der schlafenden Wache flüstert Gloucester in die schwere Nacht.",
+                    "Ich presse das Wort „die Dunkelheit“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Neben der schlafenden Wache flüstert Gloucester in die schwere Nacht. Ich presse das Wort „die Dunkelheit“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Рядом со спящим стражем Глостер шепчет в тяжёлую ночь. Я стискиваю слово «темнота» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "schreien",
+                "translation": "кричать",
+                "parts": [
+                    "Vor dem einfachen Feldbett betrachtet Gloucester die Narben vergangener Schlachten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „schreien“ wird heute nicht verraten."
+                ],
+                "sentence": "Vor dem einfachen Feldbett betrachtet Gloucester die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „schreien“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед грубой походной койкой Глостер разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «кричать» сегодня не будет предано."
+            },
+            {
+                "word": "erblinden",
+                "translation": "слепнуть",
+                "parts": [
+                    "Im Geruch von feuchtem Stroh legt Gloucester den Mantel zur Seite.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „erblinden“ darf nicht vergehen."
+                ],
+                "sentence": "Im Geruch von feuchtem Stroh legt Gloucester den Mantel zur Seite. Ich flüstere den Wächtern des Schicksals zu: Das Wort „erblinden“ darf nicht vergehen.",
+                "sentenceTranslation": "В запахе влажной соломы Глостер откладывает плащ в сторону. Я шепчу стражам судьбы: слово «слепнуть» не должно исчезнуть."
+            },
+            {
+                "word": "die Rache",
+                "translation": "месть",
+                "parts": [
+                    "Auf dem wackligen Holztisch ordnet Gloucester zerlesene Briefe.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Rache“ auf meine Lippen."
+                ],
+                "sentence": "Auf dem wackligen Holztisch ordnet Gloucester zerlesene Briefe. Wie ein stilles Gebet legt sich das Wort „die Rache“ auf meine Lippen.",
+                "sentenceTranslation": "На шатком деревянном столе Глостер раскладывает зачитанные письма. Как тихая молитва слово «месть» ложится на мои губы."
+            }
+        ]
     },
     "dover": {
         "title": "Скалы Дувра",
         "description": "Акт IV: Попытка самоубийства",
         "words": [
             {
+                "wordId": "",
                 "word": "die Verzweiflung",
                 "translation": "отчаяние",
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
@@ -2806,9 +3589,14 @@
                     "Seine Verzweiflung bricht mir das Herz. — Его отчаяние разбивает мне сердце.",
                     "Die Verzweiflung treibt mich zum Abgrund. — Отчаяние гонит меня к пропасти.",
                     "Die Verzweiflung führt mich zum Tod. — Отчаяние ведёт меня к смерти."
+                ],
+                "sentenceParts": [
+                    "Auf den weißen Klippen von Dover blickt Gloucester in den aufgewühlten Kanal.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Verzweiflung“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "springen",
                 "translation": "прыгать",
                 "transcription": "[ШПРИН-ген]",
@@ -2829,9 +3617,14 @@
                 "collocations": [
                     "Das Springen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело прыгать.",
                     "Ich will von den Klippen springen. — Я хочу прыгнуть со скал."
+                ],
+                "sentenceParts": [
+                    "Zwischen flatternden Feldzeichen richtet Gloucester den Helm.",
+                    "Das Echo des Wortes „springen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Täuschung",
                 "translation": "обман",
                 "transcription": "[ди ТОЙ-шунг]",
@@ -2858,9 +3651,14 @@
                 "collocations": [
                     "Die Täuschung ist vollkommen. — Обман совершенен.",
                     "Edgars liebevolle Täuschung rettet mich. — Любящий обман Эдгара спасает меня."
+                ],
+                "sentenceParts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Gloucester Marschrouten in den Sand.",
+                    "Ich halte das Wort „die Täuschung“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Abgrund",
                 "translation": "пропасть",
                 "transcription": "[дер АБ-грунд]",
@@ -2882,9 +3680,14 @@
                 ],
                 "collocations": [
                     "Der Abgrund ruft nach mir. — Пропасть зовёт меня."
+                ],
+                "sentenceParts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Gloucester das Siegel.",
+                    "Ich halte das Wort „der Abgrund“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "aufgeben",
                 "translation": "сдаваться",
                 "transcription": "[АУФ-ге-бен]",
@@ -2910,9 +3713,14 @@
                 "collocations": [
                     "Ich gebe auf, nachdem mein Herr gestorben ist. — Я сдаюсь после смерти моего господина.",
                     "Ich will das Leben aufgeben. — Я хочу отказаться от жизни."
+                ],
+                "sentenceParts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Gloucester dem dumpfen Meer.",
+                    "Das kalte Licht lässt das Wort „aufgeben“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Hoffnungslosigkeit",
                 "translation": "безнадёжность",
                 "transcription": "[ди ХОФ-нунгс-ло-зиг-кайт]",
@@ -2934,9 +3742,14 @@
                 ],
                 "collocations": [
                     "Die Hoffnungslosigkeit erdrückt mich. — Безнадёжность давит меня."
+                ],
+                "sentenceParts": [
+                    "Auf dem sandigen Trainingsplatz übt Gloucester das Ziehen des Schwerts.",
+                    "Mein Atem zeichnet das Wort „die Hoffnungslosigkeit“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "stürzen",
                 "translation": "падать",
                 "transcription": "[ШТЮР-цен]",
@@ -2958,9 +3771,14 @@
                 "collocations": [
                     "Der Narr spürt, wie das Stürzen alle verändert. — Шут чувствует, как умение падать меняет всех.",
                     "Ich glaube, von hohen Klippen zu stürzen. — Я верю, что падаю с высоких скал."
+                ],
+                "sentenceParts": [
+                    "Zwischen pochenden Trommeln hebt Gloucester das Banner der Hoffnung.",
+                    "Das kalte Licht lässt das Wort „stürzen“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erlösen",
                 "translation": "избавлять",
                 "transcription": "[ер-ЛЁ-зен]",
@@ -2982,6 +3800,10 @@
                 ],
                 "collocations": [
                     "Der Tod soll mich von der Schuld erlösen. — Смерть должна избавить меня от вины."
+                ],
+                "sentenceParts": [
+                    "Am Morgennebel der Küste legt Gloucester die Hand auf das pochende Herz.",
+                    "Ich presse das Wort „erlösen“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             }
         ],
@@ -2989,49 +3811,49 @@
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "обман",
-                    "прыгать",
-                    "отчаяние",
-                    "пропасть"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «springen»?",
-                "choices": [
-                    "обман",
-                    "прыгать",
                     "пропасть",
-                    "отчаяние"
+                    "отчаяние",
+                    "прыгать",
+                    "обман"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «springen»?",
+                "choices": [
+                    "прыгать",
+                    "пропасть",
+                    "обман",
+                    "отчаяние"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
-                    "падать",
                     "прыгать",
-                    "избавлять",
-                    "обман"
+                    "безнадёжность",
+                    "обман",
+                    "отчаяние"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Abgrund»?",
                 "choices": [
                     "избавлять",
                     "пропасть",
-                    "сдаваться",
-                    "безнадёжность"
+                    "обман",
+                    "сдаваться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
-                    "пропасть",
-                    "отчаяние",
+                    "избавлять",
                     "безнадёжность",
+                    "отчаяние",
                     "сдаваться"
                 ],
                 "correctIndex": 3
@@ -3039,41 +3861,124 @@
             {
                 "question": "Что означает немецкое слово «die Hoffnungslosigkeit»?",
                 "choices": [
-                    "сдаваться",
+                    "безнадёжность",
                     "прыгать",
-                    "отчаяние",
-                    "безнадёжность"
+                    "сдаваться",
+                    "пропасть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «stürzen»?",
                 "choices": [
+                    "избавлять",
                     "падать",
-                    "сдаваться",
-                    "обман",
-                    "отчаяние"
+                    "отчаяние",
+                    "сдаваться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erlösen»?",
                 "choices": [
                     "избавлять",
-                    "безнадёжность",
+                    "отчаяние",
                     "обман",
-                    "прыгать"
+                    "безнадёжность"
                 ],
                 "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Verzweiflung",
+                "translation": "отчаяние",
+                "parts": [
+                    "Auf den weißen Klippen von Dover blickt Gloucester in den aufgewühlten Kanal.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Verzweiflung“ mein Nordstern."
+                ],
+                "sentence": "Auf den weißen Klippen von Dover blickt Gloucester in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „die Verzweiflung“ mein Nordstern.",
+                "sentenceTranslation": "На белых скалах Дувра Глостер смотрит в вздыбленный пролив. Даже если мир распадается, слово «отчаяние» остаётся моим северным светом."
+            },
+            {
+                "word": "springen",
+                "translation": "прыгать",
+                "parts": [
+                    "Zwischen flatternden Feldzeichen richtet Gloucester den Helm.",
+                    "Das Echo des Wortes „springen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Zwischen flatternden Feldzeichen richtet Gloucester den Helm. Das Echo des Wortes „springen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Среди хлопающих штандартов Глостер поправляет шлем. Эхо слова «прыгать» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Täuschung",
+                "translation": "обман",
+                "parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Gloucester Marschrouten in den Sand.",
+                    "Ich halte das Wort „die Täuschung“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Gloucester Marschrouten in den Sand. Ich halte das Wort „die Täuschung“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У французского костра Глостер рисует в песке путь марша. Я держу слово «обман» как факел у сердца."
+            },
+            {
+                "word": "der Abgrund",
+                "translation": "пропасть",
+                "parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Gloucester das Siegel.",
+                    "Ich halte das Wort „der Abgrund“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Gloucester das Siegel. Ich halte das Wort „der Abgrund“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Глостер проверяет печати. Я держу слово «пропасть» как факел у сердца."
+            },
+            {
+                "word": "aufgeben",
+                "translation": "сдаваться",
+                "parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Gloucester dem dumpfen Meer.",
+                    "Das kalte Licht lässt das Wort „aufgeben“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Gloucester dem dumpfen Meer. Das kalte Licht lässt das Wort „aufgeben“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Глостер слушает глухой шум моря. Холодный свет заставляет слово «сдаваться» сиять словно расплавленное золото."
+            },
+            {
+                "word": "die Hoffnungslosigkeit",
+                "translation": "безнадёжность",
+                "parts": [
+                    "Auf dem sandigen Trainingsplatz übt Gloucester das Ziehen des Schwerts.",
+                    "Mein Atem zeichnet das Wort „die Hoffnungslosigkeit“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Auf dem sandigen Trainingsplatz übt Gloucester das Ziehen des Schwerts. Mein Atem zeichnet das Wort „die Hoffnungslosigkeit“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На песчаном плацу Глостер отрабатывает выхват меча. Моё дыхание рисует слово «безнадёжность» в холодном воздухе между нами."
+            },
+            {
+                "word": "stürzen",
+                "translation": "падать",
+                "parts": [
+                    "Zwischen pochenden Trommeln hebt Gloucester das Banner der Hoffnung.",
+                    "Das kalte Licht lässt das Wort „stürzen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Zwischen pochenden Trommeln hebt Gloucester das Banner der Hoffnung. Das kalte Licht lässt das Wort „stürzen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Под гул барабанов Глостер поднимает знамя надежды. Холодный свет заставляет слово «падать» сиять словно расплавленное золото."
+            },
+            {
+                "word": "erlösen",
+                "translation": "избавлять",
+                "parts": [
+                    "Am Morgennebel der Küste legt Gloucester die Hand auf das pochende Herz.",
+                    "Ich presse das Wort „erlösen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Am Morgennebel der Küste legt Gloucester die Hand auf das pochende Herz. Ich presse das Wort „erlösen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В утреннем тумане побережья Глостер кладёт ладонь на бьющееся сердце. Я стискиваю слово «избавлять» зубами, чтобы не вырвалось сомнение."
+            }
+        ]
     },
     "prison": {
         "title": "Прозрение и смерть",
         "description": "Акт V: Узнавание Эдгара",
         "words": [
             {
+                "wordId": "",
                 "word": "erkennen",
                 "translation": "узнавать",
                 "transcription": "[ер-КЕН-нен]",
@@ -3100,9 +4005,14 @@
                     "Erkennst du mich, dein Kind Cordelia? — Узнаёшь ли ты меня, твоё дитя Корделия?",
                     "Endlich erkenne ich meinen treuen Edgar. — Наконец я узнаю моего верного Эдгара.",
                     "Ich erkenne die Wahrheit hinter dem Schein. — Я познаю правду за видимостью."
+                ],
+                "sentenceParts": [
+                    "Im feuchten Kerker stützt Gloucester sich an den tropfenden Stein.",
+                    "Ich umarme das Wort „erkennen“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vergeben",
                 "translation": "прощать",
                 "transcription": "[фер-ГЕ-бен]",
@@ -3125,9 +4035,14 @@
                     "Das Vergeben fällt Lear unerwartet schwer. — Лиру неожиданно тяжело прощать.",
                     "Kannst du einem törichten alten Mann vergeben? — Можешь ли ты простить глупого старика?",
                     "Edgar vergibt mir meine Blindheit. — Эдгар прощает мне мою слепоту."
+                ],
+                "sentenceParts": [
+                    "Unter der trüben Laterne zählt Gloucester die eisernen Ringe der Kette.",
+                    "Ich zeichne das Wort „vergeben“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "sterben",
                 "translation": "умирать",
                 "transcription": "[ШТЕР-бен]",
@@ -3152,9 +4067,14 @@
                     "Ich sterbe ohne Reue für meine Taten. — Я умираю без раскаяния за свои дела.",
                     "Ich sterbe vor Freude und Kummer. — Я умираю от радости и горя.",
                     "Ich sterbe durch meine eigene Hand. — Я умираю от своей собственной руки."
+                ],
+                "sentenceParts": [
+                    "Neben der schweren Holztür horcht Gloucester auf entferntes Schluchzen.",
+                    "Ich halte das Wort „sterben“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Erkenntnis",
                 "translation": "осознание",
                 "transcription": "[ди ер-КЕНТ-нис]",
@@ -3178,9 +4098,14 @@
                     "Die Erkenntnis ihrer Bosheit erschüttert mich. — Осознание её злобы потрясает меня.",
                     "Die Erkenntnis kommt durch Schmerz und Verlust. — Познание приходит через боль и утрату.",
                     "Die späte Erkenntnis bricht mein Herz. — Позднее осознание разбивает моё сердце."
+                ],
+                "sentenceParts": [
+                    "Auf der kalten Steinbank zieht Gloucester den Mantel enger um die Schultern.",
+                    "Das Echo des Wortes „die Erkenntnis“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Reue",
                 "translation": "раскаяние",
                 "transcription": "[ди РОЙ-е]",
@@ -3203,9 +4128,14 @@
                     "Die Reue brennt heißer als alle Feuer der Hölle. — Раскаяние жжёт горячее всех адских огней.",
                     "Deine Reue ist nicht nötig, nur deine Liebe. — Твоё раскаяние не нужно, только твоя любовь.",
                     "Die Reue überwältigt meine Seele. — Раскаяние переполняет мою душу."
+                ],
+                "sentenceParts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Gloucester das Gesicht zum Licht.",
+                    "Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "umarmen",
                 "translation": "обнимать",
                 "transcription": "[ум-АР-мен]",
@@ -3231,9 +4161,14 @@
                 "collocations": [
                     "Lass mich dich umarmen und deine Tränen trocknen. — Позволь мне обнять тебя и вытереть твои слёзы.",
                     "Ein letztes Mal umarme ich meinen Sohn. — В последний раз я обнимаю сына."
+                ],
+                "sentenceParts": [
+                    "Am rostigen Wassereimer spiegelt Gloucester kurz die eigenen Augen.",
+                    "Wie ein stilles Gebet legt sich das Wort „umarmen“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Versöhnung",
                 "translation": "примирение",
                 "transcription": "[ди фер-ЗЁ-нунг]",
@@ -3254,9 +4189,14 @@
                 "collocations": [
                     "Für die Höflinge bleibt die Versöhnung ein ständiges Thema. — Для придворных «примирение» — постоянная тема.",
                     "Die Versöhnung kommt zu spät. — Примирение приходит слишком поздно."
+                ],
+                "sentenceParts": [
+                    "Im dumpfen Hall der Schritte zählt Gloucester den Rhythmus der Wachen.",
+                    "Mein Atem zeichnet das Wort „die Versöhnung“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Herz",
                 "translation": "сердце",
                 "transcription": "[дас ХЕРЦ]",
@@ -3278,6 +4218,10 @@
                     "Während des Sturms wirkt das Herz noch bedrückender. — Во время бури само «сердце» звучит ещё тяжелее.",
                     "Mein Herz bricht vor Schmerz und Liebe. — Моё сердце разбивается от боли и любви.",
                     "Mein Herz zerbricht vor Glück und Leid. — Моё сердце разрывается от счастья и горя."
+                ],
+                "sentenceParts": [
+                    "Vor dem verriegelten Fenster zeichnet Gloucester Kreise in den Staub.",
+                    "Ich halte das Wort „das Herz“ wie eine Fackel vor meinem Herzen."
                 ]
             }
         ],
@@ -3285,40 +4229,40 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "узнавать",
-                    "умирать",
                     "прощать",
+                    "умирать",
+                    "узнавать",
                     "осознание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
-                    "прощать",
                     "умирать",
                     "осознание",
-                    "узнавать"
+                    "узнавать",
+                    "прощать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "раскаяние",
+                    "обнимать",
                     "сердце",
-                    "умирать",
-                    "узнавать"
+                    "прощать",
+                    "умирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
                     "осознание",
                     "умирать",
-                    "узнавать",
-                    "раскаяние"
+                    "сердце",
+                    "обнимать"
                 ],
                 "correctIndex": 0
             },
@@ -3326,44 +4270,126 @@
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
                     "раскаяние",
-                    "сердце",
-                    "узнавать",
-                    "прощать"
+                    "прощать",
+                    "осознание",
+                    "сердце"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
-                    "сердце",
-                    "обнимать",
+                    "раскаяние",
                     "прощать",
-                    "раскаяние"
+                    "умирать",
+                    "обнимать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Versöhnung»?",
                 "choices": [
-                    "сердце",
-                    "осознание",
-                    "примирение",
-                    "прощать"
+                    "узнавать",
+                    "раскаяние",
+                    "обнимать",
+                    "примирение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
-                    "узнавать",
                     "прощать",
+                    "обнимать",
                     "сердце",
-                    "обнимать"
+                    "примирение"
                 ],
                 "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "erkennen",
+                "translation": "узнавать",
+                "parts": [
+                    "Im feuchten Kerker stützt Gloucester sich an den tropfenden Stein.",
+                    "Ich umarme das Wort „erkennen“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Im feuchten Kerker stützt Gloucester sich an den tropfenden Stein. Ich umarme das Wort „erkennen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В сыром подземелье Глостер опирается на сочащийся камень. Я обнимаю слово «узнавать», будто это единственный союзник."
+            },
+            {
+                "word": "vergeben",
+                "translation": "прощать",
+                "parts": [
+                    "Unter der trüben Laterne zählt Gloucester die eisernen Ringe der Kette.",
+                    "Ich zeichne das Wort „vergeben“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Unter der trüben Laterne zählt Gloucester die eisernen Ringe der Kette. Ich zeichne das Wort „vergeben“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под мутным фонарём Глостер пересчитывает железные кольца цепи. Я черчу слово «прощать» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "sterben",
+                "translation": "умирать",
+                "parts": [
+                    "Neben der schweren Holztür horcht Gloucester auf entferntes Schluchzen.",
+                    "Ich halte das Wort „sterben“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Neben der schweren Holztür horcht Gloucester auf entferntes Schluchzen. Ich halte das Wort „sterben“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У тяжёлой двери Глостер прислушивается к далёким рыданиям. Я держу слово «умирать» как факел у сердца."
+            },
+            {
+                "word": "die Erkenntnis",
+                "translation": "осознание",
+                "parts": [
+                    "Auf der kalten Steinbank zieht Gloucester den Mantel enger um die Schultern.",
+                    "Das Echo des Wortes „die Erkenntnis“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Auf der kalten Steinbank zieht Gloucester den Mantel enger um die Schultern. Das Echo des Wortes „die Erkenntnis“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На холодной каменной скамье Глостер плотнее кутается в плащ. Эхо слова «осознание» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Reue",
+                "translation": "раскаяние",
+                "parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Gloucester das Gesicht zum Licht.",
+                    "Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Gloucester das Gesicht zum Licht. Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Между тенями решёток Глостер поднимает лицо к свету. Я черчу слово «раскаяние» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "umarmen",
+                "translation": "обнимать",
+                "parts": [
+                    "Am rostigen Wassereimer spiegelt Gloucester kurz die eigenen Augen.",
+                    "Wie ein stilles Gebet legt sich das Wort „umarmen“ auf meine Lippen."
+                ],
+                "sentence": "Am rostigen Wassereimer spiegelt Gloucester kurz die eigenen Augen. Wie ein stilles Gebet legt sich das Wort „umarmen“ auf meine Lippen.",
+                "sentenceTranslation": "У ржавого ведра с водой Глостер на мгновение видит отражение глаз. Как тихая молитва слово «обнимать» ложится на мои губы."
+            },
+            {
+                "word": "die Versöhnung",
+                "translation": "примирение",
+                "parts": [
+                    "Im dumpfen Hall der Schritte zählt Gloucester den Rhythmus der Wachen.",
+                    "Mein Atem zeichnet das Wort „die Versöhnung“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im dumpfen Hall der Schritte zählt Gloucester den Rhythmus der Wachen. Mein Atem zeichnet das Wort „die Versöhnung“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В глухом эхе шагов Глостер отсчитывает ритм часовых. Моё дыхание рисует слово «примирение» в холодном воздухе между нами."
+            },
+            {
+                "word": "das Herz",
+                "translation": "сердце",
+                "parts": [
+                    "Vor dem verriegelten Fenster zeichnet Gloucester Kreise in den Staub.",
+                    "Ich halte das Wort „das Herz“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Vor dem verriegelten Fenster zeichnet Gloucester Kreise in den Staub. Ich halte das Wort „das Herz“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед заколоченным окном Глостер чертит круги в пыли. Я держу слово «сердце» как факел у сердца."
+            }
+        ]
     }
 };
 
@@ -3379,6 +4405,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3815,6 +5189,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -3883,6 +5574,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -3891,13 +5585,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4808,6 +6550,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/journeys/goneril.html
+++ b/output/journeys/goneril.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="throne">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="goneril">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="regan">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="storm">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="hut">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="dover">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="prison">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["клясться", "ложь", "наследство", "лицемерить"], "correct_index": 1}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["лицемерить", "наследство", "ложь", "клясться"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["клясться", "состояние", "лицемерить", "наследство"], "correct_index": 3}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["состояние", "обманывать", "лицемерить", "клясться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["наследство", "обманывать", "лицемерить", "жадность"], "correct_index": 3}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["лицемерить", "обманывать", "льстить", "наследство"], "correct_index": 1}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["наследство", "состояние", "льстить", "лицемерить"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["жадность", "ложь", "состояние", "льстить"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "трон", "править", "приказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["власть", "приказывать", "править", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["трон", "приказывать", "править", "господство"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["приказывать", "трон", "править", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["трон", "господство", "завоёвывать", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["править", "управлять", "завоёвывать", "господство"], "correct_index": 3}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["управлять", "завоёвывать", "господство", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["трон", "править", "завоёвывать", "подчинять"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "жестокий", "изгонять", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["унижать", "месть", "жестокий", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["жестокий", "ограничивать", "отказывать", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["отказывать", "ограничивать", "изгонять", "презирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["жестокий", "месть", "презирать", "ограничивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["ограничивать", "отказывать", "унижать", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["унижать", "мучить", "презирать", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["презирать", "ограничивать", "жестокий", "мучить"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["буря", "безжалостный", "запирать", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "отвергать", "безжалостный", "запирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["безжалостный", "буря", "ожесточаться", "беспощадный"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["буря", "ожесточаться", "безжалостный", "запирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["холод", "запирать", "буря", "ожесточаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["отвергать", "запирать", "буря", "беспощадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["беспощадный", "ожесточаться", "запирать", "безжалостный"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["раздор", "ненавидеть", "ссориться", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["предавать", "ссориться", "раздор", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["ссориться", "раздор", "изменять", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["раздор", "презрение", "ненавидеть", "страсть"], "correct_index": 2}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["изменять", "ненавидеть", "разрушать", "презрение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["ссориться", "презрение", "предавать", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["разрушать", "предавать", "изменять", "презрение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["презрение", "изменять", "раздор", "страсть"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["ревность", "соперничать", "бороться", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["бороться", "желать", "соперничать", "ревность"], "correct_index": 2}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["интрига", "бороться", "ревность", "убивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["интрига", "желать", "соперничать", "ревность"], "correct_index": 1}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["устранять", "интрига", "бороться", "соперничать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["бороться", "яд", "соперничать", "устранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["яд", "интрига", "ревность", "устранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «morden»?", "choices": ["ревность", "соперничать", "устранять", "убивать"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["вина", "умирать", "отчаяние", "отравлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отравлять", "умирать", "отчаяние", "вина"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["вина", "сожалеть", "умирать", "отравлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["вина", "отравлять", "ад", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["вина", "ад", "отчаяние", "уничтожать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["уничтожать", "ад", "вина", "погибель"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "отчаяние", "умирать", "отравлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["умирать", "вина", "сожалеть", "ад"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["наследство", "клясться", "лицемерить", "ложь"], "correct_index": 3}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["лицемерить", "ложь", "наследство", "клясться"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["льстить", "наследство", "жадность", "состояние"], "correct_index": 1}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["лицемерить", "ложь", "клясться", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["ложь", "жадность", "льстить", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "жадность", "состояние", "ложь"], "correct_index": 0}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["состояние", "жадность", "клясться", "льстить"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["жадность", "наследство", "состояние", "ложь"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "приказывать", "править", "трон"], "correct_index": 0}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["править", "приказывать", "трон", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["трон", "завоёвывать", "править", "приказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["трон", "власть", "управлять", "приказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоёвывать", "трон", "управлять", "подчинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["управлять", "приказывать", "господство", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["управлять", "править", "власть", "подчинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["господство", "власть", "управлять", "подчинять"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["жестокий", "месть", "изгонять", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["изгонять", "месть", "жестокий", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "ограничивать", "мучить", "отказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["месть", "отказывать", "изгонять", "ограничивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["отказывать", "изгонять", "ограничивать", "презирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["ограничивать", "унижать", "отказывать", "жестокий"], "correct_index": 2}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["месть", "презирать", "жестокий", "мучить"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["месть", "ограничивать", "изгонять", "мучить"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["безжалостный", "запирать", "буря", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["отвергать", "буря", "запирать", "безжалостный"], "correct_index": 1}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["запирать", "отвергать", "безжалостный", "ожесточаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["холод", "беспощадный", "буря", "запирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["отвергать", "безжалостный", "холод", "буря"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["отвергать", "беспощадный", "безжалостный", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["отвергать", "ожесточаться", "запирать", "беспощадный"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["раздор", "ненавидеть", "ссориться", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["предавать", "раздор", "ссориться", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["разрушать", "презрение", "раздор", "изменять"], "correct_index": 2}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["страсть", "ненавидеть", "презрение", "разрушать"], "correct_index": 1}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["раздор", "страсть", "изменять", "презрение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["разрушать", "ссориться", "ненавидеть", "презрение"], "correct_index": 3}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["раздор", "предавать", "страсть", "разрушать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["разрушать", "страсть", "ненавидеть", "ссориться"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["бороться", "желать", "ревность", "соперничать"], "correct_index": 2}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["ревность", "желать", "бороться", "соперничать"], "correct_index": 3}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["ревность", "бороться", "интрига", "устранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["ревность", "желать", "убивать", "интрига"], "correct_index": 1}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["желать", "интрига", "устранять", "ревность"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["устранять", "ревность", "бороться", "яд"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["убивать", "яд", "желать", "интрига"], "correct_index": 3}, {"question": "Что означает немецкое слово «morden»?", "choices": ["соперничать", "бороться", "убивать", "яд"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["умирать", "отчаяние", "отравлять", "вина"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отравлять", "умирать", "вина", "отчаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["сожалеть", "погибель", "умирать", "уничтожать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["сожалеть", "умирать", "отравлять", "вина"], "correct_index": 3}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["уничтожать", "умирать", "отравлять", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["сожалеть", "погибель", "ад", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["уничтожать", "отчаяние", "вина", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["ад", "сожалеть", "вина", "отчаяние"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Лесть и обман</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,17 +661,17 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Lüge»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -487,9 +683,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
                             
@@ -497,81 +693,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Erbe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">состояние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">льстить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">льстить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">состояние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">льстить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -583,11 +779,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">состояние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">льстить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -606,22 +802,6 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">приказывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">править</button>
@@ -632,65 +812,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «befehlen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">приказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">управлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">приказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">управлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">управлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">господство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -702,11 +898,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">управлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">господство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -716,11 +912,11 @@
                         <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">господство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">управлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
                             
@@ -735,17 +931,17 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -755,29 +951,29 @@
                         <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -787,27 +983,11 @@
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
                             
@@ -815,33 +995,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verweigern»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ограничивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verweigern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ограничивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">отказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокий</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -851,11 +1047,11 @@
                         <div class="quiz-question">Что означает немецкое слово «beschränken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
                             
@@ -874,11 +1070,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                             
@@ -886,33 +1082,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «gnadenlos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ожесточаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -922,11 +1118,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verschließen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                             
@@ -934,33 +1130,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -970,13 +1166,13 @@
                         <div class="quiz-question">Что означает немецкое слово «verhärten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1011,25 +1207,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
@@ -1037,61 +1217,45 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страсть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">разрушать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">страсть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">страсть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
                             
@@ -1101,17 +1265,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">страсть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Leidenschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страсть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страсть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1124,77 +1320,29 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Eifersucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">убивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «beseitigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
                             
@@ -1204,49 +1352,97 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Gift»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">яд</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «morden»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «beseitigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">устранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">убивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Gift»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">яд</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">убивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">яд</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «morden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">яд</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1259,23 +1455,23 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «vergiften»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
@@ -1283,9 +1479,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1295,43 +1491,11 @@
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Schuld»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ад</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vernichten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
                             
@@ -1339,49 +1503,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">погибель</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Schuld»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «vernichten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ад</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Hölle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1405,6 +1601,7 @@
         "description": "Акт I: Фальшивая любовь",
         "words": [
             {
+                "wordId": "",
                 "word": "die Lüge",
                 "translation": "ложь",
                 "transcription": "[ди ЛЮ-ге]",
@@ -1425,9 +1622,14 @@
                 "collocations": [
                     "Während des Sturms wirkt die Lüge noch bedrückender. — Во время бури само «ложь» звучит ещё тяжелее.",
                     "Die Lüge klingt süßer als die Wahrheit. — Ложь звучит слаще правды."
+                ],
+                "sentenceParts": [
+                    "Goneril steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Lüge“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "schwören",
                 "translation": "клясться",
                 "transcription": "[ШВЁ-рен]",
@@ -1448,9 +1650,14 @@
                 "collocations": [
                     "Das Schwören fällt Lear unerwartet schwer. — Лиру неожиданно тяжело клясться.",
                     "Ich schwöre, dass ich Euch mehr liebe als mein Leben. — Я клянусь, что люблю вас больше жизни."
+                ],
+                "sentenceParts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Goneril über Lears schweren Tisch.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „schwören“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Erbe",
                 "translation": "наследство",
                 "transcription": "[дас ЕР-бе]",
@@ -1471,9 +1678,14 @@
                 "collocations": [
                     "Cordelia merkt sich genau, wie das Erbe verteilt wird. — Корделия внимательно следит, кому достанется «наследство».",
                     "Das Erbe ist endlich mein. — Наследство наконец моё."
+                ],
+                "sentenceParts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Goneril die Hände hinter dem Rücken.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „das Erbe“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "heucheln",
                 "translation": "лицемерить",
                 "transcription": "[ХОЙ-хельн]",
@@ -1495,9 +1707,14 @@
                 ],
                 "collocations": [
                     "Ich muss vor meinem Vater heucheln. — Я должна лицемерить перед отцом."
+                ],
+                "sentenceParts": [
+                    "Zwischen flüsternden Höflingen gleitet Goneril über den kalten Marmorboden.",
+                    "Ich umarme das Wort „heucheln“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Gier",
                 "translation": "жадность",
                 "transcription": "[ди ГИР]",
@@ -1519,9 +1736,14 @@
                     "Der Narr spottet, sobald die Gier erwähnt wird. — Шут насмехается, едва кто-то произносит «жадность».",
                     "Die Gier nach Macht verzehrt meine Seele. — Жадность к власти пожирает мою душу.",
                     "Die Gier nach Macht treibt mich an. — Жадность к власти движет мной."
+                ],
+                "sentenceParts": [
+                    "Am Rand des purpurnen Teppichs wartet Goneril auf ein Zeichen des Königs.",
+                    "Ich zeichne das Wort „die Gier“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "täuschen",
                 "translation": "обманывать",
                 "transcription": "[ТОЙ-шен]",
@@ -1546,9 +1768,14 @@
                     "Ich täusche ihn, um sein Leben zu retten. — Я обманываю его, чтобы спасти его жизнь.",
                     "Edmund täuscht mich mit falschen Beweisen. — Эдмунд обманывает меня ложными доказательствами.",
                     "Ich täusche meinen alten Vater leicht. — Я легко обманываю старого отца."
+                ],
+                "sentenceParts": [
+                    "Unter wehenden Standarten der Schwestern senkt Goneril kurz den Blick.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „täuschen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "schmeicheln",
                 "translation": "льстить",
                 "transcription": "[ШМАЙ-хельн]",
@@ -1569,9 +1796,14 @@
                 "collocations": [
                     "Cordelia zeigt, dass das Schmeicheln auch ohne Stolz möglich ist. — Корделия показывает, что льстить можно и без гордыни.",
                     "Mit süßen Worten schmeichle ich ihm. — Сладкими словами я льщу ему."
+                ],
+                "sentenceParts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Goneril das gespannte Antlitz des Hofes.",
+                    "Das Echo des Wortes „schmeicheln“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Vermögen",
                 "translation": "состояние",
                 "transcription": "[дас фер-МЁ-ген]",
@@ -1593,6 +1825,10 @@
                 ],
                 "collocations": [
                     "Sein ganzes Vermögen wird mir gehören. — Всё его состояние будет моим."
+                ],
+                "sentenceParts": [
+                    "Im Schein der offenen Feuerbecken erhebt Goneril langsam die Stimme.",
+                    "Ich umarme das Wort „das Vermögen“, als wäre es mein einziger Verbündeter."
                 ]
             }
         ],
@@ -1600,19 +1836,19 @@
             {
                 "question": "Что означает немецкое слово «die Lüge»?",
                 "choices": [
-                    "клясться",
-                    "ложь",
                     "наследство",
-                    "лицемерить"
+                    "клясться",
+                    "лицемерить",
+                    "ложь"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «schwören»?",
                 "choices": [
                     "лицемерить",
-                    "наследство",
                     "ложь",
+                    "наследство",
                     "клясться"
                 ],
                 "correctIndex": 3
@@ -1620,71 +1856,154 @@
             {
                 "question": "Что означает немецкое слово «das Erbe»?",
                 "choices": [
-                    "клясться",
-                    "состояние",
-                    "лицемерить",
-                    "наследство"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «heucheln»?",
-                "choices": [
-                    "состояние",
-                    "обманывать",
-                    "лицемерить",
-                    "клясться"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Gier»?",
-                "choices": [
-                    "наследство",
-                    "обманывать",
-                    "лицемерить",
-                    "жадность"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «täuschen»?",
-                "choices": [
-                    "лицемерить",
-                    "обманывать",
                     "льстить",
-                    "наследство"
+                    "наследство",
+                    "жадность",
+                    "состояние"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «heucheln»?",
+                "choices": [
+                    "лицемерить",
+                    "ложь",
+                    "клясться",
+                    "обманывать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Gier»?",
+                "choices": [
+                    "ложь",
+                    "жадность",
+                    "льстить",
+                    "обманывать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «täuschen»?",
+                "choices": [
+                    "обманывать",
+                    "жадность",
+                    "состояние",
+                    "ложь"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «schmeicheln»?",
                 "choices": [
-                    "наследство",
                     "состояние",
-                    "льстить",
-                    "лицемерить"
+                    "жадность",
+                    "клясться",
+                    "льстить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Vermögen»?",
                 "choices": [
                     "жадность",
-                    "ложь",
+                    "наследство",
                     "состояние",
-                    "льстить"
+                    "ложь"
                 ],
                 "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Lüge",
+                "translation": "ложь",
+                "parts": [
+                    "Goneril steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Lüge“ bleibt lebendig."
+                ],
+                "sentence": "Goneril steht unter dem glühenden Kronleuchter des Thronsaals. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Lüge“ bleibt lebendig.",
+                "sentenceTranslation": "Гонерилья стоит под пылающей люстрой тронного зала. Каждой клеткой тела я обещаю: слово «ложь» останется живым."
+            },
+            {
+                "word": "schwören",
+                "translation": "клясться",
+                "parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Goneril über Lears schweren Tisch.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „schwören“ darf nicht vergehen."
+                ],
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Goneril über Lears schweren Tisch. Ich flüstere den Wächtern des Schicksals zu: Das Wort „schwören“ darf nicht vergehen.",
+                "sentenceTranslation": "У развернутой карты королевства Гонерилья склоняется над тяжёлым столом Лира. Я шепчу стражам судьбы: слово «клясться» не должно исчезнуть."
+            },
+            {
+                "word": "das Erbe",
+                "translation": "наследство",
+                "parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Goneril die Hände hinter dem Rücken.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „das Erbe“ bleibt lebendig."
+                ],
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Goneril die Hände hinter dem Rücken. Mit jeder Faser meines Körpers verspreche ich: Das Wort „das Erbe“ bleibt lebendig.",
+                "sentenceTranslation": "Перед каменными статуями предков Гонерилья сцепляет руки за спиной. Каждой клеткой тела я обещаю: слово «наследство» останется живым."
+            },
+            {
+                "word": "heucheln",
+                "translation": "лицемерить",
+                "parts": [
+                    "Zwischen flüsternden Höflingen gleitet Goneril über den kalten Marmorboden.",
+                    "Ich umarme das Wort „heucheln“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Zwischen flüsternden Höflingen gleitet Goneril über den kalten Marmorboden. Ich umarme das Wort „heucheln“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Между шепчущимися придворными Гонерилья скользит по холодному мраморному полу. Я обнимаю слово «лицемерить», будто это единственный союзник."
+            },
+            {
+                "word": "die Gier",
+                "translation": "жадность",
+                "parts": [
+                    "Am Rand des purpurnen Teppichs wartet Goneril auf ein Zeichen des Königs.",
+                    "Ich zeichne das Wort „die Gier“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Am Rand des purpurnen Teppichs wartet Goneril auf ein Zeichen des Königs. Ich zeichne das Wort „die Gier“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На краю пурпурного ковра Гонерилья ждёт знака от короля. Я черчу слово «жадность» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "täuschen",
+                "translation": "обманывать",
+                "parts": [
+                    "Unter wehenden Standarten der Schwestern senkt Goneril kurz den Blick.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „täuschen“ bleibt lebendig."
+                ],
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Goneril kurz den Blick. Mit jeder Faser meines Körpers verspreche ich: Das Wort „täuschen“ bleibt lebendig.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Гонерилья на миг опускает взгляд. Каждой клеткой тела я обещаю: слово «обманывать» останется живым."
+            },
+            {
+                "word": "schmeicheln",
+                "translation": "льстить",
+                "parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Goneril das gespannte Antlitz des Hofes.",
+                    "Das Echo des Wortes „schmeicheln“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Goneril das gespannte Antlitz des Hofes. Das Echo des Wortes „schmeicheln“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "За позолоченной балюстрадой Гонерилья наблюдает за напряжёнными лицами двора. Эхо слова «льстить» заглушает шёпот придворных."
+            },
+            {
+                "word": "das Vermögen",
+                "translation": "состояние",
+                "parts": [
+                    "Im Schein der offenen Feuerbecken erhebt Goneril langsam die Stimme.",
+                    "Ich umarme das Wort „das Vermögen“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Goneril langsam die Stimme. Ich umarme das Wort „das Vermögen“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В отблесках открытых жаровен Гонерилья медленно поднимает голос. Я обнимаю слово «состояние», будто это единственный союзник."
+            }
+        ]
     },
     "goneril": {
         "title": "Захват власти",
         "description": "Акт I: Раздел королевства",
         "words": [
             {
+                "wordId": "",
                 "word": "die Macht",
                 "translation": "власть",
                 "transcription": "[ди МАХТ]",
@@ -1708,9 +2027,14 @@
                     "Die Macht über das Königreich ist nah. — Власть над королевством близка.",
                     "Die Macht bedeutet nichts ohne wahre Liebe. — Власть ничего не значит без истинной любви.",
                     "Die Macht über das halbe Königreich ist mein. — Власть над половиной королевства моя."
+                ],
+                "sentenceParts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Goneril zwischen gepackten Kisten.",
+                    "Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "herrschen",
                 "translation": "править",
                 "transcription": "[ХЕР-шен]",
@@ -1733,9 +2057,14 @@
                     "Der Narr spürt, wie das Herrschen alle verändert. — Шут чувствует, как умение править меняет всех.",
                     "Ich habe lange genug geherrscht. — Я правил достаточно долго.",
                     "Jetzt herrsche ich über meine Länder. — Теперь я правлю своими землями."
+                ],
+                "sentenceParts": [
+                    "Auf der windigen Freitreppe blickt Goneril zum schweigenden Hof hinunter.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „herrschen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "befehlen",
                 "translation": "приказывать",
                 "transcription": "[бе-ФЕ-лен]",
@@ -1756,9 +2085,14 @@
                 "collocations": [
                     "Das Befehlen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело приказывать.",
                     "Ich befehle, und alle gehorchen mir. — Я приказываю, и все подчиняются мне."
+                ],
+                "sentenceParts": [
+                    "Zwischen zurückgelassenen Dienern schließt Goneril den Reisemantel enger.",
+                    "Das Echo des Wortes „befehlen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Thron",
                 "translation": "трон",
                 "transcription": "[дер ТРОН]",
@@ -1780,9 +2114,14 @@
                     "Während des Sturms wirkt der Thron noch bedrückender. — Во время бури само «трон» звучит ещё тяжелее.",
                     "Vom Thron herab verkünde ich meinen Willen. — С трона я провозглашаю свою волю.",
                     "Der Thron meines Vaters wird bald leer sein. — Трон моего отца скоро опустеет."
+                ],
+                "sentenceParts": [
+                    "Am dunklen Pferdestall streicht Goneril einem nervösen Tier über die Mähne.",
+                    "Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erobern",
                 "translation": "завоёвывать",
                 "transcription": "[ер-О-берн]",
@@ -1805,9 +2144,14 @@
                     "Der Narr spürt, wie das Erobern alle verändert. — Шут чувствует, как умение завоевывать меняет всех.",
                     "Wir erobern das Reich gemeinsam. — Мы завоёвываем королевство вместе.",
                     "Ich erobere, was mir zusteht. — Я завоёвываю то, что мне положено."
+                ],
+                "sentenceParts": [
+                    "Vor dem knarrenden Fallgatter tastet Goneril ein letztes Mal nach dem Haustor.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „erobern“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Herrschaft",
                 "translation": "господство",
                 "transcription": "[ди ХЕР-шафт]",
@@ -1834,9 +2178,14 @@
                 "collocations": [
                     "Die Herrschaft fällt nun in meine Hände. — Правление теперь переходит в мои руки.",
                     "Die Herrschaft über alle ist mein Ziel. — Господство над всеми - моя цель."
+                ],
+                "sentenceParts": [
+                    "Zwischen verstreuten Schriftrollen dreht Goneril den Ring an der Hand.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Herrschaft“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "regieren",
                 "translation": "управлять",
                 "transcription": "[ре-ГИ-рен]",
@@ -1860,9 +2209,14 @@
                     "Der Narr spürt, wie das Regieren alle verändert. — Шут чувствует, как умение управлять меняет всех.",
                     "Mit Weisheit werde ich regieren. — С мудростью я буду править.",
                     "Ich werde mit eiserner Hand regieren. — Я буду управлять железной рукой."
+                ],
+                "sentenceParts": [
+                    "Am leeren Bankettisch zählt Goneril die verlöschenden Kerzen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „regieren“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "unterwerfen",
                 "translation": "подчинять",
                 "transcription": "[ун-тер-ВЕР-фен]",
@@ -1883,6 +2237,10 @@
                 "collocations": [
                     "Der Narr spürt, wie das Unterwerfen alle verändert. — Шут чувствует, как умение подчинять меняет всех.",
                     "Alle müssen sich mir unterwerfen. — Все должны мне подчиниться."
+                ],
+                "sentenceParts": [
+                    "Zwischen schweigenden Wachen geht Goneril auf den kalten Hof hinaus.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „unterwerfen“ bleibt lebendig."
                 ]
             }
         ],
@@ -1891,90 +2249,173 @@
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
                     "власть",
-                    "трон",
+                    "приказывать",
                     "править",
-                    "приказывать"
+                    "трон"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
-                    "власть",
-                    "приказывать",
                     "править",
-                    "трон"
+                    "приказывать",
+                    "трон",
+                    "власть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «befehlen»?",
                 "choices": [
                     "трон",
-                    "приказывать",
+                    "завоёвывать",
                     "править",
-                    "господство"
+                    "приказывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
-                    "приказывать",
                     "трон",
-                    "править",
-                    "власть"
+                    "власть",
+                    "управлять",
+                    "приказывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
-                    "трон",
-                    "господство",
                     "завоёвывать",
-                    "власть"
+                    "трон",
+                    "управлять",
+                    "подчинять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
-                    "править",
                     "управлять",
-                    "завоёвывать",
-                    "господство"
+                    "приказывать",
+                    "господство",
+                    "трон"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
                     "управлять",
-                    "завоёвывать",
-                    "господство",
-                    "власть"
+                    "править",
+                    "власть",
+                    "подчинять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «unterwerfen»?",
                 "choices": [
-                    "трон",
-                    "править",
-                    "завоёвывать",
+                    "господство",
+                    "власть",
+                    "управлять",
                     "подчинять"
                 ],
                 "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Macht",
+                "translation": "власть",
+                "parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Goneril zwischen gepackten Kisten.",
+                    "Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Goneril zwischen gepackten Kisten. Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Гонерилья замирает среди нагруженных ящиков. Я обнимаю слово «власть», будто это единственный союзник."
+            },
+            {
+                "word": "herrschen",
+                "translation": "править",
+                "parts": [
+                    "Auf der windigen Freitreppe blickt Goneril zum schweigenden Hof hinunter.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „herrschen“ gehört mir."
+                ],
+                "sentence": "Auf der windigen Freitreppe blickt Goneril zum schweigenden Hof hinunter. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „herrschen“ gehört mir.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Гонерилья смотрит вниз на молчаливый двор. Буря за окнами усиливает клятву: слово «править» принадлежит мне."
+            },
+            {
+                "word": "befehlen",
+                "translation": "приказывать",
+                "parts": [
+                    "Zwischen zurückgelassenen Dienern schließt Goneril den Reisemantel enger.",
+                    "Das Echo des Wortes „befehlen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Goneril den Reisemantel enger. Das Echo des Wortes „befehlen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Среди оставленных слуг Гонерилья плотнее запахивает дорожный плащ. Эхо слова «приказывать» заглушает шёпот придворных."
+            },
+            {
+                "word": "der Thron",
+                "translation": "трон",
+                "parts": [
+                    "Am dunklen Pferdestall streicht Goneril einem nervösen Tier über die Mähne.",
+                    "Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Am dunklen Pferdestall streicht Goneril einem nervösen Tier über die Mähne. Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Гонерилья гладит гриву нервного коня. Моё дыхание рисует слово «трон» в холодном воздухе между нами."
+            },
+            {
+                "word": "erobern",
+                "translation": "завоёвывать",
+                "parts": [
+                    "Vor dem knarrenden Fallgatter tastet Goneril ein letztes Mal nach dem Haustor.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „erobern“ bleibt lebendig."
+                ],
+                "sentence": "Vor dem knarrenden Fallgatter tastet Goneril ein letztes Mal nach dem Haustor. Mit jeder Faser meines Körpers verspreche ich: Das Wort „erobern“ bleibt lebendig.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Гонерилья в последний раз касается родной двери. Каждой клеткой тела я обещаю: слово «завоёвывать» останется живым."
+            },
+            {
+                "word": "die Herrschaft",
+                "translation": "господство",
+                "parts": [
+                    "Zwischen verstreuten Schriftrollen dreht Goneril den Ring an der Hand.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Herrschaft“ gehört mir."
+                ],
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Goneril den Ring an der Hand. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Herrschaft“ gehört mir.",
+                "sentenceTranslation": "Среди разбросанных свитков Гонерилья вертит кольцо на пальце. Буря за окнами усиливает клятву: слово «господство» принадлежит мне."
+            },
+            {
+                "word": "regieren",
+                "translation": "управлять",
+                "parts": [
+                    "Am leeren Bankettisch zählt Goneril die verlöschenden Kerzen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „regieren“ wird heute nicht verraten."
+                ],
+                "sentence": "Am leeren Bankettisch zählt Goneril die verlöschenden Kerzen. Mit fester Stimme schwöre ich mir: Das Wort „regieren“ wird heute nicht verraten.",
+                "sentenceTranslation": "У пустого банкетного стола Гонерилья пересчитывает гаснущие свечи. Твёрдым голосом я клянусь себе: слово «управлять» сегодня не будет предано."
+            },
+            {
+                "word": "unterwerfen",
+                "translation": "подчинять",
+                "parts": [
+                    "Zwischen schweigenden Wachen geht Goneril auf den kalten Hof hinaus.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „unterwerfen“ bleibt lebendig."
+                ],
+                "sentence": "Zwischen schweigenden Wachen geht Goneril auf den kalten Hof hinaus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „unterwerfen“ bleibt lebendig.",
+                "sentenceTranslation": "Между молчаливыми стражниками Гонерилья выходит на холодный двор. Каждой клеткой тела я обещаю: слово «подчинять» останется живым."
+            }
+        ]
     },
     "regan": {
         "title": "Унижение отца",
         "description": "Акт II: Жестокость к Лиру",
         "words": [
             {
+                "wordId": "",
                 "word": "demütigen",
                 "translation": "унижать",
                 "transcription": "[де-МЮ-ти-ген]",
@@ -2003,9 +2444,14 @@
                     "Meine eigene Tochter will mich demütigen! — Моя собственная дочь хочет меня унизить!",
                     "Ich demütige ihn vor aller Augen. — Я унижаю его на глазах у всех.",
                     "Ich demütige meinen alten Vater ohne Mitleid. — Я унижаю старого отца без жалости."
+                ],
+                "sentenceParts": [
+                    "Im zugigen Seitenflügel lauscht Goneril dem Heulen der Küstenwinde.",
+                    "Ich zeichne das Wort „demütigen“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "grausam",
                 "translation": "жестокий",
                 "transcription": "[ГРАУ-зам]",
@@ -2027,9 +2473,14 @@
                 ],
                 "collocations": [
                     "Ich bin grausam zu dem, der mir alles gab. — Я жестока к тому, кто дал мне всё."
+                ],
+                "sentenceParts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Goneril einen zerknitterten Brief.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „grausam“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Rache",
                 "translation": "месть",
                 "transcription": "[ди РА-хе]",
@@ -2053,9 +2504,14 @@
                     "Nicht Rache, sondern Gerechtigkeit leitet meine Klinge. — Не месть, а справедливость ведёт мой клинок.",
                     "Dies ist ihre Rache für meine Treue. — Это их месть за мою верность.",
                     "Die Rache für Jahre der Unterwerfung. — Месть за годы подчинения."
+                ],
+                "sentenceParts": [
+                    "Unter farblosen Wandteppichen schreitet Goneril rastlos auf und ab.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Rache“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vertreiben",
                 "translation": "изгонять",
                 "transcription": "[фер-ТРАЙ-бен]",
@@ -2081,9 +2537,14 @@
                     "Aus meinem eigenen Haus will sie mich vertreiben! — Из моего собственного дома она хочет меня изгнать!",
                     "Ich vertreibe Edgar aus seinem Erbe. — Я изгоняю Эдгара из его наследства.",
                     "Ich vertreibe ihn aus meinem Haus. — Я изгоняю его из моего дома."
+                ],
+                "sentenceParts": [
+                    "An der schmalen Fensterluke zählt Goneril die Fackeln auf dem Hof.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verachten",
                 "translation": "презирать",
                 "transcription": "[фер-АХ-тен]",
@@ -2105,9 +2566,14 @@
                 ],
                 "collocations": [
                     "Ich verachte seine Schwäche und sein Alter. — Я презираю его слабость и старость."
+                ],
+                "sentenceParts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Goneril nach frischen Botschaften.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „verachten“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verweigern",
                 "translation": "отказывать",
                 "transcription": "[фер-ВАЙ-герн]",
@@ -2129,9 +2595,14 @@
                 ],
                 "collocations": [
                     "Ich verweigere ihm jeden Komfort. — Я отказываю ему в любом комфорте."
+                ],
+                "sentenceParts": [
+                    "Im stillen Kapellenraum kniet Goneril vor der kalten Steinfigur.",
+                    "Ich zeichne das Wort „verweigern“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "quälen",
                 "translation": "мучить",
                 "transcription": "[КВЕ-лен]",
@@ -2153,9 +2624,14 @@
                     "Der Narr spürt, wie das Quälen alle verändert. — Шут чувствует, как умение мучить меняет всех.",
                     "Es bereitet mir Freude, ihn zu quälen. — Мне доставляет радость мучить его.",
                     "Es macht mir Freude, ihn zu quälen. — Мне доставляет радость мучить его."
+                ],
+                "sentenceParts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Goneril die Laterne fest.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „quälen“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "beschränken",
                 "translation": "ограничивать",
                 "transcription": "[бе-ШРЕН-кен]",
@@ -2177,6 +2653,10 @@
                 ],
                 "collocations": [
                     "Ich beschränke seine Dienerschaft auf null. — Я ограничиваю его свиту до нуля."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der hohen Burgmauern schreibt Goneril eine fiebrige Antwort.",
+                    "Ich presse das Wort „beschränken“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             }
         ],
@@ -2184,91 +2664,174 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "унижать",
                     "жестокий",
+                    "месть",
                     "изгонять",
-                    "месть"
+                    "унижать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «grausam»?",
                 "choices": [
-                    "унижать",
+                    "изгонять",
                     "месть",
                     "жестокий",
-                    "изгонять"
+                    "унижать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "жестокий",
+                    "месть",
                     "ограничивать",
-                    "отказывать",
-                    "месть"
+                    "мучить",
+                    "отказывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
+                    "месть",
                     "отказывать",
-                    "ограничивать",
                     "изгонять",
-                    "презирать"
+                    "ограничивать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verachten»?",
                 "choices": [
-                    "жестокий",
-                    "месть",
-                    "презирать",
-                    "ограничивать"
+                    "отказывать",
+                    "изгонять",
+                    "ограничивать",
+                    "презирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verweigern»?",
                 "choices": [
                     "ограничивать",
-                    "отказывать",
                     "унижать",
-                    "месть"
+                    "отказывать",
+                    "жестокий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
-                    "унижать",
-                    "мучить",
+                    "месть",
                     "презирать",
-                    "изгонять"
+                    "жестокий",
+                    "мучить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «beschränken»?",
                 "choices": [
-                    "презирать",
+                    "месть",
                     "ограничивать",
-                    "жестокий",
+                    "изгонять",
                     "мучить"
                 ],
                 "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "demütigen",
+                "translation": "унижать",
+                "parts": [
+                    "Im zugigen Seitenflügel lauscht Goneril dem Heulen der Küstenwinde.",
+                    "Ich zeichne das Wort „demütigen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Im zugigen Seitenflügel lauscht Goneril dem Heulen der Küstenwinde. Ich zeichne das Wort „demütigen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Гонерилья слушает вой прибрежного ветра. Я вывожу слово «унижать» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "grausam",
+                "translation": "жестокий",
+                "parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Goneril einen zerknitterten Brief.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „grausam“ gehört mir."
+                ],
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Goneril einen zerknitterten Brief. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „grausam“ gehört mir.",
+                "sentenceTranslation": "Перед дымным камином замка Гонерилья складывает измятый лист. Буря за окнами усиливает клятву: слово «жестокий» принадлежит мне."
+            },
+            {
+                "word": "die Rache",
+                "translation": "месть",
+                "parts": [
+                    "Unter farblosen Wandteppichen schreitet Goneril rastlos auf und ab.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Rache“ mein Nordstern."
+                ],
+                "sentence": "Unter farblosen Wandteppichen schreitet Goneril rastlos auf und ab. Selbst wenn die Welt zerfällt, bleibt das Wort „die Rache“ mein Nordstern.",
+                "sentenceTranslation": "Под выцветшими гобеленами Гонерилья беспокойно меряет шагами зал. Даже если мир распадается, слово «месть» остаётся моим северным светом."
+            },
+            {
+                "word": "vertreiben",
+                "translation": "изгонять",
+                "parts": [
+                    "An der schmalen Fensterluke zählt Goneril die Fackeln auf dem Hof.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten."
+                ],
+                "sentence": "An der schmalen Fensterluke zählt Goneril die Fackeln auf dem Hof. Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten.",
+                "sentenceTranslation": "У узкой бойницы Гонерилья считает факелы на дворе. Твёрдым голосом я клянусь себе: слово «изгонять» сегодня не будет предано."
+            },
+            {
+                "word": "verachten",
+                "translation": "презирать",
+                "parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Goneril nach frischen Botschaften.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „verachten“ wird heute nicht verraten."
+                ],
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Goneril nach frischen Botschaften. Mit fester Stimme schwöre ich mir: Das Wort „verachten“ wird heute nicht verraten.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Гонерилья ищет свежие вести. Твёрдым голосом я клянусь себе: слово «презирать» сегодня не будет предано."
+            },
+            {
+                "word": "verweigern",
+                "translation": "отказывать",
+                "parts": [
+                    "Im stillen Kapellenraum kniet Goneril vor der kalten Steinfigur.",
+                    "Ich zeichne das Wort „verweigern“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Im stillen Kapellenraum kniet Goneril vor der kalten Steinfigur. Ich zeichne das Wort „verweigern“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В тихой капелле Гонерилья преклоняет колени перед холодной каменной фигурой. Я черчу слово «отказывать» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "quälen",
+                "translation": "мучить",
+                "parts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Goneril die Laterne fest.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „quälen“ mein Nordstern."
+                ],
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Goneril die Laterne fest. Selbst wenn die Welt zerfällt, bleibt das Wort „quälen“ mein Nordstern.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Гонерилья крепко держит фонарь. Даже если мир распадается, слово «мучить» остаётся моим северным светом."
+            },
+            {
+                "word": "beschränken",
+                "translation": "ограничивать",
+                "parts": [
+                    "Im Schatten der hohen Burgmauern schreibt Goneril eine fiebrige Antwort.",
+                    "Ich presse das Wort „beschränken“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Goneril eine fiebrige Antwort. Ich presse das Wort „beschränken“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В тени высоких стен Гонерилья пишет лихорадочный ответ. Я стискиваю слово «ограничивать» зубами, чтобы не вырвалось сомнение."
+            }
+        ]
     },
     "storm": {
         "title": "Изгнание в бурю",
         "description": "Акт III: Лир в буре",
         "words": [
             {
+                "wordId": "",
                 "word": "verstoßen",
                 "translation": "отвергать",
                 "transcription": "[фер-ШТО-сен]",
@@ -2296,9 +2859,14 @@
                     "Der König verstößt mich aus seinem Herzen. — Король изгоняет меня из своего сердца.",
                     "Ich verstoße meinen unschuldigen Sohn. — Я изгоняю своего невинного сына.",
                     "Ich verstoße meinen Vater in die Nacht. — Я отвергаю отца в ночь."
+                ],
+                "sentenceParts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Goneril gegen den Wind.",
+                    "Wie ein stilles Gebet legt sich das Wort „verstoßen“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Sturm",
                 "translation": "буря",
                 "transcription": "[дер ШТУРМ]",
@@ -2322,9 +2890,14 @@
                     "Der Sturm tobt über unseren Köpfen. — Буря бушует над нашими головами.",
                     "Im Sturm bleibe ich bei meinem König. — В буре я остаюсь с моим королём.",
                     "Der Sturm soll sein neues Zuhause sein. — Буря пусть будет его новым домом."
+                ],
+                "sentenceParts": [
+                    "Unter einem zerrissenen Banner schützt Goneril die Augen vor den Blitzen.",
+                    "Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "gnadenlos",
                 "translation": "безжалостный",
                 "transcription": "[ГНА-ден-лос]",
@@ -2346,9 +2919,14 @@
                 ],
                 "collocations": [
                     "Ich bin gnadenlos wie der Winter. — Я безжалостна как зима."
+                ],
+                "sentenceParts": [
+                    "Am Rand eines umgestürzten Baumes sucht Goneril Deckung vor dem Donner.",
+                    "Ich halte das Wort „gnadenlos“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verschließen",
                 "translation": "запирать",
                 "transcription": "[фер-ШЛИ-сен]",
@@ -2370,9 +2948,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Verschließen ist. — Во время бури становится понятно, насколько важно запирать.",
                     "Ich verschließe meine Türen vor ihm. — Я запираю двери перед ним."
+                ],
+                "sentenceParts": [
+                    "Zwischen schäumenden Wassergräben stolpert Goneril durch den Schlamm.",
+                    "Ich presse das Wort „verschließen“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Kälte",
                 "translation": "холод",
                 "transcription": "[ди КЕЛ-те]",
@@ -2397,9 +2980,14 @@
                 "collocations": [
                     "Die Kälte dringt in unsere Knochen. — Холод проникает в наши кости.",
                     "Die Kälte meines Herzens übertrifft den Winter. — Холод моего сердца превосходит зиму."
+                ],
+                "sentenceParts": [
+                    "Vor einem zuckenden Himmel hebt Goneril die Arme trotzig an.",
+                    "Ich atme tief ein und lasse nur das Wort „die Kälte“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erbarmungslos",
                 "translation": "беспощадный",
                 "transcription": "[ер-БАР-мунгс-лос]",
@@ -2428,9 +3016,14 @@
                     "Erbarmungslos verfolge ich mein Ziel. — Беспощадно я преследую свою цель.",
                     "Ich bin erbarmungslos in meiner Rache. — Я беспощадна в своей мести.",
                     "Erbarmungslos werfe ich ihn hinaus. — Беспощадно я выбрасываю его."
+                ],
+                "sentenceParts": [
+                    "Unter dem durchtränkten Umhang presst Goneril den Atem gegen die Kälte.",
+                    "Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verhärten",
                 "translation": "ожесточаться",
                 "transcription": "[фер-ХЕР-тен]",
@@ -2452,6 +3045,10 @@
                 ],
                 "collocations": [
                     "Mein Herz verhärtet sich gegen alle Bitten. — Моё сердце ожесточается против всех просьб."
+                ],
+                "sentenceParts": [
+                    "Am kläglichen Feuerrest wärmt Goneril zitternde Finger.",
+                    "Ich atme tief ein und lasse nur das Wort „verhärten“ wieder hinaus."
                 ]
             }
         ],
@@ -2459,9 +3056,9 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "буря",
                     "безжалостный",
                     "запирать",
+                    "буря",
                     "отвергать"
                 ],
                 "correctIndex": 3
@@ -2469,29 +3066,29 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "буря",
                     "отвергать",
-                    "безжалостный",
-                    "запирать"
+                    "буря",
+                    "запирать",
+                    "безжалостный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «gnadenlos»?",
                 "choices": [
+                    "запирать",
+                    "отвергать",
                     "безжалостный",
-                    "буря",
-                    "ожесточаться",
-                    "беспощадный"
+                    "ожесточаться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verschließen»?",
                 "choices": [
+                    "холод",
+                    "беспощадный",
                     "буря",
-                    "ожесточаться",
-                    "безжалостный",
                     "запирать"
                 ],
                 "correctIndex": 3
@@ -2499,41 +3096,114 @@
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
+                    "отвергать",
+                    "безжалостный",
                     "холод",
-                    "запирать",
-                    "буря",
-                    "ожесточаться"
+                    "буря"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
                     "отвергать",
-                    "запирать",
-                    "буря",
-                    "беспощадный"
+                    "беспощадный",
+                    "безжалостный",
+                    "холод"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verhärten»?",
                 "choices": [
-                    "беспощадный",
+                    "отвергать",
                     "ожесточаться",
                     "запирать",
-                    "безжалостный"
+                    "беспощадный"
                 ],
                 "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "verstoßen",
+                "translation": "отвергать",
+                "parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Goneril gegen den Wind.",
+                    "Wie ein stilles Gebet legt sich das Wort „verstoßen“ auf meine Lippen."
+                ],
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Goneril gegen den Wind. Wie ein stilles Gebet legt sich das Wort „verstoßen“ auf meine Lippen.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Гонерилья упирается в ветер. Как тихая молитва слово «отвергать» ложится на мои губы."
+            },
+            {
+                "word": "der Sturm",
+                "translation": "буря",
+                "parts": [
+                    "Unter einem zerrissenen Banner schützt Goneril die Augen vor den Blitzen.",
+                    "Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Unter einem zerrissenen Banner schützt Goneril die Augen vor den Blitzen. Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Под разорванным знаменем Гонерилья прикрывает глаза от молний. Я обнимаю слово «буря», будто это единственный союзник."
+            },
+            {
+                "word": "gnadenlos",
+                "translation": "безжалостный",
+                "parts": [
+                    "Am Rand eines umgestürzten Baumes sucht Goneril Deckung vor dem Donner.",
+                    "Ich halte das Wort „gnadenlos“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Goneril Deckung vor dem Donner. Ich halte das Wort „gnadenlos“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У поваленного дерева Гонерилья ищет укрытия от грома. Я держу слово «безжалостный» как факел у сердца."
+            },
+            {
+                "word": "verschließen",
+                "translation": "запирать",
+                "parts": [
+                    "Zwischen schäumenden Wassergräben stolpert Goneril durch den Schlamm.",
+                    "Ich presse das Wort „verschließen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Goneril durch den Schlamm. Ich presse das Wort „verschließen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Между пенящимися лужами Гонерилья пробирается через грязь. Я стискиваю слово «запирать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Kälte",
+                "translation": "холод",
+                "parts": [
+                    "Vor einem zuckenden Himmel hebt Goneril die Arme trotzig an.",
+                    "Ich atme tief ein und lasse nur das Wort „die Kälte“ wieder hinaus."
+                ],
+                "sentence": "Vor einem zuckenden Himmel hebt Goneril die Arme trotzig an. Ich atme tief ein und lasse nur das Wort „die Kälte“ wieder hinaus.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Гонерилья упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «холод»."
+            },
+            {
+                "word": "erbarmungslos",
+                "translation": "беспощадный",
+                "parts": [
+                    "Unter dem durchtränkten Umhang presst Goneril den Atem gegen die Kälte.",
+                    "Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Unter dem durchtränkten Umhang presst Goneril den Atem gegen die Kälte. Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под промокшим плащом Гонерилья прижимает дыхание к груди, спасаясь от холода. Я стискиваю слово «беспощадный» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "verhärten",
+                "translation": "ожесточаться",
+                "parts": [
+                    "Am kläglichen Feuerrest wärmt Goneril zitternde Finger.",
+                    "Ich atme tief ein und lasse nur das Wort „verhärten“ wieder hinaus."
+                ],
+                "sentence": "Am kläglichen Feuerrest wärmt Goneril zitternde Finger. Ich atme tief ein und lasse nur das Wort „verhärten“ wieder hinaus.",
+                "sentenceTranslation": "У жалких огненных углей Гонерилья греет дрожащие пальцы. Я глубоко вдыхаю и выпускаю только слово «ожесточаться»."
+            }
+        ]
     },
     "hut": {
         "title": "Конфликт с мужем",
         "description": "Акт IV: Разлад с Олбани",
         "words": [
             {
+                "wordId": "",
                 "word": "streiten",
                 "translation": "ссориться",
                 "transcription": "[ШТРАЙ-тен]",
@@ -2555,9 +3225,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Streiten ist. — Во время бури становится понятно, насколько важно спорить.",
                     "Ich streite mit meinem schwachen Mann. — Я ссорюсь со своим слабым мужем."
+                ],
+                "sentenceParts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Goneril bei der flackernden Kerze.",
+                    "Ich atme tief ein und lasse nur das Wort „streiten“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verraten",
                 "translation": "предавать",
                 "transcription": "[фер-РА-тен]",
@@ -2583,9 +3258,14 @@
                     "Ich verrate jeden an meine Herrin. — Я выдаю каждого своей госпоже.",
                     "Ich verrate meinen eigenen Vater. — Я предаю собственного отца.",
                     "Ich verrate meinen Mann für Edmund. — Я предаю мужа ради Эдмунда."
+                ],
+                "sentenceParts": [
+                    "Zwischen zerbeulten Rüstungen streicht Goneril über ein altes Wappen.",
+                    "Ich atme tief ein und lasse nur das Wort „verraten“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Zwietracht",
                 "translation": "раздор",
                 "transcription": "[ди ЦВИ-трахт]",
@@ -2607,9 +3287,14 @@
                 ],
                 "collocations": [
                     "Die Zwietracht zerstört unsere Ehe. — Раздор разрушает наш брак."
+                ],
+                "sentenceParts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Goneril fast den Kopf.",
+                    "Ich zeichne das Wort „die Zwietracht“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "hassen",
                 "translation": "ненавидеть",
                 "transcription": "[ХА-сен]",
@@ -2631,9 +3316,14 @@
                     "Das Hassen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело ненавидеть.",
                     "Ich hasse meine Schwester mehr als je zuvor. — Я ненавижу сестру больше, чем когда-либо.",
                     "Ich hasse seine Schwäche und Güte. — Я ненавижу его слабость и доброту."
+                ],
+                "sentenceParts": [
+                    "Neben der schlafenden Wache flüstert Goneril in die schwere Nacht.",
+                    "Ich zeichne das Wort „hassen“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "betrügen",
                 "translation": "изменять",
                 "transcription": "[бе-ТРЮ-ген]",
@@ -2658,9 +3348,14 @@
                 "collocations": [
                     "Cordelia zeigt, dass das Betrügen auch ohne Stolz möglich ist. — Корделия показывает, что обманывать можно и без гордыни.",
                     "Ich betrüge ihn mit Edmund. — Я изменяю ему с Эдмундом."
+                ],
+                "sentenceParts": [
+                    "Vor dem einfachen Feldbett betrachtet Goneril die Narben vergangener Schlachten.",
+                    "Ich zeichne das Wort „betrügen“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Verachtung",
                 "translation": "презрение",
                 "transcription": "[ди фер-АХ-тунг]",
@@ -2682,9 +3377,14 @@
                 ],
                 "collocations": [
                     "Meine Verachtung für ihn wächst täglich. — Моё презрение к нему растёт ежедневно."
+                ],
+                "sentenceParts": [
+                    "Im Geruch von feuchtem Stroh legt Goneril den Mantel zur Seite.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verachtung“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "zerstören",
                 "translation": "разрушать",
                 "transcription": "[цер-ШТЁ-рен]",
@@ -2705,9 +3405,14 @@
                 "collocations": [
                     "Cordelia zeigt, dass das Zerstören auch ohne Stolz möglich ist. — Корделия показывает, что разрушать можно и без гордыни.",
                     "Ich zerstöre alles, was uns verband. — Я разрушаю всё, что нас связывало."
+                ],
+                "sentenceParts": [
+                    "Auf dem wackligen Holztisch ordnet Goneril zerlesene Briefe.",
+                    "Ich presse das Wort „zerstören“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Leidenschaft",
                 "translation": "страсть",
                 "transcription": "[ди ЛАЙ-ден-шафт]",
@@ -2728,6 +3433,10 @@
                 "collocations": [
                     "Der Narr spottet, sobald die Leidenschaft erwähnt wird. — Шут насмехается, едва кто-то произносит «страсть».",
                     "Meine Leidenschaft gilt nur Edmund. — Моя страсть принадлежит только Эдмунду."
+                ],
+                "sentenceParts": [
+                    "Am Eingang der Hütte späht Goneril nach einem vertrauten Schatten.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leidenschaft“ bleibt lebendig."
                 ]
             }
         ],
@@ -2746,8 +3455,8 @@
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
                     "предавать",
-                    "ссориться",
                     "раздор",
+                    "ссориться",
                     "ненавидеть"
                 ],
                 "correctIndex": 0
@@ -2755,71 +3464,154 @@
             {
                 "question": "Что означает немецкое слово «die Zwietracht»?",
                 "choices": [
-                    "ссориться",
-                    "раздор",
-                    "изменять",
-                    "ненавидеть"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «hassen»?",
-                "choices": [
-                    "раздор",
+                    "разрушать",
                     "презрение",
-                    "ненавидеть",
-                    "страсть"
+                    "раздор",
+                    "изменять"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «betrügen»?",
+                "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
-                    "изменять",
+                    "страсть",
                     "ненавидеть",
-                    "разрушать",
-                    "презрение"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Verachtung»?",
-                "choices": [
-                    "ссориться",
                     "презрение",
-                    "предавать",
-                    "ненавидеть"
+                    "разрушать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «zerstören»?",
+                "question": "Что означает немецкое слово «betrügen»?",
                 "choices": [
-                    "разрушать",
-                    "предавать",
+                    "раздор",
+                    "страсть",
                     "изменять",
                     "презрение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Verachtung»?",
+                "choices": [
+                    "разрушать",
+                    "ссориться",
+                    "ненавидеть",
+                    "презрение"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «zerstören»?",
+                "choices": [
+                    "раздор",
+                    "предавать",
+                    "страсть",
+                    "разрушать"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Leidenschaft»?",
                 "choices": [
-                    "презрение",
-                    "изменять",
-                    "раздор",
-                    "страсть"
+                    "разрушать",
+                    "страсть",
+                    "ненавидеть",
+                    "ссориться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "streiten",
+                "translation": "ссориться",
+                "parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Goneril bei der flackernden Kerze.",
+                    "Ich atme tief ein und lasse nur das Wort „streiten“ wieder hinaus."
+                ],
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Goneril bei der flackernden Kerze. Ich atme tief ein und lasse nur das Wort „streiten“ wieder hinaus.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Гонерилья сидит у мерцающей свечи. Я глубоко вдыхаю и выпускаю только слово «ссориться»."
+            },
+            {
+                "word": "verraten",
+                "translation": "предавать",
+                "parts": [
+                    "Zwischen zerbeulten Rüstungen streicht Goneril über ein altes Wappen.",
+                    "Ich atme tief ein und lasse nur das Wort „verraten“ wieder hinaus."
+                ],
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Goneril über ein altes Wappen. Ich atme tief ein und lasse nur das Wort „verraten“ wieder hinaus.",
+                "sentenceTranslation": "Среди помятых доспехов Гонерилья гладит старый герб. Я глубоко вдыхаю и выпускаю только слово «предавать»."
+            },
+            {
+                "word": "die Zwietracht",
+                "translation": "раздор",
+                "parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Goneril fast den Kopf.",
+                    "Ich zeichne das Wort „die Zwietracht“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Goneril fast den Kopf. Ich zeichne das Wort „die Zwietracht“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "О низкую балку хижины Гонерилья едва не ударяется головой. Я черчу слово «раздор» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "hassen",
+                "translation": "ненавидеть",
+                "parts": [
+                    "Neben der schlafenden Wache flüstert Goneril in die schwere Nacht.",
+                    "Ich zeichne das Wort „hassen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Neben der schlafenden Wache flüstert Goneril in die schwere Nacht. Ich zeichne das Wort „hassen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Рядом со спящим стражем Гонерилья шепчет в тяжёлую ночь. Я черчу слово «ненавидеть» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "betrügen",
+                "translation": "изменять",
+                "parts": [
+                    "Vor dem einfachen Feldbett betrachtet Goneril die Narben vergangener Schlachten.",
+                    "Ich zeichne das Wort „betrügen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Vor dem einfachen Feldbett betrachtet Goneril die Narben vergangener Schlachten. Ich zeichne das Wort „betrügen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед грубой походной койкой Гонерилья разглядывает шрамы прошлых битв. Я черчу слово «изменять» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "die Verachtung",
+                "translation": "презрение",
+                "parts": [
+                    "Im Geruch von feuchtem Stroh legt Goneril den Mantel zur Seite.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verachtung“ bleibt lebendig."
+                ],
+                "sentence": "Im Geruch von feuchtem Stroh legt Goneril den Mantel zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verachtung“ bleibt lebendig.",
+                "sentenceTranslation": "В запахе влажной соломы Гонерилья откладывает плащ в сторону. Каждой клеткой тела я обещаю: слово «презрение» останется живым."
+            },
+            {
+                "word": "zerstören",
+                "translation": "разрушать",
+                "parts": [
+                    "Auf dem wackligen Holztisch ordnet Goneril zerlesene Briefe.",
+                    "Ich presse das Wort „zerstören“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Auf dem wackligen Holztisch ordnet Goneril zerlesene Briefe. Ich presse das Wort „zerstören“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На шатком деревянном столе Гонерилья раскладывает зачитанные письма. Я стискиваю слово «разрушать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Leidenschaft",
+                "translation": "страсть",
+                "parts": [
+                    "Am Eingang der Hütte späht Goneril nach einem vertrauten Schatten.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leidenschaft“ bleibt lebendig."
+                ],
+                "sentence": "Am Eingang der Hütte späht Goneril nach einem vertrauten Schatten. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leidenschaft“ bleibt lebendig.",
+                "sentenceTranslation": "У входа в хижину Гонерилья высматривает знакомую тень. Каждой клеткой тела я обещаю: слово «страсть» останется живым."
+            }
+        ]
     },
     "dover": {
         "title": "Соперничество",
         "description": "Акт V: Борьба за Эдмунда",
         "words": [
             {
+                "wordId": "",
                 "word": "die Eifersucht",
                 "translation": "ревность",
                 "transcription": "[ди АЙ-фер-зухт]",
@@ -2840,9 +3632,14 @@
                 "collocations": [
                     "Der Narr spottet, sobald die Eifersucht erwähnt wird. — Шут насмехается, едва кто-то произносит «ревность».",
                     "Die Eifersucht verzehrt mich von innen. — Ревность пожирает меня изнутри."
+                ],
+                "sentenceParts": [
+                    "Auf den weißen Klippen von Dover blickt Goneril in den aufgewühlten Kanal.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Eifersucht“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "rivalisieren",
                 "translation": "соперничать",
                 "transcription": "[ри-ва-ли-ЗИ-рен]",
@@ -2864,9 +3661,14 @@
                 ],
                 "collocations": [
                     "Ich rivalisiere mit meiner Schwester um Edmund. — Я соперничаю с сестрой за Эдмунда."
+                ],
+                "sentenceParts": [
+                    "Zwischen flatternden Feldzeichen richtet Goneril den Helm.",
+                    "Wie ein stilles Gebet legt sich das Wort „rivalisieren“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "kämpfen",
                 "translation": "бороться",
                 "transcription": "[КЕМП-фен]",
@@ -2890,9 +3692,14 @@
                     "Der Narr spürt, wie das Kämpfen alle verändert. — Шут чувствует, как умение бороться меняет всех.",
                     "Ich kämpfe gegen alle seine Feinde. — Я сражаюсь против всех его врагов.",
                     "Ich kämpfe um das, was ich begehre. — Я борюсь за то, чего желаю."
+                ],
+                "sentenceParts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Goneril Marschrouten in den Sand.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „kämpfen“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "begehren",
                 "translation": "желать",
                 "transcription": "[бе-ГЕ-рен]",
@@ -2918,9 +3725,14 @@
                     "Ich begehre Edmund mit brennender Lust. — Я вожделею Эдмунда с пылающей страстью.",
                     "Ich begehre die Krone für mich selbst. — Я вожделею корону для себя.",
                     "Ich begehre Edmund mehr als mein Leben. — Я желаю Эдмунда больше жизни."
+                ],
+                "sentenceParts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Goneril das Siegel.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „begehren“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "beseitigen",
                 "translation": "устранять",
                 "transcription": "[бе-ЗАЙ-ти-ген]",
@@ -2942,9 +3754,14 @@
                 ],
                 "collocations": [
                     "Ich muss meine Schwester beseitigen. — Я должна устранить свою сестру."
+                ],
+                "sentenceParts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Goneril dem dumpfen Meer.",
+                    "Ich zeichne das Wort „beseitigen“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Gift",
                 "translation": "яд",
                 "transcription": "[дас ГИФТ]",
@@ -2966,9 +3783,14 @@
                 ],
                 "collocations": [
                     "Das Gift ist bereit für meine Schwester. — Яд готов для моей сестры."
+                ],
+                "sentenceParts": [
+                    "Auf dem sandigen Trainingsplatz übt Goneril das Ziehen des Schwerts.",
+                    "Ich zeichne das Wort „das Gift“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Intrige",
                 "translation": "интрига",
                 "transcription": "[ди ин-ТРИ-ге]",
@@ -2992,9 +3814,14 @@
                     "Jede Intrige spinne ich mit Freude. — Каждую интригу я плету с радостью.",
                     "Edmunds Intrige hat mich zum Geächteten gemacht. — Интрига Эдмунда сделала меня изгоем.",
                     "Meine Intrige wird sie vernichten. — Моя интрига уничтожит её."
+                ],
+                "sentenceParts": [
+                    "Zwischen pochenden Trommeln hebt Goneril das Banner der Hoffnung.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Intrige“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "morden",
                 "translation": "убивать",
                 "transcription": "[МОР-ден]",
@@ -3016,6 +3843,10 @@
                 "collocations": [
                     "Der Narr spürt, wie das Morden alle verändert. — Шут чувствует, как умение убивать меняет всех.",
                     "Ich bin bereit zu morden für meine Lust. — Я готова убивать ради своей страсти."
+                ],
+                "sentenceParts": [
+                    "Am Morgennebel der Küste legt Goneril die Hand auf das pochende Herz.",
+                    "Wie ein stilles Gebet legt sich das Wort „morden“ auf meine Lippen."
                 ]
             }
         ],
@@ -3023,91 +3854,174 @@
             {
                 "question": "Что означает немецкое слово «die Eifersucht»?",
                 "choices": [
-                    "ревность",
-                    "соперничать",
-                    "бороться",
-                    "желать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «rivalisieren»?",
-                "choices": [
                     "бороться",
                     "желать",
-                    "соперничать",
-                    "ревность"
+                    "ревность",
+                    "соперничать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «rivalisieren»?",
+                "choices": [
+                    "ревность",
+                    "желать",
+                    "бороться",
+                    "соперничать"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
-                    "интрига",
-                    "бороться",
                     "ревность",
-                    "убивать"
+                    "бороться",
+                    "интрига",
+                    "устранять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "интрига",
+                    "ревность",
                     "желать",
-                    "соперничать",
-                    "ревность"
+                    "убивать",
+                    "интрига"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beseitigen»?",
                 "choices": [
-                    "устранять",
+                    "желать",
                     "интрига",
-                    "бороться",
-                    "соперничать"
+                    "устранять",
+                    "ревность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Gift»?",
                 "choices": [
+                    "устранять",
+                    "ревность",
                     "бороться",
-                    "яд",
-                    "соперничать",
-                    "устранять"
+                    "яд"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
+                    "убивать",
                     "яд",
-                    "интрига",
-                    "ревность",
-                    "устранять"
+                    "желать",
+                    "интрига"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «morden»?",
                 "choices": [
-                    "ревность",
                     "соперничать",
-                    "устранять",
-                    "убивать"
+                    "бороться",
+                    "убивать",
+                    "яд"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Eifersucht",
+                "translation": "ревность",
+                "parts": [
+                    "Auf den weißen Klippen von Dover blickt Goneril in den aufgewühlten Kanal.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Eifersucht“ auf meine Lippen."
+                ],
+                "sentence": "Auf den weißen Klippen von Dover blickt Goneril in den aufgewühlten Kanal. Wie ein stilles Gebet legt sich das Wort „die Eifersucht“ auf meine Lippen.",
+                "sentenceTranslation": "На белых скалах Дувра Гонерилья смотрит в вздыбленный пролив. Как тихая молитва слово «ревность» ложится на мои губы."
+            },
+            {
+                "word": "rivalisieren",
+                "translation": "соперничать",
+                "parts": [
+                    "Zwischen flatternden Feldzeichen richtet Goneril den Helm.",
+                    "Wie ein stilles Gebet legt sich das Wort „rivalisieren“ auf meine Lippen."
+                ],
+                "sentence": "Zwischen flatternden Feldzeichen richtet Goneril den Helm. Wie ein stilles Gebet legt sich das Wort „rivalisieren“ auf meine Lippen.",
+                "sentenceTranslation": "Среди хлопающих штандартов Гонерилья поправляет шлем. Как тихая молитва слово «соперничать» ложится на мои губы."
+            },
+            {
+                "word": "kämpfen",
+                "translation": "бороться",
+                "parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Goneril Marschrouten in den Sand.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „kämpfen“ mein Nordstern."
+                ],
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Goneril Marschrouten in den Sand. Selbst wenn die Welt zerfällt, bleibt das Wort „kämpfen“ mein Nordstern.",
+                "sentenceTranslation": "У французского костра Гонерилья рисует в песке путь марша. Даже если мир распадается, слово «бороться» остаётся моим северным светом."
+            },
+            {
+                "word": "begehren",
+                "translation": "желать",
+                "parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Goneril das Siegel.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „begehren“ wird heute nicht verraten."
+                ],
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Goneril das Siegel. Mit fester Stimme schwöre ich mir: Das Wort „begehren“ wird heute nicht verraten.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Гонерилья проверяет печати. Твёрдым голосом я клянусь себе: слово «желать» сегодня не будет предано."
+            },
+            {
+                "word": "beseitigen",
+                "translation": "устранять",
+                "parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Goneril dem dumpfen Meer.",
+                    "Ich zeichne das Wort „beseitigen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Goneril dem dumpfen Meer. Ich zeichne das Wort „beseitigen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Гонерилья слушает глухой шум моря. Я черчу слово «устранять» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "das Gift",
+                "translation": "яд",
+                "parts": [
+                    "Auf dem sandigen Trainingsplatz übt Goneril das Ziehen des Schwerts.",
+                    "Ich zeichne das Wort „das Gift“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Auf dem sandigen Trainingsplatz übt Goneril das Ziehen des Schwerts. Ich zeichne das Wort „das Gift“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На песчаном плацу Гонерилья отрабатывает выхват меча. Я вывожу слово «яд» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "die Intrige",
+                "translation": "интрига",
+                "parts": [
+                    "Zwischen pochenden Trommeln hebt Goneril das Banner der Hoffnung.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Intrige“ darf nicht vergehen."
+                ],
+                "sentence": "Zwischen pochenden Trommeln hebt Goneril das Banner der Hoffnung. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Intrige“ darf nicht vergehen.",
+                "sentenceTranslation": "Под гул барабанов Гонерилья поднимает знамя надежды. Я шепчу стражам судьбы: слово «интрига» не должно исчезнуть."
+            },
+            {
+                "word": "morden",
+                "translation": "убивать",
+                "parts": [
+                    "Am Morgennebel der Küste legt Goneril die Hand auf das pochende Herz.",
+                    "Wie ein stilles Gebet legt sich das Wort „morden“ auf meine Lippen."
+                ],
+                "sentence": "Am Morgennebel der Küste legt Goneril die Hand auf das pochende Herz. Wie ein stilles Gebet legt sich das Wort „morden“ auf meine Lippen.",
+                "sentenceTranslation": "В утреннем тумане побережья Гонерилья кладёт ладонь на бьющееся сердце. Как тихая молитва слово «убивать» ложится на мои губы."
+            }
+        ]
     },
     "prison": {
         "title": "Самоуничтожение",
         "description": "Акт V: Отравление и смерть",
         "words": [
             {
+                "wordId": "",
                 "word": "vergiften",
                 "translation": "отравлять",
                 "transcription": "[фер-ГИФ-тен]",
@@ -3128,9 +4042,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Vergiften ist. — Во время бури становится понятно, насколько важно отравлять.",
                     "Ich vergifte erst meine Schwester, dann mich selbst. — Я отравляю сначала сестру, потом себя."
+                ],
+                "sentenceParts": [
+                    "Im feuchten Kerker stützt Goneril sich an den tropfenden Stein.",
+                    "Das Echo des Wortes „vergiften“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Verzweiflung",
                 "translation": "отчаяние",
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
@@ -3154,9 +4073,14 @@
                     "Seine Verzweiflung bricht mir das Herz. — Его отчаяние разбивает мне сердце.",
                     "Die Verzweiflung treibt mich zum Abgrund. — Отчаяние гонит меня к пропасти.",
                     "Die Verzweiflung führt mich zum Tod. — Отчаяние ведёт меня к смерти."
+                ],
+                "sentenceParts": [
+                    "Unter der trüben Laterne zählt Goneril die eisernen Ringe der Kette.",
+                    "Das Echo des Wortes „die Verzweiflung“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "sterben",
                 "translation": "умирать",
                 "transcription": "[ШТЕР-бен]",
@@ -3181,9 +4105,14 @@
                     "Ich sterbe ohne Reue für meine Taten. — Я умираю без раскаяния за свои дела.",
                     "Ich sterbe vor Freude und Kummer. — Я умираю от радости и горя.",
                     "Ich sterbe durch meine eigene Hand. — Я умираю от своей собственной руки."
+                ],
+                "sentenceParts": [
+                    "Neben der schweren Holztür horcht Goneril auf entferntes Schluchzen.",
+                    "Ich zeichne das Wort „sterben“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Schuld",
                 "translation": "вина",
                 "transcription": "[ди ШУЛЬД]",
@@ -3204,9 +4133,14 @@
                 "collocations": [
                     "Während des Sturms wirkt die Schuld noch bedrückender. — Во время бури само «вина» звучит ещё тяжелее.",
                     "Die Schuld erdrückt mich am Ende. — Вина давит меня в конце."
+                ],
+                "sentenceParts": [
+                    "Auf der kalten Steinbank zieht Goneril den Mantel enger um die Schultern.",
+                    "Ich halte das Wort „die Schuld“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vernichten",
                 "translation": "уничтожать",
                 "transcription": "[фер-НИХ-тен]",
@@ -3227,9 +4161,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Vernichten ist. — Во время бури становится понятно, насколько важно уничтожать.",
                     "Ich vernichte mich selbst durch meine Bosheit. — Я уничтожаю себя своим злом."
+                ],
+                "sentenceParts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Goneril das Gesicht zum Licht.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vernichten“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Verderben",
                 "translation": "погибель",
                 "transcription": "[дас фер-ДЕР-бен]",
@@ -3251,9 +4190,14 @@
                 ],
                 "collocations": [
                     "Das Verderben holt mich ein. — Погибель настигает меня."
+                ],
+                "sentenceParts": [
+                    "Am rostigen Wassereimer spiegelt Goneril kurz die eigenen Augen.",
+                    "Mein Atem zeichnet das Wort „das Verderben“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "bereuen",
                 "translation": "сожалеть",
                 "transcription": "[бе-РОЙ-ен]",
@@ -3277,9 +4221,14 @@
                     "Am Ende bereue ich meine Taten. — В конце я сожалею о своих делах.",
                     "Später werde ich diese Tat bitter bereuen. — Позже я горько пожалею об этом поступке.",
                     "Zu spät bereue ich meine Taten. — Слишком поздно я сожалею о своих делах."
+                ],
+                "sentenceParts": [
+                    "Im dumpfen Hall der Schritte zählt Goneril den Rhythmus der Wachen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „bereuen“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Hölle",
                 "translation": "ад",
                 "transcription": "[ди ХЁ-ле]",
@@ -3300,6 +4249,10 @@
                 "collocations": [
                     "Cordelia merkt sich genau, wie die Hölle verteilt wird. — Корделия внимательно следит, кому достанется «ад».",
                     "Die Hölle wartet auf meine schwarze Seele. — Ад ждёт мою чёрную душу."
+                ],
+                "sentenceParts": [
+                    "Vor dem verriegelten Fenster zeichnet Goneril Kreise in den Staub.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Hölle“ mein Nordstern."
                 ]
             }
         ],
@@ -3307,85 +4260,167 @@
             {
                 "question": "Что означает немецкое слово «vergiften»?",
                 "choices": [
-                    "вина",
                     "умирать",
                     "отчаяние",
-                    "отравлять"
+                    "отравлять",
+                    "вина"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
                     "отравлять",
                     "умирать",
-                    "отчаяние",
-                    "вина"
+                    "вина",
+                    "отчаяние"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "вина",
                     "сожалеть",
+                    "погибель",
                     "умирать",
-                    "отравлять"
+                    "уничтожать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Schuld»?",
                 "choices": [
-                    "вина",
+                    "сожалеть",
+                    "умирать",
                     "отравлять",
-                    "ад",
+                    "вина"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «vernichten»?",
+                "choices": [
+                    "уничтожать",
+                    "умирать",
+                    "отравлять",
                     "отчаяние"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «vernichten»?",
-                "choices": [
-                    "вина",
-                    "ад",
-                    "отчаяние",
-                    "уничтожать"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «das Verderben»?",
                 "choices": [
-                    "уничтожать",
+                    "сожалеть",
+                    "погибель",
                     "ад",
-                    "вина",
-                    "погибель"
+                    "умирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "сожалеть",
+                    "уничтожать",
                     "отчаяние",
-                    "умирать",
-                    "отравлять"
+                    "вина",
+                    "сожалеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Hölle»?",
                 "choices": [
-                    "умирать",
-                    "вина",
+                    "ад",
                     "сожалеть",
-                    "ад"
+                    "вина",
+                    "отчаяние"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "vergiften",
+                "translation": "отравлять",
+                "parts": [
+                    "Im feuchten Kerker stützt Goneril sich an den tropfenden Stein.",
+                    "Das Echo des Wortes „vergiften“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Im feuchten Kerker stützt Goneril sich an den tropfenden Stein. Das Echo des Wortes „vergiften“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В сыром подземелье Гонерилья опирается на сочащийся камень. Эхо слова «отравлять» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Verzweiflung",
+                "translation": "отчаяние",
+                "parts": [
+                    "Unter der trüben Laterne zählt Goneril die eisernen Ringe der Kette.",
+                    "Das Echo des Wortes „die Verzweiflung“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Unter der trüben Laterne zählt Goneril die eisernen Ringe der Kette. Das Echo des Wortes „die Verzweiflung“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Под мутным фонарём Гонерилья пересчитывает железные кольца цепи. Эхо слова «отчаяние» заглушает шёпот придворных."
+            },
+            {
+                "word": "sterben",
+                "translation": "умирать",
+                "parts": [
+                    "Neben der schweren Holztür horcht Goneril auf entferntes Schluchzen.",
+                    "Ich zeichne das Wort „sterben“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Neben der schweren Holztür horcht Goneril auf entferntes Schluchzen. Ich zeichne das Wort „sterben“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У тяжёлой двери Гонерилья прислушивается к далёким рыданиям. Я черчу слово «умирать» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "die Schuld",
+                "translation": "вина",
+                "parts": [
+                    "Auf der kalten Steinbank zieht Goneril den Mantel enger um die Schultern.",
+                    "Ich halte das Wort „die Schuld“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Auf der kalten Steinbank zieht Goneril den Mantel enger um die Schultern. Ich halte das Wort „die Schuld“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На холодной каменной скамье Гонерилья плотнее кутается в плащ. Я держу слово «вина» как факел у сердца."
+            },
+            {
+                "word": "vernichten",
+                "translation": "уничтожать",
+                "parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Goneril das Gesicht zum Licht.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vernichten“ gehört mir."
+                ],
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Goneril das Gesicht zum Licht. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vernichten“ gehört mir.",
+                "sentenceTranslation": "Между тенями решёток Гонерилья поднимает лицо к свету. Буря за окнами усиливает клятву: слово «уничтожать» принадлежит мне."
+            },
+            {
+                "word": "das Verderben",
+                "translation": "погибель",
+                "parts": [
+                    "Am rostigen Wassereimer spiegelt Goneril kurz die eigenen Augen.",
+                    "Mein Atem zeichnet das Wort „das Verderben“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Am rostigen Wassereimer spiegelt Goneril kurz die eigenen Augen. Mein Atem zeichnet das Wort „das Verderben“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "У ржавого ведра с водой Гонерилья на мгновение видит отражение глаз. Моё дыхание рисует слово «погибель» в холодном воздухе между нами."
+            },
+            {
+                "word": "bereuen",
+                "translation": "сожалеть",
+                "parts": [
+                    "Im dumpfen Hall der Schritte zählt Goneril den Rhythmus der Wachen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „bereuen“ darf nicht vergehen."
+                ],
+                "sentence": "Im dumpfen Hall der Schritte zählt Goneril den Rhythmus der Wachen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „bereuen“ darf nicht vergehen.",
+                "sentenceTranslation": "В глухом эхе шагов Гонерилья отсчитывает ритм часовых. Я шепчу стражам судьбы: слово «сожалеть» не должно исчезнуть."
+            },
+            {
+                "word": "die Hölle",
+                "translation": "ад",
+                "parts": [
+                    "Vor dem verriegelten Fenster zeichnet Goneril Kreise in den Staub.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Hölle“ mein Nordstern."
+                ],
+                "sentence": "Vor dem verriegelten Fenster zeichnet Goneril Kreise in den Staub. Selbst wenn die Welt zerfällt, bleibt das Wort „die Hölle“ mein Nordstern.",
+                "sentenceTranslation": "Перед заколоченным окном Гонерилья чертит круги в пыли. Даже если мир распадается, слово «ад» остаётся моим северным светом."
+            }
+        ]
     }
 };
 
@@ -3401,6 +4436,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3837,6 +5220,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -3905,6 +5605,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -3913,13 +5616,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4830,6 +6581,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/journeys/kent.html
+++ b/output/journeys/kent.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="loyalty">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="banishment">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="disguise">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="service">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="stocks">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="storm_companion">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="final_loyalty">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["возражать", "мужество", "защищать", "верность"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "верность", "возражать", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["искренний", "возражать", "верность", "мужество"], "correct_index": 1}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["искренний", "защищать", "предупреждать", "слуга"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["мужество", "искренний", "справедливый", "возражать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["верность", "защищать", "возражать", "слуга"], "correct_index": 3}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["предупреждать", "искренний", "мужество", "справедливый"], "correct_index": 0}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["возражать", "справедливый", "слуга", "верность"], "correct_index": 1}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["несправедливость", "изгнание", "гнев", "изгнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["гнев", "изгнание", "несправедливость", "изгнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["гнев", "несправедливость", "изгнание", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["изгнанный", "прощание", "изгнание", "возвращаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["наказание", "прощание", "изгнание", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возвращаться", "изгнанный", "гнев", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["несправедливость", "возвращаться", "гнев", "изгнанный"], "correct_index": 1}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["хитрость", "переодевание", "неузнанный", "притворяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["притворяться", "хитрость", "неузнанный", "переодевание"], "correct_index": 1}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["притворяться", "переодевание", "неузнанный", "изменять"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["притворяться", "верный", "неузнанный", "хитрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["неузнанный", "хитрость", "изменять", "наниматься"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["верный", "неузнанный", "борода", "притворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["изменять", "переодевание", "наниматься", "неузнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["верный", "наниматься", "изменять", "притворяться"], "correct_index": 0}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["защита", "опасность", "служба", "охранять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["опасность", "охранять", "защита", "служба"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["защита", "опасность", "сражаться", "служба"], "correct_index": 1}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["опасность", "охранять", "сражаться", "служба"], "correct_index": 1}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["сражаться", "советовать", "опасность", "охранять"], "correct_index": 0}, {"question": "Что означает немецкое слово «raten»?", "choices": ["стража", "советовать", "служба", "охранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["служба", "защита", "стража", "охранять"], "correct_index": 2}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "стойкость", "унижение", "сковывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["наказание", "сковывать", "стойкость", "унижение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["унижение", "позор", "терпеть", "стойкость"], "correct_index": 3}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["терпеть", "наказание", "сковывать", "колодка"], "correct_index": 2}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["терпеть", "позор", "стойкость", "колодка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["сковывать", "выдерживать", "колодка", "позор"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["сковывать", "выдерживать", "терпеть", "позор"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["наказание", "колодка", "позор", "выдерживать"], "correct_index": 2}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["сопровождать", "утешать", "буря", "поддержка"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["буря", "поддержка", "утешать", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["сопровождать", "буря", "холод", "убежище"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["сопровождать", "выдерживать", "утешать", "поддержка"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["убежище", "буря", "поддержка", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["выдерживать", "буря", "холод", "поддержка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["поддержка", "холод", "убежище", "сопровождать"], "correct_index": 1}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "вечный", "плакать", "прощание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["вечный", "смерть", "плакать", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["плакать", "сдаваться", "скорбь", "вечный"], "correct_index": 3}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["истощение", "вечный", "прощание", "плакать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["скорбь", "истощение", "вечный", "плакать"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["вечный", "истощение", "скорбь", "сдаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["смерть", "вечный", "сдаваться", "скорбь"], "correct_index": 3}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["смерть", "следовать", "сдаваться", "прощание"], "correct_index": 1}]}'>
+        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["верность", "возражать", "мужество", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["защищать", "мужество", "возражать", "верность"], "correct_index": 1}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["верность", "защищать", "слуга", "возражать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["слуга", "защищать", "мужество", "возражать"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["искренний", "мужество", "верность", "возражать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["предупреждать", "возражать", "слуга", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["верность", "искренний", "предупреждать", "слуга"], "correct_index": 2}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["справедливый", "слуга", "верность", "защищать"], "correct_index": 0}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["несправедливость", "гнев", "изгнание", "изгнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["изгнанный", "несправедливость", "изгнание", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["гнев", "изгнание", "прощание", "несправедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["гнев", "изгнание", "изгнанный", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "изгнание", "возвращаться", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возвращаться", "изгнанный", "гнев", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["возвращаться", "наказание", "изгнанный", "прощание"], "correct_index": 0}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["переодевание", "притворяться", "неузнанный", "хитрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["неузнанный", "переодевание", "хитрость", "притворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["неузнанный", "борода", "переодевание", "хитрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["притворяться", "неузнанный", "верный", "переодевание"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["наниматься", "переодевание", "неузнанный", "изменять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["переодевание", "верный", "наниматься", "борода"], "correct_index": 3}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["наниматься", "переодевание", "притворяться", "неузнанный"], "correct_index": 0}, {"question": "Что означает немецкое слово «treu»?", "choices": ["верный", "неузнанный", "хитрость", "борода"], "correct_index": 0}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["служба", "охранять", "защита", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["служба", "защита", "опасность", "охранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["охранять", "опасность", "служба", "стража"], "correct_index": 1}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["сражаться", "опасность", "охранять", "стража"], "correct_index": 2}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["сражаться", "служба", "советовать", "стража"], "correct_index": 0}, {"question": "Что означает немецкое слово «raten»?", "choices": ["советовать", "сражаться", "защита", "стража"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["опасность", "защита", "сражаться", "стража"], "correct_index": 3}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["сковывать", "наказание", "унижение", "стойкость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["стойкость", "сковывать", "наказание", "унижение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["унижение", "стойкость", "колодка", "сковывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["стойкость", "выдерживать", "сковывать", "наказание"], "correct_index": 2}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["колодка", "унижение", "терпеть", "стойкость"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["колодка", "терпеть", "унижение", "сковывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["колодка", "унижение", "наказание", "выдерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["унижение", "наказание", "позор", "терпеть"], "correct_index": 2}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["поддержка", "буря", "сопровождать", "утешать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["утешать", "поддержка", "сопровождать", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["убежище", "сопровождать", "утешать", "выдерживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["холод", "буря", "выдерживать", "утешать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["утешать", "выдерживать", "сопровождать", "убежище"], "correct_index": 3}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["утешать", "сопровождать", "холод", "выдерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["выдерживать", "сопровождать", "утешать", "холод"], "correct_index": 3}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["плакать", "вечный", "смерть", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["смерть", "плакать", "вечный", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "следовать", "смерть", "истощение"], "correct_index": 0}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["скорбь", "сдаваться", "истощение", "плакать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["истощение", "плакать", "смерть", "следовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["скорбь", "смерть", "следовать", "сдаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["следовать", "плакать", "сдаваться", "скорбь"], "correct_index": 3}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["сдаваться", "скорбь", "истощение", "следовать"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Верность королю</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,31 +661,15 @@
             <div class="quiz-phase-container active" data-phase="loyalty">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
@@ -497,17 +677,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «widersprechen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -517,9 +713,57 @@
                         <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «warnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">искренний</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предупреждать</button>
                             
@@ -529,65 +773,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">искренний</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «warnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">искренний</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «gerecht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">справедливый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,15 +796,15 @@
             <div class="quiz-phase-container" data-phase="banishment">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verbannung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
                             
@@ -616,17 +812,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -638,43 +834,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verbannt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -696,17 +892,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -719,15 +915,31 @@
             <div class="quiz-phase-container" data-phase="disguise">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
                             
@@ -735,33 +947,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">переодевание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">борода</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -773,57 +969,57 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">переодевание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наниматься</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наниматься</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">наниматься</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наниматься</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
                             
@@ -837,11 +1033,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,33 +1050,33 @@
             <div class="quiz-phase-container" data-phase="service">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Dienst»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">служба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">служба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -890,29 +1086,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «bewachen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -924,43 +1120,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">советовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">советовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «raten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">советовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">советовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сражаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Wache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,17 +1169,17 @@
             <div class="quiz-phase-container" data-phase="stocks">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -993,11 +1189,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
                             
@@ -1005,17 +1201,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Standhaftigkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">колодка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1025,61 +1221,61 @@
                         <div class="quiz-question">Что означает немецкое слово «fesseln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">колодка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «erdulden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">колодка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">колодка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">колодка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «ausharren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">колодка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «ausharren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">колодка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1089,13 +1285,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">позор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,17 +1304,17 @@
             <div class="quiz-phase-container" data-phase="storm_companion">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1128,27 +1324,59 @@
                         <div class="quiz-question">Что означает немецкое слово «der Beistand»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">убежище</button>
                             
@@ -1156,65 +1384,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">убежище</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,15 +1423,15 @@
             <div class="quiz-phase-container" data-phase="final_loyalty">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
@@ -1247,11 +1443,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
@@ -1259,17 +1455,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">следовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">истощение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1279,11 +1475,11 @@
                         <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">истощение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
                             
@@ -1291,17 +1487,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Erschöpfung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">следовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1311,11 +1507,11 @@
                         <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
                             
@@ -1327,9 +1523,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">следовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
                             
@@ -1339,17 +1535,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «folgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">следовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">истощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">следовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1373,6 +1569,7 @@
         "description": "Акт I: Защищает Корделию в тронном зале",
         "words": [
             {
+                "wordId": "",
                 "word": "die Treue",
                 "translation": "верность",
                 "transcription": "[ди ТРОЙ-е]",
@@ -1394,9 +1591,14 @@
                     "Der Narr spottet, sobald die Treue erwähnt wird. — Шут насмехается, едва кто-то произносит «верность».",
                     "Meine Treue gilt der Wahrheit und der echten Liebe. — Моя верность принадлежит правде и истинной любви.",
                     "Die Treue zu meinem König ist unerschütterlich. — Верность моему королю непоколебима."
+                ],
+                "sentenceParts": [
+                    "Mitten im Tumult der Thronfeier tritt Kent vor den Königsthron.",
+                    "Ich zeichne das Wort „die Treue“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Mut",
                 "translation": "мужество",
                 "transcription": "[дер МУТ]",
@@ -1418,9 +1620,14 @@
                     "Lears Herz wird schwer, wenn der Mut zur Sprache kommt. — Сердце Лира тяжелеет: «мужество» звучит слишком близко.",
                     "Endlich finde ich den Mut zu widersprechen. — Наконец я нахожу мужество возражать.",
                     "Der Mut fordert mich, die Wahrheit zu sagen. — Мужество требует от меня говорить правду."
+                ],
+                "sentenceParts": [
+                    "Zwischen scharfgezogenen Schwertern stellt sich Kent vor die jüngste Tochter.",
+                    "Ich halte das Wort „der Mut“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "widersprechen",
                 "translation": "возражать",
                 "transcription": "[ВИ-дер-шпре-хен]",
@@ -1442,9 +1649,14 @@
                 "collocations": [
                     "Der Narr spürt, wie das Widersprechen alle verändert. — Шут чувствует, как умение противоречить меняет всех.",
                     "Ich widerspreche dem König für seine eigene Ehre. — Я возражаю королю ради его же чести."
+                ],
+                "sentenceParts": [
+                    "Vor der erstaunten Ritterschar reißt Kent sein Wappen vom Brustpanzer.",
+                    "Ich presse das Wort „widersprechen“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verteidigen",
                 "translation": "защищать",
                 "transcription": "[фер-ТАЙ-ди-ген]",
@@ -1467,9 +1679,14 @@
                 "collocations": [
                     "Das Verteidigen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело защищать.",
                     "Ich verteidige Корделия gegen Ungerechtigkeit. — Я защищаю Корделию от несправедливости."
+                ],
+                "sentenceParts": [
+                    "Unter den strengen Blicken des Hofes schlägt Kent die Faust auf das Geländer.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „verteidigen“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "aufrichtig",
                 "translation": "искренний",
                 "transcription": "[АУФ-рих-тиг]",
@@ -1491,9 +1708,14 @@
                 ],
                 "collocations": [
                     "Ich bin aufrichtig, auch wenn es gefährlich ist. — Я искренен, даже если это опасно."
+                ],
+                "sentenceParts": [
+                    "Neben Lears Stab kniet Kent und hebt unbeirrbar den Kopf.",
+                    "Das Echo des Wortes „aufrichtig“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Diener",
                 "translation": "слуга",
                 "transcription": "[дер ДИ-нер]",
@@ -1515,9 +1737,14 @@
                     "Während des Sturms wirkt der Diener noch bedrückender. — Во время бури само «слуга» звучит ещё тяжелее.",
                     "Als Diener gehorche ich meiner Herrin blind. — Как слуга я слепо подчиняюсь своей госпоже.",
                     "Als treuer Diener spreche ich offen. — Как верный слуга, я говорю открыто."
+                ],
+                "sentenceParts": [
+                    "Auf den Stufen zur Thronrampe breitet Kent schützend die Arme aus.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Diener“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "warnen",
                 "translation": "предупреждать",
                 "transcription": "[ВАР-нен]",
@@ -1539,9 +1766,14 @@
                 ],
                 "collocations": [
                     "Ich warne den König vor seinem Fehler. — Я предупреждаю короля об его ошибке."
+                ],
+                "sentenceParts": [
+                    "Zwischen höfischen Fanfaren ruft Kent seine Warnung gegen das Hofgeflüster.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „warnen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "gerecht",
                 "translation": "справедливый",
                 "transcription": "[ге-РЕХТ]",
@@ -1563,6 +1795,10 @@
                 ],
                 "collocations": [
                     "Ich kämpfe für das, was gerecht ist. — Я борюсь за то, что справедливо."
+                ],
+                "sentenceParts": [
+                    "Im Schatten des Königsbanners legt Kent die Hand auf das Herz.",
+                    "Ich presse das Wort „gerecht“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             }
         ],
@@ -1570,91 +1806,174 @@
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
-                    "возражать",
-                    "мужество",
-                    "защищать",
-                    "верность"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Mut»?",
-                "choices": [
-                    "мужество",
                     "верность",
                     "возражать",
+                    "мужество",
                     "защищать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «widersprechen»?",
+                "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
-                    "искренний",
+                    "защищать",
+                    "мужество",
                     "возражать",
-                    "верность",
-                    "мужество"
+                    "верность"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «widersprechen»?",
+                "choices": [
+                    "верность",
+                    "защищать",
+                    "слуга",
+                    "возражать"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «verteidigen»?",
                 "choices": [
-                    "искренний",
+                    "слуга",
                     "защищать",
-                    "предупреждать",
-                    "слуга"
+                    "мужество",
+                    "возражать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufrichtig»?",
                 "choices": [
-                    "мужество",
                     "искренний",
-                    "справедливый",
-                    "возражать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Diener»?",
-                "choices": [
+                    "мужество",
                     "верность",
-                    "защищать",
-                    "возражать",
-                    "слуга"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «warnen»?",
-                "choices": [
-                    "предупреждать",
-                    "искренний",
-                    "мужество",
-                    "справедливый"
+                    "возражать"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «der Diener»?",
+                "choices": [
+                    "предупреждать",
+                    "возражать",
+                    "слуга",
+                    "защищать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «warnen»?",
+                "choices": [
+                    "верность",
+                    "искренний",
+                    "предупреждать",
+                    "слуга"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «gerecht»?",
                 "choices": [
-                    "возражать",
                     "справедливый",
                     "слуга",
-                    "верность"
+                    "верность",
+                    "защищать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Treue",
+                "translation": "верность",
+                "parts": [
+                    "Mitten im Tumult der Thronfeier tritt Kent vor den Königsthron.",
+                    "Ich zeichne das Wort „die Treue“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Mitten im Tumult der Thronfeier tritt Kent vor den Königsthron. Ich zeichne das Wort „die Treue“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Посреди суматохи тронной церемонии Кент выходит к королевскому трону. Я вывожу слово «верность» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "der Mut",
+                "translation": "мужество",
+                "parts": [
+                    "Zwischen scharfgezogenen Schwertern stellt sich Kent vor die jüngste Tochter.",
+                    "Ich halte das Wort „der Mut“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Zwischen scharfgezogenen Schwertern stellt sich Kent vor die jüngste Tochter. Ich halte das Wort „der Mut“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Между обнажёнными мечами Кент встаёт перед младшей дочерью. Я держу слово «мужество» как факел у сердца."
+            },
+            {
+                "word": "widersprechen",
+                "translation": "возражать",
+                "parts": [
+                    "Vor der erstaunten Ritterschar reißt Kent sein Wappen vom Brustpanzer.",
+                    "Ich presse das Wort „widersprechen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Vor der erstaunten Ritterschar reißt Kent sein Wappen vom Brustpanzer. Ich presse das Wort „widersprechen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Перед изумлёнными рыцарями Кент срывает герб с нагрудника. Я стискиваю слово «возражать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "verteidigen",
+                "translation": "защищать",
+                "parts": [
+                    "Unter den strengen Blicken des Hofes schlägt Kent die Faust auf das Geländer.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „verteidigen“ darf nicht vergehen."
+                ],
+                "sentence": "Unter den strengen Blicken des Hofes schlägt Kent die Faust auf das Geländer. Ich flüstere den Wächtern des Schicksals zu: Das Wort „verteidigen“ darf nicht vergehen.",
+                "sentenceTranslation": "Под строгими взглядами двора Кент бьёт кулаком по перилам. Я шепчу стражам судьбы: слово «защищать» не должно исчезнуть."
+            },
+            {
+                "word": "aufrichtig",
+                "translation": "искренний",
+                "parts": [
+                    "Neben Lears Stab kniet Kent und hebt unbeirrbar den Kopf.",
+                    "Das Echo des Wortes „aufrichtig“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Neben Lears Stab kniet Kent und hebt unbeirrbar den Kopf. Das Echo des Wortes „aufrichtig“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У посоха Лира Кент встаёт на колено и упрямо поднимает голову. Эхо слова «искренний» заглушает шёпот придворных."
+            },
+            {
+                "word": "der Diener",
+                "translation": "слуга",
+                "parts": [
+                    "Auf den Stufen zur Thronrampe breitet Kent schützend die Arme aus.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Diener“ bleibt lebendig."
+                ],
+                "sentence": "Auf den Stufen zur Thronrampe breitet Kent schützend die Arme aus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Diener“ bleibt lebendig.",
+                "sentenceTranslation": "На ступенях ведущих к трону Кент защитно разводит руки. Каждой клеткой тела я обещаю: слово «слуга» останется живым."
+            },
+            {
+                "word": "warnen",
+                "translation": "предупреждать",
+                "parts": [
+                    "Zwischen höfischen Fanfaren ruft Kent seine Warnung gegen das Hofgeflüster.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „warnen“ gehört mir."
+                ],
+                "sentence": "Zwischen höfischen Fanfaren ruft Kent seine Warnung gegen das Hofgeflüster. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „warnen“ gehört mir.",
+                "sentenceTranslation": "Среди придворных фанфар Кент выкрикивает предупреждение против шёпота двора. Буря за окнами усиливает клятву: слово «предупреждать» принадлежит мне."
+            },
+            {
+                "word": "gerecht",
+                "translation": "справедливый",
+                "parts": [
+                    "Im Schatten des Königsbanners legt Kent die Hand auf das Herz.",
+                    "Ich presse das Wort „gerecht“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Im Schatten des Königsbanners legt Kent die Hand auf das Herz. Ich presse das Wort „gerecht“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В тени королевского знамени Кент кладёт руку на сердце. Я стискиваю слово «справедливый» зубами, чтобы не вырвалось сомнение."
+            }
+        ]
     },
     "banishment": {
         "title": "Изгнание",
         "description": "Акт I: Изгнан за правду",
         "words": [
             {
+                "wordId": "",
                 "word": "die Verbannung",
                 "translation": "изгнание",
                 "transcription": "[ди фер-БА-нунг]",
@@ -1677,9 +1996,14 @@
                 ],
                 "collocations": [
                     "Die Verbannung ist der Preis für meine Ehrlichkeit. — Изгнание - цена моей честности."
+                ],
+                "sentenceParts": [
+                    "Auf den kalten Stufen des Hofes hört Kent das Urteil der Verbannung.",
+                    "Ich zeichne das Wort „die Verbannung“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Ungerechtigkeit",
                 "translation": "несправедливость",
                 "transcription": "[ди УН-ге-рех-тиг-кайт]",
@@ -1705,9 +2029,14 @@
                 "collocations": [
                     "Diese Ungerechtigkeit werde ich nicht akzeptieren. — Эту несправедливость я не приму.",
                     "Ich begehe große Ungerechtigkeit. — Я совершаю большую несправедливость."
+                ],
+                "sentenceParts": [
+                    "Zwischen abziehenden Soldaten hält Kent nur den Reisestock in der Hand.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Ungerechtigkeit“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Zorn",
                 "translation": "гнев",
                 "transcription": "[дер ЦОРН]",
@@ -1731,9 +2060,14 @@
                     "Sein Zorn ist grenzenlos und blind. — Его гнев безграничен и слеп.",
                     "Der Zorn des Königs trifft mich ungerecht. — Гнев короля поражает меня несправедливо.",
                     "Mein Zorn kennt keine Barmherzigkeit. — Мой гнев не знает милосердия."
+                ],
+                "sentenceParts": [
+                    "Vor dem geschlossenen Burgtor wirft Kent den Blick noch einmal zurück.",
+                    "Das kalte Licht lässt das Wort „der Zorn“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verbannt",
                 "translation": "изгнанный",
                 "transcription": "[фер-БАНТ]",
@@ -1755,9 +2089,14 @@
                 ],
                 "collocations": [
                     "Verbannt aus dem Land, das ich liebe. — Изгнан из страны, которую люблю."
+                ],
+                "sentenceParts": [
+                    "Auf dem Regenpflaster bleibt Kent stehen, während die Trommeln schweigen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbannt“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Abschied",
                 "translation": "прощание",
                 "transcription": "[дер АБ-шид]",
@@ -1790,9 +2129,14 @@
                     "Unser Abschied ist nur vorübergehend. — Наше прощание лишь временно.",
                     "Der Abschied vom Hof schmerzt mich tief. — Прощание с двором глубоко ранит меня.",
                     "Der Abschied von meinem König bricht mein Herz. — Прощание с моим королём разбивает моё сердце."
+                ],
+                "sentenceParts": [
+                    "Zwischen verstreuten Reisebündeln befestigt Kent das Schwert am Gürtel.",
+                    "Ich atme tief ein und lasse nur das Wort „der Abschied“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Strafe",
                 "translation": "наказание",
                 "transcription": "[ди ШТРА-фе]",
@@ -1818,9 +2162,15 @@
                     "Diese Strafe erdulde ich für meinen König. — Это наказание я терплю ради короля.",
                     "Die Strafe für Widerspruch ist hart. — Наказание за возражение сурово.",
                     "Dies ist die gerechte Strafe für meine Grausamkeit. — Это справедливая кара за мою жестокость."
+                ],
+                "sentenceParts": [
+                    "Unter dem grauen Himmel zieht Kent den Mantelkragen hoch.",
+                    "Ich presse das Wort „die Strafe“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "zurückkehren",
                 "translation": "возвращаться",
                 "transcription": "[цу-РЮК-ке-рен]",
@@ -1844,6 +2194,10 @@
                     "Cordelia zeigt, dass das Zurückkehren auch ohne Stolz möglich ist. — Корделия показывает, что возвращаться можно и без гордыни.",
                     "Mit einer Armee kehre ich zurück, meinen Vater zu retten. — С армией я возвращаюсь спасти моего отца.",
                     "Ich schwöre, verkleidet zurückzukehren. — Я клянусь вернуться переодетым."
+                ],
+                "sentenceParts": [
+                    "Vor der trostlosen Landstraße richtet Kent den Blick entschlossen nach vorn.",
+                    "Mein Atem zeichnet das Wort „zurückkehren“ in die kalte Luft zwischen uns."
                 ]
             }
         ],
@@ -1852,51 +2206,51 @@
                 "question": "Что означает немецкое слово «die Verbannung»?",
                 "choices": [
                     "несправедливость",
-                    "изгнание",
-                    "гнев",
-                    "изгнанный"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
-                "choices": [
                     "гнев",
                     "изгнание",
-                    "несправедливость",
                     "изгнанный"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
+                "choices": [
+                    "изгнанный",
+                    "несправедливость",
+                    "изгнание",
+                    "гнев"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
                     "гнев",
-                    "несправедливость",
                     "изгнание",
-                    "наказание"
+                    "прощание",
+                    "несправедливость"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verbannt»?",
                 "choices": [
-                    "изгнанный",
-                    "прощание",
+                    "гнев",
                     "изгнание",
-                    "возвращаться"
+                    "изгнанный",
+                    "прощание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "наказание",
                     "прощание",
                     "изгнание",
-                    "гнев"
+                    "возвращаться",
+                    "наказание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
@@ -1911,21 +2265,95 @@
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
-                    "несправедливость",
                     "возвращаться",
-                    "гнев",
-                    "изгнанный"
+                    "наказание",
+                    "изгнанный",
+                    "прощание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Verbannung",
+                "translation": "изгнание",
+                "parts": [
+                    "Auf den kalten Stufen des Hofes hört Kent das Urteil der Verbannung.",
+                    "Ich zeichne das Wort „die Verbannung“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Auf den kalten Stufen des Hofes hört Kent das Urteil der Verbannung. Ich zeichne das Wort „die Verbannung“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На холодных ступенях двора Кент слышит приговор об изгнании. Я черчу слово «изгнание» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "die Ungerechtigkeit",
+                "translation": "несправедливость",
+                "parts": [
+                    "Zwischen abziehenden Soldaten hält Kent nur den Reisestock in der Hand.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Ungerechtigkeit“ auf meine Lippen."
+                ],
+                "sentence": "Zwischen abziehenden Soldaten hält Kent nur den Reisestock in der Hand. Wie ein stilles Gebet legt sich das Wort „die Ungerechtigkeit“ auf meine Lippen.",
+                "sentenceTranslation": "Среди расходящихся солдат Кент сжимает в руке лишь дорожный посох. Как тихая молитва слово «несправедливость» ложится на мои губы."
+            },
+            {
+                "word": "der Zorn",
+                "translation": "гнев",
+                "parts": [
+                    "Vor dem geschlossenen Burgtor wirft Kent den Blick noch einmal zurück.",
+                    "Das kalte Licht lässt das Wort „der Zorn“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Vor dem geschlossenen Burgtor wirft Kent den Blick noch einmal zurück. Das kalte Licht lässt das Wort „der Zorn“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "У закрытых ворот замка Кент бросает последний взгляд назад. Холодный свет заставляет слово «гнев» сиять словно расплавленное золото."
+            },
+            {
+                "word": "verbannt",
+                "translation": "изгнанный",
+                "parts": [
+                    "Auf dem Regenpflaster bleibt Kent stehen, während die Trommeln schweigen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbannt“ gehört mir."
+                ],
+                "sentence": "Auf dem Regenpflaster bleibt Kent stehen, während die Trommeln schweigen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbannt“ gehört mir.",
+                "sentenceTranslation": "На мокрой мостовой Кент замирает, пока барабаны смолкают. Буря за окнами усиливает клятву: слово «изгнанный» принадлежит мне."
+            },
+            {
+                "word": "der Abschied",
+                "translation": "прощание",
+                "parts": [
+                    "Zwischen verstreuten Reisebündeln befestigt Kent das Schwert am Gürtel.",
+                    "Ich atme tief ein und lasse nur das Wort „der Abschied“ wieder hinaus."
+                ],
+                "sentence": "Zwischen verstreuten Reisebündeln befestigt Kent das Schwert am Gürtel. Ich atme tief ein und lasse nur das Wort „der Abschied“ wieder hinaus.",
+                "sentenceTranslation": "Среди разбросанных узлов Кент затягивает меч на поясе. Я глубоко вдыхаю и выпускаю только слово «прощание»."
+            },
+            {
+                "word": "die Strafe",
+                "translation": "наказание",
+                "parts": [
+                    "Unter dem grauen Himmel zieht Kent den Mantelkragen hoch.",
+                    "Ich presse das Wort „die Strafe“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Unter dem grauen Himmel zieht Kent den Mantelkragen hoch. Ich presse das Wort „die Strafe“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под серым небом Кент поднимает ворот плаща. Я стискиваю слово «наказание» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "zurückkehren",
+                "translation": "возвращаться",
+                "parts": [
+                    "Vor der trostlosen Landstraße richtet Kent den Blick entschlossen nach vorn.",
+                    "Mein Atem zeichnet das Wort „zurückkehren“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Vor der trostlosen Landstraße richtet Kent den Blick entschlossen nach vorn. Mein Atem zeichnet das Wort „zurückkehren“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед пустынной дорогой Кент решительно смотрит вперёд. Моё дыхание рисует слово «возвращаться» в холодном воздухе между нами."
+            }
+        ]
     },
     "disguise": {
         "title": "Маскировка",
         "description": "Акт I-II: Возвращается как слуга Кай",
         "words": [
             {
+                "wordId": "",
                 "word": "die Verkleidung",
                 "translation": "переодевание",
                 "transcription": "[ди фер-КЛАЙ-дунг]",
@@ -1952,9 +2380,14 @@
                 "collocations": [
                     "Diese Verkleidung ist meine einzige Rettung. — Эта маскировка - моё единственное спасение.",
                     "In Verkleidung diene ich meinem König weiter. — В переодевании я продолжаю служить королю."
+                ],
+                "sentenceParts": [
+                    "In der verqualmten Herberge streift Kent das grobe Knechtsgewand über.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Verkleidung“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die List",
                 "translation": "хитрость",
                 "transcription": "[ди ЛИСТ]",
@@ -1984,9 +2417,14 @@
                     "Meine List bewahrt ihn vor dem Selbstmord. — Моя хитрость спасает его от самоубийства.",
                     "Mit List gewinne ich sein Vertrauen. — Хитростью я завоёвываю его доверие.",
                     "Mit List kehre ich an den Hof zurück. — Хитростью я возвращаюсь ко двору."
+                ],
+                "sentenceParts": [
+                    "Vor einem beschlagenen Spiegel übt Kent die raue Stimme des Kays.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "unerkannt",
                 "translation": "неузнанный",
                 "transcription": "[УН-ер-кант]",
@@ -2008,9 +2446,14 @@
                 ],
                 "collocations": [
                     "Unerkannt bleibe ich an seiner Seite. — Неузнанным я остаюсь рядом с ним."
+                ],
+                "sentenceParts": [
+                    "Unter einem zerknitterten Hut verbirgt Kent die königliche Haltung.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unerkannt“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vorgeben",
                 "translation": "притворяться",
                 "transcription": "[ФОР-ге-бен]",
@@ -2033,9 +2476,14 @@
                 ],
                 "collocations": [
                     "Ich gebe vor, ein einfacher Mann zu sein. — Я притворяюсь простым человеком."
+                ],
+                "sentenceParts": [
+                    "Zwischen neugierigen Fuhrknechten studiert Kent die Dienstbefehle.",
+                    "Ich zeichne das Wort „vorgeben“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verstellen",
                 "translation": "изменять",
                 "transcription": "[фер-ШТЕ-лен]",
@@ -2058,9 +2506,14 @@
                 ],
                 "collocations": [
                     "Ich verstelle meine Stimme und Haltung. — Я изменяю свой голос и осанку."
+                ],
+                "sentenceParts": [
+                    "Am Ufer des Hafens wäscht Kent die Spuren des alten Lebens ab.",
+                    "Ich atme tief ein und lasse nur das Wort „verstellen“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Bart",
                 "translation": "борода",
                 "transcription": "[дер БАРТ]",
@@ -2082,9 +2535,14 @@
                 ],
                 "collocations": [
                     "Mit falschem Bart bin ich nicht zu erkennen. — С фальшивой бородой меня не узнать."
+                ],
+                "sentenceParts": [
+                    "Auf dem staubigen Markt prüft Kent die Tragriemen des Gepäcks.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Bart“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "anheuern",
                 "translation": "наниматься",
                 "transcription": "[АН-хой-ерн]",
@@ -2106,9 +2564,14 @@
                 ],
                 "collocations": [
                     "Als Кай heuere ich beim König an. — Как Кай я нанимаюсь к королю."
+                ],
+                "sentenceParts": [
+                    "Im Schatten einer Gasse versteckt Kent den einst glänzenden Siegelring.",
+                    "Das kalte Licht lässt das Wort „anheuern“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "treu",
                 "translation": "верный",
                 "transcription": "[ТРОЙ]",
@@ -2134,6 +2597,10 @@
                 "collocations": [
                     "Treu bleibe ich trotz der Verkleidung. — Верным остаюсь несмотря на переодевание.",
                     "Ich bleibe treu, wenn alle anderen fliehen. — Я остаюсь верным, когда все остальные бегут."
+                ],
+                "sentenceParts": [
+                    "Unter einem Wagenrad kauert Kent, bis der Ruf nach Dienern erschallt.",
+                    "Das Echo des Wortes „treu“ übertönt das Flüstern der Höflinge."
                 ]
             }
         ],
@@ -2141,91 +2608,174 @@
             {
                 "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
-                    "хитрость",
                     "переодевание",
-                    "неузнанный",
-                    "притворяться"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die List»?",
-                "choices": [
                     "притворяться",
-                    "хитрость",
-                    "неузнанный",
-                    "переодевание"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «unerkannt»?",
-                "choices": [
-                    "притворяться",
-                    "переодевание",
-                    "неузнанный",
-                    "изменять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «vorgeben»?",
-                "choices": [
-                    "притворяться",
-                    "верный",
                     "неузнанный",
                     "хитрость"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «verstellen»?",
+                "question": "Что означает немецкое слово «die List»?",
                 "choices": [
                     "неузнанный",
+                    "переодевание",
                     "хитрость",
-                    "изменять",
-                    "наниматься"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Bart»?",
-                "choices": [
-                    "верный",
-                    "неузнанный",
-                    "борода",
                     "притворяться"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «unerkannt»?",
+                "choices": [
+                    "неузнанный",
+                    "борода",
+                    "переодевание",
+                    "хитрость"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «vorgeben»?",
+                "choices": [
+                    "притворяться",
+                    "неузнанный",
+                    "верный",
+                    "переодевание"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verstellen»?",
+                "choices": [
+                    "наниматься",
+                    "переодевание",
+                    "неузнанный",
+                    "изменять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Bart»?",
+                "choices": [
+                    "переодевание",
+                    "верный",
+                    "наниматься",
+                    "борода"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «anheuern»?",
                 "choices": [
-                    "изменять",
-                    "переодевание",
                     "наниматься",
+                    "переодевание",
+                    "притворяться",
                     "неузнанный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
                     "верный",
-                    "наниматься",
-                    "изменять",
-                    "притворяться"
+                    "неузнанный",
+                    "хитрость",
+                    "борода"
                 ],
                 "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Verkleidung",
+                "translation": "переодевание",
+                "parts": [
+                    "In der verqualmten Herberge streift Kent das grobe Knechtsgewand über.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Verkleidung“ auf meine Lippen."
+                ],
+                "sentence": "In der verqualmten Herberge streift Kent das grobe Knechtsgewand über. Wie ein stilles Gebet legt sich das Wort „die Verkleidung“ auf meine Lippen.",
+                "sentenceTranslation": "В задымлённой харчевне Кент натягивает грубое платье слуги. Как тихая молитва слово «переодевание» ложится на мои губы."
+            },
+            {
+                "word": "die List",
+                "translation": "хитрость",
+                "parts": [
+                    "Vor einem beschlagenen Spiegel übt Kent die raue Stimme des Kays.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern."
+                ],
+                "sentence": "Vor einem beschlagenen Spiegel übt Kent die raue Stimme des Kays. Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern.",
+                "sentenceTranslation": "Перед запотевшим зеркалом Кент тренирует хриплый голос Кая. Даже если мир распадается, слово «хитрость» остаётся моим северным светом."
+            },
+            {
+                "word": "unerkannt",
+                "translation": "неузнанный",
+                "parts": [
+                    "Unter einem zerknitterten Hut verbirgt Kent die königliche Haltung.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unerkannt“ gehört mir."
+                ],
+                "sentence": "Unter einem zerknitterten Hut verbirgt Kent die königliche Haltung. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unerkannt“ gehört mir.",
+                "sentenceTranslation": "Под мятой шляпой Кент скрывает королевскую осанку. Буря за окнами усиливает клятву: слово «неузнанный» принадлежит мне."
+            },
+            {
+                "word": "vorgeben",
+                "translation": "притворяться",
+                "parts": [
+                    "Zwischen neugierigen Fuhrknechten studiert Kent die Dienstbefehle.",
+                    "Ich zeichne das Wort „vorgeben“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Zwischen neugierigen Fuhrknechten studiert Kent die Dienstbefehle. Ich zeichne das Wort „vorgeben“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Среди любопытных возниц Кент изучает служебные приказы. Я вывожу слово «притворяться» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "verstellen",
+                "translation": "изменять",
+                "parts": [
+                    "Am Ufer des Hafens wäscht Kent die Spuren des alten Lebens ab.",
+                    "Ich atme tief ein und lasse nur das Wort „verstellen“ wieder hinaus."
+                ],
+                "sentence": "Am Ufer des Hafens wäscht Kent die Spuren des alten Lebens ab. Ich atme tief ein und lasse nur das Wort „verstellen“ wieder hinaus.",
+                "sentenceTranslation": "На пристани Кент смывает следы прежней жизни. Я глубоко вдыхаю и выпускаю только слово «изменять»."
+            },
+            {
+                "word": "der Bart",
+                "translation": "борода",
+                "parts": [
+                    "Auf dem staubigen Markt prüft Kent die Tragriemen des Gepäcks.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Bart“ darf nicht vergehen."
+                ],
+                "sentence": "Auf dem staubigen Markt prüft Kent die Tragriemen des Gepäcks. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Bart“ darf nicht vergehen.",
+                "sentenceTranslation": "На пыльном рынке Кент проверяет ремни поклажи. Я шепчу стражам судьбы: слово «борода» не должно исчезнуть."
+            },
+            {
+                "word": "anheuern",
+                "translation": "наниматься",
+                "parts": [
+                    "Im Schatten einer Gasse versteckt Kent den einst glänzenden Siegelring.",
+                    "Das kalte Licht lässt das Wort „anheuern“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Im Schatten einer Gasse versteckt Kent den einst glänzenden Siegelring. Das kalte Licht lässt das Wort „anheuern“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "В тени переулка Кент прячет некогда блестящий перстень. Холодный свет заставляет слово «наниматься» сиять словно расплавленное золото."
+            },
+            {
+                "word": "treu",
+                "translation": "верный",
+                "parts": [
+                    "Unter einem Wagenrad kauert Kent, bis der Ruf nach Dienern erschallt.",
+                    "Das Echo des Wortes „treu“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Unter einem Wagenrad kauert Kent, bis der Ruf nach Dienern erschallt. Das Echo des Wortes „treu“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Под колесом телеги Кент затаивается, пока не прозвучит зов для слуг. Эхо слова «верный» заглушает шёпот придворных."
+            }
+        ]
     },
     "service": {
         "title": "Тайная служба",
         "description": "Акт II-III: Служит неузнанным",
         "words": [
             {
+                "wordId": "",
                 "word": "der Dienst",
                 "translation": "служба",
                 "transcription": "[дер ДИНСТ]",
@@ -2247,9 +2797,14 @@
                 ],
                 "collocations": [
                     "Mein Dienst geht über die Verbannung hinaus. — Моя служба идёт дальше изгнания."
+                ],
+                "sentenceParts": [
+                    "Im nächtlichen Wachraum poliert Kent schweigend die Rüstung des Königs.",
+                    "Das Echo des Wortes „der Dienst“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Schutz",
                 "translation": "защита",
                 "transcription": "[дер ШУТЦ]",
@@ -2271,9 +2826,14 @@
                 ],
                 "collocations": [
                     "Ich biete Schutz, ohne erkannt zu werden. — Я предоставляю защиту, не будучи узнанным."
+                ],
+                "sentenceParts": [
+                    "Neben dem Lager des erschöpften Herrschers hält Kent unbeweglich Wache.",
+                    "Das Echo des Wortes „der Schutz“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Gefahr",
                 "translation": "опасность",
                 "transcription": "[ди ге-ФАР]",
@@ -2296,9 +2856,14 @@
                     "Die Gefahr lauert überall um mich herum. — Опасность подстерегает меня повсюду.",
                     "Trotz Gefahr bleibe ich beim König. — Несмотря на опасность, я остаюсь с королём.",
                     "Die Gefahr der Entdeckung ist groß. — Опасность разоблачения велика."
+                ],
+                "sentenceParts": [
+                    "Unter Regenmänteln der Wachen verbirgt Kent seine Narben.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Gefahr“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "bewachen",
                 "translation": "охранять",
                 "transcription": "[бе-ВА-хен]",
@@ -2320,9 +2885,14 @@
                 ],
                 "collocations": [
                     "Heimlich bewache ich meinen alten Herrn. — Тайно я охраняю своего старого господина."
+                ],
+                "sentenceParts": [
+                    "Am Stalltor sattelt Kent in der Dunkelheit ein trotziges Pferd.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „bewachen“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "kämpfen",
                 "translation": "сражаться",
                 "transcription": "[КЕМП-фен]",
@@ -2346,9 +2916,14 @@
                     "Der Narr spürt, wie das Kämpfen alle verändert. — Шут чувствует, как умение бороться меняет всех.",
                     "Ich kämpfe gegen alle seine Feinde. — Я сражаюсь против всех его врагов.",
                     "Ich kämpfe um das, was ich begehre. — Я борюсь за то, чего желаю."
+                ],
+                "sentenceParts": [
+                    "In der Küche der Dienerschaft füllt Kent den dampfenden Becher.",
+                    "Ich zeichne das Wort „kämpfen“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "raten",
                 "translation": "советовать",
                 "transcription": "[РА-тен]",
@@ -2370,9 +2945,14 @@
                 ],
                 "collocations": [
                     "Als Кай rate ich ihm zur Vorsicht. — Как Кай я советую ему осторожность."
+                ],
+                "sentenceParts": [
+                    "Vor der Schlafstatt des Königs ordnet Kent die verstreuten Decken.",
+                    "Ich umarme das Wort „raten“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Wache",
                 "translation": "стража",
                 "transcription": "[ди ВА-хе]",
@@ -2394,6 +2974,10 @@
                 ],
                 "collocations": [
                     "Ich halte Wache über seinen Schlaf. — Я держу стражу над его сном."
+                ],
+                "sentenceParts": [
+                    "Auf dem Hof prüft Kent das Zaumzeug, bevor der Morgen graut.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Wache“ mein Nordstern."
                 ]
             }
         ],
@@ -2401,81 +2985,154 @@
             {
                 "question": "Что означает немецкое слово «der Dienst»?",
                 "choices": [
-                    "защита",
-                    "опасность",
                     "служба",
-                    "охранять"
+                    "охранять",
+                    "защита",
+                    "опасность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Schutz»?",
                 "choices": [
-                    "опасность",
-                    "охранять",
+                    "служба",
                     "защита",
-                    "служба"
+                    "опасность",
+                    "охранять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "защита",
+                    "охранять",
                     "опасность",
-                    "сражаться",
-                    "служба"
+                    "служба",
+                    "стража"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bewachen»?",
                 "choices": [
+                    "сражаться",
                     "опасность",
                     "охранять",
-                    "сражаться",
-                    "служба"
+                    "стража"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
                     "сражаться",
+                    "служба",
                     "советовать",
-                    "опасность",
-                    "охранять"
+                    "стража"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «raten»?",
                 "choices": [
-                    "стража",
                     "советовать",
-                    "служба",
-                    "охранять"
+                    "сражаться",
+                    "защита",
+                    "стража"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Wache»?",
                 "choices": [
-                    "служба",
+                    "опасность",
                     "защита",
-                    "стража",
-                    "охранять"
+                    "сражаться",
+                    "стража"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Dienst",
+                "translation": "служба",
+                "parts": [
+                    "Im nächtlichen Wachraum poliert Kent schweigend die Rüstung des Königs.",
+                    "Das Echo des Wortes „der Dienst“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Im nächtlichen Wachraum poliert Kent schweigend die Rüstung des Königs. Das Echo des Wortes „der Dienst“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В ночной караульной Кент молча полирует королевские доспехи. Эхо слова «служба» заглушает шёпот придворных."
+            },
+            {
+                "word": "der Schutz",
+                "translation": "защита",
+                "parts": [
+                    "Neben dem Lager des erschöpften Herrschers hält Kent unbeweglich Wache.",
+                    "Das Echo des Wortes „der Schutz“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Neben dem Lager des erschöpften Herrschers hält Kent unbeweglich Wache. Das Echo des Wortes „der Schutz“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У ложа измождённого правителя Кент неподвижно несёт стражу. Эхо слова «защита» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Gefahr",
+                "translation": "опасность",
+                "parts": [
+                    "Unter Regenmänteln der Wachen verbirgt Kent seine Narben.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Gefahr“ bleibt lebendig."
+                ],
+                "sentence": "Unter Regenmänteln der Wachen verbirgt Kent seine Narben. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Gefahr“ bleibt lebendig.",
+                "sentenceTranslation": "Под дождевыми плащами стражей Кент скрывает свои шрамы. Каждой клеткой тела я обещаю: слово «опасность» останется живым."
+            },
+            {
+                "word": "bewachen",
+                "translation": "охранять",
+                "parts": [
+                    "Am Stalltor sattelt Kent in der Dunkelheit ein trotziges Pferd.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „bewachen“ mein Nordstern."
+                ],
+                "sentence": "Am Stalltor sattelt Kent in der Dunkelheit ein trotziges Pferd. Selbst wenn die Welt zerfällt, bleibt das Wort „bewachen“ mein Nordstern.",
+                "sentenceTranslation": "У дверей конюшни Кент в темноте осёдлывает упрямого коня. Даже если мир распадается, слово «охранять» остаётся моим северным светом."
+            },
+            {
+                "word": "kämpfen",
+                "translation": "сражаться",
+                "parts": [
+                    "In der Küche der Dienerschaft füllt Kent den dampfenden Becher.",
+                    "Ich zeichne das Wort „kämpfen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "In der Küche der Dienerschaft füllt Kent den dampfenden Becher. Ich zeichne das Wort „kämpfen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В кухне прислуги Кент наполняет дымящийся кубок. Я черчу слово «сражаться» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "raten",
+                "translation": "советовать",
+                "parts": [
+                    "Vor der Schlafstatt des Königs ordnet Kent die verstreuten Decken.",
+                    "Ich umarme das Wort „raten“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Vor der Schlafstatt des Königs ordnet Kent die verstreuten Decken. Ich umarme das Wort „raten“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Перед ложем короля Кент раскладывает разбросанные покрывала. Я обнимаю слово «советовать», будто это единственный союзник."
+            },
+            {
+                "word": "die Wache",
+                "translation": "стража",
+                "parts": [
+                    "Auf dem Hof prüft Kent das Zaumzeug, bevor der Morgen graut.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Wache“ mein Nordstern."
+                ],
+                "sentence": "Auf dem Hof prüft Kent das Zaumzeug, bevor der Morgen graut. Selbst wenn die Welt zerfällt, bleibt das Wort „die Wache“ mein Nordstern.",
+                "sentenceTranslation": "Во дворе Кент проверяет уздечку, пока не рассвело. Даже если мир распадается, слово «стража» остаётся моим северным светом."
+            }
+        ]
     },
     "stocks": {
         "title": "В колодках",
         "description": "Акт II: Наказан Корнуоллом",
         "words": [
             {
+                "wordId": "",
                 "word": "die Strafe",
                 "translation": "наказание",
                 "transcription": "[ди ШТРА-фе]",
@@ -2501,9 +3158,14 @@
                     "Diese Strafe erdulde ich für meinen König. — Это наказание я терплю ради короля.",
                     "Die Strafe für Widerspruch ist hart. — Наказание за возражение сурово.",
                     "Dies ist die gerechte Strafe für meine Grausamkeit. — Это справедливая кара за мою жестокость."
+                ],
+                "sentenceParts": [
+                    "Im Regen der Burgmauer sitzt Kent mit gefesselten Füßen in den harten Hölzern.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Strafe“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Demütigung",
                 "translation": "унижение",
                 "transcription": "[ди де-МЮ-ти-гунг]",
@@ -2525,9 +3187,15 @@
                 ],
                 "collocations": [
                     "Die Demütigung macht mich nur stärker. — Унижение делает меня только сильнее."
+                ],
+                "sentenceParts": [
+                    "Neben den Spottliedern der Wachen hält Kent den Kopf stolz erhoben.",
+                    "Ich presse das Wort „die Demütigung“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Standhaftigkeit",
                 "translation": "стойкость",
                 "transcription": "[ди ШТАНД-хаф-тиг-кайт]",
@@ -2549,9 +3217,14 @@
                 ],
                 "collocations": [
                     "Mit Standhaftigkeit ertrage ich die Schmach. — Со стойкостью я переношу позор."
+                ],
+                "sentenceParts": [
+                    "Vor dem trüben Mondlicht reibt Kent den schmerzenden Nacken.",
+                    "Ich zeichne das Wort „die Standhaftigkeit“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "fesseln",
                 "translation": "сковывать",
                 "transcription": "[ФЕ-сельн]",
@@ -2573,9 +3246,14 @@
                 ],
                 "collocations": [
                     "Sie fesseln mich wie einen gemeinen Dieb. — Они сковывают меня как обычного вора."
+                ],
+                "sentenceParts": [
+                    "Zwischen den Pfützen der Nacht starren Kents Schuhe in den Himmel.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „fesseln“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erdulden",
                 "translation": "терпеть",
                 "transcription": "[ер-ДУЛЬ-ден]",
@@ -2599,9 +3277,14 @@
                 ],
                 "collocations": [
                     "Ich erdulde die Schande ohne Klage. — Я терплю позор без жалоб."
+                ],
+                "sentenceParts": [
+                    "Am Morgenfrost haucht Kent Eisblumen auf das Holz.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „erdulden“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Stock",
                 "translation": "колодка",
                 "transcription": "[дер ШТОК]",
@@ -2623,9 +3306,14 @@
                 ],
                 "collocations": [
                     "Im Stock sitze ich die ganze Nacht. — В колодке я сижу всю ночь."
+                ],
+                "sentenceParts": [
+                    "Neben einem verirrten Bauernkind lächelt Kent trotz der Demütigung.",
+                    "Das kalte Licht lässt das Wort „der Stock“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ausharren",
                 "translation": "выдерживать",
                 "transcription": "[АУС-ха-рен]",
@@ -2649,9 +3337,14 @@
                 ],
                 "collocations": [
                     "Ich harre aus bis zur Befreiung. — Я выдерживаю до освобождения."
+                ],
+                "sentenceParts": [
+                    "Unter dem grauen Himmel zählt Kent geduldig die Tropfen auf dem Gesicht.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „ausharren“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Schande",
                 "translation": "позор",
                 "transcription": "[ди ШАН-де]",
@@ -2672,6 +3365,10 @@
                 "collocations": [
                     "Der Narr spottet, sobald die Schande erwähnt wird. — Шут насмехается, едва кто-то произносит «позор».",
                     "Diese Schande ist Cornwall's, nicht meine. — Этот позор Корнуолла, не мой."
+                ],
+                "sentenceParts": [
+                    "Auf dem verlassenen Hof lauscht Kent dem fern rollenden Donner.",
+                    "Das kalte Licht lässt das Wort „die Schande“ wie geschmolzenes Gold erscheinen."
                 ]
             }
         ],
@@ -2679,19 +3376,19 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
+                    "сковывать",
                     "наказание",
-                    "стойкость",
                     "унижение",
-                    "сковывать"
+                    "стойкость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Demütigung»?",
                 "choices": [
-                    "наказание",
-                    "сковывать",
                     "стойкость",
+                    "сковывать",
+                    "наказание",
                     "унижение"
                 ],
                 "correctIndex": 3
@@ -2700,70 +3397,154 @@
                 "question": "Что означает немецкое слово «die Standhaftigkeit»?",
                 "choices": [
                     "унижение",
-                    "позор",
-                    "терпеть",
-                    "стойкость"
+                    "стойкость",
+                    "колодка",
+                    "сковывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «fesseln»?",
                 "choices": [
-                    "терпеть",
-                    "наказание",
+                    "стойкость",
+                    "выдерживать",
                     "сковывать",
-                    "колодка"
+                    "наказание"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erdulden»?",
                 "choices": [
+                    "колодка",
+                    "унижение",
                     "терпеть",
-                    "позор",
-                    "стойкость",
-                    "колодка"
+                    "стойкость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Stock»?",
                 "choices": [
-                    "сковывать",
-                    "выдерживать",
                     "колодка",
-                    "позор"
+                    "терпеть",
+                    "унижение",
+                    "сковывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ausharren»?",
                 "choices": [
-                    "сковывать",
-                    "выдерживать",
-                    "терпеть",
-                    "позор"
+                    "колодка",
+                    "унижение",
+                    "наказание",
+                    "выдерживать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Schande»?",
                 "choices": [
+                    "унижение",
                     "наказание",
-                    "колодка",
                     "позор",
-                    "выдерживать"
+                    "терпеть"
                 ],
                 "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Strafe",
+                "translation": "наказание",
+                "parts": [
+                    "Im Regen der Burgmauer sitzt Kent mit gefesselten Füßen in den harten Hölzern.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Strafe“ darf nicht vergehen."
+                ],
+                "sentence": "Im Regen der Burgmauer sitzt Kent mit gefesselten Füßen in den harten Hölzern. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Strafe“ darf nicht vergehen.",
+                "sentenceTranslation": "Под дождём у крепостной стены Кент сидит с закреплёнными ногами в жёстких колодках. Я шепчу стражам судьбы: слово «наказание» не должно исчезнуть."
+            },
+            {
+                "word": "die Demütigung",
+                "translation": "унижение",
+                "parts": [
+                    "Neben den Spottliedern der Wachen hält Kent den Kopf stolz erhoben.",
+                    "Ich presse das Wort „die Demütigung“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Neben den Spottliedern der Wachen hält Kent den Kopf stolz erhoben. Ich presse das Wort „die Demütigung“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под насмешливые песни стражи Кент гордо держит голову. Я стискиваю слово «унижение» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Standhaftigkeit",
+                "translation": "стойкость",
+                "parts": [
+                    "Vor dem trüben Mondlicht reibt Kent den schmerzenden Nacken.",
+                    "Ich zeichne das Wort „die Standhaftigkeit“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Vor dem trüben Mondlicht reibt Kent den schmerzenden Nacken. Ich zeichne das Wort „die Standhaftigkeit“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В тусклом лунном свете Кент растирает затёкшую шею. Я черчу слово «стойкость» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "fesseln",
+                "translation": "сковывать",
+                "parts": [
+                    "Zwischen den Pfützen der Nacht starren Kents Schuhe in den Himmel.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „fesseln“ mein Nordstern."
+                ],
+                "sentence": "Zwischen den Pfützen der Nacht starren Kents Schuhe in den Himmel. Selbst wenn die Welt zerfällt, bleibt das Wort „fesseln“ mein Nordstern.",
+                "sentenceTranslation": "Среди ночных луж сапоги Кент устремлены в небо. Даже если мир распадается, слово «сковывать» остаётся моим северным светом."
+            },
+            {
+                "word": "erdulden",
+                "translation": "терпеть",
+                "parts": [
+                    "Am Morgenfrost haucht Kent Eisblumen auf das Holz.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „erdulden“ mein Nordstern."
+                ],
+                "sentence": "Am Morgenfrost haucht Kent Eisblumen auf das Holz. Selbst wenn die Welt zerfällt, bleibt das Wort „erdulden“ mein Nordstern.",
+                "sentenceTranslation": "В утренний мороз Кент выдыхает ледяные узоры на дерево. Даже если мир распадается, слово «терпеть» остаётся моим северным светом."
+            },
+            {
+                "word": "der Stock",
+                "translation": "колодка",
+                "parts": [
+                    "Neben einem verirrten Bauernkind lächelt Kent trotz der Demütigung.",
+                    "Das kalte Licht lässt das Wort „der Stock“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Neben einem verirrten Bauernkind lächelt Kent trotz der Demütigung. Das kalte Licht lässt das Wort „der Stock“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Рядом с заблудившимся крестьянином Кент улыбается несмотря на унижение. Холодный свет заставляет слово «колодка» сиять словно расплавленное золото."
+            },
+            {
+                "word": "ausharren",
+                "translation": "выдерживать",
+                "parts": [
+                    "Unter dem grauen Himmel zählt Kent geduldig die Tropfen auf dem Gesicht.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „ausharren“ darf nicht vergehen."
+                ],
+                "sentence": "Unter dem grauen Himmel zählt Kent geduldig die Tropfen auf dem Gesicht. Ich flüstere den Wächtern des Schicksals zu: Das Wort „ausharren“ darf nicht vergehen.",
+                "sentenceTranslation": "Под серым небом Кент терпеливо считает капли на лице. Я шепчу стражам судьбы: слово «выдерживать» не должно исчезнуть."
+            },
+            {
+                "word": "die Schande",
+                "translation": "позор",
+                "parts": [
+                    "Auf dem verlassenen Hof lauscht Kent dem fern rollenden Donner.",
+                    "Das kalte Licht lässt das Wort „die Schande“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Auf dem verlassenen Hof lauscht Kent dem fern rollenden Donner. Das kalte Licht lässt das Wort „die Schande“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "На пустынном дворе Кент прислушивается к далёкому грохоту грома. Холодный свет заставляет слово «позор» сиять словно расплавленное золото."
+            }
+        ]
     },
     "storm_companion": {
         "title": "Спутник в буре",
         "description": "Акт III: Поддерживает Лира",
         "words": [
             {
+                "wordId": "",
                 "word": "der Sturm",
                 "translation": "буря",
                 "transcription": "[дер ШТУРМ]",
@@ -2787,9 +3568,14 @@
                     "Der Sturm tobt über unseren Köpfen. — Буря бушует над нашими головами.",
                     "Im Sturm bleibe ich bei meinem König. — В буре я остаюсь с моим королём.",
                     "Der Sturm soll sein neues Zuhause sein. — Буря пусть будет его новым домом."
+                ],
+                "sentenceParts": [
+                    "Mit der Laterne in der Faust sucht Kent nach dem Schatten des Königs.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Beistand",
                 "translation": "поддержка",
                 "transcription": "[дер БАЙ-штанд]",
@@ -2811,9 +3597,14 @@
                 ],
                 "collocations": [
                     "Mein Beistand ist alles, was ich bieten kann. — Моя поддержка - всё, что я могу предложить."
+                ],
+                "sentenceParts": [
+                    "Neben dem tobenden Monarchen breitet Kent den Mantel wie ein Schild.",
+                    "Das kalte Licht lässt das Wort „der Beistand“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "begleiten",
                 "translation": "сопровождать",
                 "transcription": "[бе-ГЛАЙ-тен]",
@@ -2841,9 +3632,14 @@
                     "Als Tom begleite ich Lear durch seine dunkelste Stunde. — Как Том, я сопровождаю Лира в его самый тёмный час.",
                     "Ich begleite ihn durch Wind und Regen. — Я сопровождаю его сквозь ветер и дождь.",
                     "Treu begleite ich meinen verrückten König. — Верно я сопровождаю своего безумного короля."
+                ],
+                "sentenceParts": [
+                    "Auf dem überfluteten Pfad hält Kent das Pferd am Zügel.",
+                    "Ich zeichne das Wort „begleiten“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "trösten",
                 "translation": "утешать",
                 "transcription": "[ТРЁС-тен]",
@@ -2866,9 +3662,14 @@
                     "Als Fremder tröste ich meinen eigenen Vater. — Как чужой, я утешаю собственного отца.",
                     "Lass mich dich trösten in dieser dunklen Stunde. — Позволь мне утешить тебя в этот тёмный час.",
                     "Mit Worten tröste ich den wahnsinnigen König. — Словами я утешаю безумного короля."
+                ],
+                "sentenceParts": [
+                    "Zwischen klatschenden Ästen ruft Kent beruhigende Worte.",
+                    "Mein Atem zeichnet das Wort „trösten“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Zuflucht",
                 "translation": "убежище",
                 "transcription": "[ди ЦУ-флухт]",
@@ -2891,9 +3692,15 @@
                 ],
                 "collocations": [
                     "Ich suche Zuflucht für uns beide. — Я ищу убежище для нас обоих."
+                ],
+                "sentenceParts": [
+                    "Vor der klappernden Hütte hebt Kent die Fackel,",
+                    "um den Weg zu zeigen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Zuflucht“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "durchhalten",
                 "translation": "выдерживать",
                 "transcription": "[ДУРХ-халь-тен]",
@@ -2916,9 +3723,14 @@
                 "collocations": [
                     "Das Durchhalten fällt Lear unerwartet schwer. — Лиру неожиданно тяжело выдерживать.",
                     "Gemeinsam werden wir durchhalten. — Вместе мы выдержим."
+                ],
+                "sentenceParts": [
+                    "Am Rand des Moorfelds stützt Kent den taumelnden Herrscher.",
+                    "Ich umarme das Wort „durchhalten“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Kälte",
                 "translation": "холод",
                 "transcription": "[ди КЕЛ-те]",
@@ -2943,6 +3755,11 @@
                 "collocations": [
                     "Die Kälte dringt in unsere Knochen. — Холод проникает в наши кости.",
                     "Die Kälte meines Herzens übertrifft den Winter. — Холод моего сердца превосходит зиму."
+                ],
+                "sentenceParts": [
+                    "Unter dem peitschenden Regen spricht Kent ein leises Trostlied.",
+                    "Ich presse das Wort „die Kälte“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             }
         ],
@@ -2950,81 +3767,156 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "сопровождать",
-                    "утешать",
+                    "поддержка",
                     "буря",
-                    "поддержка"
+                    "сопровождать",
+                    "утешать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Beistand»?",
                 "choices": [
-                    "буря",
-                    "поддержка",
                     "утешать",
-                    "сопровождать"
+                    "поддержка",
+                    "сопровождать",
+                    "буря"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
+                    "убежище",
                     "сопровождать",
-                    "буря",
-                    "холод",
-                    "убежище"
+                    "утешать",
+                    "выдерживать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "сопровождать",
+                    "холод",
+                    "буря",
                     "выдерживать",
-                    "утешать",
-                    "поддержка"
+                    "утешать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Zuflucht»?",
                 "choices": [
-                    "убежище",
-                    "буря",
-                    "поддержка",
-                    "сопровождать"
+                    "утешать",
+                    "выдерживать",
+                    "сопровождать",
+                    "убежище"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «durchhalten»?",
                 "choices": [
-                    "выдерживать",
-                    "буря",
+                    "утешать",
+                    "сопровождать",
                     "холод",
-                    "поддержка"
+                    "выдерживать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "поддержка",
-                    "холод",
-                    "убежище",
-                    "сопровождать"
+                    "выдерживать",
+                    "сопровождать",
+                    "утешать",
+                    "холод"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Sturm",
+                "translation": "буря",
+                "parts": [
+                    "Mit der Laterne in der Faust sucht Kent nach dem Schatten des Königs.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen."
+                ],
+                "sentence": "Mit der Laterne in der Faust sucht Kent nach dem Schatten des Königs. Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen.",
+                "sentenceTranslation": "С фонарём в кулаке Кент ищет тень короля. Как тихая молитва слово «буря» ложится на мои губы."
+            },
+            {
+                "word": "der Beistand",
+                "translation": "поддержка",
+                "parts": [
+                    "Neben dem tobenden Monarchen breitet Kent den Mantel wie ein Schild.",
+                    "Das kalte Licht lässt das Wort „der Beistand“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Neben dem tobenden Monarchen breitet Kent den Mantel wie ein Schild. Das kalte Licht lässt das Wort „der Beistand“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Рядом с бушующим монархом Кент раскрывает плащ как щит. Холодный свет заставляет слово «поддержка» сиять словно расплавленное золото."
+            },
+            {
+                "word": "begleiten",
+                "translation": "сопровождать",
+                "parts": [
+                    "Auf dem überfluteten Pfad hält Kent das Pferd am Zügel.",
+                    "Ich zeichne das Wort „begleiten“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Auf dem überfluteten Pfad hält Kent das Pferd am Zügel. Ich zeichne das Wort „begleiten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На затопленной тропе Кент держит коня за повод. Я вывожу слово «сопровождать» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "trösten",
+                "translation": "утешать",
+                "parts": [
+                    "Zwischen klatschenden Ästen ruft Kent beruhigende Worte.",
+                    "Mein Atem zeichnet das Wort „trösten“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Zwischen klatschenden Ästen ruft Kent beruhigende Worte. Mein Atem zeichnet das Wort „trösten“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Среди хлещущих веток Кент говорит успокаивающие слова. Моё дыхание рисует слово «утешать» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Zuflucht",
+                "translation": "убежище",
+                "parts": [
+                    "Vor der klappernden Hütte hebt Kent die Fackel,",
+                    "um den Weg zu zeigen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Zuflucht“ bleibt lebendig."
+                ],
+                "sentence": "Vor der klappernden Hütte hebt Kent die Fackel, um den Weg zu zeigen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Zuflucht“ bleibt lebendig.",
+                "sentenceTranslation": "Перед дрожащей хижиной Кент поднимает факел, освещая путь. Каждой клеткой тела я обещаю: слово «убежище» останется живым."
+            },
+            {
+                "word": "durchhalten",
+                "translation": "выдерживать",
+                "parts": [
+                    "Am Rand des Moorfelds stützt Kent den taumelnden Herrscher.",
+                    "Ich umarme das Wort „durchhalten“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Am Rand des Moorfelds stützt Kent den taumelnden Herrscher. Ich umarme das Wort „durchhalten“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "На краю болотного поля Кент поддерживает качающегося правителя. Я обнимаю слово «выдерживать», будто это единственный союзник."
+            },
+            {
+                "word": "die Kälte",
+                "translation": "холод",
+                "parts": [
+                    "Unter dem peitschenden Regen spricht Kent ein leises Trostlied.",
+                    "Ich presse das Wort „die Kälte“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Unter dem peitschenden Regen spricht Kent ein leises Trostlied. Ich presse das Wort „die Kälte“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Под хлещущим дождём Кент тихо напевает утешительную песнь. Я стискиваю слово «холод» зубами, чтобы не вырвалось сомнение."
+            }
+        ]
     },
     "final_loyalty": {
         "title": "Верность до конца",
         "description": "Акт V: Остаётся с умирающим Лиром",
         "words": [
             {
+                "wordId": "",
                 "word": "der Tod",
                 "translation": "смерть",
                 "transcription": "[дер ТОД]",
@@ -3049,9 +3941,14 @@
                     "Der Tod trennt uns nur für kurze Zeit. — Смерть разлучает нас лишь ненадолго.",
                     "Bis zum Tod bleibe ich an seiner Seite. — До смерти я остаюсь рядом с ним.",
                     "Der Tod kommt für mich zu früh. — Смерть приходит ко мне слишком рано."
+                ],
+                "sentenceParts": [
+                    "Im stillen Sterbezimmer wacht Kent an Lears letztem Lager.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Tod“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Abschied",
                 "translation": "прощание",
                 "transcription": "[дер АБ-шид]",
@@ -3084,9 +3981,14 @@
                     "Unser Abschied ist nur vorübergehend. — Наше прощание лишь временно.",
                     "Der Abschied vom Hof schmerzt mich tief. — Прощание с двором глубоко ранит меня.",
                     "Der Abschied von meinem König bricht mein Herz. — Прощание с моим королём разбивает моё сердце."
+                ],
+                "sentenceParts": [
+                    "Neben der verlöschenden Kerze streicht Kent über den zerrissenen Umhang.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Abschied“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ewig",
                 "translation": "вечный",
                 "transcription": "[Э-виг]",
@@ -3115,9 +4017,14 @@
                     "Unsere Liebe wird ewig dauern, mein Kind. — Наша любовь будет вечной, дитя моё.",
                     "Unsere Liebe ist ewig, Vater. — Наша любовь вечна, отец.",
                     "Meine Treue ist ewig, über den Tod hinaus. — Моя верность вечна, за пределами смерти."
+                ],
+                "sentenceParts": [
+                    "Vor den starren Wachen flüstert Kent ein letztes Versprechen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „ewig“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "weinen",
                 "translation": "плакать",
                 "transcription": "[ВАЙ-нен]",
@@ -3138,9 +4045,14 @@
                 "collocations": [
                     "Das Weinen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело плакать.",
                     "Ich weine um meinen gefallenen König. — Я плачу о моём павшем короле."
+                ],
+                "sentenceParts": [
+                    "Auf dem leeren Thronstuhl legt Kent den eigenen Stab nieder.",
+                    "Mein Atem zeichnet das Wort „weinen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Erschöpfung",
                 "translation": "истощение",
                 "transcription": "[ди ер-ШЁП-фунг]",
@@ -3162,9 +4074,14 @@
                 ],
                 "collocations": [
                     "Die Erschöpfung überwältigt meinen alten Körper. — Истощение одолевает моё старое тело."
+                ],
+                "sentenceParts": [
+                    "Zwischen verblassenden Wandmalereien schließt Kent kurz die Augen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Erschöpfung“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "aufgeben",
                 "translation": "сдаваться",
                 "transcription": "[АУФ-ге-бен]",
@@ -3190,9 +4107,14 @@
                 "collocations": [
                     "Ich gebe auf, nachdem mein Herr gestorben ist. — Я сдаюсь после смерти моего господина.",
                     "Ich will das Leben aufgeben. — Я хочу отказаться от жизни."
+                ],
+                "sentenceParts": [
+                    "Am offenen Fenster lässt Kent den kalten Morgen herein.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufgeben“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Trauer",
                 "translation": "скорбь",
                 "transcription": "[ди ТРАУ-ер]",
@@ -3216,9 +4138,14 @@
                     "Die Trauer überwältigt meine Seele. — Скорбь переполняет мою душу.",
                     "Die Trauer ist zu schwer zu ertragen. — Скорбь слишком тяжела, чтобы вынести.",
                     "Die Trauer um Корделия macht mich stumm. — Печаль о Корделии делает меня немым."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der Trauernden hält Kent Lears Hand bis zum letzten Schlag.",
+                    "Ich zeichne das Wort „die Trauer“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "folgen",
                 "translation": "следовать",
                 "transcription": "[ФОЛЬ-ген]",
@@ -3239,6 +4166,10 @@
                 "collocations": [
                     "Cordelia zeigt, dass das Folgen auch ohne Stolz möglich ist. — Корделия показывает, что следовать можно и без гордыни.",
                     "Bald folge ich meinem König ins Jenseits. — Скоро я последую за королём в иной мир."
+                ],
+                "sentenceParts": [
+                    "Vor der stillen Hofkapelle beugt Kent das Knie für ein stummes Gebet.",
+                    "Ich halte das Wort „folgen“ wie eine Fackel vor meinem Herzen."
                 ]
             }
         ],
@@ -3246,19 +4177,19 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "смерть",
-                    "вечный",
                     "плакать",
+                    "вечный",
+                    "смерть",
                     "прощание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "вечный",
                     "смерть",
                     "плакать",
+                    "вечный",
                     "прощание"
                 ],
                 "correctIndex": 3
@@ -3266,19 +4197,19 @@
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "плакать",
-                    "сдаваться",
-                    "скорбь",
-                    "вечный"
+                    "вечный",
+                    "следовать",
+                    "смерть",
+                    "истощение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «weinen»?",
                 "choices": [
+                    "скорбь",
+                    "сдаваться",
                     "истощение",
-                    "вечный",
-                    "прощание",
                     "плакать"
                 ],
                 "correctIndex": 3
@@ -3286,19 +4217,19 @@
             {
                 "question": "Что означает немецкое слово «die Erschöpfung»?",
                 "choices": [
-                    "скорбь",
                     "истощение",
-                    "вечный",
-                    "плакать"
+                    "плакать",
+                    "смерть",
+                    "следовать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
-                    "вечный",
-                    "истощение",
                     "скорбь",
+                    "смерть",
+                    "следовать",
                     "сдаваться"
                 ],
                 "correctIndex": 3
@@ -3306,8 +4237,8 @@
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "смерть",
-                    "вечный",
+                    "следовать",
+                    "плакать",
                     "сдаваться",
                     "скорбь"
                 ],
@@ -3316,15 +4247,97 @@
             {
                 "question": "Что означает немецкое слово «folgen»?",
                 "choices": [
-                    "смерть",
-                    "следовать",
                     "сдаваться",
-                    "прощание"
+                    "скорбь",
+                    "истощение",
+                    "следовать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Tod",
+                "translation": "смерть",
+                "parts": [
+                    "Im stillen Sterbezimmer wacht Kent an Lears letztem Lager.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Tod“ gehört mir."
+                ],
+                "sentence": "Im stillen Sterbezimmer wacht Kent an Lears letztem Lager. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Tod“ gehört mir.",
+                "sentenceTranslation": "В тихой опочивальне смерти Кент стоит у последнего ложа Лира. Буря за окнами усиливает клятву: слово «смерть» принадлежит мне."
+            },
+            {
+                "word": "der Abschied",
+                "translation": "прощание",
+                "parts": [
+                    "Neben der verlöschenden Kerze streicht Kent über den zerrissenen Umhang.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Abschied“ auf meine Lippen."
+                ],
+                "sentence": "Neben der verlöschenden Kerze streicht Kent über den zerrissenen Umhang. Wie ein stilles Gebet legt sich das Wort „der Abschied“ auf meine Lippen.",
+                "sentenceTranslation": "У догорающей свечи Кент гладит разорванный плащ. Как тихая молитва слово «прощание» ложится на мои губы."
+            },
+            {
+                "word": "ewig",
+                "translation": "вечный",
+                "parts": [
+                    "Vor den starren Wachen flüstert Kent ein letztes Versprechen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „ewig“ wird heute nicht verraten."
+                ],
+                "sentence": "Vor den starren Wachen flüstert Kent ein letztes Versprechen. Mit fester Stimme schwöre ich mir: Das Wort „ewig“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед оцепеневшими стражами Кент шепчет последнее обещание. Твёрдым голосом я клянусь себе: слово «вечный» сегодня не будет предано."
+            },
+            {
+                "word": "weinen",
+                "translation": "плакать",
+                "parts": [
+                    "Auf dem leeren Thronstuhl legt Kent den eigenen Stab nieder.",
+                    "Mein Atem zeichnet das Wort „weinen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Auf dem leeren Thronstuhl legt Kent den eigenen Stab nieder. Mein Atem zeichnet das Wort „weinen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На пустом троне Кент кладёт свой посох. Моё дыхание рисует слово «плакать» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Erschöpfung",
+                "translation": "истощение",
+                "parts": [
+                    "Zwischen verblassenden Wandmalereien schließt Kent kurz die Augen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Erschöpfung“ mein Nordstern."
+                ],
+                "sentence": "Zwischen verblassenden Wandmalereien schließt Kent kurz die Augen. Selbst wenn die Welt zerfällt, bleibt das Wort „die Erschöpfung“ mein Nordstern.",
+                "sentenceTranslation": "Среди блекнущих настенных росписей Кент на мгновение закрывает глаза. Даже если мир распадается, слово «истощение» остаётся моим северным светом."
+            },
+            {
+                "word": "aufgeben",
+                "translation": "сдаваться",
+                "parts": [
+                    "Am offenen Fenster lässt Kent den kalten Morgen herein.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufgeben“ darf nicht vergehen."
+                ],
+                "sentence": "Am offenen Fenster lässt Kent den kalten Morgen herein. Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufgeben“ darf nicht vergehen.",
+                "sentenceTranslation": "У распахнутого окна Кент впускает холодное утро. Я шепчу стражам судьбы: слово «сдаваться» не должно исчезнуть."
+            },
+            {
+                "word": "die Trauer",
+                "translation": "скорбь",
+                "parts": [
+                    "Im Schatten der Trauernden hält Kent Lears Hand bis zum letzten Schlag.",
+                    "Ich zeichne das Wort „die Trauer“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Im Schatten der Trauernden hält Kent Lears Hand bis zum letzten Schlag. Ich zeichne das Wort „die Trauer“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "В тени скорбящих Кент держит руку Лира до последнего удара. Я вывожу слово «скорбь» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "folgen",
+                "translation": "следовать",
+                "parts": [
+                    "Vor der stillen Hofkapelle beugt Kent das Knie für ein stummes Gebet.",
+                    "Ich halte das Wort „folgen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Vor der stillen Hofkapelle beugt Kent das Knie für ein stummes Gebet. Ich halte das Wort „folgen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед молчаливой придворной часовней Кент преклоняет колено в безмолвной молитве. Я держу слово «следовать» как факел у сердца."
+            }
+        ]
     }
 };
 
@@ -3340,6 +4353,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3776,6 +5137,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -3844,6 +5522,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -3852,13 +5533,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4769,6 +6498,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/journeys/king_lear.html
+++ b/output/journeys/king_lear.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="throne">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="goneril">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="regan">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="storm">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="hut">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="dover">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="prison">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["трон", "королевство", "править", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["власть", "править", "королевство", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "корона", "править", "церемония"], "correct_index": 0}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["власть", "великолепный", "трон", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["корона", "власть", "великолепный", "провозглашать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["власть", "править", "великолепный", "корона"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["власть", "трон", "королевство", "церемония"], "correct_index": 3}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["великолепный", "провозглашать", "корона", "королевство"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["неблагодарность", "унижать", "проклинать", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["унижать", "проклинать", "неблагодарность", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["унижать", "изгонять", "неблагодарность", "гнев"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["сожалеть", "проклинать", "изгонять", "проклятие"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["унижать", "изгонять", "проклятие", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["неблагодарность", "обида", "сожалеть", "проклятие"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["изгонять", "проклятие", "гнев", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["обида", "неблагодарность", "изгонять", "проклятие"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["отчаяние", "жестокость", "отвергать", "покидать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["жестокость", "отвергать", "покидать", "отчаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["покидать", "отчаяние", "жестокость", "одиночество"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "слеза", "отвергать", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["покидать", "одиночество", "нужда", "просить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["одиночество", "отчаяние", "жестокость", "слеза"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["одиночество", "отвергать", "слеза", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["нужда", "жестокость", "покидать", "слеза"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["бушевать", "гром", "буря", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["буря", "гром", "безумие", "бушевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «toben»?", "choices": ["буря", "бушевать", "безумие", "молния"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["гром", "безумие", "голый", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["бушевать", "кричать", "голый", "молния"], "correct_index": 3}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["буря", "голый", "хаос", "кричать"], "correct_index": 3}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["безумие", "хаос", "голый", "бушевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["буря", "гром", "хаос", "безумие"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищий", "мёрзнуть", "нищета", "бедный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["мёрзнуть", "нищий", "нищета", "бедный"], "correct_index": 1}, {"question": "Что означает немецкое слово «arm»?", "choices": ["бедный", "нищий", "шут", "познание"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["бедный", "нищета", "нищий", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["страдать", "шут", "нищий", "хижина"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "мёрзнуть", "бедный", "хижина"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "познание", "бедный", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["познание", "бедный", "хижина", "мёрзнуть"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["раскаяние", "правда", "узнавать", "понимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["узнавать", "раскаяние", "правда", "понимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "мудрость", "узнавать", "виновный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["понимать", "узнавать", "виновный", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "прощать", "понимать", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "раскаяние", "мудрость", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["узнавать", "правда", "прозрение", "виновный"], "correct_index": 2}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["узнавать", "правда", "мудрость", "виновный"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["умирать", "смерть", "прощать", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "умирать", "конец", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["прощание", "умирать", "скорбь", "вечный"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["скорбь", "сердце", "конец", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["сердце", "прощание", "прощать", "скорбь"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["конец", "смерть", "вечный", "скорбь"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["вечный", "прощание", "сердце", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "конец", "скорбь", "прощать"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["власть", "королевство", "трон", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["трон", "власть", "править", "королевство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["провозглашать", "власть", "править", "церемония"], "correct_index": 1}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["провозглашать", "править", "трон", "корона"], "correct_index": 1}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["королевство", "провозглашать", "трон", "церемония"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["королевство", "корона", "править", "великолепный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["великолепный", "королевство", "провозглашать", "церемония"], "correct_index": 3}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["королевство", "власть", "провозглашать", "великолепный"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "проклинать", "неблагодарность", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["неблагодарность", "проклинать", "унижать", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["обида", "изгонять", "унижать", "неблагодарность"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["унижать", "обида", "гнев", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["гнев", "сожалеть", "унижать", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["гнев", "сожалеть", "унижать", "обида"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "изгонять", "проклинать", "обида"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["сожалеть", "проклинать", "гнев", "проклятие"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["покидать", "отчаяние", "отвергать", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["покидать", "отчаяние", "отвергать", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["покидать", "отвергать", "жестокость", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["одиночество", "слеза", "отчаяние", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["нужда", "просить", "одиночество", "отвергать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["жестокость", "одиночество", "просить", "слеза"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["отчаяние", "отвергать", "слеза", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["одиночество", "жестокость", "слеза", "нужда"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["гром", "безумие", "буря", "бушевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["буря", "бушевать", "безумие", "гром"], "correct_index": 2}, {"question": "Что означает немецкое слово «toben»?", "choices": ["кричать", "бушевать", "хаос", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["безумие", "кричать", "гром", "бушевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["гром", "буря", "кричать", "молния"], "correct_index": 3}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["буря", "голый", "гром", "кричать"], "correct_index": 3}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["гром", "кричать", "молния", "голый"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["безумие", "кричать", "буря", "хаос"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищий", "бедный", "мёрзнуть", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["мёрзнуть", "бедный", "нищета", "нищий"], "correct_index": 3}, {"question": "Что означает немецкое слово «arm»?", "choices": ["бедный", "шут", "страдать", "нищий"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["познание", "нищета", "страдать", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["нищета", "шут", "хижина", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["нищета", "страдать", "хижина", "шут"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["бедный", "нищета", "страдать", "шут"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["познание", "бедный", "шут", "страдать"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["раскаяние", "понимать", "правда", "узнавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["правда", "раскаяние", "понимать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["узнавать", "прощать", "понимать", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["узнавать", "раскаяние", "виновный", "прозрение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["прозрение", "узнавать", "мудрость", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["виновный", "прозрение", "прощать", "понимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["понимать", "прозрение", "виновный", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["мудрость", "прощать", "правда", "виновный"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["смерть", "прощать", "конец", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["конец", "умирать", "смерть", "прощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["конец", "скорбь", "умирать", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["смерть", "скорбь", "вечный", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["умирать", "конец", "сердце", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["вечный", "прощание", "прощать", "скорбь"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["сердце", "прощать", "конец", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["прощать", "прощание", "смерть", "вечный"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,61 +661,13 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">великолепный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                             
@@ -529,33 +677,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">корона</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">великолепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">великолепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">великолепный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -565,11 +761,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                             
@@ -577,17 +773,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «prächtig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">корона</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">великолепный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,15 +796,15 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
@@ -620,11 +816,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
@@ -632,81 +828,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Undankbarkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклятие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -716,11 +912,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Fluch»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
                             
@@ -735,33 +931,33 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -773,57 +969,57 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нужда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">просить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">просить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">слеза</button>
                             
@@ -835,7 +1031,7 @@
                         <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
@@ -847,17 +1043,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Not»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слеза</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нужда</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -874,13 +1070,13 @@
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -892,11 +1088,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -906,29 +1102,29 @@
                         <div class="quiz-question">Что означает немецкое слово «toben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -938,11 +1134,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
                             
@@ -958,7 +1154,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
                             
@@ -966,33 +1162,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Chaos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хаос</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1005,33 +1201,33 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1043,11 +1239,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">познание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1057,11 +1253,11 @@
                         <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">познание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
@@ -1069,49 +1265,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">познание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1125,9 +1321,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1140,93 +1336,77 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verstehen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="2">виновный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прозрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
@@ -1236,17 +1416,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">виновный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прозрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">виновный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1256,11 +1452,11 @@
                         <div class="quiz-question">Что означает немецкое слово «schuldig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
                             
@@ -1275,31 +1471,31 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
@@ -1307,31 +1503,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1339,17 +1519,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1359,11 +1555,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
                             
@@ -1371,33 +1567,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1421,6 +1617,7 @@
         "description": "Акт I: Разделение королевства",
         "words": [
             {
+                "wordId": "",
                 "word": "der Thron",
                 "translation": "трон",
                 "transcription": "[дер ТРОН]",
@@ -1442,9 +1639,14 @@
                     "Während des Sturms wirkt der Thron noch bedrückender. — Во время бури само «трон» звучит ещё тяжелее.",
                     "Vom Thron herab verkünde ich meinen Willen. — С трона я провозглашаю свою волю.",
                     "Der Thron meines Vaters wird bald leer sein. — Трон моего отца скоро опустеет."
+                ],
+                "sentenceParts": [
+                    "König Lear steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Königreich",
                 "translation": "королевство",
                 "transcription": "[дас КЁ-ниг-райх]",
@@ -1466,9 +1668,14 @@
                     "Lears Herz wird schwer, wenn das Königreich zur Sprache kommt. — Сердце Лира тяжелеет: «королевство» звучит слишком близко.",
                     "Mein Königreich teile ich unter meinen Töchtern. — Моё королевство я делю между дочерьми.",
                     "Ich diene dem Königreich mit Ehre. — Я служу королевству с честью."
+                ],
+                "sentenceParts": [
+                    "Neben der ausgerollten Reichskarte beugt sich König Lear über Lears schweren Tisch.",
+                    "Das kalte Licht lässt das Wort „das Königreich“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Macht",
                 "translation": "власть",
                 "transcription": "[ди МАХТ]",
@@ -1492,9 +1699,14 @@
                     "Die Macht über das Königreich ist nah. — Власть над королевством близка.",
                     "Die Macht bedeutet nichts ohne wahre Liebe. — Власть ничего не значит без истинной любви.",
                     "Die Macht über das halbe Königreich ist mein. — Власть над половиной королевства моя."
+                ],
+                "sentenceParts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt König Lear die Hände hinter dem Rücken.",
+                    "Mein Atem zeichnet das Wort „die Macht“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "herrschen",
                 "translation": "править",
                 "transcription": "[ХЕР-шен]",
@@ -1517,9 +1729,14 @@
                     "Der Narr spürt, wie das Herrschen alle verändert. — Шут чувствует, как умение править меняет всех.",
                     "Ich habe lange genug geherrscht. — Я правил достаточно долго.",
                     "Jetzt herrsche ich über meine Länder. — Теперь я правлю своими землями."
+                ],
+                "sentenceParts": [
+                    "Zwischen flüsternden Höflingen gleitet König Lear über den kalten Marmorboden.",
+                    "Mein Atem zeichnet das Wort „herrschen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verkünden",
                 "translation": "провозглашать",
                 "transcription": "[фер-КЮН-ден]",
@@ -1545,9 +1762,14 @@
                 "collocations": [
                     "Ich verkünde die Teilung meines Reiches. — Я провозглашаю раздел моего королевства.",
                     "Ich verkünde nur die Wahrheit meines Herzens. — Я провозглашаю только правду моего сердца."
+                ],
+                "sentenceParts": [
+                    "Am Rand des purpurnen Teppichs wartet König Lear auf ein Zeichen des Königs.",
+                    "Ich zeichne das Wort „verkünden“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Krone",
                 "translation": "корона",
                 "transcription": "[ди КРО-не]",
@@ -1568,9 +1790,14 @@
                 "collocations": [
                     "Im Thronsaal verstummen die Gespräche über die Krone nie. — В тронном зале постоянно звучит слово «корона».",
                     "Diese Krone ist schwer geworden für mein altes Haupt. — Эта корона стала тяжела для моей старой головы."
+                ],
+                "sentenceParts": [
+                    "Unter wehenden Standarten der Schwestern senkt König Lear kurz den Blick.",
+                    "Ich zeichne das Wort „die Krone“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Zeremonie",
                 "translation": "церемония",
                 "transcription": "[ди це-ре-мо-НИ]",
@@ -1596,9 +1823,14 @@
                 "collocations": [
                     "Die Zeremonie der Teilung beginnt jetzt. — Церемония раздела начинается сейчас.",
                     "Die Zeremonie beginnt im prächtigen Thronsaal. — Церемония начинается в великолепном тронном зале."
+                ],
+                "sentenceParts": [
+                    "Hinter der vergoldeten Balustrade beobachtet König Lear das gespannte Antlitz des Hofes.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Zeremonie“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "prächtig",
                 "translation": "великолепный",
                 "transcription": "[ПРЕХ-тиг]",
@@ -1620,6 +1852,10 @@
                 ],
                 "collocations": [
                     "Ein prächtiger Tag für eine verhängnisvolle Entscheidung. — Великолепный день для рокового решения."
+                ],
+                "sentenceParts": [
+                    "Im Schein der offenen Feuerbecken erhebt König Lear langsam die Stimme.",
+                    "Ich halte das Wort „prächtig“ wie eine Fackel vor meinem Herzen."
                 ]
             }
         ],
@@ -1627,69 +1863,69 @@
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
-                    "трон",
-                    "королевство",
-                    "править",
-                    "власть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «das Königreich»?",
-                "choices": [
                     "власть",
-                    "править",
                     "королевство",
-                    "трон"
+                    "трон",
+                    "править"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «das Königreich»?",
+                "choices": [
+                    "трон",
+                    "власть",
+                    "править",
+                    "королевство"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
+                    "провозглашать",
                     "власть",
-                    "корона",
                     "править",
                     "церемония"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
-                    "власть",
-                    "великолепный",
+                    "провозглашать",
+                    "править",
                     "трон",
-                    "править"
+                    "корона"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
-                    "корона",
-                    "власть",
-                    "великолепный",
-                    "провозглашать"
+                    "королевство",
+                    "провозглашать",
+                    "трон",
+                    "церемония"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Krone»?",
                 "choices": [
-                    "власть",
+                    "королевство",
+                    "корона",
                     "править",
-                    "великолепный",
-                    "корона"
+                    "великолепный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
-                    "власть",
-                    "трон",
+                    "великолепный",
                     "королевство",
+                    "провозглашать",
                     "церемония"
                 ],
                 "correctIndex": 3
@@ -1697,21 +1933,104 @@
             {
                 "question": "Что означает немецкое слово «prächtig»?",
                 "choices": [
-                    "великолепный",
+                    "королевство",
+                    "власть",
                     "провозглашать",
-                    "корона",
-                    "королевство"
+                    "великолепный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Thron",
+                "translation": "трон",
+                "parts": [
+                    "König Lear steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "König Lear steht unter dem glühenden Kronleuchter des Thronsaals. Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Лир стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «трон» в холодном воздухе между нами."
+            },
+            {
+                "word": "das Königreich",
+                "translation": "королевство",
+                "parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich König Lear über Lears schweren Tisch.",
+                    "Das kalte Licht lässt das Wort „das Königreich“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich König Lear über Lears schweren Tisch. Das kalte Licht lässt das Wort „das Königreich“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "У развернутой карты королевства Лир склоняется над тяжёлым столом Лира. Холодный свет заставляет слово «королевство» сиять словно расплавленное золото."
+            },
+            {
+                "word": "die Macht",
+                "translation": "власть",
+                "parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt König Lear die Hände hinter dem Rücken.",
+                    "Mein Atem zeichnet das Wort „die Macht“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt König Lear die Hände hinter dem Rücken. Mein Atem zeichnet das Wort „die Macht“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Перед каменными статуями предков Лир сцепляет руки за спиной. Моё дыхание рисует слово «власть» в холодном воздухе между нами."
+            },
+            {
+                "word": "herrschen",
+                "translation": "править",
+                "parts": [
+                    "Zwischen flüsternden Höflingen gleitet König Lear über den kalten Marmorboden.",
+                    "Mein Atem zeichnet das Wort „herrschen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Zwischen flüsternden Höflingen gleitet König Lear über den kalten Marmorboden. Mein Atem zeichnet das Wort „herrschen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Между шепчущимися придворными Лир скользит по холодному мраморному полу. Моё дыхание рисует слово «править» в холодном воздухе между нами."
+            },
+            {
+                "word": "verkünden",
+                "translation": "провозглашать",
+                "parts": [
+                    "Am Rand des purpurnen Teppichs wartet König Lear auf ein Zeichen des Königs.",
+                    "Ich zeichne das Wort „verkünden“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Am Rand des purpurnen Teppichs wartet König Lear auf ein Zeichen des Königs. Ich zeichne das Wort „verkünden“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "На краю пурпурного ковра Лир ждёт знака от короля. Я вывожу слово «провозглашать» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "die Krone",
+                "translation": "корона",
+                "parts": [
+                    "Unter wehenden Standarten der Schwestern senkt König Lear kurz den Blick.",
+                    "Ich zeichne das Wort „die Krone“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Unter wehenden Standarten der Schwestern senkt König Lear kurz den Blick. Ich zeichne das Wort „die Krone“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Лир на миг опускает взгляд. Я вывожу слово «корона» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "die Zeremonie",
+                "translation": "церемония",
+                "parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet König Lear das gespannte Antlitz des Hofes.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Zeremonie“ wird heute nicht verraten."
+                ],
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet König Lear das gespannte Antlitz des Hofes. Mit fester Stimme schwöre ich mir: Das Wort „die Zeremonie“ wird heute nicht verraten.",
+                "sentenceTranslation": "За позолоченной балюстрадой Лир наблюдает за напряжёнными лицами двора. Твёрдым голосом я клянусь себе: слово «церемония» сегодня не будет предано."
+            },
+            {
+                "word": "prächtig",
+                "translation": "великолепный",
+                "parts": [
+                    "Im Schein der offenen Feuerbecken erhebt König Lear langsam die Stimme.",
+                    "Ich halte das Wort „prächtig“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Im Schein der offenen Feuerbecken erhebt König Lear langsam die Stimme. Ich halte das Wort „prächtig“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В отблесках открытых жаровен Лир медленно поднимает голос. Я держу слово «великолепный» как факел у сердца."
+            }
+        ]
     },
     "goneril": {
         "title": "У Гонерильи",
         "description": "Акт I: Предательство старшей дочери",
         "words": [
             {
+                "wordId": "",
                 "word": "demütigen",
                 "translation": "унижать",
                 "transcription": "[де-МЮ-ти-ген]",
@@ -1740,9 +2059,14 @@
                     "Meine eigene Tochter will mich demütigen! — Моя собственная дочь хочет меня унизить!",
                     "Ich demütige ihn vor aller Augen. — Я унижаю его на глазах у всех.",
                     "Ich demütige meinen alten Vater ohne Mitleid. — Я унижаю старого отца без жалости."
+                ],
+                "sentenceParts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt König Lear zwischen gepackten Kisten.",
+                    "Ich halte das Wort „demütigen“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Zorn",
                 "translation": "гнев",
                 "transcription": "[дер ЦОРН]",
@@ -1766,9 +2090,15 @@
                     "Sein Zorn ist grenzenlos und blind. — Его гнев безграничен и слеп.",
                     "Der Zorn des Königs trifft mich ungerecht. — Гнев короля поражает меня несправедливо.",
                     "Mein Zorn kennt keine Barmherzigkeit. — Мой гнев не знает милосердия."
+                ],
+                "sentenceParts": [
+                    "Auf der windigen Freitreppe blickt König Lear zum schweigenden Hof hinunter.",
+                    "Ich presse das Wort „der Zorn“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Undankbarkeit",
                 "translation": "неблагодарность",
                 "transcription": "[ди УН-данк-бар-кайт]",
@@ -1790,9 +2120,14 @@
                 ],
                 "collocations": [
                     "Die Undankbarkeit ist schärfer als der Zahn einer Schlange! — Неблагодарность острее змеиного зуба!"
+                ],
+                "sentenceParts": [
+                    "Zwischen zurückgelassenen Dienern schließt König Lear den Reisemantel enger.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Undankbarkeit“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verfluchen",
                 "translation": "проклинать",
                 "transcription": "[фер-ФЛУ-хен]",
@@ -1817,9 +2152,14 @@
                     "Ich verfluche dich bei allen Sternen! — Я проклинаю тебя всеми звёздами!",
                     "Sterbend verfluche ich meine Mörder. — Умирая, я проклинаю своих убийц.",
                     "Im Zorn verfluche ich Edgar. — В гневе я проклинаю Эдгара."
+                ],
+                "sentenceParts": [
+                    "Am dunklen Pferdestall streicht König Lear einem nervösen Tier über die Mähne.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „verfluchen“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vertreiben",
                 "translation": "изгонять",
                 "transcription": "[фер-ТРАЙ-бен]",
@@ -1845,9 +2185,14 @@
                     "Aus meinem eigenen Haus will sie mich vertreiben! — Из моего собственного дома она хочет меня изгнать!",
                     "Ich vertreibe Edgar aus seinem Erbe. — Я изгоняю Эдгара из его наследства.",
                     "Ich vertreibe ihn aus meinem Haus. — Я изгоняю его из моего дома."
+                ],
+                "sentenceParts": [
+                    "Vor dem knarrenden Fallgatter tastet König Lear ein letztes Mal nach dem Haustor.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Kränkung",
                 "translation": "обида",
                 "transcription": "[ди КРЭН-кунг]",
@@ -1869,9 +2214,14 @@
                 ],
                 "collocations": [
                     "Diese Kränkung werde ich nicht vergessen! — Эту обиду я не забуду!"
+                ],
+                "sentenceParts": [
+                    "Zwischen verstreuten Schriftrollen dreht König Lear den Ring an der Hand.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Kränkung“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "bereuen",
                 "translation": "сожалеть",
                 "transcription": "[бе-РОЙ-ен]",
@@ -1895,9 +2245,14 @@
                     "Am Ende bereue ich meine Taten. — В конце я сожалею о своих делах.",
                     "Später werde ich diese Tat bitter bereuen. — Позже я горько пожалею об этом поступке.",
                     "Zu spät bereue ich meine Taten. — Слишком поздно я сожалею о своих делах."
+                ],
+                "sentenceParts": [
+                    "Am leeren Bankettisch zählt König Lear die verlöschenden Kerzen.",
+                    "Wie ein stilles Gebet legt sich das Wort „bereuen“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Fluch",
                 "translation": "проклятие",
                 "transcription": "[дер ФЛУХ]",
@@ -1918,6 +2273,10 @@
                 "collocations": [
                     "Cordelia merkt sich genau, wie der Fluch verteilt wird. — Корделия внимательно следит, кому достанется «проклятие».",
                     "Mein Fluch soll über dich kommen! — Моё проклятие падёт на тебя!"
+                ],
+                "sentenceParts": [
+                    "Zwischen schweigenden Wachen geht König Lear auf den kalten Hof hinaus.",
+                    "Ich zeichne das Wort „der Fluch“ in Gedanken über die Linien des Schicksals."
                 ]
             }
         ],
@@ -1925,19 +2284,19 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "неблагодарность",
                     "унижать",
                     "проклинать",
+                    "неблагодарность",
                     "гнев"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "унижать",
-                    "проклинать",
                     "неблагодарность",
+                    "проклинать",
+                    "унижать",
                     "гнев"
                 ],
                 "correctIndex": 3
@@ -1945,71 +2304,155 @@
             {
                 "question": "Что означает немецкое слово «die Undankbarkeit»?",
                 "choices": [
-                    "унижать",
-                    "изгонять",
-                    "неблагодарность",
-                    "гнев"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «verfluchen»?",
-                "choices": [
-                    "сожалеть",
-                    "проклинать",
-                    "изгонять",
-                    "проклятие"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «vertreiben»?",
-                "choices": [
-                    "унижать",
-                    "изгонять",
-                    "проклятие",
-                    "гнев"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Kränkung»?",
-                "choices": [
-                    "неблагодарность",
                     "обида",
-                    "сожалеть",
-                    "проклятие"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «bereuen»?",
-                "choices": [
                     "изгонять",
-                    "проклятие",
-                    "гнев",
-                    "сожалеть"
+                    "унижать",
+                    "неблагодарность"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «verfluchen»?",
+                "choices": [
+                    "унижать",
+                    "обида",
+                    "гнев",
+                    "проклинать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «vertreiben»?",
+                "choices": [
+                    "гнев",
+                    "сожалеть",
+                    "унижать",
+                    "изгонять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Kränkung»?",
+                "choices": [
+                    "гнев",
+                    "сожалеть",
+                    "унижать",
+                    "обида"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «bereuen»?",
+                "choices": [
+                    "сожалеть",
+                    "изгонять",
+                    "проклинать",
+                    "обида"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «der Fluch»?",
                 "choices": [
-                    "обида",
-                    "неблагодарность",
-                    "изгонять",
+                    "сожалеть",
+                    "проклинать",
+                    "гнев",
                     "проклятие"
                 ],
                 "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "demütigen",
+                "translation": "унижать",
+                "parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt König Lear zwischen gepackten Kisten.",
+                    "Ich halte das Wort „demütigen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt König Lear zwischen gepackten Kisten. Ich halte das Wort „demütigen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Лир замирает среди нагруженных ящиков. Я держу слово «унижать» как факел у сердца."
+            },
+            {
+                "word": "der Zorn",
+                "translation": "гнев",
+                "parts": [
+                    "Auf der windigen Freitreppe blickt König Lear zum schweigenden Hof hinunter.",
+                    "Ich presse das Wort „der Zorn“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Auf der windigen Freitreppe blickt König Lear zum schweigenden Hof hinunter. Ich presse das Wort „der Zorn“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Лир смотрит вниз на молчаливый двор. Я стискиваю слово «гнев» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Undankbarkeit",
+                "translation": "неблагодарность",
+                "parts": [
+                    "Zwischen zurückgelassenen Dienern schließt König Lear den Reisemantel enger.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Undankbarkeit“ mein Nordstern."
+                ],
+                "sentence": "Zwischen zurückgelassenen Dienern schließt König Lear den Reisemantel enger. Selbst wenn die Welt zerfällt, bleibt das Wort „die Undankbarkeit“ mein Nordstern.",
+                "sentenceTranslation": "Среди оставленных слуг Лир плотнее запахивает дорожный плащ. Даже если мир распадается, слово «неблагодарность» остаётся моим северным светом."
+            },
+            {
+                "word": "verfluchen",
+                "translation": "проклинать",
+                "parts": [
+                    "Am dunklen Pferdestall streicht König Lear einem nervösen Tier über die Mähne.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „verfluchen“ darf nicht vergehen."
+                ],
+                "sentence": "Am dunklen Pferdestall streicht König Lear einem nervösen Tier über die Mähne. Ich flüstere den Wächtern des Schicksals zu: Das Wort „verfluchen“ darf nicht vergehen.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Лир гладит гриву нервного коня. Я шепчу стражам судьбы: слово «проклинать» не должно исчезнуть."
+            },
+            {
+                "word": "vertreiben",
+                "translation": "изгонять",
+                "parts": [
+                    "Vor dem knarrenden Fallgatter tastet König Lear ein letztes Mal nach dem Haustor.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten."
+                ],
+                "sentence": "Vor dem knarrenden Fallgatter tastet König Lear ein letztes Mal nach dem Haustor. Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Лир в последний раз касается родной двери. Твёрдым голосом я клянусь себе: слово «изгонять» сегодня не будет предано."
+            },
+            {
+                "word": "die Kränkung",
+                "translation": "обида",
+                "parts": [
+                    "Zwischen verstreuten Schriftrollen dreht König Lear den Ring an der Hand.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Kränkung“ bleibt lebendig."
+                ],
+                "sentence": "Zwischen verstreuten Schriftrollen dreht König Lear den Ring an der Hand. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Kränkung“ bleibt lebendig.",
+                "sentenceTranslation": "Среди разбросанных свитков Лир вертит кольцо на пальце. Каждой клеткой тела я обещаю: слово «обида» останется живым."
+            },
+            {
+                "word": "bereuen",
+                "translation": "сожалеть",
+                "parts": [
+                    "Am leeren Bankettisch zählt König Lear die verlöschenden Kerzen.",
+                    "Wie ein stilles Gebet legt sich das Wort „bereuen“ auf meine Lippen."
+                ],
+                "sentence": "Am leeren Bankettisch zählt König Lear die verlöschenden Kerzen. Wie ein stilles Gebet legt sich das Wort „bereuen“ auf meine Lippen.",
+                "sentenceTranslation": "У пустого банкетного стола Лир пересчитывает гаснущие свечи. Как тихая молитва слово «сожалеть» ложится на мои губы."
+            },
+            {
+                "word": "der Fluch",
+                "translation": "проклятие",
+                "parts": [
+                    "Zwischen schweigenden Wachen geht König Lear auf den kalten Hof hinaus.",
+                    "Ich zeichne das Wort „der Fluch“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Zwischen schweigenden Wachen geht König Lear auf den kalten Hof hinaus. Ich zeichne das Wort „der Fluch“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Между молчаливыми стражниками Лир выходит на холодный двор. Я черчу слово «проклятие» в мыслях поверх линий судьбы."
+            }
+        ]
     },
     "regan": {
         "title": "У Реганы",
         "description": "Акт II: Предательство младшей дочери",
         "words": [
             {
+                "wordId": "",
                 "word": "verlassen",
                 "translation": "покидать",
                 "transcription": "[фер-ЛА-сен]",
@@ -2031,9 +2474,14 @@
                     "Der Narr spürt, wie das Verlassen alle verändert. — Шут чувствует, как умение покидать меняет всех.",
                     "Auch Regan will mich verlassen und verstoßen! — И Регана хочет меня покинуть и отвергнуть!",
                     "Schweren Herzens verlasse ich mein Vaterland. — С тяжёлым сердцем я покидаю родину."
+                ],
+                "sentenceParts": [
+                    "Im zugigen Seitenflügel lauscht König Lear dem Heulen der Küstenwinde.",
+                    "Wie ein stilles Gebet legt sich das Wort „verlassen“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verstoßen",
                 "translation": "отвергать",
                 "transcription": "[фер-ШТО-сен]",
@@ -2061,9 +2509,14 @@
                     "Der König verstößt mich aus seinem Herzen. — Король изгоняет меня из своего сердца.",
                     "Ich verstoße meinen unschuldigen Sohn. — Я изгоняю своего невинного сына.",
                     "Ich verstoße meinen Vater in die Nacht. — Я отвергаю отца в ночь."
+                ],
+                "sentenceParts": [
+                    "Vor dem rauchigen Kamin der Burg faltet König Lear einen zerknitterten Brief.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Grausamkeit",
                 "translation": "жестокость",
                 "transcription": "[ди ГРАУ-зам-кайт]",
@@ -2096,9 +2549,14 @@
                     "Meine Grausamkeit kennt keine Grenzen. — Моя жестокость не знает границ.",
                     "Meine Grausamkeit übertrifft die meiner Schwester. — Моя жестокость превосходит жестокость сестры.",
                     "Die Grausamkeit meiner Frau gefällt mir. — Жестокость моей жены мне нравится."
+                ],
+                "sentenceParts": [
+                    "Unter farblosen Wandteppichen schreitet König Lear rastlos auf und ab.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Grausamkeit“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Verzweiflung",
                 "translation": "отчаяние",
                 "transcription": "[ди фер-ЦВАЙ-флунг]",
@@ -2122,9 +2580,14 @@
                     "Seine Verzweiflung bricht mir das Herz. — Его отчаяние разбивает мне сердце.",
                     "Die Verzweiflung treibt mich zum Abgrund. — Отчаяние гонит меня к пропасти.",
                     "Die Verzweiflung führt mich zum Tod. — Отчаяние ведёт меня к смерти."
+                ],
+                "sentenceParts": [
+                    "An der schmalen Fensterluke zählt König Lear die Fackeln auf dem Hof.",
+                    "Ich zeichne das Wort „die Verzweiflung“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "betteln",
                 "translation": "просить",
                 "transcription": "[БЕ-тельн]",
@@ -2152,9 +2615,14 @@
                 "collocations": [
                     "Um mein Leben bettle ich vergeblich. — О жизни я умоляю напрасно.",
                     "Muss ich um Unterkunft betteln bei meinen eigenen Kindern? — Должен ли я просить крова у собственных детей?"
+                ],
+                "sentenceParts": [
+                    "Zwischen Reisekoffern der Gesandten sucht König Lear nach frischen Botschaften.",
+                    "Ich presse das Wort „betteln“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Einsamkeit",
                 "translation": "одиночество",
                 "transcription": "[ди АЙН-зам-кайт]",
@@ -2176,9 +2644,14 @@
                     "Cordelia merkt sich genau, wie die Einsamkeit verteilt wird. — Корделия внимательно следит, кому достанется «одиночество».",
                     "Die Einsamkeit umgibt mich wie ein kalter Mantel. — Одиночество окружает меня как холодный плащ.",
                     "In der Einsamkeit denke ich an ihn. — В одиночестве я думаю о нём."
+                ],
+                "sentenceParts": [
+                    "Im stillen Kapellenraum kniet König Lear vor der kalten Steinfigur.",
+                    "Ich umarme das Wort „die Einsamkeit“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Träne",
                 "translation": "слеза",
                 "transcription": "[ди ТРЭ-не]",
@@ -2199,9 +2672,16 @@
                 "collocations": [
                     "Lears Herz wird schwer, wenn die Träne zur Sprache kommt. — Сердце Лира тяжелеет: «слеза» звучит слишком близко.",
                     "Keine Träne will ich für diese Undankbaren vergießen! — Ни одной слезы я не пролью за этих неблагодарных!"
+                ],
+                "sentenceParts": [
+                    "Auf dem Balkon,",
+                    "den das Meer besprüht,",
+                    "hält König Lear die Laterne fest.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Träne“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Not",
                 "translation": "нужда",
                 "transcription": "[ди НОТ]",
@@ -2222,6 +2702,10 @@
                 "collocations": [
                     "Der Narr spottet, sobald die Not erwähnt wird. — Шут насмехается, едва кто-то произносит «нужда».",
                     "In meiner Not erkennen sie mich nicht als Vater. — В моей нужде они не признают меня отцом."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der hohen Burgmauern schreibt König Lear eine fiebrige Antwort.",
+                    "Mein Atem zeichnet das Wort „die Not“ in die kalte Luft zwischen uns."
                 ]
             }
         ],
@@ -2229,67 +2713,67 @@
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
-                    "отчаяние",
-                    "жестокость",
-                    "отвергать",
-                    "покидать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verstoßen»?",
-                "choices": [
-                    "жестокость",
-                    "отвергать",
-                    "покидать",
-                    "отчаяние"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Grausamkeit»?",
-                "choices": [
                     "покидать",
                     "отчаяние",
-                    "жестокость",
-                    "одиночество"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Verzweiflung»?",
-                "choices": [
-                    "отчаяние",
-                    "слеза",
                     "отвергать",
                     "жестокость"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «betteln»?",
+                "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
                     "покидать",
-                    "одиночество",
-                    "нужда",
-                    "просить"
+                    "отчаяние",
+                    "отвергать",
+                    "жестокость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Grausamkeit»?",
+                "choices": [
+                    "покидать",
+                    "отвергать",
+                    "жестокость",
+                    "отчаяние"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Verzweiflung»?",
+                "choices": [
+                    "одиночество",
+                    "слеза",
+                    "отчаяние",
+                    "покидать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «betteln»?",
+                "choices": [
+                    "нужда",
+                    "просить",
+                    "одиночество",
+                    "отвергать"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
-                    "одиночество",
-                    "отчаяние",
                     "жестокость",
+                    "одиночество",
+                    "просить",
                     "слеза"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Träne»?",
                 "choices": [
-                    "одиночество",
+                    "отчаяние",
                     "отвергать",
                     "слеза",
                     "жестокость"
@@ -2299,21 +2783,106 @@
             {
                 "question": "Что означает немецкое слово «die Not»?",
                 "choices": [
-                    "нужда",
+                    "одиночество",
                     "жестокость",
-                    "покидать",
-                    "слеза"
+                    "слеза",
+                    "нужда"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "verlassen",
+                "translation": "покидать",
+                "parts": [
+                    "Im zugigen Seitenflügel lauscht König Lear dem Heulen der Küstenwinde.",
+                    "Wie ein stilles Gebet legt sich das Wort „verlassen“ auf meine Lippen."
+                ],
+                "sentence": "Im zugigen Seitenflügel lauscht König Lear dem Heulen der Küstenwinde. Wie ein stilles Gebet legt sich das Wort „verlassen“ auf meine Lippen.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Лир слушает вой прибрежного ветра. Как тихая молитва слово «покидать» ложится на мои губы."
+            },
+            {
+                "word": "verstoßen",
+                "translation": "отвергать",
+                "parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet König Lear einen zerknitterten Brief.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig."
+                ],
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet König Lear einen zerknitterten Brief. Mit jeder Faser meines Körpers verspreche ich: Das Wort „verstoßen“ bleibt lebendig.",
+                "sentenceTranslation": "Перед дымным камином замка Лир складывает измятый лист. Каждой клеткой тела я обещаю: слово «отвергать» останется живым."
+            },
+            {
+                "word": "die Grausamkeit",
+                "translation": "жестокость",
+                "parts": [
+                    "Unter farblosen Wandteppichen schreitet König Lear rastlos auf und ab.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Grausamkeit“ auf meine Lippen."
+                ],
+                "sentence": "Unter farblosen Wandteppichen schreitet König Lear rastlos auf und ab. Wie ein stilles Gebet legt sich das Wort „die Grausamkeit“ auf meine Lippen.",
+                "sentenceTranslation": "Под выцветшими гобеленами Лир беспокойно меряет шагами зал. Как тихая молитва слово «жестокость» ложится на мои губы."
+            },
+            {
+                "word": "die Verzweiflung",
+                "translation": "отчаяние",
+                "parts": [
+                    "An der schmalen Fensterluke zählt König Lear die Fackeln auf dem Hof.",
+                    "Ich zeichne das Wort „die Verzweiflung“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "An der schmalen Fensterluke zählt König Lear die Fackeln auf dem Hof. Ich zeichne das Wort „die Verzweiflung“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У узкой бойницы Лир считает факелы на дворе. Я черчу слово «отчаяние» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "betteln",
+                "translation": "просить",
+                "parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht König Lear nach frischen Botschaften.",
+                    "Ich presse das Wort „betteln“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht König Lear nach frischen Botschaften. Ich presse das Wort „betteln“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Лир ищет свежие вести. Я стискиваю слово «просить» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "die Einsamkeit",
+                "translation": "одиночество",
+                "parts": [
+                    "Im stillen Kapellenraum kniet König Lear vor der kalten Steinfigur.",
+                    "Ich umarme das Wort „die Einsamkeit“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Im stillen Kapellenraum kniet König Lear vor der kalten Steinfigur. Ich umarme das Wort „die Einsamkeit“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В тихой капелле Лир преклоняет колени перед холодной каменной фигурой. Я обнимаю слово «одиночество», будто это единственный союзник."
+            },
+            {
+                "word": "die Träne",
+                "translation": "слеза",
+                "parts": [
+                    "Auf dem Balkon,",
+                    "den das Meer besprüht,",
+                    "hält König Lear die Laterne fest.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Träne“ mein Nordstern."
+                ],
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält König Lear die Laterne fest. Selbst wenn die Welt zerfällt, bleibt das Wort „die Träne“ mein Nordstern.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Лир крепко держит фонарь. Даже если мир распадается, слово «слеза» остаётся моим северным светом."
+            },
+            {
+                "word": "die Not",
+                "translation": "нужда",
+                "parts": [
+                    "Im Schatten der hohen Burgmauern schreibt König Lear eine fiebrige Antwort.",
+                    "Mein Atem zeichnet das Wort „die Not“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im Schatten der hohen Burgmauern schreibt König Lear eine fiebrige Antwort. Mein Atem zeichnet das Wort „die Not“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тени высоких стен Лир пишет лихорадочный ответ. Моё дыхание рисует слово «нужда» в холодном воздухе между нами."
+            }
+        ]
     },
     "storm": {
         "title": "Буря",
         "description": "Акт III: Безумие в буре",
         "words": [
             {
+                "wordId": "",
                 "word": "der Sturm",
                 "translation": "буря",
                 "transcription": "[дер ШТУРМ]",
@@ -2337,9 +2906,14 @@
                     "Der Sturm tobt über unseren Köpfen. — Буря бушует над нашими головами.",
                     "Im Sturm bleibe ich bei meinem König. — В буре я остаюсь с моим королём.",
                     "Der Sturm soll sein neues Zuhause sein. — Буря пусть будет его новым домом."
+                ],
+                "sentenceParts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich König Lear gegen den Wind.",
+                    "Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Wahnsinn",
                 "translation": "безумие",
                 "transcription": "[дер ВАН-зин]",
@@ -2362,9 +2936,14 @@
                     "Der Wahnsinn ist gnädiger als die Vernunft! — Безумие милосерднее разума!",
                     "Ich spiele den Wahnsinn, um zu überleben. — Я играю безумие, чтобы выжить.",
                     "Im Wahnsinn finden wir uns als Brüder. — В безумии мы находим друг друга как братья."
+                ],
+                "sentenceParts": [
+                    "Unter einem zerrissenen Banner schützt König Lear die Augen vor den Blitzen.",
+                    "Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "toben",
                 "translation": "бушевать",
                 "transcription": "[ТО-бен]",
@@ -2385,9 +2964,14 @@
                 "collocations": [
                     "Das Toben fällt Lear unerwartet schwer. — Лиру неожиданно тяжело бушевать.",
                     "Lasst die Winde toben und die Blitze fallen! — Пусть ветры бушуют и молнии падают!"
+                ],
+                "sentenceParts": [
+                    "Am Rand eines umgestürzten Baumes sucht König Lear Deckung vor dem Donner.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „toben“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Donner",
                 "translation": "гром",
                 "transcription": "[дер ДО-нер]",
@@ -2409,9 +2993,14 @@
                     "Für die Höflinge bleibt der Donner ein ständiges Thema. — Для придворных «гром» — постоянная тема.",
                     "Der Donner ist die Stimme der Götter! — Гром - это голос богов!",
                     "Der Donner übertönt unsere Schreie. — Гром заглушает наши крики."
+                ],
+                "sentenceParts": [
+                    "Zwischen schäumenden Wassergräben stolpert König Lear durch den Schlamm.",
+                    "Ich umarme das Wort „der Donner“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Blitz",
                 "translation": "молния",
                 "transcription": "[дер БЛИЦ]",
@@ -2433,9 +3022,14 @@
                     "Für die Höflinge bleibt der Blitz ein ständiges Thema. — Для придворных «молния» — постоянная тема.",
                     "Die Blitze sollen meine weißen Haare verbrennen! — Пусть молнии сожгут мои седые волосы!",
                     "Die Blitze erhellen unser Elend. — Молнии освещают нашу нищету."
+                ],
+                "sentenceParts": [
+                    "Vor einem zuckenden Himmel hebt König Lear die Arme trotzig an.",
+                    "Ich atme tief ein und lasse nur das Wort „der Blitz“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "schreien",
                 "translation": "кричать",
                 "transcription": "[ШРАЙ-ен]",
@@ -2461,9 +3055,14 @@
                 "collocations": [
                     "Ich schreie in den Wind meine Wut hinaus! — Я кричу в ветер свою ярость!",
                     "Ich schreie vor unerträglichem Schmerz. — Я кричу от невыносимой боли."
+                ],
+                "sentenceParts": [
+                    "Unter dem durchtränkten Umhang presst König Lear den Atem gegen die Kälte.",
+                    "Ich zeichne das Wort „schreien“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "nackt",
                 "translation": "голый",
                 "transcription": "[НАКТ]",
@@ -2489,9 +3088,14 @@
                 "collocations": [
                     "Nackt kam ich auf die Welt, nackt gehe ich! — Голым я пришёл в мир, голым и уйду!",
                     "Fast nackt wandere ich durch die Wildnis. — Почти голый, я брожу по дикой местности."
+                ],
+                "sentenceParts": [
+                    "Am kläglichen Feuerrest wärmt König Lear zitternde Finger.",
+                    "Ich zeichne das Wort „nackt“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Chaos",
                 "translation": "хаос",
                 "transcription": "[дас ХА-ос]",
@@ -2512,6 +3116,10 @@
                 "collocations": [
                     "Während des Sturms wirkt das Chaos noch bedrückender. — Во время бури само «хаос» звучит ещё тяжелее.",
                     "Das Chaos in der Natur spiegelt meine Seele! — Хаос в природе отражает мою душу!"
+                ],
+                "sentenceParts": [
+                    "Zwischen heulenden Hunden ruft König Lear gegen den tosenden Sturm an.",
+                    "Ich halte das Wort „das Chaos“ wie eine Fackel vor meinem Herzen."
                 ]
             }
         ],
@@ -2519,10 +3127,10 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "бушевать",
                     "гром",
+                    "безумие",
                     "буря",
-                    "безумие"
+                    "бушевать"
                 ],
                 "correctIndex": 2
             },
@@ -2530,38 +3138,38 @@
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
                     "буря",
-                    "гром",
+                    "бушевать",
                     "безумие",
-                    "бушевать"
+                    "гром"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «toben»?",
                 "choices": [
-                    "буря",
+                    "кричать",
                     "бушевать",
-                    "безумие",
-                    "молния"
+                    "хаос",
+                    "безумие"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Donner»?",
                 "choices": [
-                    "гром",
                     "безумие",
-                    "голый",
-                    "буря"
+                    "кричать",
+                    "гром",
+                    "бушевать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Blitz»?",
                 "choices": [
-                    "бушевать",
+                    "гром",
+                    "буря",
                     "кричать",
-                    "голый",
                     "молния"
                 ],
                 "correctIndex": 3
@@ -2571,7 +3179,7 @@
                 "choices": [
                     "буря",
                     "голый",
-                    "хаос",
+                    "гром",
                     "кричать"
                 ],
                 "correctIndex": 3
@@ -2579,31 +3187,114 @@
             {
                 "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
-                    "безумие",
-                    "хаос",
-                    "голый",
-                    "бушевать"
+                    "гром",
+                    "кричать",
+                    "молния",
+                    "голый"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Chaos»?",
                 "choices": [
+                    "безумие",
+                    "кричать",
                     "буря",
-                    "гром",
-                    "хаос",
-                    "безумие"
+                    "хаос"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Sturm",
+                "translation": "буря",
+                "parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich König Lear gegen den Wind.",
+                    "Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich König Lear gegen den Wind. Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Лир упирается в ветер. Я обнимаю слово «буря», будто это единственный союзник."
+            },
+            {
+                "word": "der Wahnsinn",
+                "translation": "безумие",
+                "parts": [
+                    "Unter einem zerrissenen Banner schützt König Lear die Augen vor den Blitzen.",
+                    "Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Unter einem zerrissenen Banner schützt König Lear die Augen vor den Blitzen. Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Под разорванным знаменем Лир прикрывает глаза от молний. Моё дыхание рисует слово «безумие» в холодном воздухе между нами."
+            },
+            {
+                "word": "toben",
+                "translation": "бушевать",
+                "parts": [
+                    "Am Rand eines umgestürzten Baumes sucht König Lear Deckung vor dem Donner.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „toben“ darf nicht vergehen."
+                ],
+                "sentence": "Am Rand eines umgestürzten Baumes sucht König Lear Deckung vor dem Donner. Ich flüstere den Wächtern des Schicksals zu: Das Wort „toben“ darf nicht vergehen.",
+                "sentenceTranslation": "У поваленного дерева Лир ищет укрытия от грома. Я шепчу стражам судьбы: слово «бушевать» не должно исчезнуть."
+            },
+            {
+                "word": "der Donner",
+                "translation": "гром",
+                "parts": [
+                    "Zwischen schäumenden Wassergräben stolpert König Lear durch den Schlamm.",
+                    "Ich umarme das Wort „der Donner“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Zwischen schäumenden Wassergräben stolpert König Lear durch den Schlamm. Ich umarme das Wort „der Donner“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Между пенящимися лужами Лир пробирается через грязь. Я обнимаю слово «гром», будто это единственный союзник."
+            },
+            {
+                "word": "der Blitz",
+                "translation": "молния",
+                "parts": [
+                    "Vor einem zuckenden Himmel hebt König Lear die Arme trotzig an.",
+                    "Ich atme tief ein und lasse nur das Wort „der Blitz“ wieder hinaus."
+                ],
+                "sentence": "Vor einem zuckenden Himmel hebt König Lear die Arme trotzig an. Ich atme tief ein und lasse nur das Wort „der Blitz“ wieder hinaus.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Лир упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «молния»."
+            },
+            {
+                "word": "schreien",
+                "translation": "кричать",
+                "parts": [
+                    "Unter dem durchtränkten Umhang presst König Lear den Atem gegen die Kälte.",
+                    "Ich zeichne das Wort „schreien“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Unter dem durchtränkten Umhang presst König Lear den Atem gegen die Kälte. Ich zeichne das Wort „schreien“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под промокшим плащом Лир прижимает дыхание к груди, спасаясь от холода. Я вывожу слово «кричать» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "nackt",
+                "translation": "голый",
+                "parts": [
+                    "Am kläglichen Feuerrest wärmt König Lear zitternde Finger.",
+                    "Ich zeichne das Wort „nackt“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Am kläglichen Feuerrest wärmt König Lear zitternde Finger. Ich zeichne das Wort „nackt“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "У жалких огненных углей Лир греет дрожащие пальцы. Я черчу слово «голый» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "das Chaos",
+                "translation": "хаос",
+                "parts": [
+                    "Zwischen heulenden Hunden ruft König Lear gegen den tosenden Sturm an.",
+                    "Ich halte das Wort „das Chaos“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Zwischen heulenden Hunden ruft König Lear gegen den tosenden Sturm an. Ich halte das Wort „das Chaos“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Среди воющих псов Лир перекрикивает беснующуюся бурю. Я держу слово «хаос» как факел у сердца."
+            }
+        ]
     },
     "hut": {
         "title": "Хижина",
         "description": "Акт III: Встреча с Эдгаром",
         "words": [
             {
+                "wordId": "",
                 "word": "das Elend",
                 "translation": "нищета",
                 "transcription": "[дас Э-ленд]",
@@ -2625,9 +3316,14 @@
                     "Im Thronsaal verstummen die Gespräche über das Elend nie. — В тронном зале постоянно звучит слово «нищета».",
                     "Im Elend erkenne ich die Wahrheit der Welt. — В нищете я познаю истину мира.",
                     "Im Elend lerne ich die wahre Natur des Menschen. — В нищете я познаю истинную природу человека."
+                ],
+                "sentenceParts": [
+                    "Im dunklen Zelt der Feldärzte sitzt König Lear bei der flackernden Kerze.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „das Elend“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Bettler",
                 "translation": "нищий",
                 "transcription": "[дер БЕТ-лер]",
@@ -2652,9 +3348,14 @@
                 "collocations": [
                     "Dieser Bettler ist glücklicher als ich, der König! — Этот нищий счастливее меня, короля!",
                     "Als Bettler bin ich unsichtbar für meine Feinde. — Как нищий, я невидим для врагов."
+                ],
+                "sentenceParts": [
+                    "Zwischen zerbeulten Rüstungen streicht König Lear über ein altes Wappen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „der Bettler“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "arm",
                 "translation": "бедный",
                 "transcription": "[АРМ]",
@@ -2676,9 +3377,14 @@
                 ],
                 "collocations": [
                     "Die Armen leiden mehr als Könige jemals wissen. — Бедные страдают больше, чем короли когда-либо узнают."
+                ],
+                "sentenceParts": [
+                    "Am niedrigen Dachbalken der Hütte stößt König Lear fast den Kopf.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „arm“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "frieren",
                 "translation": "мёрзнуть",
                 "transcription": "[ФРИ-рен]",
@@ -2707,9 +3413,14 @@
                     "Wir alle frieren in dieser kalten Welt. — Мы все мёрзнем в этом холодном мире.",
                     "Wir frieren gemeinsam in dieser kalten Nacht. — Мы мёрзнем вместе в эту холодную ночь.",
                     "Wir frieren gemeinsam in der kalten Nacht. — Мы мёрзнем вместе в холодную ночь."
+                ],
+                "sentenceParts": [
+                    "Neben der schlafenden Wache flüstert König Lear in die schwere Nacht.",
+                    "Das kalte Licht lässt das Wort „frieren“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Hütte",
                 "translation": "хижина",
                 "transcription": "[ди ХЮ-те]",
@@ -2735,9 +3446,14 @@
                 "collocations": [
                     "Diese Hütte ist ein Palast für die Verlassenen. — Эта хижина - дворец для покинутых.",
                     "In dieser armseligen Hütte finden wir Zuflucht. — В этой жалкой хижине мы находим убежище."
+                ],
+                "sentenceParts": [
+                    "Vor dem einfachen Feldbett betrachtet König Lear die Narben vergangener Schlachten.",
+                    "Ich zeichne das Wort „die Hütte“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "leiden",
                 "translation": "страдать",
                 "transcription": "[ЛАЙ-ден]",
@@ -2762,9 +3478,14 @@
                     "Er muss furchtbar leiden ohne mich. — Он должно быть ужасно страдает без меня.",
                     "Ich leide furchtbare Qualen. — Я страдаю от ужасных мук.",
                     "Zum ersten Mal leide ich selbst. — Впервые я сам страдаю."
+                ],
+                "sentenceParts": [
+                    "Im Geruch von feuchtem Stroh legt König Lear den Mantel zur Seite.",
+                    "Mein Atem zeichnet das Wort „leiden“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Narr",
                 "translation": "шут",
                 "transcription": "[дер НАР]",
@@ -2786,9 +3507,14 @@
                     "Im Thronsaal verstummen die Gespräche über der Narr nie. — В тронном зале постоянно звучит слово «шут».",
                     "Mein Narr ist weiser als ich je war. — Мой шут мудрее, чем я когда-либо был.",
                     "Als Narr sage ich die Wahrheit durch Scherze. — Как шут я говорю правду через шутки."
+                ],
+                "sentenceParts": [
+                    "Auf dem wackligen Holztisch ordnet König Lear zerlesene Briefe.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Narr“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Erkenntnis",
                 "translation": "познание",
                 "transcription": "[ди ер-КЕНТ-нис]",
@@ -2812,6 +3538,10 @@
                     "Die Erkenntnis ihrer Bosheit erschüttert mich. — Осознание её злобы потрясает меня.",
                     "Die Erkenntnis kommt durch Schmerz und Verlust. — Познание приходит через боль и утрату.",
                     "Die späte Erkenntnis bricht mein Herz. — Позднее осознание разбивает моё сердце."
+                ],
+                "sentenceParts": [
+                    "Am Eingang der Hütte späht König Lear nach einem vertrauten Schatten.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Erkenntnis“ darf nicht vergehen."
                 ]
             }
         ],
@@ -2820,38 +3550,38 @@
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
                     "нищий",
+                    "бедный",
                     "мёрзнуть",
-                    "нищета",
-                    "бедный"
+                    "нищета"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
                     "мёрзнуть",
-                    "нищий",
+                    "бедный",
                     "нищета",
-                    "бедный"
+                    "нищий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «arm»?",
                 "choices": [
                     "бедный",
-                    "нищий",
                     "шут",
-                    "познание"
+                    "страдать",
+                    "нищий"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "бедный",
+                    "познание",
                     "нищета",
-                    "нищий",
+                    "страдать",
                     "мёрзнуть"
                 ],
                 "correctIndex": 3
@@ -2859,51 +3589,134 @@
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
-                    "страдать",
+                    "нищета",
                     "шут",
-                    "нищий",
-                    "хижина"
+                    "хижина",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
+                    "нищета",
                     "страдать",
-                    "мёрзнуть",
-                    "бедный",
-                    "хижина"
+                    "хижина",
+                    "шут"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "шут",
-                    "познание",
                     "бедный",
-                    "страдать"
+                    "нищета",
+                    "страдать",
+                    "шут"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
                     "познание",
                     "бедный",
-                    "хижина",
-                    "мёрзнуть"
+                    "шут",
+                    "страдать"
                 ],
                 "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "das Elend",
+                "translation": "нищета",
+                "parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt König Lear bei der flackernden Kerze.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „das Elend“ mein Nordstern."
+                ],
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt König Lear bei der flackernden Kerze. Selbst wenn die Welt zerfällt, bleibt das Wort „das Elend“ mein Nordstern.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Лир сидит у мерцающей свечи. Даже если мир распадается, слово «нищета» остаётся моим северным светом."
+            },
+            {
+                "word": "der Bettler",
+                "translation": "нищий",
+                "parts": [
+                    "Zwischen zerbeulten Rüstungen streicht König Lear über ein altes Wappen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „der Bettler“ wird heute nicht verraten."
+                ],
+                "sentence": "Zwischen zerbeulten Rüstungen streicht König Lear über ein altes Wappen. Mit fester Stimme schwöre ich mir: Das Wort „der Bettler“ wird heute nicht verraten.",
+                "sentenceTranslation": "Среди помятых доспехов Лир гладит старый герб. Твёрдым голосом я клянусь себе: слово «нищий» сегодня не будет предано."
+            },
+            {
+                "word": "arm",
+                "translation": "бедный",
+                "parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt König Lear fast den Kopf.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „arm“ mein Nordstern."
+                ],
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt König Lear fast den Kopf. Selbst wenn die Welt zerfällt, bleibt das Wort „arm“ mein Nordstern.",
+                "sentenceTranslation": "О низкую балку хижины Лир едва не ударяется головой. Даже если мир распадается, слово «бедный» остаётся моим северным светом."
+            },
+            {
+                "word": "frieren",
+                "translation": "мёрзнуть",
+                "parts": [
+                    "Neben der schlafenden Wache flüstert König Lear in die schwere Nacht.",
+                    "Das kalte Licht lässt das Wort „frieren“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Neben der schlafenden Wache flüstert König Lear in die schwere Nacht. Das kalte Licht lässt das Wort „frieren“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Рядом со спящим стражем Лир шепчет в тяжёлую ночь. Холодный свет заставляет слово «мёрзнуть» сиять словно расплавленное золото."
+            },
+            {
+                "word": "die Hütte",
+                "translation": "хижина",
+                "parts": [
+                    "Vor dem einfachen Feldbett betrachtet König Lear die Narben vergangener Schlachten.",
+                    "Ich zeichne das Wort „die Hütte“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Vor dem einfachen Feldbett betrachtet König Lear die Narben vergangener Schlachten. Ich zeichne das Wort „die Hütte“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед грубой походной койкой Лир разглядывает шрамы прошлых битв. Я черчу слово «хижина» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "leiden",
+                "translation": "страдать",
+                "parts": [
+                    "Im Geruch von feuchtem Stroh legt König Lear den Mantel zur Seite.",
+                    "Mein Atem zeichnet das Wort „leiden“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im Geruch von feuchtem Stroh legt König Lear den Mantel zur Seite. Mein Atem zeichnet das Wort „leiden“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В запахе влажной соломы Лир откладывает плащ в сторону. Моё дыхание рисует слово «страдать» в холодном воздухе между нами."
+            },
+            {
+                "word": "der Narr",
+                "translation": "шут",
+                "parts": [
+                    "Auf dem wackligen Holztisch ordnet König Lear zerlesene Briefe.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Narr“ mein Nordstern."
+                ],
+                "sentence": "Auf dem wackligen Holztisch ordnet König Lear zerlesene Briefe. Selbst wenn die Welt zerfällt, bleibt das Wort „der Narr“ mein Nordstern.",
+                "sentenceTranslation": "На шатком деревянном столе Лир раскладывает зачитанные письма. Даже если мир распадается, слово «шут» остаётся моим северным светом."
+            },
+            {
+                "word": "die Erkenntnis",
+                "translation": "познание",
+                "parts": [
+                    "Am Eingang der Hütte späht König Lear nach einem vertrauten Schatten.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Erkenntnis“ darf nicht vergehen."
+                ],
+                "sentence": "Am Eingang der Hütte späht König Lear nach einem vertrauten Schatten. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Erkenntnis“ darf nicht vergehen.",
+                "sentenceTranslation": "У входа в хижину Лир высматривает знакомую тень. Я шепчу стражам судьбы: слово «познание» не должно исчезнуть."
+            }
+        ]
     },
     "dover": {
         "title": "Дувр",
         "description": "Акт IV: Встреча с Корделией",
         "words": [
             {
+                "wordId": "",
                 "word": "erkennen",
                 "translation": "узнавать",
                 "transcription": "[эр-КЕ-нен]",
@@ -2930,9 +3743,14 @@
                     "Erkennst du mich, dein Kind Cordelia? — Узнаёшь ли ты меня, твоё дитя Корделия?",
                     "Endlich erkenne ich meinen treuen Edgar. — Наконец я узнаю моего верного Эдгара.",
                     "Ich erkenne die Wahrheit hinter dem Schein. — Я познаю правду за видимостью."
+                ],
+                "sentenceParts": [
+                    "Auf den weißen Klippen von Dover blickt König Lear in den aufgewühlten Kanal.",
+                    "Ich halte das Wort „erkennen“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verstehen",
                 "translation": "понимать",
                 "transcription": "[фер-ШТЕ-ен]",
@@ -2954,9 +3772,14 @@
                 "collocations": [
                     "Cordelia zeigt, dass das Verstehen auch ohne Stolz möglich ist. — Корделия показывает, что понимать можно и без гордыни.",
                     "Jetzt verstehe ich, wer mich wirklich liebte. — Теперь я понимаю, кто действительно меня любил."
+                ],
+                "sentenceParts": [
+                    "Zwischen flatternden Feldzeichen richtet König Lear den Helm.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verstehen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Wahrheit",
                 "translation": "правда",
                 "transcription": "[ди ВАР-хайт]",
@@ -2979,9 +3802,14 @@
                     "Die Wahrheit war immer in deinen Worten, Kind. — Правда всегда была в твоих словах, дитя.",
                     "Die Wahrheit war vor meinen Augen verborgen. — Правда была скрыта от моих глаз.",
                     "Die Wahrheit verpacke ich in lustige Lieder. — Правду я заворачиваю в весёлые песни."
+                ],
+                "sentenceParts": [
+                    "Am Lagerfeuer der Franzosen zeichnet König Lear Marschrouten in den Sand.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Wahrheit“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Reue",
                 "translation": "раскаяние",
                 "transcription": "[ди РОЙ-е]",
@@ -3004,9 +3832,14 @@
                     "Die Reue brennt heißer als alle Feuer der Hölle. — Раскаяние жжёт горячее всех адских огней.",
                     "Deine Reue ist nicht nötig, nur deine Liebe. — Твоё раскаяние не нужно, только твоя любовь.",
                     "Die Reue überwältigt meine Seele. — Раскаяние переполняет мою душу."
+                ],
+                "sentenceParts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert König Lear das Siegel.",
+                    "Das Echo des Wortes „die Reue“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Weisheit",
                 "translation": "мудрость",
                 "transcription": "[ди ВАЙС-хайт]",
@@ -3038,9 +3871,14 @@
                     "Die Weisheit kommt zu spät zu mir. — Мудрость приходит ко мне слишком поздно.",
                     "Durch Leiden habe ich Weisheit erlangt. — Через страдания я обрёл мудрость.",
                     "Hinter meinen Späßen verbirgt sich Weisheit. — За моими шутками скрывается мудрость."
+                ],
+                "sentenceParts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht König Lear dem dumpfen Meer.",
+                    "Ich umarme das Wort „die Weisheit“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vergeben",
                 "translation": "прощать",
                 "transcription": "[фер-ГЕ-бен]",
@@ -3063,9 +3901,14 @@
                     "Das Vergeben fällt Lear unerwartet schwer. — Лиру неожиданно тяжело прощать.",
                     "Kannst du einem törichten alten Mann vergeben? — Можешь ли ты простить глупого старика?",
                     "Edgar vergibt mir meine Blindheit. — Эдгар прощает мне мою слепоту."
+                ],
+                "sentenceParts": [
+                    "Auf dem sandigen Trainingsplatz übt König Lear das Ziehen des Schwerts.",
+                    "Wie ein stilles Gebet legt sich das Wort „vergeben“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Einsicht",
                 "translation": "прозрение",
                 "transcription": "[ди АЙН-зихт]",
@@ -3087,9 +3930,14 @@
                 ],
                 "collocations": [
                     "Die Einsicht verbrennt meine Seele. — Прозрение сжигает мою душу."
+                ],
+                "sentenceParts": [
+                    "Zwischen pochenden Trommeln hebt König Lear das Banner der Hoffnung.",
+                    "Mein Atem zeichnet das Wort „die Einsicht“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "schuldig",
                 "translation": "виновный",
                 "transcription": "[ШУЛЬ-диг]",
@@ -3111,6 +3959,10 @@
                 ],
                 "collocations": [
                     "Ich bin schuldig vor meiner Tochter. — Я виновен перед своей дочерью."
+                ],
+                "sentenceParts": [
+                    "Am Morgennebel der Küste legt König Lear die Hand auf das pochende Herz.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „schuldig“ mein Nordstern."
                 ]
             }
         ],
@@ -3119,90 +3971,173 @@
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
                     "раскаяние",
+                    "понимать",
                     "правда",
-                    "узнавать",
-                    "понимать"
+                    "узнавать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verstehen»?",
                 "choices": [
-                    "узнавать",
+                    "правда",
                     "раскаяние",
-                    "правда",
-                    "понимать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Wahrheit»?",
-                "choices": [
-                    "правда",
-                    "мудрость",
-                    "узнавать",
-                    "виновный"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Reue»?",
-                "choices": [
                     "понимать",
-                    "узнавать",
-                    "виновный",
-                    "раскаяние"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Weisheit»?",
-                "choices": [
-                    "мудрость",
-                    "прощать",
-                    "понимать",
-                    "раскаяние"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «vergeben»?",
-                "choices": [
-                    "прощать",
-                    "раскаяние",
-                    "мудрость",
-                    "правда"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Einsicht»?",
-                "choices": [
-                    "узнавать",
-                    "правда",
-                    "прозрение",
-                    "виновный"
+                    "узнавать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «schuldig»?",
+                "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
                     "узнавать",
-                    "правда",
+                    "прощать",
+                    "понимать",
+                    "правда"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Reue»?",
+                "choices": [
+                    "узнавать",
+                    "раскаяние",
+                    "виновный",
+                    "прозрение"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Weisheit»?",
+                "choices": [
+                    "прозрение",
+                    "узнавать",
                     "мудрость",
+                    "правда"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «vergeben»?",
+                "choices": [
+                    "виновный",
+                    "прозрение",
+                    "прощать",
+                    "понимать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Einsicht»?",
+                "choices": [
+                    "понимать",
+                    "прозрение",
+                    "виновный",
+                    "мудрость"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «schuldig»?",
+                "choices": [
+                    "мудрость",
+                    "прощать",
+                    "правда",
                     "виновный"
                 ],
                 "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "erkennen",
+                "translation": "узнавать",
+                "parts": [
+                    "Auf den weißen Klippen von Dover blickt König Lear in den aufgewühlten Kanal.",
+                    "Ich halte das Wort „erkennen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Auf den weißen Klippen von Dover blickt König Lear in den aufgewühlten Kanal. Ich halte das Wort „erkennen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На белых скалах Дувра Лир смотрит в вздыбленный пролив. Я держу слово «узнавать» как факел у сердца."
+            },
+            {
+                "word": "verstehen",
+                "translation": "понимать",
+                "parts": [
+                    "Zwischen flatternden Feldzeichen richtet König Lear den Helm.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verstehen“ gehört mir."
+                ],
+                "sentence": "Zwischen flatternden Feldzeichen richtet König Lear den Helm. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verstehen“ gehört mir.",
+                "sentenceTranslation": "Среди хлопающих штандартов Лир поправляет шлем. Буря за окнами усиливает клятву: слово «понимать» принадлежит мне."
+            },
+            {
+                "word": "die Wahrheit",
+                "translation": "правда",
+                "parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet König Lear Marschrouten in den Sand.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Wahrheit“ gehört mir."
+                ],
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet König Lear Marschrouten in den Sand. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Wahrheit“ gehört mir.",
+                "sentenceTranslation": "У французского костра Лир рисует в песке путь марша. Буря за окнами усиливает клятву: слово «правда» принадлежит мне."
+            },
+            {
+                "word": "die Reue",
+                "translation": "раскаяние",
+                "parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert König Lear das Siegel.",
+                    "Das Echo des Wortes „die Reue“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert König Lear das Siegel. Das Echo des Wortes „die Reue“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Лир проверяет печати. Эхо слова «раскаяние» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Weisheit",
+                "translation": "мудрость",
+                "parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht König Lear dem dumpfen Meer.",
+                    "Ich umarme das Wort „die Weisheit“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht König Lear dem dumpfen Meer. Ich umarme das Wort „die Weisheit“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Лир слушает глухой шум моря. Я обнимаю слово «мудрость», будто это единственный союзник."
+            },
+            {
+                "word": "vergeben",
+                "translation": "прощать",
+                "parts": [
+                    "Auf dem sandigen Trainingsplatz übt König Lear das Ziehen des Schwerts.",
+                    "Wie ein stilles Gebet legt sich das Wort „vergeben“ auf meine Lippen."
+                ],
+                "sentence": "Auf dem sandigen Trainingsplatz übt König Lear das Ziehen des Schwerts. Wie ein stilles Gebet legt sich das Wort „vergeben“ auf meine Lippen.",
+                "sentenceTranslation": "На песчаном плацу Лир отрабатывает выхват меча. Как тихая молитва слово «прощать» ложится на мои губы."
+            },
+            {
+                "word": "die Einsicht",
+                "translation": "прозрение",
+                "parts": [
+                    "Zwischen pochenden Trommeln hebt König Lear das Banner der Hoffnung.",
+                    "Mein Atem zeichnet das Wort „die Einsicht“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Zwischen pochenden Trommeln hebt König Lear das Banner der Hoffnung. Mein Atem zeichnet das Wort „die Einsicht“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Под гул барабанов Лир поднимает знамя надежды. Моё дыхание рисует слово «прозрение» в холодном воздухе между нами."
+            },
+            {
+                "word": "schuldig",
+                "translation": "виновный",
+                "parts": [
+                    "Am Morgennebel der Küste legt König Lear die Hand auf das pochende Herz.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „schuldig“ mein Nordstern."
+                ],
+                "sentence": "Am Morgennebel der Küste legt König Lear die Hand auf das pochende Herz. Selbst wenn die Welt zerfällt, bleibt das Wort „schuldig“ mein Nordstern.",
+                "sentenceTranslation": "В утреннем тумане побережья Лир кладёт ладонь на бьющееся сердце. Даже если мир распадается, слово «виновный» остаётся моим северным светом."
+            }
+        ]
     },
     "prison": {
         "title": "Тюрьма",
         "description": "Акт V: Финал трагедии",
         "words": [
             {
+                "wordId": "",
                 "word": "verzeihen",
                 "translation": "прощать",
                 "transcription": "[фер-ЦАЙ-ен]",
@@ -3225,9 +4160,14 @@
                     "Cordelia zeigt, dass das Verzeihen auch ohne Stolz möglich ist. — Корделия показывает, что прощать можно и без гордыни.",
                     "Verzeih mir, ich bin nur ein törichter alter Mann. — Прости меня, я всего лишь глупый старик.",
                     "Ich verzeihe dir alles, mein lieber Vater. — Я прощаю тебе всё, мой дорогой отец."
+                ],
+                "sentenceParts": [
+                    "Im feuchten Kerker stützt König Lear sich an den tropfenden Stein.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verzeihen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Tod",
                 "translation": "смерть",
                 "transcription": "[дер ТОД]",
@@ -3252,9 +4192,14 @@
                     "Der Tod trennt uns nur für kurze Zeit. — Смерть разлучает нас лишь ненадолго.",
                     "Bis zum Tod bleibe ich an seiner Seite. — До смерти я остаюсь рядом с ним.",
                     "Der Tod kommt für mich zu früh. — Смерть приходит ко мне слишком рано."
+                ],
+                "sentenceParts": [
+                    "Unter der trüben Laterne zählt König Lear die eisernen Ringe der Kette.",
+                    "Ich umarme das Wort „der Tod“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "sterben",
                 "translation": "умирать",
                 "transcription": "[ШТЕР-бен]",
@@ -3279,9 +4224,14 @@
                     "Ich sterbe ohne Reue für meine Taten. — Я умираю без раскаяния за свои дела.",
                     "Ich sterbe vor Freude und Kummer. — Я умираю от радости и горя.",
                     "Ich sterbe durch meine eigene Hand. — Я умираю от своей собственной руки."
+                ],
+                "sentenceParts": [
+                    "Neben der schweren Holztür horcht König Lear auf entferntes Schluchzen.",
+                    "Wie ein stilles Gebet legt sich das Wort „sterben“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Ende",
                 "translation": "конец",
                 "transcription": "[дас ЕН-де]",
@@ -3305,9 +4255,15 @@
                     "Das Ende kommt schnell und gerecht. — Конец приходит быстро и справедливо.",
                     "Dies ist nicht das Ende, nur ein Übergang. — Это не конец, только переход.",
                     "Mein Ende kommt durch eines Dieners Hand. — Мой конец приходит от руки слуги."
+                ],
+                "sentenceParts": [
+                    "Auf der kalten Steinbank zieht König Lear den Mantel enger um die Schultern.",
+                    "Ich presse das Wort „das Ende“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Herz",
                 "translation": "сердце",
                 "transcription": "[дас ХЕРЦ]",
@@ -3329,9 +4285,14 @@
                     "Während des Sturms wirkt das Herz noch bedrückender. — Во время бури само «сердце» звучит ещё тяжелее.",
                     "Mein Herz bricht vor Schmerz und Liebe. — Моё сердце разбивается от боли и любви.",
                     "Mein Herz zerbricht vor Glück und Leid. — Моё сердце разрывается от счастья и горя."
+                ],
+                "sentenceParts": [
+                    "Zwischen Schatten der Gitterstäbe hebt König Lear das Gesicht zum Licht.",
+                    "Ich umarme das Wort „das Herz“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Trauer",
                 "translation": "скорбь",
                 "transcription": "[ди ТРАУ-ер]",
@@ -3355,9 +4316,14 @@
                     "Die Trauer überwältigt meine Seele. — Скорбь переполняет мою душу.",
                     "Die Trauer ist zu schwer zu ertragen. — Скорбь слишком тяжела, чтобы вынести.",
                     "Die Trauer um Корделия macht mich stumm. — Печаль о Корделии делает меня немым."
+                ],
+                "sentenceParts": [
+                    "Am rostigen Wassereimer spiegelt König Lear kurz die eigenen Augen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Trauer“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Abschied",
                 "translation": "прощание",
                 "transcription": "[дер АБ-шид]",
@@ -3390,9 +4356,15 @@
                     "Unser Abschied ist nur vorübergehend. — Наше прощание лишь временно.",
                     "Der Abschied vom Hof schmerzt mich tief. — Прощание с двором глубоко ранит меня.",
                     "Der Abschied von meinem König bricht mein Herz. — Прощание с моим королём разбивает моё сердце."
+                ],
+                "sentenceParts": [
+                    "Im dumpfen Hall der Schritte zählt König Lear den Rhythmus der Wachen.",
+                    "Ich presse das Wort „der Abschied“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ewig",
                 "translation": "вечный",
                 "transcription": "[Э-виг]",
@@ -3421,6 +4393,10 @@
                     "Unsere Liebe wird ewig dauern, mein Kind. — Наша любовь будет вечной, дитя моё.",
                     "Unsere Liebe ist ewig, Vater. — Наша любовь вечна, отец.",
                     "Meine Treue ist ewig, über den Tod hinaus. — Моя верность вечна, за пределами смерти."
+                ],
+                "sentenceParts": [
+                    "Vor dem verriegelten Fenster zeichnet König Lear Kreise in den Staub.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „ewig“ darf nicht vergehen."
                 ]
             }
         ],
@@ -3428,59 +4404,59 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "умирать",
                     "смерть",
                     "прощать",
-                    "конец"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Tod»?",
-                "choices": [
-                    "смерть",
-                    "умирать",
                     "конец",
-                    "прощать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «sterben»?",
-                "choices": [
-                    "прощание",
-                    "умирать",
-                    "скорбь",
-                    "вечный"
+                    "умирать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «das Ende»?",
+                "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "скорбь",
-                    "сердце",
                     "конец",
+                    "умирать",
+                    "смерть",
+                    "прощать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «sterben»?",
+                "choices": [
+                    "конец",
+                    "скорбь",
+                    "умирать",
                     "смерть"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «das Ende»?",
+                "choices": [
+                    "смерть",
+                    "скорбь",
+                    "вечный",
+                    "конец"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
+                    "умирать",
+                    "конец",
                     "сердце",
-                    "прощание",
-                    "прощать",
-                    "скорбь"
+                    "прощание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "конец",
-                    "смерть",
                     "вечный",
+                    "прощание",
+                    "прощать",
                     "скорбь"
                 ],
                 "correctIndex": 3
@@ -3488,25 +4464,109 @@
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "вечный",
-                    "прощание",
                     "сердце",
-                    "умирать"
+                    "прощать",
+                    "конец",
+                    "прощание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "вечный",
-                    "конец",
-                    "скорбь",
-                    "прощать"
+                    "прощать",
+                    "прощание",
+                    "смерть",
+                    "вечный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "verzeihen",
+                "translation": "прощать",
+                "parts": [
+                    "Im feuchten Kerker stützt König Lear sich an den tropfenden Stein.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verzeihen“ gehört mir."
+                ],
+                "sentence": "Im feuchten Kerker stützt König Lear sich an den tropfenden Stein. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verzeihen“ gehört mir.",
+                "sentenceTranslation": "В сыром подземелье Лир опирается на сочащийся камень. Буря за окнами усиливает клятву: слово «прощать» принадлежит мне."
+            },
+            {
+                "word": "der Tod",
+                "translation": "смерть",
+                "parts": [
+                    "Unter der trüben Laterne zählt König Lear die eisernen Ringe der Kette.",
+                    "Ich umarme das Wort „der Tod“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Unter der trüben Laterne zählt König Lear die eisernen Ringe der Kette. Ich umarme das Wort „der Tod“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Под мутным фонарём Лир пересчитывает железные кольца цепи. Я обнимаю слово «смерть», будто это единственный союзник."
+            },
+            {
+                "word": "sterben",
+                "translation": "умирать",
+                "parts": [
+                    "Neben der schweren Holztür horcht König Lear auf entferntes Schluchzen.",
+                    "Wie ein stilles Gebet legt sich das Wort „sterben“ auf meine Lippen."
+                ],
+                "sentence": "Neben der schweren Holztür horcht König Lear auf entferntes Schluchzen. Wie ein stilles Gebet legt sich das Wort „sterben“ auf meine Lippen.",
+                "sentenceTranslation": "У тяжёлой двери Лир прислушивается к далёким рыданиям. Как тихая молитва слово «умирать» ложится на мои губы."
+            },
+            {
+                "word": "das Ende",
+                "translation": "конец",
+                "parts": [
+                    "Auf der kalten Steinbank zieht König Lear den Mantel enger um die Schultern.",
+                    "Ich presse das Wort „das Ende“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Auf der kalten Steinbank zieht König Lear den Mantel enger um die Schultern. Ich presse das Wort „das Ende“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На холодной каменной скамье Лир плотнее кутается в плащ. Я стискиваю слово «конец» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "das Herz",
+                "translation": "сердце",
+                "parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt König Lear das Gesicht zum Licht.",
+                    "Ich umarme das Wort „das Herz“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt König Lear das Gesicht zum Licht. Ich umarme das Wort „das Herz“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Между тенями решёток Лир поднимает лицо к свету. Я обнимаю слово «сердце», будто это единственный союзник."
+            },
+            {
+                "word": "die Trauer",
+                "translation": "скорбь",
+                "parts": [
+                    "Am rostigen Wassereimer spiegelt König Lear kurz die eigenen Augen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Trauer“ gehört mir."
+                ],
+                "sentence": "Am rostigen Wassereimer spiegelt König Lear kurz die eigenen Augen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Trauer“ gehört mir.",
+                "sentenceTranslation": "У ржавого ведра с водой Лир на мгновение видит отражение глаз. Буря за окнами усиливает клятву: слово «скорбь» принадлежит мне."
+            },
+            {
+                "word": "der Abschied",
+                "translation": "прощание",
+                "parts": [
+                    "Im dumpfen Hall der Schritte zählt König Lear den Rhythmus der Wachen.",
+                    "Ich presse das Wort „der Abschied“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Im dumpfen Hall der Schritte zählt König Lear den Rhythmus der Wachen. Ich presse das Wort „der Abschied“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В глухом эхе шагов Лир отсчитывает ритм часовых. Я стискиваю слово «прощание» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "ewig",
+                "translation": "вечный",
+                "parts": [
+                    "Vor dem verriegelten Fenster zeichnet König Lear Kreise in den Staub.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „ewig“ darf nicht vergehen."
+                ],
+                "sentence": "Vor dem verriegelten Fenster zeichnet König Lear Kreise in den Staub. Ich flüstere den Wächtern des Schicksals zu: Das Wort „ewig“ darf nicht vergehen.",
+                "sentenceTranslation": "Перед заколоченным окном Лир чертит круги в пыли. Я шепчу стражам судьбы: слово «вечный» не должно исчезнуть."
+            }
+        ]
     }
 };
 
@@ -3522,6 +4582,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3958,6 +5366,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -4026,6 +5751,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -4034,13 +5762,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4951,6 +6727,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/journeys/oswald.html
+++ b/output/journeys/oswald.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="steward">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="messenger">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="insult">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="spy">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="schemer">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="pursuer">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="coward_death">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["слуга", "послушание", "преданность", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["послушание", "преданность", "служить", "слуга"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["управляющий", "покорный", "послушание", "преданность"], "correct_index": 3}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["преданность", "исполнять", "служить", "управляющий"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["раболепный", "покорный", "служить", "управляющий"], "correct_index": 3}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["преданность", "раболепный", "управляющий", "покорный"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["исполнять", "управляющий", "раболепный", "покорный"], "correct_index": 2}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["покорный", "преданность", "исполнять", "раболепный"], "correct_index": 2}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["передавать", "поручение", "спешка", "гонец"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["гонец", "спешка", "поручение", "передавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["спешка", "передавать", "поручение", "послание"], "correct_index": 0}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["передавать", "послание", "спешить", "спешка"], "correct_index": 0}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["спешить", "торопиться", "поручение", "гонец"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["гонец", "спешить", "передавать", "послание"], "correct_index": 3}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["передавать", "спешка", "гонец", "торопиться"], "correct_index": 3}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["трусость", "оскорбление", "оскорблять", "неуважение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорблять", "оскорбление", "трусость", "неуважение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["оскорблять", "пренебрегать", "трусость", "высмеивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["трусливый", "оскорблять", "дерзкий", "пренебрегать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["оскорблять", "пренебрегать", "дерзкий", "высмеивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «frech»?", "choices": ["трусость", "высмеивать", "дерзкий", "пренебрегать"], "correct_index": 2}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["неуважение", "оскорблять", "оскорбление", "пренебрегать"], "correct_index": 3}, {"question": "Что означает немецкое слово «feige»?", "choices": ["пренебрегать", "неуважение", "трусливый", "трусость"], "correct_index": 2}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["шпионить", "предательство", "скрытность", "шпион"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["предательство", "шпионить", "шпион", "скрытность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["шпион", "скрытность", "вынюхивать", "шпионить"], "correct_index": 1}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["шпион", "шпионить", "выдавать", "подслушивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["выдавать", "шпион", "скрытность", "подслушивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["вынюхивать", "скрытность", "подслушивать", "выдавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["подслушивать", "предательство", "шпионить", "вынюхивать"], "correct_index": 3}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "ковать", "план", "коварство"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["коварство", "план", "интрига", "ковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["коварство", "коварный", "интрига", "ковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["ковать", "интрига", "коварный", "хитрый"], "correct_index": 0}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["план", "коварство", "хитрый", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["коварный", "план", "коварство", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["обманывать", "интрига", "хитрый", "план"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["хитрый", "коварство", "ловушка", "обманывать"], "correct_index": 2}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["преследование", "охота", "гнаться", "преследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["преследовать", "преследование", "гнаться", "охота"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["гнаться", "травить", "преследовать", "преследование"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["выслеживать", "преследовать", "травить", "гнаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["травить", "выслеживать", "охота", "преследование"], "correct_index": 1}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["гнаться", "преследование", "охота", "травить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["преследование", "добыча", "преследовать", "охота"], "correct_index": 1}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["трусость", "поражение", "падать", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["падать", "трусость", "поражение", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["хныкать", "проигрывать", "поражение", "жалкий"], "correct_index": 2}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["смерть", "падать", "поражение", "трусость"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["проигрывать", "поражение", "смерть", "хныкать"], "correct_index": 0}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["падать", "хныкать", "умолять", "проигрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["умолять", "проигрывать", "падать", "трусость"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["смерть", "хныкать", "падать", "жалкий"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["слуга", "послушание", "преданность", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["служить", "слуга", "преданность", "послушание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["покорный", "служить", "преданность", "слуга"], "correct_index": 2}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["покорный", "служить", "управляющий", "послушание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["покорный", "послушание", "управляющий", "раболепный"], "correct_index": 2}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["слуга", "покорный", "служить", "исполнять"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["раболепный", "управляющий", "исполнять", "послушание"], "correct_index": 0}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["исполнять", "раболепный", "покорный", "управляющий"], "correct_index": 0}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["передавать", "спешка", "гонец", "поручение"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["гонец", "спешка", "передавать", "поручение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["передавать", "спешить", "спешка", "торопиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["торопиться", "поручение", "гонец", "передавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["спешить", "гонец", "поручение", "передавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["передавать", "спешка", "послание", "гонец"], "correct_index": 2}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["послание", "торопиться", "спешить", "спешка"], "correct_index": 1}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["оскорбление", "трусость", "неуважение", "оскорблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорбление", "трусость", "оскорблять", "неуважение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["трусость", "оскорблять", "высмеивать", "оскорбление"], "correct_index": 0}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["оскорбление", "пренебрегать", "оскорблять", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["дерзкий", "оскорбление", "высмеивать", "пренебрегать"], "correct_index": 2}, {"question": "Что означает немецкое слово «frech»?", "choices": ["оскорблять", "дерзкий", "трусливый", "трусость"], "correct_index": 1}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["высмеивать", "дерзкий", "оскорблять", "пренебрегать"], "correct_index": 3}, {"question": "Что означает немецкое слово «feige»?", "choices": ["трусость", "высмеивать", "дерзкий", "трусливый"], "correct_index": 3}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["предательство", "шпион", "скрытность", "шпионить"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["скрытность", "шпион", "предательство", "шпионить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["выдавать", "подслушивать", "шпион", "скрытность"], "correct_index": 3}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["шпионить", "подслушивать", "скрытность", "выдавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["подслушивать", "выдавать", "шпионить", "предательство"], "correct_index": 0}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["выдавать", "шпион", "скрытность", "шпионить"], "correct_index": 0}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["шпионить", "вынюхивать", "шпион", "подслушивать"], "correct_index": 1}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "ковать", "план", "коварство"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["интрига", "коварство", "план", "ковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["ловушка", "хитрый", "план", "коварство"], "correct_index": 3}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["коварство", "план", "обманывать", "ковать"], "correct_index": 3}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["коварство", "интрига", "коварный", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["хитрый", "план", "интрига", "коварный"], "correct_index": 3}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["ловушка", "ковать", "обманывать", "хитрый"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["ковать", "ловушка", "коварный", "план"], "correct_index": 1}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["гнаться", "преследование", "охота", "преследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["преследовать", "гнаться", "охота", "преследование"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["гнаться", "выслеживать", "преследовать", "охота"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["гнаться", "преследование", "преследовать", "травить"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["гнаться", "добыча", "преследование", "выслеживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["гнаться", "травить", "охота", "преследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["гнаться", "травить", "преследовать", "добыча"], "correct_index": 3}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "трусость", "падать", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["трусость", "поражение", "падать", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["трусость", "проигрывать", "умолять", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "жалкий", "смерть", "хныкать"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["хныкать", "проигрывать", "поражение", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["хныкать", "смерть", "проигрывать", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["проигрывать", "умолять", "поражение", "жалкий"], "correct_index": 1}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["трусость", "жалкий", "хныкать", "умолять"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Управляющий</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -481,15 +677,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Gehorsam»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преданность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Ergebenheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">преданность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
                             
@@ -497,97 +709,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Ergebenheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">управляющий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">исполнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раболепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">покорный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раболепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">покорный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «befolgen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раболепный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">исполнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раболепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «befolgen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">раболепный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">покорный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -600,23 +796,23 @@
             <div class="quiz-phase-container" data-phase="messenger">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Bote»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Auftrag»?</div>
                         <div class="quiz-choices">
                             
@@ -624,41 +820,41 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Eile»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «überbringen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">послание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «überbringen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">торопиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -670,9 +866,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">послание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
                             
@@ -680,33 +892,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спешить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «eilen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">послание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -719,17 +915,17 @@
             <div class="quiz-phase-container" data-phase="insult">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Beleidigung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -739,11 +935,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Respektlosigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
                             
@@ -751,65 +947,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пренебрегать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «beleidigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пренебрегать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «frech»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">высмеивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «beleidigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пренебрегать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «frech»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дерзкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">трусливый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -819,11 +1015,11 @@
                         <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">высмеивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дерзкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
                             
@@ -831,17 +1027,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «feige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неуважение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">высмеивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусливый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,29 +1050,45 @@
             <div class="quiz-phase-container" data-phase="spy">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Spion»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
                             
@@ -886,40 +1098,40 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вынюхивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «spionieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «lauschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подслушивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
@@ -928,39 +1140,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подслушивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «schnüffeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подслушивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вынюхивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вынюхивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -989,49 +1185,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">коварный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1041,61 +1237,61 @@
                         <div class="quiz-question">Что означает немецкое слово «hintergehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «tückisch»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verschlagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «tückisch»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verschlagen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1108,15 +1304,15 @@
             <div class="quiz-phase-container" data-phase="pursuer">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Verfolgung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
@@ -1124,17 +1320,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Jagd»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1146,57 +1342,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выслеживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">травить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">травить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «hetzen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
                             
@@ -1204,17 +1368,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Beute»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">добыча</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выслеживать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «hetzen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Beute»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">добыча</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,8 +1423,24 @@
             <div class="quiz-phase-container" data-phase="coward_death">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
@@ -1243,61 +1455,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жалкий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
@@ -1307,49 +1487,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хныкать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">умолять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жалкий</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erbärmlich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хныкать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жалкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умолять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1373,6 +1569,7 @@
         "description": "Акт I: Верный слуга Гонерильи",
         "words": [
             {
+                "wordId": "",
                 "word": "der Diener",
                 "translation": "слуга",
                 "transcription": "[дер ДИ-нер]",
@@ -1394,9 +1591,14 @@
                     "Während des Sturms wirkt der Diener noch bedrückender. — Во время бури само «слуга» звучит ещё тяжелее.",
                     "Als Diener gehorche ich meiner Herrin blind. — Как слуга я слепо подчиняюсь своей госпоже.",
                     "Als treuer Diener spreche ich offen. — Как верный слуга, я говорю открыто."
+                ],
+                "sentenceParts": [
+                    "Im Saal der Herrin richtet Oswald die silbernen Teller entlang der langen Tafel aus.",
+                    "Ich zeichne das Wort „der Diener“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Gehorsam",
                 "translation": "послушание",
                 "transcription": "[дер ге-ХОР-зам]",
@@ -1418,9 +1620,14 @@
                 ],
                 "collocations": [
                     "Mein Gehorsam kennt keine Fragen. — Моё послушание не знает вопросов."
+                ],
+                "sentenceParts": [
+                    "Vor dem Spiegel prüft Oswald den makellosen Sitz des Dienerkleids.",
+                    "Ich halte das Wort „der Gehorsam“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Ergebenheit",
                 "translation": "преданность",
                 "transcription": "[ди ер-ГЕ-бен-хайт]",
@@ -1442,9 +1649,15 @@
                 ],
                 "collocations": [
                     "Meine Ergebenheit gilt nur Lady Goneril. — Моя преданность принадлежит только леди Гонерилье."
+                ],
+                "sentenceParts": [
+                    "Zwischen Rechnungsbüchern notiert Oswald jedes Fass Wein.",
+                    "Ich presse das Wort „die Ergebenheit“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "dienen",
                 "translation": "служить",
                 "transcription": "[ДИ-нен]",
@@ -1466,9 +1679,14 @@
                     "Im Sturm zeigt sich, wie wichtig das Dienen ist. — Во время бури становится понятно, насколько важно служить.",
                     "Ich diene ohne Gewissen oder Ehre. — Я служу без совести и чести.",
                     "Ich diene dem König seit vielen Jahren. — Я служу королю много лет."
+                ],
+                "sentenceParts": [
+                    "Am Hofeingang begrüßt Oswald mit steifem Nicken die ankommenden Lords.",
+                    "Wie ein stilles Gebet legt sich das Wort „dienen“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Verwalter",
                 "translation": "управляющий",
                 "transcription": "[дер фер-ВАЛЬ-тер]",
@@ -1490,9 +1708,14 @@
                 ],
                 "collocations": [
                     "Als Verwalter kontrolliere ich den Haushalt. — Как управляющий я контролирую дом."
+                ],
+                "sentenceParts": [
+                    "Unter den wachsamen Augen Gonerils verteilt Oswald die Tagesbefehle.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „der Verwalter“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ergeben",
                 "translation": "покорный",
                 "transcription": "[ер-ГЕ-бен]",
@@ -1514,9 +1737,14 @@
                 ],
                 "collocations": [
                     "Ergeben folge ich jedem Befehl. — Покорно я следую каждому приказу."
+                ],
+                "sentenceParts": [
+                    "Auf der Küchenrampe kontrolliert Oswald die frischen Vorräte.",
+                    "Das Echo des Wortes „ergeben“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "unterwürfig",
                 "translation": "раболепный",
                 "transcription": "[УН-тер-вюр-фиг]",
@@ -1538,9 +1766,14 @@
                 ],
                 "collocations": [
                     "Unterwürfig krieche ich vor meiner Herrin. — Раболепно я пресмыкаюсь перед госпожой."
+                ],
+                "sentenceParts": [
+                    "Neben der Ahnengalerie wischt Oswald letzte Staubkörner fort.",
+                    "Ich umarme das Wort „unterwürfig“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "befolgen",
                 "translation": "исполнять",
                 "transcription": "[бе-ФОЛЬ-ген]",
@@ -1563,6 +1796,10 @@
                 ],
                 "collocations": [
                     "Jeden Befehl befolge ich sofort. — Каждый приказ я исполняю немедленно."
+                ],
+                "sentenceParts": [
+                    "Im Kontor versiegelt Oswald sorgsam die königliche Korrespondenz.",
+                    "Ich atme tief ein und lasse nur das Wort „befolgen“ wieder hinaus."
                 ]
             }
         ],
@@ -1580,81 +1817,165 @@
             {
                 "question": "Что означает немецкое слово «der Gehorsam»?",
                 "choices": [
-                    "послушание",
-                    "преданность",
                     "служить",
-                    "слуга"
+                    "слуга",
+                    "преданность",
+                    "послушание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ergebenheit»?",
                 "choices": [
-                    "управляющий",
                     "покорный",
-                    "послушание",
-                    "преданность"
+                    "служить",
+                    "преданность",
+                    "слуга"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
-                    "преданность",
-                    "исполнять",
+                    "покорный",
                     "служить",
-                    "управляющий"
+                    "управляющий",
+                    "послушание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Verwalter»?",
                 "choices": [
-                    "раболепный",
                     "покорный",
-                    "служить",
-                    "управляющий"
+                    "послушание",
+                    "управляющий",
+                    "раболепный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ergeben»?",
                 "choices": [
-                    "преданность",
-                    "раболепный",
-                    "управляющий",
-                    "покорный"
+                    "слуга",
+                    "покорный",
+                    "служить",
+                    "исполнять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unterwürfig»?",
                 "choices": [
-                    "исполнять",
-                    "управляющий",
                     "раболепный",
-                    "покорный"
+                    "управляющий",
+                    "исполнять",
+                    "послушание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «befolgen»?",
                 "choices": [
-                    "покорный",
-                    "преданность",
                     "исполнять",
-                    "раболепный"
+                    "раболепный",
+                    "покорный",
+                    "управляющий"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Diener",
+                "translation": "слуга",
+                "parts": [
+                    "Im Saal der Herrin richtet Oswald die silbernen Teller entlang der langen Tafel aus.",
+                    "Ich zeichne das Wort „der Diener“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Im Saal der Herrin richtet Oswald die silbernen Teller entlang der langen Tafel aus. Ich zeichne das Wort „der Diener“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "В зале госпожи Освальд выравнивает серебряные блюда вдоль длинного стола. Я черчу слово «слуга» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "der Gehorsam",
+                "translation": "послушание",
+                "parts": [
+                    "Vor dem Spiegel prüft Oswald den makellosen Sitz des Dienerkleids.",
+                    "Ich halte das Wort „der Gehorsam“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Vor dem Spiegel prüft Oswald den makellosen Sitz des Dienerkleids. Ich halte das Wort „der Gehorsam“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Перед зеркалом Освальд проверяет безупречную посадку дворецкого наряда. Я держу слово «послушание» как факел у сердца."
+            },
+            {
+                "word": "die Ergebenheit",
+                "translation": "преданность",
+                "parts": [
+                    "Zwischen Rechnungsbüchern notiert Oswald jedes Fass Wein.",
+                    "Ich presse das Wort „die Ergebenheit“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Zwischen Rechnungsbüchern notiert Oswald jedes Fass Wein. Ich presse das Wort „die Ergebenheit“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Среди бухгалтерских книг Освальд записывает каждую бочку вина. Я стискиваю слово «преданность» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "dienen",
+                "translation": "служить",
+                "parts": [
+                    "Am Hofeingang begrüßt Oswald mit steifem Nicken die ankommenden Lords.",
+                    "Wie ein stilles Gebet legt sich das Wort „dienen“ auf meine Lippen."
+                ],
+                "sentence": "Am Hofeingang begrüßt Oswald mit steifem Nicken die ankommenden Lords. Wie ein stilles Gebet legt sich das Wort „dienen“ auf meine Lippen.",
+                "sentenceTranslation": "У входа во двор Освальд сдержанно кивает прибывающим лордам. Как тихая молитва слово «служить» ложится на мои губы."
+            },
+            {
+                "word": "der Verwalter",
+                "translation": "управляющий",
+                "parts": [
+                    "Unter den wachsamen Augen Gonerils verteilt Oswald die Tagesbefehle.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „der Verwalter“ wird heute nicht verraten."
+                ],
+                "sentence": "Unter den wachsamen Augen Gonerils verteilt Oswald die Tagesbefehle. Mit fester Stimme schwöre ich mir: Das Wort „der Verwalter“ wird heute nicht verraten.",
+                "sentenceTranslation": "Под внимательным взглядом Гонерильи Освальд раздаёт дневные распоряжения. Твёрдым голосом я клянусь себе: слово «управляющий» сегодня не будет предано."
+            },
+            {
+                "word": "ergeben",
+                "translation": "покорный",
+                "parts": [
+                    "Auf der Küchenrampe kontrolliert Oswald die frischen Vorräte.",
+                    "Das Echo des Wortes „ergeben“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Auf der Küchenrampe kontrolliert Oswald die frischen Vorräte. Das Echo des Wortes „ergeben“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На кухонном пандусе Освальд проверяет свежие припасы. Эхо слова «покорный» заглушает шёпот придворных."
+            },
+            {
+                "word": "unterwürfig",
+                "translation": "раболепный",
+                "parts": [
+                    "Neben der Ahnengalerie wischt Oswald letzte Staubkörner fort.",
+                    "Ich umarme das Wort „unterwürfig“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Neben der Ahnengalerie wischt Oswald letzte Staubkörner fort. Ich umarme das Wort „unterwürfig“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "Рядом с галереей предков Освальд смахивает последние пылинки. Я обнимаю слово «раболепный», будто это единственный союзник."
+            },
+            {
+                "word": "befolgen",
+                "translation": "исполнять",
+                "parts": [
+                    "Im Kontor versiegelt Oswald sorgsam die königliche Korrespondenz.",
+                    "Ich atme tief ein und lasse nur das Wort „befolgen“ wieder hinaus."
+                ],
+                "sentence": "Im Kontor versiegelt Oswald sorgsam die königliche Korrespondenz. Ich atme tief ein und lasse nur das Wort „befolgen“ wieder hinaus.",
+                "sentenceTranslation": "В конторе Освальд тщательно запечатывает королевскую корреспонденцию. Я глубоко вдыхаю и выпускаю только слово «исполнять»."
+            }
+        ]
     },
     "messenger": {
         "title": "Гонец",
         "description": "Акт I-II: Передаёт приказы",
         "words": [
             {
+                "wordId": "",
                 "word": "der Bote",
                 "translation": "гонец",
                 "transcription": "[дер БО-те]",
@@ -1676,9 +1997,14 @@
                 "collocations": [
                     "Lears Herz wird schwer, wenn der Bote zur Sprache kommt. — Сердце Лира тяжелеет: «посланник» звучит слишком близко.",
                     "Als Bote überbringe ich böse Nachrichten. — Как гонец я приношу дурные вести."
+                ],
+                "sentenceParts": [
+                    "Auf staubigen Straßen peitscht Oswald das Pferd zu größerer Eile.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Bote“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Auftrag",
                 "translation": "поручение",
                 "transcription": "[дер АУФ-траг]",
@@ -1700,9 +2026,14 @@
                 ],
                 "collocations": [
                     "Jeden Auftrag erfülle ich gewissenhaft. — Каждое поручение я выполняю добросовестно."
+                ],
+                "sentenceParts": [
+                    "Vor verschlossenen Toren zeigt Oswald das mit Wachs versiegelte Schreiben.",
+                    "Das kalte Licht lässt das Wort „der Auftrag“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Eile",
                 "translation": "спешка",
                 "transcription": "[ди АЙ-ле]",
@@ -1724,9 +2055,14 @@
                 ],
                 "collocations": [
                     "In großer Eile renne ich hin und her. — В большой спешке я бегаю туда-сюда."
+                ],
+                "sentenceParts": [
+                    "In der Nacht rast Oswald mit einer Laterne als einzigem Stern.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Eile“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "überbringen",
                 "translation": "передавать",
                 "transcription": "[ю-бер-БРИН-ген]",
@@ -1748,9 +2084,14 @@
                 ],
                 "collocations": [
                     "Ich überbringe Befehle an alle Diener. — Я передаю приказы всем слугам."
+                ],
+                "sentenceParts": [
+                    "Am Grenzposten überreicht Oswald den Befehl mit überheblichem Lächeln.",
+                    "Das Echo des Wortes „überbringen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "hasten",
                 "translation": "спешить",
                 "transcription": "[ХАС-тен]",
@@ -1772,9 +2113,14 @@
                 ],
                 "collocations": [
                     "Ich haste von einem Ort zum anderen. — Я спешу с места на место."
+                ],
+                "sentenceParts": [
+                    "Zwischen zerrissenen Bannern schützt Oswald die Nachricht vor dem Regen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „hasten“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Botschaft",
                 "translation": "послание",
                 "transcription": "[ди БОТ-шафт]",
@@ -1796,9 +2142,14 @@
                 ],
                 "collocations": [
                     "Die Botschaft meiner Herrin ist grausam. — Послание моей госпожи жестоко."
+                ],
+                "sentenceParts": [
+                    "Auf dem Hofe Lear erhebt Oswald die Stimme über den Tumult.",
+                    "Das Echo des Wortes „die Botschaft“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "eilen",
                 "translation": "торопиться",
                 "transcription": "[АЙ-лен]",
@@ -1820,6 +2171,10 @@
                 ],
                 "collocations": [
                     "Ich eile, um ihre Wünsche zu erfüllen. — Я тороплюсь исполнить её желания."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der Stallungen tauscht Oswald heimlich versiegelte Rollen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „eilen“ wird heute nicht verraten."
                 ]
             }
         ],
@@ -1828,80 +2183,153 @@
                 "question": "Что означает немецкое слово «der Bote»?",
                 "choices": [
                     "передавать",
-                    "поручение",
                     "спешка",
-                    "гонец"
+                    "гонец",
+                    "поручение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Auftrag»?",
                 "choices": [
                     "гонец",
                     "спешка",
-                    "поручение",
-                    "передавать"
+                    "передавать",
+                    "поручение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Eile»?",
                 "choices": [
-                    "спешка",
                     "передавать",
-                    "поручение",
-                    "послание"
+                    "спешить",
+                    "спешка",
+                    "торопиться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «überbringen»?",
                 "choices": [
-                    "передавать",
-                    "послание",
-                    "спешить",
-                    "спешка"
+                    "торопиться",
+                    "поручение",
+                    "гонец",
+                    "передавать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hasten»?",
                 "choices": [
                     "спешить",
-                    "торопиться",
+                    "гонец",
                     "поручение",
-                    "гонец"
+                    "передавать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Botschaft»?",
                 "choices": [
-                    "гонец",
-                    "спешить",
                     "передавать",
-                    "послание"
+                    "спешка",
+                    "послание",
+                    "гонец"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «eilen»?",
                 "choices": [
-                    "передавать",
-                    "спешка",
-                    "гонец",
-                    "торопиться"
+                    "послание",
+                    "торопиться",
+                    "спешить",
+                    "спешка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Bote",
+                "translation": "гонец",
+                "parts": [
+                    "Auf staubigen Straßen peitscht Oswald das Pferd zu größerer Eile.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Bote“ gehört mir."
+                ],
+                "sentence": "Auf staubigen Straßen peitscht Oswald das Pferd zu größerer Eile. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Bote“ gehört mir.",
+                "sentenceTranslation": "На пыльных дорогах Освальд подгоняет коня к большей скорости. Буря за окнами усиливает клятву: слово «гонец» принадлежит мне."
+            },
+            {
+                "word": "der Auftrag",
+                "translation": "поручение",
+                "parts": [
+                    "Vor verschlossenen Toren zeigt Oswald das mit Wachs versiegelte Schreiben.",
+                    "Das kalte Licht lässt das Wort „der Auftrag“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Vor verschlossenen Toren zeigt Oswald das mit Wachs versiegelte Schreiben. Das kalte Licht lässt das Wort „der Auftrag“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Перед закрытыми воротами Освальд предъявляет письмо, запечатанное воском. Холодный свет заставляет слово «поручение» сиять словно расплавленное золото."
+            },
+            {
+                "word": "die Eile",
+                "translation": "спешка",
+                "parts": [
+                    "In der Nacht rast Oswald mit einer Laterne als einzigem Stern.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Eile“ mein Nordstern."
+                ],
+                "sentence": "In der Nacht rast Oswald mit einer Laterne als einzigem Stern. Selbst wenn die Welt zerfällt, bleibt das Wort „die Eile“ mein Nordstern.",
+                "sentenceTranslation": "Ночью Освальд мчится, освещаемый одной лишь латерной. Даже если мир распадается, слово «спешка» остаётся моим северным светом."
+            },
+            {
+                "word": "überbringen",
+                "translation": "передавать",
+                "parts": [
+                    "Am Grenzposten überreicht Oswald den Befehl mit überheblichem Lächeln.",
+                    "Das Echo des Wortes „überbringen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Am Grenzposten überreicht Oswald den Befehl mit überheblichem Lächeln. Das Echo des Wortes „überbringen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На пограничной заставе Освальд вручает приказ с высокомерной улыбкой. Эхо слова «передавать» заглушает шёпот придворных."
+            },
+            {
+                "word": "hasten",
+                "translation": "спешить",
+                "parts": [
+                    "Zwischen zerrissenen Bannern schützt Oswald die Nachricht vor dem Regen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „hasten“ darf nicht vergehen."
+                ],
+                "sentence": "Zwischen zerrissenen Bannern schützt Oswald die Nachricht vor dem Regen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „hasten“ darf nicht vergehen.",
+                "sentenceTranslation": "Среди порванных знамён Освальд прикрывает письмо от дождя. Я шепчу стражам судьбы: слово «спешить» не должно исчезнуть."
+            },
+            {
+                "word": "die Botschaft",
+                "translation": "послание",
+                "parts": [
+                    "Auf dem Hofe Lear erhebt Oswald die Stimme über den Tumult.",
+                    "Das Echo des Wortes „die Botschaft“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Auf dem Hofe Lear erhebt Oswald die Stimme über den Tumult. Das Echo des Wortes „die Botschaft“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На дворе Лира Освальд возвышает голос над шумом. Эхо слова «послание» заглушает шёпот придворных."
+            },
+            {
+                "word": "eilen",
+                "translation": "торопиться",
+                "parts": [
+                    "Im Schatten der Stallungen tauscht Oswald heimlich versiegelte Rollen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „eilen“ wird heute nicht verraten."
+                ],
+                "sentence": "Im Schatten der Stallungen tauscht Oswald heimlich versiegelte Rollen. Mit fester Stimme schwöre ich mir: Das Wort „eilen“ wird heute nicht verraten.",
+                "sentenceTranslation": "В тени конюшен Освальд тайно меняет запечатанные свитки. Твёрдым голосом я клянусь себе: слово «торопиться» сегодня не будет предано."
+            }
+        ]
     },
     "insult": {
         "title": "Оскорбитель",
         "description": "Акт II: Оскорбляет Лира",
         "words": [
             {
+                "wordId": "",
                 "word": "die Beleidigung",
                 "translation": "оскорбление",
                 "transcription": "[ди бе-ЛАЙ-ди-гунг]",
@@ -1923,9 +2351,14 @@
                 ],
                 "collocations": [
                     "Jede Beleidigung spreche ich mit Genuss aus. — Каждое оскорбление я произношу с наслаждением."
+                ],
+                "sentenceParts": [
+                    "Vor dem gealterten König verneigt sich Oswald nur einen Hauch zu wenig.",
+                    "Das Echo des Wortes „die Beleidigung“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Respektlosigkeit",
                 "translation": "неуважение",
                 "transcription": "[ди рес-ПЕКТ-ло-зиг-кайт]",
@@ -1947,9 +2380,14 @@
                 ],
                 "collocations": [
                     "Meine Respektlosigkeit kennt keine Grenzen. — Моё неуважение не знает границ."
+                ],
+                "sentenceParts": [
+                    "Am Torbogen blockiert Oswald den Weg mit erhobenem Stab.",
+                    "Ich halte das Wort „die Respektlosigkeit“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Feigheit",
                 "translation": "трусость",
                 "transcription": "[ди ФАЙГ-хайт]",
@@ -1974,9 +2412,14 @@
                 "collocations": [
                     "Aus Feigheit greife ich nur Schwache an. — Из трусости я нападаю только на слабых.",
                     "Meine Feigheit führt zu meinem Ende. — Моя трусость приводит к моему концу."
+                ],
+                "sentenceParts": [
+                    "Zwischen entrüsteten Rittern rollt Oswald mit den Augen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Feigheit“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "beleidigen",
                 "translation": "оскорблять",
                 "transcription": "[бе-ЛАЙ-ди-ген]",
@@ -1997,9 +2440,14 @@
                 "collocations": [
                     "Der Narr spürt, wie das Beleidigen alle verändert. — Шут чувствует, как умение оскорблять меняет всех.",
                     "Ich beleidige den alten König ohne Scham. — Я оскорбляю старого короля без стыда."
+                ],
+                "sentenceParts": [
+                    "Auf der Treppe wischt Oswald imaginären Staub von Lears Mantel.",
+                    "Ich halte das Wort „beleidigen“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verhöhnen",
                 "translation": "высмеивать",
                 "transcription": "[фер-ХЁ-нен]",
@@ -2027,9 +2475,14 @@
                 "collocations": [
                     "Ich verhöhne seine königliche Würde. — Я высмеиваю его королевское достоинство.",
                     "Ich verhöhne seine väterliche Liebe. — Я насмехаюсь над его отцовской любовью."
+                ],
+                "sentenceParts": [
+                    "Neben Gonerils kühlen Blick flüstert Oswald eine spitze Bemerkung.",
+                    "Das kalte Licht lässt das Wort „verhöhnen“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "frech",
                 "translation": "дерзкий",
                 "transcription": "[ФРЕХ]",
@@ -2051,9 +2504,14 @@
                 ],
                 "collocations": [
                     "Frech widerspreche ich dem alten Mann. — Дерзко я возражаю старику."
+                ],
+                "sentenceParts": [
+                    "Auf dem Hof setzt Oswald sich mit verschränkten Armen gegen jede Bitte zur Wehr.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „frech“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "missachten",
                 "translation": "пренебрегать",
                 "transcription": "[МИС-ах-тен]",
@@ -2075,9 +2533,14 @@
                 ],
                 "collocations": [
                     "Ich missachte seinen früheren Rang. — Я пренебрегаю его прежним рангом."
+                ],
+                "sentenceParts": [
+                    "Im Flur stößt Oswald den alten König absichtlich zur Seite.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „missachten“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "feige",
                 "translation": "трусливый",
                 "transcription": "[ФАЙ-ге]",
@@ -2099,6 +2562,10 @@
                 ],
                 "collocations": [
                     "Feige verstecke ich mich hinter meiner Herrin. — Трусливо я прячусь за своей госпожой."
+                ],
+                "sentenceParts": [
+                    "Auf dem Balkon lacht Oswald laut über Lears Hilflosigkeit.",
+                    "Ich halte das Wort „feige“ wie eine Fackel vor meinem Herzen."
                 ]
             }
         ],
@@ -2106,19 +2573,19 @@
             {
                 "question": "Что означает немецкое слово «die Beleidigung»?",
                 "choices": [
-                    "трусость",
                     "оскорбление",
-                    "оскорблять",
-                    "неуважение"
+                    "трусость",
+                    "неуважение",
+                    "оскорблять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Respektlosigkeit»?",
                 "choices": [
-                    "оскорблять",
                     "оскорбление",
                     "трусость",
+                    "оскорблять",
                     "неуважение"
                 ],
                 "correctIndex": 3
@@ -2126,49 +2593,49 @@
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
-                    "оскорблять",
-                    "пренебрегать",
                     "трусость",
-                    "высмеивать"
+                    "оскорблять",
+                    "высмеивать",
+                    "оскорбление"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beleidigen»?",
                 "choices": [
-                    "трусливый",
+                    "оскорбление",
+                    "пренебрегать",
                     "оскорблять",
-                    "дерзкий",
-                    "пренебрегать"
+                    "трусость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "оскорблять",
-                    "пренебрегать",
                     "дерзкий",
-                    "высмеивать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «frech»?",
-                "choices": [
-                    "трусость",
+                    "оскорбление",
                     "высмеивать",
-                    "дерзкий",
                     "пренебрегать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «frech»?",
+                "choices": [
+                    "оскорблять",
+                    "дерзкий",
+                    "трусливый",
+                    "трусость"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «missachten»?",
                 "choices": [
-                    "неуважение",
+                    "высмеивать",
+                    "дерзкий",
                     "оскорблять",
-                    "оскорбление",
                     "пренебрегать"
                 ],
                 "correctIndex": 3
@@ -2176,21 +2643,104 @@
             {
                 "question": "Что означает немецкое слово «feige»?",
                 "choices": [
-                    "пренебрегать",
-                    "неуважение",
-                    "трусливый",
-                    "трусость"
+                    "трусость",
+                    "высмеивать",
+                    "дерзкий",
+                    "трусливый"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Beleidigung",
+                "translation": "оскорбление",
+                "parts": [
+                    "Vor dem gealterten König verneigt sich Oswald nur einen Hauch zu wenig.",
+                    "Das Echo des Wortes „die Beleidigung“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Vor dem gealterten König verneigt sich Oswald nur einen Hauch zu wenig. Das Echo des Wortes „die Beleidigung“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Перед постаревшим королём Освальд кланяется лишь на долю меньше. Эхо слова «оскорбление» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Respektlosigkeit",
+                "translation": "неуважение",
+                "parts": [
+                    "Am Torbogen blockiert Oswald den Weg mit erhobenem Stab.",
+                    "Ich halte das Wort „die Respektlosigkeit“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Am Torbogen blockiert Oswald den Weg mit erhobenem Stab. Ich halte das Wort „die Respektlosigkeit“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В проёме ворот Освальд преграждает путь поднятым жезлом. Я держу слово «неуважение» как факел у сердца."
+            },
+            {
+                "word": "die Feigheit",
+                "translation": "трусость",
+                "parts": [
+                    "Zwischen entrüsteten Rittern rollt Oswald mit den Augen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Feigheit“ bleibt lebendig."
+                ],
+                "sentence": "Zwischen entrüsteten Rittern rollt Oswald mit den Augen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Feigheit“ bleibt lebendig.",
+                "sentenceTranslation": "Среди возмущённых рыцарей Освальд закатывает глаза. Каждой клеткой тела я обещаю: слово «трусость» останется живым."
+            },
+            {
+                "word": "beleidigen",
+                "translation": "оскорблять",
+                "parts": [
+                    "Auf der Treppe wischt Oswald imaginären Staub von Lears Mantel.",
+                    "Ich halte das Wort „beleidigen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Auf der Treppe wischt Oswald imaginären Staub von Lears Mantel. Ich halte das Wort „beleidigen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На лестнице Освальд стряхивает воображаемую пыль с плаща Лира. Я держу слово «оскорблять» как факел у сердца."
+            },
+            {
+                "word": "verhöhnen",
+                "translation": "высмеивать",
+                "parts": [
+                    "Neben Gonerils kühlen Blick flüstert Oswald eine spitze Bemerkung.",
+                    "Das kalte Licht lässt das Wort „verhöhnen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Neben Gonerils kühlen Blick flüstert Oswald eine spitze Bemerkung. Das kalte Licht lässt das Wort „verhöhnen“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Рядом с холодным взглядом Гонерильи Освальд шепчет едкое замечание. Холодный свет заставляет слово «высмеивать» сиять словно расплавленное золото."
+            },
+            {
+                "word": "frech",
+                "translation": "дерзкий",
+                "parts": [
+                    "Auf dem Hof setzt Oswald sich mit verschränkten Armen gegen jede Bitte zur Wehr.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „frech“ mein Nordstern."
+                ],
+                "sentence": "Auf dem Hof setzt Oswald sich mit verschränkten Armen gegen jede Bitte zur Wehr. Selbst wenn die Welt zerfällt, bleibt das Wort „frech“ mein Nordstern.",
+                "sentenceTranslation": "На дворе Освальд скрестив руки сопротивляется любой просьбе. Даже если мир распадается, слово «дерзкий» остаётся моим северным светом."
+            },
+            {
+                "word": "missachten",
+                "translation": "пренебрегать",
+                "parts": [
+                    "Im Flur stößt Oswald den alten König absichtlich zur Seite.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „missachten“ bleibt lebendig."
+                ],
+                "sentence": "Im Flur stößt Oswald den alten König absichtlich zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „missachten“ bleibt lebendig.",
+                "sentenceTranslation": "В коридоре Освальд нарочно отталкивает старого короля в сторону. Каждой клеткой тела я обещаю: слово «пренебрегать» останется живым."
+            },
+            {
+                "word": "feige",
+                "translation": "трусливый",
+                "parts": [
+                    "Auf dem Balkon lacht Oswald laut über Lears Hilflosigkeit.",
+                    "Ich halte das Wort „feige“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Auf dem Balkon lacht Oswald laut über Lears Hilflosigkeit. Ich halte das Wort „feige“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На балконе Освальд громко смеётся над беспомощностью Лира. Я держу слово «трусливый» как факел у сердца."
+            }
+        ]
     },
     "spy": {
         "title": "Шпион",
         "description": "Акт III: Шпионит за всеми",
         "words": [
             {
+                "wordId": "",
                 "word": "der Spion",
                 "translation": "шпион",
                 "transcription": "[дер шпи-ОН]",
@@ -2212,9 +2762,15 @@
                 ],
                 "collocations": [
                     "Als Spion lausche ich an jeder Tür. — Как шпион я подслушиваю у каждой двери."
+                ],
+                "sentenceParts": [
+                    "Im Dunkel des Treppenhauses hält Oswald den Atem an,",
+                    "um Gespräche zu belauschen.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Spion“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Verrat",
                 "translation": "предательство",
                 "transcription": "[дер фер-РАТ]",
@@ -2238,9 +2794,14 @@
                     "Der Verrat ist mein tägliches Geschäft. — Предательство - моё ежедневное дело.",
                     "Der Verrat meines Bruders zerstört mein Leben. — Предательство моего брата разрушает мою жизнь.",
                     "Meine Hilfe gilt als Verrat. — Моя помощь считается изменой."
+                ],
+                "sentenceParts": [
+                    "Hinter schweren Vorhängen notiert Oswald jedes geflüsterte Wort.",
+                    "Das kalte Licht lässt das Wort „der Verrat“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Heimlichkeit",
                 "translation": "скрытность",
                 "transcription": "[ди ХАЙМ-лих-кайт]",
@@ -2262,9 +2823,14 @@
                 ],
                 "collocations": [
                     "In Heimlichkeit sammle ich Informationen. — В скрытности я собираю информацию."
+                ],
+                "sentenceParts": [
+                    "Auf den Mauern späht Oswald nach Reitern am Horizont.",
+                    "Ich halte das Wort „die Heimlichkeit“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "spionieren",
                 "translation": "шпионить",
                 "transcription": "[шпи-о-НИ-рен]",
@@ -2286,9 +2852,14 @@
                 ],
                 "collocations": [
                     "Ich spioniere für meine böse Herrin. — Я шпионю для моей злой госпожи."
+                ],
+                "sentenceParts": [
+                    "Zwischen Küchenmägden tauscht Oswald Gerüchte gegen Kupferstücke.",
+                    "Ich halte das Wort „spionieren“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "lauschen",
                 "translation": "подслушивать",
                 "transcription": "[ЛАУ-шен]",
@@ -2310,9 +2881,14 @@
                 ],
                 "collocations": [
                     "Heimlich lausche ich allen Gesprächen. — Тайно я подслушиваю все разговоры."
+                ],
+                "sentenceParts": [
+                    "Im Kerzenlicht zeichnet Oswald geheime Wege auf Pergament.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „lauschen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verraten",
                 "translation": "выдавать",
                 "transcription": "[фер-РА-тен]",
@@ -2338,9 +2914,14 @@
                     "Ich verrate jeden an meine Herrin. — Я выдаю каждого своей госпоже.",
                     "Ich verrate meinen eigenen Vater. — Я предаю собственного отца.",
                     "Ich verrate meinen Mann für Edmund. — Я предаю мужа ради Эдмунда."
+                ],
+                "sentenceParts": [
+                    "Unter dem Fenster von Regan beugt Oswald sich tief in die Nacht hinaus.",
+                    "Ich zeichne das Wort „verraten“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "schnüffeln",
                 "translation": "вынюхивать",
                 "transcription": "[ШНЮФ-фельн]",
@@ -2362,6 +2943,10 @@
                 ],
                 "collocations": [
                     "Überall schnüffle ich nach Geheimnissen. — Везде я вынюхиваю секреты."
+                ],
+                "sentenceParts": [
+                    "Vor Gonerils Gemach übergibt Oswald flüsternd die gesammelten Nachrichten.",
+                    "Ich zeichne das Wort „schnüffeln“ in Gedanken über die Linien des Schicksals."
                 ]
             }
         ],
@@ -2369,81 +2954,155 @@
             {
                 "question": "Что означает немецкое слово «der Spion»?",
                 "choices": [
-                    "шпионить",
                     "предательство",
-                    "скрытность",
-                    "шпион"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Verrat»?",
-                "choices": [
-                    "предательство",
-                    "шпионить",
-                    "шпион",
-                    "скрытность"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Heimlichkeit»?",
-                "choices": [
                     "шпион",
                     "скрытность",
-                    "вынюхивать",
                     "шпионить"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «der Verrat»?",
+                "choices": [
+                    "скрытность",
+                    "шпион",
+                    "предательство",
+                    "шпионить"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Heimlichkeit»?",
+                "choices": [
+                    "выдавать",
+                    "подслушивать",
+                    "шпион",
+                    "скрытность"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «spionieren»?",
                 "choices": [
-                    "шпион",
                     "шпионить",
-                    "выдавать",
-                    "подслушивать"
+                    "подслушивать",
+                    "скрытность",
+                    "выдавать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «lauschen»?",
                 "choices": [
+                    "подслушивать",
                     "выдавать",
-                    "шпион",
-                    "скрытность",
-                    "подслушивать"
+                    "шпионить",
+                    "предательство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "вынюхивать",
+                    "выдавать",
+                    "шпион",
                     "скрытность",
-                    "подслушивать",
-                    "выдавать"
+                    "шпионить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «schnüffeln»?",
                 "choices": [
-                    "подслушивать",
-                    "предательство",
                     "шпионить",
-                    "вынюхивать"
+                    "вынюхивать",
+                    "шпион",
+                    "подслушивать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Spion",
+                "translation": "шпион",
+                "parts": [
+                    "Im Dunkel des Treppenhauses hält Oswald den Atem an,",
+                    "um Gespräche zu belauschen.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Spion“ auf meine Lippen."
+                ],
+                "sentence": "Im Dunkel des Treppenhauses hält Oswald den Atem an, um Gespräche zu belauschen. Wie ein stilles Gebet legt sich das Wort „der Spion“ auf meine Lippen.",
+                "sentenceTranslation": "В темноте лестницы Освальд задерживает дыхание, подслушивая разговоры. Как тихая молитва слово «шпион» ложится на мои губы."
+            },
+            {
+                "word": "der Verrat",
+                "translation": "предательство",
+                "parts": [
+                    "Hinter schweren Vorhängen notiert Oswald jedes geflüsterte Wort.",
+                    "Das kalte Licht lässt das Wort „der Verrat“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Hinter schweren Vorhängen notiert Oswald jedes geflüsterte Wort. Das kalte Licht lässt das Wort „der Verrat“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "За тяжёлыми портьерами Освальд записывает каждое прошептанное слово. Холодный свет заставляет слово «предательство» сиять словно расплавленное золото."
+            },
+            {
+                "word": "die Heimlichkeit",
+                "translation": "скрытность",
+                "parts": [
+                    "Auf den Mauern späht Oswald nach Reitern am Horizont.",
+                    "Ich halte das Wort „die Heimlichkeit“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Auf den Mauern späht Oswald nach Reitern am Horizont. Ich halte das Wort „die Heimlichkeit“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "На стенах Освальд высматривает всадников на горизонте. Я держу слово «скрытность» как факел у сердца."
+            },
+            {
+                "word": "spionieren",
+                "translation": "шпионить",
+                "parts": [
+                    "Zwischen Küchenmägden tauscht Oswald Gerüchte gegen Kupferstücke.",
+                    "Ich halte das Wort „spionieren“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Zwischen Küchenmägden tauscht Oswald Gerüchte gegen Kupferstücke. Ich halte das Wort „spionieren“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Среди кухонных служанок Освальд обменивает слухи на медяки. Я держу слово «шпионить» как факел у сердца."
+            },
+            {
+                "word": "lauschen",
+                "translation": "подслушивать",
+                "parts": [
+                    "Im Kerzenlicht zeichnet Oswald geheime Wege auf Pergament.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „lauschen“ gehört mir."
+                ],
+                "sentence": "Im Kerzenlicht zeichnet Oswald geheime Wege auf Pergament. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „lauschen“ gehört mir.",
+                "sentenceTranslation": "При свете свечи Освальд вычерчивает тайные пути на пергаменте. Буря за окнами усиливает клятву: слово «подслушивать» принадлежит мне."
+            },
+            {
+                "word": "verraten",
+                "translation": "выдавать",
+                "parts": [
+                    "Unter dem Fenster von Regan beugt Oswald sich tief in die Nacht hinaus.",
+                    "Ich zeichne das Wort „verraten“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Unter dem Fenster von Regan beugt Oswald sich tief in die Nacht hinaus. Ich zeichne das Wort „verraten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под окном Реганы Освальд глубоко склоняется в ночную тьму. Я вывожу слово «выдавать» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "schnüffeln",
+                "translation": "вынюхивать",
+                "parts": [
+                    "Vor Gonerils Gemach übergibt Oswald flüsternd die gesammelten Nachrichten.",
+                    "Ich zeichne das Wort „schnüffeln“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Vor Gonerils Gemach übergibt Oswald flüsternd die gesammelten Nachrichten. Ich zeichne das Wort „schnüffeln“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Перед покоями Гонерильи Освальд шёпотом передаёт собранные вести. Я черчу слово «вынюхивать» в мыслях поверх линий судьбы."
+            }
+        ]
     },
     "schemer": {
         "title": "Интриган",
         "description": "Акт IV: Плетёт интриги",
         "words": [
             {
+                "wordId": "",
                 "word": "die Intrige",
                 "translation": "интрига",
                 "transcription": "[ди ин-ТРИ-ге]",
@@ -2467,9 +3126,15 @@
                     "Jede Intrige spinne ich mit Freude. — Каждую интригу я плету с радостью.",
                     "Edmunds Intrige hat mich zum Geächteten gemacht. — Интрига Эдмунда сделала меня изгоем.",
                     "Meine Intrige wird sie vernichten. — Моя интрига уничтожит её."
+                ],
+                "sentenceParts": [
+                    "In der Schreibstube entwirft Oswald ein Netz aus widersprüchlichen Botschaften.",
+                    "Ich presse das Wort „die Intrige“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Plan",
                 "translation": "план",
                 "transcription": "[дер ПЛАН]",
@@ -2495,9 +3160,14 @@
                 "collocations": [
                     "Mein hinterhältiger Plan wird funktionieren. — Мой коварный план сработает.",
                     "Mein Plan wird perfekt ausgeführt. — Мой план выполняется идеально."
+                ],
+                "sentenceParts": [
+                    "Neben Gonerils Lager zeichnet Oswald heimlich zwei Namen auf ein Pergament.",
+                    "Ich zeichne das Wort „der Plan“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Hinterlist",
                 "translation": "коварство",
                 "transcription": "[ди ХИН-тер-лист]",
@@ -2519,9 +3189,15 @@
                 ],
                 "collocations": [
                     "Mit Hinterlist verfolge ich meine Ziele. — С коварством я преследую свои цели."
+                ],
+                "sentenceParts": [
+                    "Auf der Gartenterrasse verbrennt Oswald Beweise im bronzezeitigen Becken.",
+                    "Ich presse das Wort „die Hinterlist“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "schmieden",
                 "translation": "ковать",
                 "transcription": "[ШМИ-ден]",
@@ -2543,9 +3219,14 @@
                 ],
                 "collocations": [
                     "Ich schmiede Pläne gegen alle Feinde. — Я кую планы против всех врагов."
+                ],
+                "sentenceParts": [
+                    "Im Stall flüstert Oswald falsche Befehle in die Ohren der Reiter.",
+                    "Ich umarme das Wort „schmieden“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "hintergehen",
                 "translation": "обманывать",
                 "transcription": "[ХИН-тер-ге-ен]",
@@ -2569,9 +3250,14 @@
                 ],
                 "collocations": [
                     "Ich hintergehe jeden, der mir traut. — Я обманываю каждого, кто мне доверяет."
+                ],
+                "sentenceParts": [
+                    "Vor Regans Dienern versteckt Oswald die Briefe im Futter der Pferde.",
+                    "Das Echo des Wortes „hintergehen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "tückisch",
                 "translation": "коварный",
                 "transcription": "[ТЮ-киш]",
@@ -2593,9 +3279,14 @@
                 ],
                 "collocations": [
                     "Tückisch plane ich meinen nächsten Schritt. — Коварно я планирую свой следующий шаг."
+                ],
+                "sentenceParts": [
+                    "Unter der Laube formt Oswald aus Wachs ein neues Siegel.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „tückisch“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verschlagen",
                 "translation": "хитрый",
                 "transcription": "[фер-ШЛАГ-ен]",
@@ -2617,9 +3308,14 @@
                 ],
                 "collocations": [
                     "Verschlagen verberge ich meine wahren Absichten. — Хитро я скрываю свои истинные намерения."
+                ],
+                "sentenceParts": [
+                    "In der Mitternachtspause verteilt Oswald verschlüsselte Notizen.",
+                    "Das Echo des Wortes „verschlagen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Falle",
                 "translation": "ловушка",
                 "transcription": "[ди ФА-ле]",
@@ -2645,6 +3341,11 @@
                 "collocations": [
                     "Ich stelle Fallen für die Ahnungslosen. — Я ставлю ловушки для ничего не подозревающих.",
                     "Ich tappe blind in Edmunds Falle. — Я слепо попадаю в ловушку Эдмунда."
+                ],
+                "sentenceParts": [
+                    "Auf dem Kartentisch verschiebt Oswald Figuren, als wären es echte Menschen.",
+                    "Ich presse das Wort „die Falle“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             }
         ],
@@ -2662,39 +3363,39 @@
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
+                    "интрига",
                     "коварство",
                     "план",
-                    "интрига",
                     "ковать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Hinterlist»?",
                 "choices": [
-                    "коварство",
-                    "коварный",
-                    "интрига",
-                    "ковать"
+                    "ловушка",
+                    "хитрый",
+                    "план",
+                    "коварство"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «schmieden»?",
                 "choices": [
-                    "ковать",
-                    "интрига",
-                    "коварный",
-                    "хитрый"
+                    "коварство",
+                    "план",
+                    "обманывать",
+                    "ковать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hintergehen»?",
                 "choices": [
-                    "план",
                     "коварство",
-                    "хитрый",
+                    "интрига",
+                    "коварный",
                     "обманывать"
                 ],
                 "correctIndex": 3
@@ -2702,41 +3403,127 @@
             {
                 "question": "Что означает немецкое слово «tückisch»?",
                 "choices": [
-                    "коварный",
+                    "хитрый",
                     "план",
-                    "коварство",
-                    "обманывать"
+                    "интрига",
+                    "коварный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verschlagen»?",
                 "choices": [
+                    "ловушка",
+                    "ковать",
                     "обманывать",
-                    "интрига",
-                    "хитрый",
-                    "план"
+                    "хитрый"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
-                    "хитрый",
-                    "коварство",
+                    "ковать",
                     "ловушка",
-                    "обманывать"
+                    "коварный",
+                    "план"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Intrige",
+                "translation": "интрига",
+                "parts": [
+                    "In der Schreibstube entwirft Oswald ein Netz aus widersprüchlichen Botschaften.",
+                    "Ich presse das Wort „die Intrige“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "In der Schreibstube entwirft Oswald ein Netz aus widersprüchlichen Botschaften. Ich presse das Wort „die Intrige“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В писчей комнате Освальд плетёт сеть противоречивых посланий. Я стискиваю слово «интрига» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "der Plan",
+                "translation": "план",
+                "parts": [
+                    "Neben Gonerils Lager zeichnet Oswald heimlich zwei Namen auf ein Pergament.",
+                    "Ich zeichne das Wort „der Plan“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Neben Gonerils Lager zeichnet Oswald heimlich zwei Namen auf ein Pergament. Ich zeichne das Wort „der Plan“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Рядом с ложем Гонерильи Освальд тайком выводит два имени на пергаменте. Я черчу слово «план» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "die Hinterlist",
+                "translation": "коварство",
+                "parts": [
+                    "Auf der Gartenterrasse verbrennt Oswald Beweise im bronzezeitigen Becken.",
+                    "Ich presse das Wort „die Hinterlist“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Auf der Gartenterrasse verbrennt Oswald Beweise im bronzezeitigen Becken. Ich presse das Wort „die Hinterlist“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На садовой террасе Освальд сжигает улики в бронзовой чаше. Я стискиваю слово «коварство» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "schmieden",
+                "translation": "ковать",
+                "parts": [
+                    "Im Stall flüstert Oswald falsche Befehle in die Ohren der Reiter.",
+                    "Ich umarme das Wort „schmieden“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Im Stall flüstert Oswald falsche Befehle in die Ohren der Reiter. Ich umarme das Wort „schmieden“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В конюшне Освальд шепчет ложные приказы в уши всадников. Я обнимаю слово «ковать», будто это единственный союзник."
+            },
+            {
+                "word": "hintergehen",
+                "translation": "обманывать",
+                "parts": [
+                    "Vor Regans Dienern versteckt Oswald die Briefe im Futter der Pferde.",
+                    "Das Echo des Wortes „hintergehen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Vor Regans Dienern versteckt Oswald die Briefe im Futter der Pferde. Das Echo des Wortes „hintergehen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "Перед слугами Реганы Освальд прячет письма в корме лошадей. Эхо слова «обманывать» заглушает шёпот придворных."
+            },
+            {
+                "word": "tückisch",
+                "translation": "коварный",
+                "parts": [
+                    "Unter der Laube formt Oswald aus Wachs ein neues Siegel.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „tückisch“ mein Nordstern."
+                ],
+                "sentence": "Unter der Laube formt Oswald aus Wachs ein neues Siegel. Selbst wenn die Welt zerfällt, bleibt das Wort „tückisch“ mein Nordstern.",
+                "sentenceTranslation": "Под беседкой Освальд отливает из воска новую печать. Даже если мир распадается, слово «коварный» остаётся моим северным светом."
+            },
+            {
+                "word": "verschlagen",
+                "translation": "хитрый",
+                "parts": [
+                    "In der Mitternachtspause verteilt Oswald verschlüsselte Notizen.",
+                    "Das Echo des Wortes „verschlagen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "In der Mitternachtspause verteilt Oswald verschlüsselte Notizen. Das Echo des Wortes „verschlagen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "В полночный перерыв Освальд раздаёт зашифрованные записки. Эхо слова «хитрый» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Falle",
+                "translation": "ловушка",
+                "parts": [
+                    "Auf dem Kartentisch verschiebt Oswald Figuren, als wären es echte Menschen.",
+                    "Ich presse das Wort „die Falle“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Auf dem Kartentisch verschiebt Oswald Figuren, als wären es echte Menschen. Ich presse das Wort „die Falle“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "На столе с картами Освальд переставляет фигурки, будто это живые люди. Я стискиваю слово «ловушка» зубами, чтобы не вырвалось сомнение."
+            }
+        ]
     },
     "pursuer": {
         "title": "Преследователь",
         "description": "Акт IV: Преследует Глостера",
         "words": [
             {
+                "wordId": "",
                 "word": "die Verfolgung",
                 "translation": "преследование",
                 "transcription": "[ди фер-ФОЛЬ-гунг]",
@@ -2758,9 +3545,14 @@
                 ],
                 "collocations": [
                     "Die Verfolgung des blinden Grafen beginnt. — Преследование слепого графа начинается."
+                ],
+                "sentenceParts": [
+                    "Mit gespannter Armbrust durchstreift Oswald die nächtlichen Felder.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verfolgung“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Jagd",
                 "translation": "охота",
                 "transcription": "[ди ЯГДТ]",
@@ -2782,9 +3574,14 @@
                 ],
                 "collocations": [
                     "Die Jagd auf Gloucester macht mir Spaß. — Охота на Глостера доставляет мне удовольствие."
+                ],
+                "sentenceParts": [
+                    "Auf dem Küstenpfad späht Oswald nach Spuren des fliehenden Grafen.",
+                    "Das Echo des Wortes „die Jagd“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verfolgen",
                 "translation": "преследовать",
                 "transcription": "[фер-ФОЛЬ-ген]",
@@ -2806,9 +3603,14 @@
                     "Der Narr spürt, wie das Verfolgen alle verändert. — Шут чувствует, как умение преследовать меняет всех.",
                     "Gnadenlos verfolge ich den alten Mann. — Безжалостно я преследую старика.",
                     "Die Soldaten verfolgen mich wie einen Verbrecher. — Солдаты преследуют меня как преступника."
+                ],
+                "sentenceParts": [
+                    "Zwischen Dornenhecken zückt Oswald das versteckte Messer.",
+                    "Mein Atem zeichnet das Wort „verfolgen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "jagen",
                 "translation": "гнаться",
                 "transcription": "[Я-ген]",
@@ -2835,9 +3637,14 @@
                 "collocations": [
                     "Wie ein Hund jage ich meine Beute. — Как собака я гонюсь за добычей.",
                     "Ich jage meinen Sohn fort wie einen Verbrecher. — Я гоню сына прочь как преступника."
+                ],
+                "sentenceParts": [
+                    "Am Moorloch testet Oswald die Tiefe mit der Spitze der Lanze.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „jagen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "aufspüren",
                 "translation": "выслеживать",
                 "transcription": "[АУФ-шпю-рен]",
@@ -2859,9 +3666,14 @@
                 ],
                 "collocations": [
                     "Ich spüre den Flüchtling überall auf. — Я выслеживаю беглеца повсюду."
+                ],
+                "sentenceParts": [
+                    "Vor einem verlassenen Hof horcht Oswald auf das Schnaufen der Pferde.",
+                    "Wie ein stilles Gebet legt sich das Wort „aufspüren“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "hetzen",
                 "translation": "травить",
                 "transcription": "[ХЕ-цен]",
@@ -2883,9 +3695,14 @@
                 ],
                 "collocations": [
                     "Ich hetze ihn bis zum Ende. — Я травлю его до конца."
+                ],
+                "sentenceParts": [
+                    "Unter Regans Banner motiviert Oswald die Soldaten zu schnellerer Jagd.",
+                    "Ich halte das Wort „hetzen“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Beute",
                 "translation": "добыча",
                 "transcription": "[ди БОЙ-те]",
@@ -2907,6 +3724,10 @@
                 ],
                 "collocations": [
                     "Der Graf ist meine leichte Beute. — Граф - моя лёгкая добыча."
+                ],
+                "sentenceParts": [
+                    "Auf den Klippen über Dover späht Oswald in die graue Ferne.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Beute“ wird heute nicht verraten."
                 ]
             }
         ],
@@ -2914,81 +3735,154 @@
             {
                 "question": "Что означает немецкое слово «die Verfolgung»?",
                 "choices": [
+                    "гнаться",
                     "преследование",
                     "охота",
-                    "гнаться",
                     "преследовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Jagd»?",
                 "choices": [
                     "преследовать",
-                    "преследование",
                     "гнаться",
-                    "охота"
+                    "охота",
+                    "преследование"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
                     "гнаться",
-                    "травить",
+                    "выслеживать",
                     "преследовать",
-                    "преследование"
+                    "охота"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
-                    "выслеживать",
+                    "гнаться",
+                    "преследование",
                     "преследовать",
-                    "травить",
-                    "гнаться"
+                    "травить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «aufspüren»?",
                 "choices": [
-                    "травить",
-                    "выслеживать",
-                    "охота",
-                    "преследование"
+                    "гнаться",
+                    "добыча",
+                    "преследование",
+                    "выслеживать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hetzen»?",
                 "choices": [
                     "гнаться",
-                    "преследование",
+                    "травить",
                     "охота",
-                    "травить"
+                    "преследовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Beute»?",
                 "choices": [
-                    "преследование",
-                    "добыча",
+                    "гнаться",
+                    "травить",
                     "преследовать",
-                    "охота"
+                    "добыча"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Verfolgung",
+                "translation": "преследование",
+                "parts": [
+                    "Mit gespannter Armbrust durchstreift Oswald die nächtlichen Felder.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verfolgung“ bleibt lebendig."
+                ],
+                "sentence": "Mit gespannter Armbrust durchstreift Oswald die nächtlichen Felder. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verfolgung“ bleibt lebendig.",
+                "sentenceTranslation": "С натянутым арбалетом Освальд прочёсывает ночные поля. Каждой клеткой тела я обещаю: слово «преследование» останется живым."
+            },
+            {
+                "word": "die Jagd",
+                "translation": "охота",
+                "parts": [
+                    "Auf dem Küstenpfad späht Oswald nach Spuren des fliehenden Grafen.",
+                    "Das Echo des Wortes „die Jagd“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Auf dem Küstenpfad späht Oswald nach Spuren des fliehenden Grafen. Das Echo des Wortes „die Jagd“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На прибрежной тропе Освальд высматривает следы бегущего графа. Эхо слова «охота» заглушает шёпот придворных."
+            },
+            {
+                "word": "verfolgen",
+                "translation": "преследовать",
+                "parts": [
+                    "Zwischen Dornenhecken zückt Oswald das versteckte Messer.",
+                    "Mein Atem zeichnet das Wort „verfolgen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Zwischen Dornenhecken zückt Oswald das versteckte Messer. Mein Atem zeichnet das Wort „verfolgen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Среди колючих кустов Освальд выхватывает спрятанный нож. Моё дыхание рисует слово «преследовать» в холодном воздухе между нами."
+            },
+            {
+                "word": "jagen",
+                "translation": "гнаться",
+                "parts": [
+                    "Am Moorloch testet Oswald die Tiefe mit der Spitze der Lanze.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „jagen“ gehört mir."
+                ],
+                "sentence": "Am Moorloch testet Oswald die Tiefe mit der Spitze der Lanze. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „jagen“ gehört mir.",
+                "sentenceTranslation": "У болотной ямы Освальд проверяет глубину наконечником копья. Буря за окнами усиливает клятву: слово «гнаться» принадлежит мне."
+            },
+            {
+                "word": "aufspüren",
+                "translation": "выслеживать",
+                "parts": [
+                    "Vor einem verlassenen Hof horcht Oswald auf das Schnaufen der Pferde.",
+                    "Wie ein stilles Gebet legt sich das Wort „aufspüren“ auf meine Lippen."
+                ],
+                "sentence": "Vor einem verlassenen Hof horcht Oswald auf das Schnaufen der Pferde. Wie ein stilles Gebet legt sich das Wort „aufspüren“ auf meine Lippen.",
+                "sentenceTranslation": "У заброшенного двора Освальд прислушивается к сопению коней. Как тихая молитва слово «выслеживать» ложится на мои губы."
+            },
+            {
+                "word": "hetzen",
+                "translation": "травить",
+                "parts": [
+                    "Unter Regans Banner motiviert Oswald die Soldaten zu schnellerer Jagd.",
+                    "Ich halte das Wort „hetzen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Unter Regans Banner motiviert Oswald die Soldaten zu schnellerer Jagd. Ich halte das Wort „hetzen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Под знаменем Реганы Освальд подгоняет солдат к более быстрой охоте. Я держу слово «травить» как факел у сердца."
+            },
+            {
+                "word": "die Beute",
+                "translation": "добыча",
+                "parts": [
+                    "Auf den Klippen über Dover späht Oswald in die graue Ferne.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Beute“ wird heute nicht verraten."
+                ],
+                "sentence": "Auf den Klippen über Dover späht Oswald in die graue Ferne. Mit fester Stimme schwöre ich mir: Das Wort „die Beute“ wird heute nicht verraten.",
+                "sentenceTranslation": "На скалах над Дувром Освальд вглядывается в серую даль. Твёрдым голосом я клянусь себе: слово «добыча» сегодня не будет предано."
+            }
+        ]
     },
     "coward_death": {
         "title": "Смерть труса",
         "description": "Акт IV: Убит Эдгаром",
         "words": [
             {
+                "wordId": "",
                 "word": "der Tod",
                 "translation": "смерть",
                 "transcription": "[дер ТОД]",
@@ -3013,9 +3907,14 @@
                     "Der Tod trennt uns nur für kurze Zeit. — Смерть разлучает нас лишь ненадолго.",
                     "Bis zum Tod bleibe ich an seiner Seite. — До смерти я остаюсь рядом с ним.",
                     "Der Tod kommt für mich zu früh. — Смерть приходит ко мне слишком рано."
+                ],
+                "sentenceParts": [
+                    "Im dunstigen Wald stürzt Oswald vor Edgars Klinge rückwärts.",
+                    "Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Feigheit",
                 "translation": "трусость",
                 "transcription": "[ди ФАЙГ-хайт]",
@@ -3040,9 +3939,14 @@
                 "collocations": [
                     "Aus Feigheit greife ich nur Schwache an. — Из трусости я нападаю только на слабых.",
                     "Meine Feigheit führt zu meinem Ende. — Моя трусость приводит к моему концу."
+                ],
+                "sentenceParts": [
+                    "Neben einem morschen Baum bittet Oswald mit erhobenen Händen um Gnade.",
+                    "Ich halte das Wort „die Feigheit“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Niederlage",
                 "translation": "поражение",
                 "transcription": "[ди НИ-дер-ла-ге]",
@@ -3068,9 +3972,14 @@
                 "collocations": [
                     "Die Niederlage ist mein letztes Schicksal. — Поражение - моя последняя судьба.",
                     "Die Niederlage ist vollkommen. — Поражение полное."
+                ],
+                "sentenceParts": [
+                    "Am Boden liegend tastet Oswald vergeblich nach dem verlorenen Schwert.",
+                    "Ich halte das Wort „die Niederlage“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "fallen",
                 "translation": "падать",
                 "transcription": "[ФА-лен]",
@@ -3093,9 +4002,14 @@
                     "Der Narr spürt, wie das Fallen alle verändert. — Шут чувствует, как умение падать меняет всех.",
                     "Ich falle wie der Feigling, der ich bin. — Я падаю как трус, которым являюсь.",
                     "Ich falle von seinem gerechten Schwert. — Я падаю от его справедливого меча."
+                ],
+                "sentenceParts": [
+                    "Vor Edgars ernster Miene rutscht Oswald im nassen Laub aus.",
+                    "Wie ein stilles Gebet legt sich das Wort „fallen“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "unterliegen",
                 "translation": "проигрывать",
                 "transcription": "[ун-тер-ЛИ-ген]",
@@ -3118,9 +4032,14 @@
                 ],
                 "collocations": [
                     "Ich unterliege dem edlen Edgar. — Я проигрываю благородному Эдгару."
+                ],
+                "sentenceParts": [
+                    "Unter einem kalten Regen stammelt Oswald letzte Ausflüchte.",
+                    "Mein Atem zeichnet das Wort „unterliegen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "wimmern",
                 "translation": "хныкать",
                 "transcription": "[ВИМ-мерн]",
@@ -3142,9 +4061,14 @@
                 ],
                 "collocations": [
                     "Wimmernd bitte ich um Gnade. — Хныкая, я прошу о пощаде."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der Bäume erkennt Oswald zu spät die gerechte Vergeltung.",
+                    "Ich umarme das Wort „wimmern“, als wäre es mein einziger Verbündeter."
                 ]
             },
             {
+                "wordId": "",
                 "word": "betteln",
                 "translation": "умолять",
                 "transcription": "[БЕ-тельн]",
@@ -3172,9 +4096,14 @@
                 "collocations": [
                     "Um mein Leben bettle ich vergeblich. — О жизни я умоляю напрасно.",
                     "Muss ich um Unterkunft betteln bei meinen eigenen Kindern? — Должен ли я просить крова у собственных детей?"
+                ],
+                "sentenceParts": [
+                    "Auf dem Waldboden erlischt Oswalds Atem ohne Ehrenwache.",
+                    "Ich zeichne das Wort „betteln“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erbärmlich",
                 "translation": "жалкий",
                 "transcription": "[ер-БЕРМ-лих]",
@@ -3196,6 +4125,10 @@
                 ],
                 "collocations": [
                     "Erbärmlich ende ich wie ich gelebt habe. — Жалко я заканчиваю, как и жил."
+                ],
+                "sentenceParts": [
+                    "Neben dem fallengelassenen Brief liegt Oswald reglos im Schlamm.",
+                    "Das kalte Licht lässt das Wort „erbärmlich“ wie geschmolzenes Gold erscheinen."
                 ]
             }
         ],
@@ -3203,85 +4136,167 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
+                    "смерть",
                     "трусость",
-                    "поражение",
                     "падать",
-                    "смерть"
+                    "поражение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
-                    "падать",
                     "трусость",
                     "поражение",
+                    "падать",
                     "смерть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "хныкать",
+                    "трусость",
                     "проигрывать",
-                    "поражение",
-                    "жалкий"
+                    "умолять",
+                    "поражение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
-                    "смерть",
                     "падать",
-                    "поражение",
-                    "трусость"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «unterliegen»?",
-                "choices": [
-                    "проигрывать",
-                    "поражение",
+                    "жалкий",
                     "смерть",
                     "хныкать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «wimmern»?",
+                "question": "Что означает немецкое слово «unterliegen»?",
                 "choices": [
-                    "падать",
                     "хныкать",
-                    "умолять",
-                    "проигрывать"
+                    "проигрывать",
+                    "поражение",
+                    "падать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «betteln»?",
+                "question": "Что означает немецкое слово «wimmern»?",
                 "choices": [
-                    "умолять",
+                    "хныкать",
+                    "смерть",
                     "проигрывать",
-                    "падать",
-                    "трусость"
+                    "поражение"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «erbärmlich»?",
+                "question": "Что означает немецкое слово «betteln»?",
                 "choices": [
-                    "смерть",
-                    "хныкать",
-                    "падать",
+                    "проигрывать",
+                    "умолять",
+                    "поражение",
                     "жалкий"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «erbärmlich»?",
+                "choices": [
+                    "трусость",
+                    "жалкий",
+                    "хныкать",
+                    "умолять"
+                ],
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "der Tod",
+                "translation": "смерть",
+                "parts": [
+                    "Im dunstigen Wald stürzt Oswald vor Edgars Klinge rückwärts.",
+                    "Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im dunstigen Wald stürzt Oswald vor Edgars Klinge rückwärts. Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В туманном лесу Освальд падает навзничь перед клинком Эдгара. Моё дыхание рисует слово «смерть» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Feigheit",
+                "translation": "трусость",
+                "parts": [
+                    "Neben einem morschen Baum bittet Oswald mit erhobenen Händen um Gnade.",
+                    "Ich halte das Wort „die Feigheit“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Neben einem morschen Baum bittet Oswald mit erhobenen Händen um Gnade. Ich halte das Wort „die Feigheit“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У трухлявого дерева Освальд вздымает руки, умоляя о пощаде. Я держу слово «трусость» как факел у сердца."
+            },
+            {
+                "word": "die Niederlage",
+                "translation": "поражение",
+                "parts": [
+                    "Am Boden liegend tastet Oswald vergeblich nach dem verlorenen Schwert.",
+                    "Ich halte das Wort „die Niederlage“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Am Boden liegend tastet Oswald vergeblich nach dem verlorenen Schwert. Ich halte das Wort „die Niederlage“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Лежа на земле, Освальд тщетно ищет потерянный меч. Я держу слово «поражение» как факел у сердца."
+            },
+            {
+                "word": "fallen",
+                "translation": "падать",
+                "parts": [
+                    "Vor Edgars ernster Miene rutscht Oswald im nassen Laub aus.",
+                    "Wie ein stilles Gebet legt sich das Wort „fallen“ auf meine Lippen."
+                ],
+                "sentence": "Vor Edgars ernster Miene rutscht Oswald im nassen Laub aus. Wie ein stilles Gebet legt sich das Wort „fallen“ auf meine Lippen.",
+                "sentenceTranslation": "Перед суровым взглядом Эдгара Освальд скользит на мокрой листве. Как тихая молитва слово «падать» ложится на мои губы."
+            },
+            {
+                "word": "unterliegen",
+                "translation": "проигрывать",
+                "parts": [
+                    "Unter einem kalten Regen stammelt Oswald letzte Ausflüchte.",
+                    "Mein Atem zeichnet das Wort „unterliegen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Unter einem kalten Regen stammelt Oswald letzte Ausflüchte. Mein Atem zeichnet das Wort „unterliegen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Под холодным дождём Освальд лепечет последние оправдания. Моё дыхание рисует слово «проигрывать» в холодном воздухе между нами."
+            },
+            {
+                "word": "wimmern",
+                "translation": "хныкать",
+                "parts": [
+                    "Im Schatten der Bäume erkennt Oswald zu spät die gerechte Vergeltung.",
+                    "Ich umarme das Wort „wimmern“, als wäre es mein einziger Verbündeter."
+                ],
+                "sentence": "Im Schatten der Bäume erkennt Oswald zu spät die gerechte Vergeltung. Ich umarme das Wort „wimmern“, als wäre es mein einziger Verbündeter.",
+                "sentenceTranslation": "В тени деревьев Освальд слишком поздно осознаёт справедливое возмездие. Я обнимаю слово «хныкать», будто это единственный союзник."
+            },
+            {
+                "word": "betteln",
+                "translation": "умолять",
+                "parts": [
+                    "Auf dem Waldboden erlischt Oswalds Atem ohne Ehrenwache.",
+                    "Ich zeichne das Wort „betteln“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Auf dem Waldboden erlischt Oswalds Atem ohne Ehrenwache. Ich zeichne das Wort „betteln“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На лесной земле дыхание Освальд гаснет без почётного караула. Я черчу слово «умолять» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "erbärmlich",
+                "translation": "жалкий",
+                "parts": [
+                    "Neben dem fallengelassenen Brief liegt Oswald reglos im Schlamm.",
+                    "Das kalte Licht lässt das Wort „erbärmlich“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Neben dem fallengelassenen Brief liegt Oswald reglos im Schlamm. Das kalte Licht lässt das Wort „erbärmlich“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Рядом с оброненным письмом Освальд неподвижно лежит в грязи. Холодный свет заставляет слово «жалкий» сиять словно расплавленное золото."
+            }
+        ]
     }
 };
 
@@ -3297,6 +4312,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3733,6 +5096,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -3801,6 +5481,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -3809,13 +5492,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4726,6 +6457,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/journeys/regan.html
+++ b/output/journeys/regan.html
@@ -150,6 +150,202 @@
             </div>
         </div>
 
+        <div class="constructor-section">
+            <h2>🧩 Конструктор предложений</h2>
+            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+
+            
+            <section class="constructor-panel active" data-phase="throne">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="goneril">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="regan">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="storm">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="hut">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="dover">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+            <section class="constructor-panel" data-phase="prison">
+                <div class="constructor-header">
+                    <div class="constructor-word" data-constructor-word>—</div>
+                    <div class="constructor-translation" data-constructor-translation></div>
+                    <div class="constructor-progress" data-constructor-progress></div>
+                </div>
+                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                <div class="constructor-areas">
+                    <div class="constructor-source" data-constructor-source></div>
+                    <div class="constructor-target" data-constructor-target>
+                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                    </div>
+                </div>
+
+                <div class="constructor-controls">
+                    <button class="constructor-control constructor-check" type="button">Проверить</button>
+                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                </div>
+
+                <div class="constructor-feedback" aria-live="polite"></div>
+                <div class="constructor-original" data-constructor-original></div>
+
+                
+            </section>
+            
+        </div>
+
         <div class="relations-wrapper">
             
             
@@ -446,7 +642,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["притворяться", "фальшь", "превосходить", "состязаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["превосходить", "состязаться", "притворяться", "фальшь"], "correct_index": 0}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["состязаться", "превосходить", "разыгрывать", "выманивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["состязаться", "притворяться", "алчность", "фальшь"], "correct_index": 3}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["разыгрывать", "состязаться", "алчность", "превосходить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["выманивать", "хитрость", "алчность", "фальшь"], "correct_index": 1}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["хитрость", "выманивать", "превосходить", "фальшь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["состязаться", "выманивать", "фальшь", "алчность"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["планировать", "делить", "заговорить", "союз"], "correct_index": 3}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["заговорить", "делить", "союз", "планировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «planen»?", "choices": ["планировать", "делить", "договариваться", "стратегия"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["стратегия", "сговор", "планировать", "заговорить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["делить", "заговорить", "планировать", "сговор"], "correct_index": 3}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["договариваться", "стратегия", "союз", "делить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["стратегия", "делить", "планировать", "сговор"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["унижать", "злоба", "пытать", "насмехаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["пытать", "насмехаться", "унижать", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["жестоко обращаться", "насмехаться", "отвергать", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["унижать", "насмехаться", "злоба", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["пытать", "жестоко обращаться", "жестокость", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["пытать", "насмехаться", "злоба", "жёсткость"], "correct_index": 3}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["жёсткость", "жестокость", "унижать", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["унижать", "пытать", "жестокость", "жёсткость"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "садизм", "выкалывать", "наслаждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["садизм", "наслаждаться", "ослеплять", "выкалывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["растаптывать", "наслаждаться", "ослеплять", "садизм"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["ослеплять", "выкалывать", "растаптывать", "беспощадный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["ослеплять", "садизм", "беспощадный", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["беспощадный", "растаптывать", "брутальность", "наслаждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["садизм", "беспощадный", "брутальность", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["растаптывать", "брутальность", "пытка", "ослеплять"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вдова", "вожделеть", "вожделение", "соблазнять"], "correct_index": 0}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вожделение", "вдова", "вожделеть", "соблазнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["вдова", "соблазнять", "добиваться", "похоть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["добиваться", "заманивать", "вожделение", "соблазнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «locken»?", "choices": ["вожделеть", "заманивать", "соблазнять", "добиваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["похоть", "вожделение", "добиваться", "заманивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «werben»?", "choices": ["добиваться", "вожделение", "вожделеть", "вдова"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["соревноваться", "соперничество", "угрожать", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["угрожать", "соперничество", "ненавидеть", "соревноваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["угрожать", "ненавидеть", "соревноваться", "бороться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["угрожать", "соперничество", "не доверять", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["угрожать", "бороться", "соперничество", "не доверять"], "correct_index": 1}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["бороться", "не доверять", "угрожать", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["ненавидеть", "не доверять", "соперничество", "подозревать"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["отравленный", "страдать", "мучение", "издыхать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["отравленный", "издыхать", "мучение", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["страдать", "проклинать", "проклятый", "издыхать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["издыхать", "расплачиваться", "мучение", "отравленный"], "correct_index": 2}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["проклинать", "проклятый", "отравленный", "расплачиваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["издыхать", "расплачиваться", "рок", "отравленный"], "correct_index": 2}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["мучение", "расплачиваться", "издыхать", "проклинать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["проклятый", "страдать", "расплачиваться", "издыхать"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["превосходить", "притворяться", "фальшь", "состязаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["состязаться", "фальшь", "притворяться", "превосходить"], "correct_index": 3}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["превосходить", "состязаться", "фальшь", "хитрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["алчность", "состязаться", "выманивать", "фальшь"], "correct_index": 3}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["алчность", "состязаться", "разыгрывать", "выманивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die List»?", "choices": ["алчность", "притворяться", "хитрость", "состязаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["разыгрывать", "состязаться", "хитрость", "выманивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["превосходить", "алчность", "выманивать", "разыгрывать"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["планировать", "заговорить", "делить", "союз"], "correct_index": 3}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["планировать", "союз", "делить", "заговорить"], "correct_index": 2}, {"question": "Что означает немецкое слово «planen»?", "choices": ["планировать", "стратегия", "делить", "сговор"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["заговорить", "делить", "сговор", "стратегия"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["стратегия", "союз", "договариваться", "сговор"], "correct_index": 3}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["стратегия", "договариваться", "заговорить", "планировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["стратегия", "договариваться", "делить", "союз"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["злоба", "унижать", "пытать", "насмехаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["злоба", "пытать", "унижать", "насмехаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["злоба", "жёсткость", "насмехаться", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["жестоко обращаться", "злоба", "насмехаться", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["насмехаться", "злоба", "жестоко обращаться", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жестоко обращаться", "жестокость", "жёсткость", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["жестоко обращаться", "жестокость", "жёсткость", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жёсткость", "злоба", "пытать", "жестокость"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["выкалывать", "садизм", "наслаждаться", "ослеплять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["ослеплять", "наслаждаться", "садизм", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["ослеплять", "садизм", "наслаждаться", "пытка"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["выкалывать", "беспощадный", "брутальность", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["ослеплять", "выкалывать", "пытка", "беспощадный"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["наслаждаться", "брутальность", "ослеплять", "беспощадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["беспощадный", "ослеплять", "растаптывать", "брутальность"], "correct_index": 3}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["пытка", "брутальность", "садизм", "растаптывать"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вдова", "соблазнять", "вожделеть", "вожделение"], "correct_index": 0}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вожделение", "вдова", "вожделеть", "соблазнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["заманивать", "соблазнять", "добиваться", "вдова"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["вожделение", "добиваться", "вдова", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «locken»?", "choices": ["заманивать", "добиваться", "похоть", "вожделение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["заманивать", "похоть", "вдова", "добиваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «werben»?", "choices": ["вдова", "соблазнять", "добиваться", "похоть"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["соперничество", "угрожать", "соревноваться", "ненавидеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["ненавидеть", "угрожать", "соревноваться", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["бороться", "угрожать", "соперничество", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["подозревать", "соперничество", "соревноваться", "бороться"], "correct_index": 1}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["ненавидеть", "соревноваться", "бороться", "не доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["соревноваться", "подозревать", "бороться", "не доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["ненавидеть", "подозревать", "не доверять", "соперничество"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["издыхать", "страдать", "мучение", "отравленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["мучение", "издыхать", "страдать", "отравленный"], "correct_index": 2}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["расплачиваться", "издыхать", "проклинать", "рок"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["проклятый", "проклинать", "издыхать", "мучение"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["рок", "мучение", "проклинать", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["отравленный", "страдать", "расплачиваться", "рок"], "correct_index": 3}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["рок", "расплачиваться", "издыхать", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["отравленный", "проклятый", "расплачиваться", "издыхать"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Притворная любовь</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -465,15 +661,15 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vortäuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
                             
@@ -481,33 +677,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «übertreffen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «wetteifern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «wetteifern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -517,11 +713,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Falschheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">алчность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выманивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
                             
@@ -529,65 +725,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erschleichen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">алчность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">алчность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erschleichen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Habgier»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">алчность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">алчность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">разыгрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -606,9 +802,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
                             
@@ -616,17 +812,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «teilen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -638,27 +834,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стратегия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сговор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -668,11 +864,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">договариваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
                             
@@ -680,17 +876,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">договариваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -702,11 +898,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">договариваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -723,9 +919,9 @@
                         <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
@@ -739,59 +935,43 @@
                         <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жёсткость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестоко обращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
@@ -799,17 +979,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестоко обращаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -819,11 +1015,11 @@
                         <div class="quiz-question">Что означает немецкое слово «abweisen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                             
@@ -831,17 +1027,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,31 +1050,31 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
                             
@@ -886,47 +1082,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «genießen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">растаптывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
@@ -934,49 +1098,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">растаптывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Brutalität»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Brutalität»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">растаптывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">растаптывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -995,11 +1191,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1025,6 +1221,70 @@
                         <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
                         <div class="quiz-choices">
                             
+                            <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «locken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «werben»?</div>
+                        <div class="quiz-choices">
+                            
                             <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
@@ -1037,70 +1297,6 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">добиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «locken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">заманивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «werben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">добиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                 
                 <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
             </div>
@@ -1108,15 +1304,15 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «wettkämpfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
@@ -1124,33 +1320,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «bedrohen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1160,27 +1356,27 @@
                         <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">не доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">не доверять</button>
                             
@@ -1188,33 +1384,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">не доверять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «argwöhnen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">не доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1227,31 +1423,79 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vergiftet»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">расплачиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклятый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">рок</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
@@ -1259,65 +1503,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклятый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отравленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">расплачиваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Verhängnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1327,25 +1523,25 @@
                         <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рок</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verflucht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклятый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
                             
@@ -1373,6 +1569,7 @@
         "description": "Акт I: Соревнование в лести",
         "words": [
             {
+                "wordId": "",
                 "word": "vortäuschen",
                 "translation": "притворяться",
                 "transcription": "[ФОР-той-шен]",
@@ -1395,9 +1592,14 @@
                 ],
                 "collocations": [
                     "Ich täusche Liebe vor, die nie existierte. — Я притворяюсь в любви, которой никогда не было."
+                ],
+                "sentenceParts": [
+                    "Regan steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mein Atem zeichnet das Wort „vortäuschen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "übertreffen",
                 "translation": "превосходить",
                 "transcription": "[ю-бер-ТРЕ-фен]",
@@ -1419,9 +1621,14 @@
                 ],
                 "collocations": [
                     "Ich will meine Schwester in der Lüge übertreffen. — Я хочу превзойти сестру во лжи."
+                ],
+                "sentenceParts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Regan über Lears schweren Tisch.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „übertreffen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "wetteifern",
                 "translation": "состязаться",
                 "transcription": "[ВЕТ-ай-ферн]",
@@ -1443,9 +1650,14 @@
                 ],
                 "collocations": [
                     "Wir wetteifern um das größte Erbe. — Мы состязаемся за большее наследство."
+                ],
+                "sentenceParts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Regan die Hände hinter dem Rücken.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „wetteifern“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Falschheit",
                 "translation": "фальшь",
                 "transcription": "[ди ФАЛЬШ-хайт]",
@@ -1467,9 +1679,14 @@
                 ],
                 "collocations": [
                     "Meine Falschheit kennt keine Grenzen. — Моя фальшь не знает границ."
+                ],
+                "sentenceParts": [
+                    "Zwischen flüsternden Höflingen gleitet Regan über den kalten Marmorboden.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Falschheit“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vorspielen",
                 "translation": "разыгрывать",
                 "transcription": "[ФОР-шпи-лен]",
@@ -1491,9 +1708,14 @@
                 ],
                 "collocations": [
                     "Ich spiele ihm Töchterliebe vor. — Я разыгрываю перед ним дочернюю любовь."
+                ],
+                "sentenceParts": [
+                    "Am Rand des purpurnen Teppichs wartet Regan auf ein Zeichen des Königs.",
+                    "Das Echo des Wortes „vorspielen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die List",
                 "translation": "хитрость",
                 "transcription": "[ди ЛИСТ]",
@@ -1523,9 +1745,14 @@
                     "Meine List bewahrt ihn vor dem Selbstmord. — Моя хитрость спасает его от самоубийства.",
                     "Mit List gewinne ich sein Vertrauen. — Хитростью я завоёвываю его доверие.",
                     "Mit List kehre ich an den Hof zurück. — Хитростью я возвращаюсь ко двору."
+                ],
+                "sentenceParts": [
+                    "Unter wehenden Standarten der Schwestern senkt Regan kurz den Blick.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die List“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erschleichen",
                 "translation": "выманивать",
                 "transcription": "[ер-ШЛАЙ-хен]",
@@ -1547,9 +1774,14 @@
                 ],
                 "collocations": [
                     "Ich erschleiche mir sein Königreich. — Я выманиваю его королевство."
+                ],
+                "sentenceParts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Regan das gespannte Antlitz des Hofes.",
+                    "Wie ein stilles Gebet legt sich das Wort „erschleichen“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Habgier",
                 "translation": "алчность",
                 "transcription": "[ди ХАБ-гир]",
@@ -1571,6 +1803,10 @@
                 ],
                 "collocations": [
                     "Die Habgier treibt meine süßen Worte. — Алчность движет моими сладкими словами."
+                ],
+                "sentenceParts": [
+                    "Im Schein der offenen Feuerbecken erhebt Regan langsam die Stimme.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Habgier“ gehört mir."
                 ]
             }
         ],
@@ -1578,39 +1814,39 @@
             {
                 "question": "Что означает немецкое слово «vortäuschen»?",
                 "choices": [
+                    "превосходить",
                     "притворяться",
                     "фальшь",
-                    "превосходить",
                     "состязаться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «übertreffen»?",
                 "choices": [
-                    "превосходить",
                     "состязаться",
+                    "фальшь",
                     "притворяться",
-                    "фальшь"
+                    "превосходить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «wetteifern»?",
                 "choices": [
-                    "состязаться",
                     "превосходить",
-                    "разыгрывать",
-                    "выманивать"
+                    "состязаться",
+                    "фальшь",
+                    "хитрость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Falschheit»?",
                 "choices": [
-                    "состязаться",
-                    "притворяться",
                     "алчность",
+                    "состязаться",
+                    "выманивать",
                     "фальшь"
                 ],
                 "correctIndex": 3
@@ -1618,51 +1854,134 @@
             {
                 "question": "Что означает немецкое слово «vorspielen»?",
                 "choices": [
-                    "разыгрывать",
-                    "состязаться",
                     "алчность",
-                    "превосходить"
+                    "состязаться",
+                    "разыгрывать",
+                    "выманивать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "выманивать",
-                    "хитрость",
                     "алчность",
-                    "фальшь"
+                    "притворяться",
+                    "хитрость",
+                    "состязаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erschleichen»?",
                 "choices": [
+                    "разыгрывать",
+                    "состязаться",
                     "хитрость",
-                    "выманивать",
-                    "превосходить",
-                    "фальшь"
+                    "выманивать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Habgier»?",
                 "choices": [
-                    "состязаться",
+                    "превосходить",
+                    "алчность",
                     "выманивать",
-                    "фальшь",
-                    "алчность"
+                    "разыгрывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "vortäuschen",
+                "translation": "притворяться",
+                "parts": [
+                    "Regan steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mein Atem zeichnet das Wort „vortäuschen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Regan steht unter dem glühenden Kronleuchter des Thronsaals. Mein Atem zeichnet das Wort „vortäuschen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "Регана стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «притворяться» в холодном воздухе между нами."
+            },
+            {
+                "word": "übertreffen",
+                "translation": "превосходить",
+                "parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Regan über Lears schweren Tisch.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „übertreffen“ bleibt lebendig."
+                ],
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Regan über Lears schweren Tisch. Mit jeder Faser meines Körpers verspreche ich: Das Wort „übertreffen“ bleibt lebendig.",
+                "sentenceTranslation": "У развернутой карты королевства Регана склоняется над тяжёлым столом Лира. Каждой клеткой тела я обещаю: слово «превосходить» останется живым."
+            },
+            {
+                "word": "wetteifern",
+                "translation": "состязаться",
+                "parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Regan die Hände hinter dem Rücken.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „wetteifern“ darf nicht vergehen."
+                ],
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Regan die Hände hinter dem Rücken. Ich flüstere den Wächtern des Schicksals zu: Das Wort „wetteifern“ darf nicht vergehen.",
+                "sentenceTranslation": "Перед каменными статуями предков Регана сцепляет руки за спиной. Я шепчу стражам судьбы: слово «состязаться» не должно исчезнуть."
+            },
+            {
+                "word": "die Falschheit",
+                "translation": "фальшь",
+                "parts": [
+                    "Zwischen flüsternden Höflingen gleitet Regan über den kalten Marmorboden.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Falschheit“ wird heute nicht verraten."
+                ],
+                "sentence": "Zwischen flüsternden Höflingen gleitet Regan über den kalten Marmorboden. Mit fester Stimme schwöre ich mir: Das Wort „die Falschheit“ wird heute nicht verraten.",
+                "sentenceTranslation": "Между шепчущимися придворными Регана скользит по холодному мраморному полу. Твёрдым голосом я клянусь себе: слово «фальшь» сегодня не будет предано."
+            },
+            {
+                "word": "vorspielen",
+                "translation": "разыгрывать",
+                "parts": [
+                    "Am Rand des purpurnen Teppichs wartet Regan auf ein Zeichen des Königs.",
+                    "Das Echo des Wortes „vorspielen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Am Rand des purpurnen Teppichs wartet Regan auf ein Zeichen des Königs. Das Echo des Wortes „vorspielen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На краю пурпурного ковра Регана ждёт знака от короля. Эхо слова «разыгрывать» заглушает шёпот придворных."
+            },
+            {
+                "word": "die List",
+                "translation": "хитрость",
+                "parts": [
+                    "Unter wehenden Standarten der Schwestern senkt Regan kurz den Blick.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die List“ darf nicht vergehen."
+                ],
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Regan kurz den Blick. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die List“ darf nicht vergehen.",
+                "sentenceTranslation": "Под развевающимися штандартами сестёр Регана на миг опускает взгляд. Я шепчу стражам судьбы: слово «хитрость» не должно исчезнуть."
+            },
+            {
+                "word": "erschleichen",
+                "translation": "выманивать",
+                "parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Regan das gespannte Antlitz des Hofes.",
+                    "Wie ein stilles Gebet legt sich das Wort „erschleichen“ auf meine Lippen."
+                ],
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Regan das gespannte Antlitz des Hofes. Wie ein stilles Gebet legt sich das Wort „erschleichen“ auf meine Lippen.",
+                "sentenceTranslation": "За позолоченной балюстрадой Регана наблюдает за напряжёнными лицами двора. Как тихая молитва слово «выманивать» ложится на мои губы."
+            },
+            {
+                "word": "die Habgier",
+                "translation": "алчность",
+                "parts": [
+                    "Im Schein der offenen Feuerbecken erhebt Regan langsam die Stimme.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Habgier“ gehört mir."
+                ],
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Regan langsam die Stimme. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Habgier“ gehört mir.",
+                "sentenceTranslation": "В отблесках открытых жаровен Регана медленно поднимает голос. Буря за окнами усиливает клятву: слово «алчность» принадлежит мне."
+            }
+        ]
     },
     "goneril": {
         "title": "Раздел власти",
         "description": "Акт I-II: Союз с сестрой",
         "words": [
             {
+                "wordId": "",
                 "word": "das Bündnis",
                 "translation": "союз",
                 "transcription": "[дас БЮНД-нис]",
@@ -1688,9 +2007,14 @@
                 "collocations": [
                     "Unser Bündnis ist stark und grausam. — Наш союз силён и жесток.",
                     "Ein Bündnis mit Goneril gegen unseren Vater. — Союз с Гонерильей против нашего отца."
+                ],
+                "sentenceParts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Regan zwischen gepackten Kisten.",
+                    "Mein Atem zeichnet das Wort „das Bündnis“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "teilen",
                 "translation": "делить",
                 "transcription": "[ТАЙ-лен]",
@@ -1711,9 +2035,14 @@
                 "collocations": [
                     "Der Narr spürt, wie das Teilen alle verändert. — Шут чувствует, как умение делить меняет всех.",
                     "Wir teilen das Reich zwischen uns. — Мы делим королевство между собой."
+                ],
+                "sentenceParts": [
+                    "Auf der windigen Freitreppe blickt Regan zum schweigenden Hof hinunter.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „teilen“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "planen",
                 "translation": "планировать",
                 "transcription": "[ПЛА-нен]",
@@ -1735,9 +2064,14 @@
                 ],
                 "collocations": [
                     "Wir planen den Untergang des alten Königs. — Мы планируем падение старого короля."
+                ],
+                "sentenceParts": [
+                    "Zwischen zurückgelassenen Dienern schließt Regan den Reisemantel enger.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „planen“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verschwören",
                 "translation": "заговорить",
                 "transcription": "[фер-ШВЁ-рен]",
@@ -1758,9 +2092,14 @@
                 "collocations": [
                     "Cordelia zeigt, dass das Verschwören auch ohne Stolz möglich ist. — Корделия показывает, что заговорить можно и без гордыни.",
                     "Wir verschwören uns gegen ihn. — Мы составляем заговор против него."
+                ],
+                "sentenceParts": [
+                    "Am dunklen Pferdestall streicht Regan einem nervösen Tier über die Mähne.",
+                    "Ich halte das Wort „verschwören“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Absprache",
                 "translation": "сговор",
                 "transcription": "[ди АБ-шпра-хе]",
@@ -1782,9 +2121,14 @@
                 ],
                 "collocations": [
                     "Unsere Absprache ist perfekt. — Наш сговор совершенен."
+                ],
+                "sentenceParts": [
+                    "Vor dem knarrenden Fallgatter tastet Regan ein letztes Mal nach dem Haustor.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Absprache“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "vereinbaren",
                 "translation": "договариваться",
                 "transcription": "[фер-АЙН-ба-рен]",
@@ -1806,9 +2150,14 @@
                 ],
                 "collocations": [
                     "Wir vereinbaren gemeinsame Grausamkeit. — Мы договариваемся о совместной жестокости."
+                ],
+                "sentenceParts": [
+                    "Zwischen verstreuten Schriftrollen dreht Regan den Ring an der Hand.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „vereinbaren“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Strategie",
                 "translation": "стратегия",
                 "transcription": "[ди штра-те-ГИ]",
@@ -1830,6 +2179,10 @@
                 ],
                 "collocations": [
                     "Unsere Strategie wird ihn brechen. — Наша стратегия сломает его."
+                ],
+                "sentenceParts": [
+                    "Am leeren Bankettisch zählt Regan die verlöschenden Kerzen.",
+                    "Das Echo des Wortes „die Strategie“ übertönt das Flüstern der Höflinge."
                 ]
             }
         ],
@@ -1838,8 +2191,8 @@
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
                     "планировать",
-                    "делить",
                     "заговорить",
+                    "делить",
                     "союз"
                 ],
                 "correctIndex": 3
@@ -1847,39 +2200,39 @@
             {
                 "question": "Что означает немецкое слово «teilen»?",
                 "choices": [
-                    "заговорить",
-                    "делить",
+                    "планировать",
                     "союз",
-                    "планировать"
+                    "делить",
+                    "заговорить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «planen»?",
                 "choices": [
                     "планировать",
+                    "стратегия",
                     "делить",
-                    "договариваться",
-                    "стратегия"
+                    "сговор"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verschwören»?",
                 "choices": [
-                    "стратегия",
+                    "заговорить",
+                    "делить",
                     "сговор",
-                    "планировать",
-                    "заговорить"
+                    "стратегия"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Absprache»?",
                 "choices": [
-                    "делить",
-                    "заговорить",
-                    "планировать",
+                    "стратегия",
+                    "союз",
+                    "договариваться",
                     "сговор"
                 ],
                 "correctIndex": 3
@@ -1887,31 +2240,104 @@
             {
                 "question": "Что означает немецкое слово «vereinbaren»?",
                 "choices": [
-                    "договариваться",
                     "стратегия",
-                    "союз",
-                    "делить"
+                    "договариваться",
+                    "заговорить",
+                    "планировать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Strategie»?",
                 "choices": [
                     "стратегия",
+                    "договариваться",
                     "делить",
-                    "планировать",
-                    "сговор"
+                    "союз"
                 ],
                 "correctIndex": 0
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "das Bündnis",
+                "translation": "союз",
+                "parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Regan zwischen gepackten Kisten.",
+                    "Mein Atem zeichnet das Wort „das Bündnis“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Regan zwischen gepackten Kisten. Mein Atem zeichnet das Wort „das Bündnis“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В гулком проёме ворот замка Гонерильи Регана замирает среди нагруженных ящиков. Моё дыхание рисует слово «союз» в холодном воздухе между нами."
+            },
+            {
+                "word": "teilen",
+                "translation": "делить",
+                "parts": [
+                    "Auf der windigen Freitreppe blickt Regan zum schweigenden Hof hinunter.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „teilen“ wird heute nicht verraten."
+                ],
+                "sentence": "Auf der windigen Freitreppe blickt Regan zum schweigenden Hof hinunter. Mit fester Stimme schwöre ich mir: Das Wort „teilen“ wird heute nicht verraten.",
+                "sentenceTranslation": "На продуваемой ветром лестнице Регана смотрит вниз на молчаливый двор. Твёрдым голосом я клянусь себе: слово «делить» сегодня не будет предано."
+            },
+            {
+                "word": "planen",
+                "translation": "планировать",
+                "parts": [
+                    "Zwischen zurückgelassenen Dienern schließt Regan den Reisemantel enger.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „planen“ bleibt lebendig."
+                ],
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Regan den Reisemantel enger. Mit jeder Faser meines Körpers verspreche ich: Das Wort „planen“ bleibt lebendig.",
+                "sentenceTranslation": "Среди оставленных слуг Регана плотнее запахивает дорожный плащ. Каждой клеткой тела я обещаю: слово «планировать» останется живым."
+            },
+            {
+                "word": "verschwören",
+                "translation": "заговорить",
+                "parts": [
+                    "Am dunklen Pferdestall streicht Regan einem nervösen Tier über die Mähne.",
+                    "Ich halte das Wort „verschwören“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Am dunklen Pferdestall streicht Regan einem nervösen Tier über die Mähne. Ich halte das Wort „verschwören“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У тёмного конюшенного ряда Регана гладит гриву нервного коня. Я держу слово «заговорить» как факел у сердца."
+            },
+            {
+                "word": "die Absprache",
+                "translation": "сговор",
+                "parts": [
+                    "Vor dem knarrenden Fallgatter tastet Regan ein letztes Mal nach dem Haustor.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Absprache“ darf nicht vergehen."
+                ],
+                "sentence": "Vor dem knarrenden Fallgatter tastet Regan ein letztes Mal nach dem Haustor. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Absprache“ darf nicht vergehen.",
+                "sentenceTranslation": "Перед скрипящим подъёмным мостом Регана в последний раз касается родной двери. Я шепчу стражам судьбы: слово «сговор» не должно исчезнуть."
+            },
+            {
+                "word": "vereinbaren",
+                "translation": "договариваться",
+                "parts": [
+                    "Zwischen verstreuten Schriftrollen dreht Regan den Ring an der Hand.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „vereinbaren“ bleibt lebendig."
+                ],
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Regan den Ring an der Hand. Mit jeder Faser meines Körpers verspreche ich: Das Wort „vereinbaren“ bleibt lebendig.",
+                "sentenceTranslation": "Среди разбросанных свитков Регана вертит кольцо на пальце. Каждой клеткой тела я обещаю: слово «договариваться» останется живым."
+            },
+            {
+                "word": "die Strategie",
+                "translation": "стратегия",
+                "parts": [
+                    "Am leeren Bankettisch zählt Regan die verlöschenden Kerzen.",
+                    "Das Echo des Wortes „die Strategie“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Am leeren Bankettisch zählt Regan die verlöschenden Kerzen. Das Echo des Wortes „die Strategie“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У пустого банкетного стола Регана пересчитывает гаснущие свечи. Эхо слова «стратегия» заглушает шёпот придворных."
+            }
+        ]
     },
     "regan": {
         "title": "Жестокость в замке",
         "description": "Акт II: Унижение отца",
         "words": [
             {
+                "wordId": "",
                 "word": "foltern",
                 "translation": "пытать",
                 "transcription": "[ФОЛЬ-терн]",
@@ -1937,9 +2363,14 @@
                 "collocations": [
                     "Ich foltere ihn mit kalten Worten. — Я пытаю его холодными словами.",
                     "Mit Lust foltere ich den alten Mann. — С наслаждением я пытаю старика."
+                ],
+                "sentenceParts": [
+                    "Im zugigen Seitenflügel lauscht Regan dem Heulen der Küstenwinde.",
+                    "Mein Atem zeichnet das Wort „foltern“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erniedrigen",
                 "translation": "унижать",
                 "transcription": "[ер-НИД-ри-ген]",
@@ -1966,9 +2397,14 @@
                 "collocations": [
                     "Ich erniedrige den einst mächtigen König. — Я унижаю некогда могущественного короля.",
                     "Ich erniedrige den treuen Diener. — Я унижаю верного слугу."
+                ],
+                "sentenceParts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Regan einen zerknitterten Brief.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erniedrigen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verhöhnen",
                 "translation": "насмехаться",
                 "transcription": "[фер-ХЁ-нен]",
@@ -1996,9 +2432,14 @@
                 "collocations": [
                     "Ich verhöhne seine königliche Würde. — Я высмеиваю его королевское достоинство.",
                     "Ich verhöhne seine väterliche Liebe. — Я насмехаюсь над его отцовской любовью."
+                ],
+                "sentenceParts": [
+                    "Unter farblosen Wandteppichen schreitet Regan rastlos auf und ab.",
+                    "Ich halte das Wort „verhöhnen“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Bosheit",
                 "translation": "злоба",
                 "transcription": "[ди БОС-хайт]",
@@ -2024,9 +2465,14 @@
                 "collocations": [
                     "Meine Bosheit kennt kein Erbarmen. — Моя злоба не знает милосердия.",
                     "Unsere Bosheit macht uns zum perfekten Paar. — Наша злоба делает нас идеальной парой."
+                ],
+                "sentenceParts": [
+                    "An der schmalen Fensterluke zählt Regan die Fackeln auf dem Hof.",
+                    "Ich halte das Wort „die Bosheit“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "misshandeln",
                 "translation": "жестоко обращаться",
                 "transcription": "[МИС-хан-дельн]",
@@ -2049,9 +2495,14 @@
                 ],
                 "collocations": [
                     "Ich misshandle den alten Mann. — Я жестоко обращаюсь со стариком."
+                ],
+                "sentenceParts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Regan nach frischen Botschaften.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „misshandeln“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Härte",
                 "translation": "жёсткость",
                 "transcription": "[ди ХЕР-те]",
@@ -2078,9 +2529,15 @@
                 "collocations": [
                     "Mit eiserner Härte stoße ich ihn fort. — С железной жёсткостью я отталкиваю его.",
                     "Mit eiserner Härte regieren wir zusammen. — С железной суровостью мы правим вместе."
+                ],
+                "sentenceParts": [
+                    "Im stillen Kapellenraum kniet Regan vor der kalten Steinfigur.",
+                    "Ich presse das Wort „die Härte“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "abweisen",
                 "translation": "отвергать",
                 "transcription": "[АБ-вай-зен]",
@@ -2103,9 +2560,14 @@
                 ],
                 "collocations": [
                     "Ich weise alle seine Bitten ab. — Я отвергаю все его просьбы."
+                ],
+                "sentenceParts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Regan die Laterne fest.",
+                    "Mein Atem zeichnet das Wort „abweisen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Grausamkeit",
                 "translation": "жестокость",
                 "transcription": "[ди ГРАУ-зам-кайт]",
@@ -2138,6 +2600,10 @@
                     "Meine Grausamkeit kennt keine Grenzen. — Моя жестокость не знает границ.",
                     "Meine Grausamkeit übertrifft die meiner Schwester. — Моя жестокость превосходит жестокость сестры.",
                     "Die Grausamkeit meiner Frau gefällt mir. — Жестокость моей жены мне нравится."
+                ],
+                "sentenceParts": [
+                    "Im Schatten der hohen Burgmauern schreibt Regan eine fiebrige Antwort.",
+                    "Mein Atem zeichnet das Wort „die Grausamkeit“ in die kalte Luft zwischen uns."
                 ]
             }
         ],
@@ -2145,8 +2611,8 @@
             {
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
-                    "унижать",
                     "злоба",
+                    "унижать",
                     "пытать",
                     "насмехаться"
                 ],
@@ -2155,59 +2621,59 @@
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
+                    "злоба",
                     "пытать",
-                    "насмехаться",
                     "унижать",
-                    "злоба"
+                    "насмехаться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "жестоко обращаться",
-                    "насмехаться",
-                    "отвергать",
-                    "злоба"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Bosheit»?",
-                "choices": [
-                    "унижать",
-                    "насмехаться",
                     "злоба",
-                    "пытать"
+                    "жёсткость",
+                    "насмехаться",
+                    "отвергать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «misshandeln»?",
+                "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
-                    "пытать",
                     "жестоко обращаться",
-                    "жестокость",
+                    "злоба",
+                    "насмехаться",
                     "унижать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Härte»?",
+                "question": "Что означает немецкое слово «misshandeln»?",
                 "choices": [
-                    "пытать",
                     "насмехаться",
                     "злоба",
-                    "жёсткость"
+                    "жестоко обращаться",
+                    "отвергать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Härte»?",
+                "choices": [
+                    "жестоко обращаться",
+                    "жестокость",
+                    "жёсткость",
+                    "унижать"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «abweisen»?",
                 "choices": [
-                    "жёсткость",
+                    "жестоко обращаться",
                     "жестокость",
-                    "унижать",
+                    "жёсткость",
                     "отвергать"
                 ],
                 "correctIndex": 3
@@ -2215,21 +2681,105 @@
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "унижать",
+                    "жёсткость",
+                    "злоба",
                     "пытать",
-                    "жестокость",
-                    "жёсткость"
+                    "жестокость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "foltern",
+                "translation": "пытать",
+                "parts": [
+                    "Im zugigen Seitenflügel lauscht Regan dem Heulen der Küstenwinde.",
+                    "Mein Atem zeichnet das Wort „foltern“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im zugigen Seitenflügel lauscht Regan dem Heulen der Küstenwinde. Mein Atem zeichnet das Wort „foltern“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В продуваемом ветром боковом крыле Регана слушает вой прибрежного ветра. Моё дыхание рисует слово «пытать» в холодном воздухе между нами."
+            },
+            {
+                "word": "erniedrigen",
+                "translation": "унижать",
+                "parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Regan einen zerknitterten Brief.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erniedrigen“ gehört mir."
+                ],
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Regan einen zerknitterten Brief. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erniedrigen“ gehört mir.",
+                "sentenceTranslation": "Перед дымным камином замка Регана складывает измятый лист. Буря за окнами усиливает клятву: слово «унижать» принадлежит мне."
+            },
+            {
+                "word": "verhöhnen",
+                "translation": "насмехаться",
+                "parts": [
+                    "Unter farblosen Wandteppichen schreitet Regan rastlos auf und ab.",
+                    "Ich halte das Wort „verhöhnen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Unter farblosen Wandteppichen schreitet Regan rastlos auf und ab. Ich halte das Wort „verhöhnen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Под выцветшими гобеленами Регана беспокойно меряет шагами зал. Я держу слово «насмехаться» как факел у сердца."
+            },
+            {
+                "word": "die Bosheit",
+                "translation": "злоба",
+                "parts": [
+                    "An der schmalen Fensterluke zählt Regan die Fackeln auf dem Hof.",
+                    "Ich halte das Wort „die Bosheit“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "An der schmalen Fensterluke zählt Regan die Fackeln auf dem Hof. Ich halte das Wort „die Bosheit“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "У узкой бойницы Регана считает факелы на дворе. Я держу слово «злоба» как факел у сердца."
+            },
+            {
+                "word": "misshandeln",
+                "translation": "жестоко обращаться",
+                "parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Regan nach frischen Botschaften.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „misshandeln“ bleibt lebendig."
+                ],
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Regan nach frischen Botschaften. Mit jeder Faser meines Körpers verspreche ich: Das Wort „misshandeln“ bleibt lebendig.",
+                "sentenceTranslation": "Среди дорожных сундуков послов Регана ищет свежие вести. Каждой клеткой тела я обещаю: слово «жестоко обращаться» останется живым."
+            },
+            {
+                "word": "die Härte",
+                "translation": "жёсткость",
+                "parts": [
+                    "Im stillen Kapellenraum kniet Regan vor der kalten Steinfigur.",
+                    "Ich presse das Wort „die Härte“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Im stillen Kapellenraum kniet Regan vor der kalten Steinfigur. Ich presse das Wort „die Härte“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "В тихой капелле Регана преклоняет колени перед холодной каменной фигурой. Я стискиваю слово «жёсткость» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "abweisen",
+                "translation": "отвергать",
+                "parts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Regan die Laterne fest.",
+                    "Mein Atem zeichnet das Wort „abweisen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Regan die Laterne fest. Mein Atem zeichnet das Wort „abweisen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "На балконе, омываемом морскими брызгами, Регана крепко держит фонарь. Моё дыхание рисует слово «отвергать» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Grausamkeit",
+                "translation": "жестокость",
+                "parts": [
+                    "Im Schatten der hohen Burgmauern schreibt Regan eine fiebrige Antwort.",
+                    "Mein Atem zeichnet das Wort „die Grausamkeit“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Regan eine fiebrige Antwort. Mein Atem zeichnet das Wort „die Grausamkeit“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "В тени высоких стен Регана пишет лихорадочный ответ. Моё дыхание рисует слово «жестокость» в холодном воздухе между нами."
+            }
+        ]
     },
     "storm": {
         "title": "Ослепление Глостера",
         "description": "Акт III: Садистское удовольствие",
         "words": [
             {
+                "wordId": "",
                 "word": "blenden",
                 "translation": "ослеплять",
                 "transcription": "[БЛЕН-ден]",
@@ -2253,9 +2803,14 @@
                     "Wir blenden den treuen Grafen Gloucester. — Мы ослепляем верного графа Глостера.",
                     "Eigenhändig blende ich Gloucester. — Собственноручно я ослепляю Глостера.",
                     "Sie blenden mich für meinen Verrat. — Они ослепляют меня за мою измену."
+                ],
+                "sentenceParts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Regan gegen den Wind.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "der Sadismus",
                 "translation": "садизм",
                 "transcription": "[дер за-ДИС-мус]",
@@ -2280,9 +2835,14 @@
                 "collocations": [
                     "Mein Sadismus findet Befriedigung. — Мой садизм находит удовлетворение.",
                     "Mein Sadismus kennt keine Grenzen. — Мой садизм не знает границ."
+                ],
+                "sentenceParts": [
+                    "Unter einem zerrissenen Banner schützt Regan die Augen vor den Blitzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Sadismus“ bleibt lebendig."
                 ]
             },
             {
+                "wordId": "",
                 "word": "genießen",
                 "translation": "наслаждаться",
                 "transcription": "[ге-НИ-сен]",
@@ -2304,9 +2864,14 @@
                 ],
                 "collocations": [
                     "Ich genieße jeden Schrei des Schmerzes. — Я наслаждаюсь каждым криком боли."
+                ],
+                "sentenceParts": [
+                    "Am Rand eines umgestürzten Baumes sucht Regan Deckung vor dem Donner.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „genießen“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "ausstechen",
                 "translation": "выкалывать",
                 "transcription": "[АУС-ште-хен]",
@@ -2331,9 +2896,14 @@
                 "collocations": [
                     "Stecht ihm beide Augen aus! — Выколите ему оба глаза!",
                     "Seine Augen steche ich mit Freude aus. — Его глаза я выкалываю с радостью."
+                ],
+                "sentenceParts": [
+                    "Zwischen schäumenden Wassergräben stolpert Regan durch den Schlamm.",
+                    "Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Folter",
                 "translation": "пытка",
                 "transcription": "[ди ФОЛЬ-тер]",
@@ -2363,9 +2933,14 @@
                     "Die Folter ist meine Unterhaltung. — Пытка - моё развлечение.",
                     "Die Folter ist mein liebstes Werkzeug. — Пытка - мой любимый инструмент.",
                     "Die Folter ist grausam und erbarmungslos. — Пытка жестока и беспощадна."
+                ],
+                "sentenceParts": [
+                    "Vor einem zuckenden Himmel hebt Regan die Arme trotzig an.",
+                    "Ich zeichne das Wort „die Folter“ in Gedanken über die Linien des Schicksals."
                 ]
             },
             {
+                "wordId": "",
                 "word": "erbarmungslos",
                 "translation": "беспощадный",
                 "transcription": "[ер-БАР-мунгс-лос]",
@@ -2394,9 +2969,14 @@
                     "Erbarmungslos verfolge ich mein Ziel. — Беспощадно я преследую свою цель.",
                     "Ich bin erbarmungslos in meiner Rache. — Я беспощадна в своей мести.",
                     "Erbarmungslos werfe ich ihn hinaus. — Беспощадно я выбрасываю его."
+                ],
+                "sentenceParts": [
+                    "Unter dem durchtränkten Umhang presst Regan den Atem gegen die Kälte.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „erbarmungslos“ darf nicht vergehen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Brutalität",
                 "translation": "брутальность",
                 "transcription": "[ди бру-та-ли-ТЕТ]",
@@ -2418,9 +2998,14 @@
                 ],
                 "collocations": [
                     "Meine Brutalität erschreckt sogar Cornwall. — Моя брутальность пугает даже Корнуолла."
+                ],
+                "sentenceParts": [
+                    "Am kläglichen Feuerrest wärmt Regan zitternde Finger.",
+                    "Das kalte Licht lässt das Wort „die Brutalität“ wie geschmolzenes Gold erscheinen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "zertreten",
                 "translation": "растаптывать",
                 "transcription": "[цер-ТРЕ-тен]",
@@ -2442,6 +3027,10 @@
                 ],
                 "collocations": [
                     "Ich zertrete seine Augen unter meinem Fuß. — Я растаптываю его глаза под ногой."
+                ],
+                "sentenceParts": [
+                    "Zwischen heulenden Hunden ruft Regan gegen den tosenden Sturm an.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „zertreten“ bleibt lebendig."
                 ]
             }
         ],
@@ -2449,91 +3038,174 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "ослеплять",
-                    "садизм",
                     "выкалывать",
-                    "наслаждаться"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Sadismus»?",
-                "choices": [
                     "садизм",
                     "наслаждаться",
-                    "ослеплять",
-                    "выкалывать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «genießen»?",
-                "choices": [
-                    "растаптывать",
-                    "наслаждаться",
-                    "ослеплять",
-                    "садизм"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «ausstechen»?",
-                "choices": [
-                    "ослеплять",
-                    "выкалывать",
-                    "растаптывать",
-                    "беспощадный"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Folter»?",
-                "choices": [
-                    "ослеплять",
-                    "садизм",
-                    "беспощадный",
-                    "пытка"
+                    "ослеплять"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «erbarmungslos»?",
+                "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
-                    "беспощадный",
-                    "растаптывать",
-                    "брутальность",
-                    "наслаждаться"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Brutalität»?",
-                "choices": [
+                    "ослеплять",
+                    "наслаждаться",
                     "садизм",
-                    "беспощадный",
-                    "брутальность",
                     "выкалывать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «zertreten»?",
+                "question": "Что означает немецкое слово «genießen»?",
                 "choices": [
-                    "растаптывать",
+                    "ослеплять",
+                    "садизм",
+                    "наслаждаться",
+                    "пытка"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «ausstechen»?",
+                "choices": [
+                    "выкалывать",
+                    "беспощадный",
                     "брутальность",
-                    "пытка",
                     "ослеплять"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Folter»?",
+                "choices": [
+                    "ослеплять",
+                    "выкалывать",
+                    "пытка",
+                    "беспощадный"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «erbarmungslos»?",
+                "choices": [
+                    "наслаждаться",
+                    "брутальность",
+                    "ослеплять",
+                    "беспощадный"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Brutalität»?",
+                "choices": [
+                    "беспощадный",
+                    "ослеплять",
+                    "растаптывать",
+                    "брутальность"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «zertreten»?",
+                "choices": [
+                    "пытка",
+                    "брутальность",
+                    "садизм",
+                    "растаптывать"
+                ],
+                "correctIndex": 3
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "blenden",
+                "translation": "ослеплять",
+                "parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Regan gegen den Wind.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen."
+                ],
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Regan gegen den Wind. Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen.",
+                "sentenceTranslation": "Посреди хлещущей дождём пустоши Регана упирается в ветер. Я шепчу стражам судьбы: слово «ослеплять» не должно исчезнуть."
+            },
+            {
+                "word": "der Sadismus",
+                "translation": "садизм",
+                "parts": [
+                    "Unter einem zerrissenen Banner schützt Regan die Augen vor den Blitzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Sadismus“ bleibt lebendig."
+                ],
+                "sentence": "Unter einem zerrissenen Banner schützt Regan die Augen vor den Blitzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Sadismus“ bleibt lebendig.",
+                "sentenceTranslation": "Под разорванным знаменем Регана прикрывает глаза от молний. Каждой клеткой тела я обещаю: слово «садизм» останется живым."
+            },
+            {
+                "word": "genießen",
+                "translation": "наслаждаться",
+                "parts": [
+                    "Am Rand eines umgestürzten Baumes sucht Regan Deckung vor dem Donner.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „genießen“ gehört mir."
+                ],
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Regan Deckung vor dem Donner. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „genießen“ gehört mir.",
+                "sentenceTranslation": "У поваленного дерева Регана ищет укрытия от грома. Буря за окнами усиливает клятву: слово «наслаждаться» принадлежит мне."
+            },
+            {
+                "word": "ausstechen",
+                "translation": "выкалывать",
+                "parts": [
+                    "Zwischen schäumenden Wassergräben stolpert Regan durch den Schlamm.",
+                    "Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus."
+                ],
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Regan durch den Schlamm. Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus.",
+                "sentenceTranslation": "Между пенящимися лужами Регана пробирается через грязь. Я глубоко вдыхаю и выпускаю только слово «выкалывать»."
+            },
+            {
+                "word": "die Folter",
+                "translation": "пытка",
+                "parts": [
+                    "Vor einem zuckenden Himmel hebt Regan die Arme trotzig an.",
+                    "Ich zeichne das Wort „die Folter“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Vor einem zuckenden Himmel hebt Regan die Arme trotzig an. Ich zeichne das Wort „die Folter“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "На фоне вспыхивающего неба Регана упрямо поднимает руки. Я черчу слово «пытка» в мыслях поверх линий судьбы."
+            },
+            {
+                "word": "erbarmungslos",
+                "translation": "беспощадный",
+                "parts": [
+                    "Unter dem durchtränkten Umhang presst Regan den Atem gegen die Kälte.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „erbarmungslos“ darf nicht vergehen."
+                ],
+                "sentence": "Unter dem durchtränkten Umhang presst Regan den Atem gegen die Kälte. Ich flüstere den Wächtern des Schicksals zu: Das Wort „erbarmungslos“ darf nicht vergehen.",
+                "sentenceTranslation": "Под промокшим плащом Регана прижимает дыхание к груди, спасаясь от холода. Я шепчу стражам судьбы: слово «беспощадный» не должно исчезнуть."
+            },
+            {
+                "word": "die Brutalität",
+                "translation": "брутальность",
+                "parts": [
+                    "Am kläglichen Feuerrest wärmt Regan zitternde Finger.",
+                    "Das kalte Licht lässt das Wort „die Brutalität“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Am kläglichen Feuerrest wärmt Regan zitternde Finger. Das kalte Licht lässt das Wort „die Brutalität“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "У жалких огненных углей Регана греет дрожащие пальцы. Холодный свет заставляет слово «брутальность» сиять словно расплавленное золото."
+            },
+            {
+                "word": "zertreten",
+                "translation": "растаптывать",
+                "parts": [
+                    "Zwischen heulenden Hunden ruft Regan gegen den tosenden Sturm an.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „zertreten“ bleibt lebendig."
+                ],
+                "sentence": "Zwischen heulenden Hunden ruft Regan gegen den tosenden Sturm an. Mit jeder Faser meines Körpers verspreche ich: Das Wort „zertreten“ bleibt lebendig.",
+                "sentenceTranslation": "Среди воющих псов Регана перекрикивает беснующуюся бурю. Каждой клеткой тела я обещаю: слово «растаптывать» останется живым."
+            }
+        ]
     },
     "hut": {
         "title": "Вдовство и похоть",
         "description": "Акт IV: Смерть Корнуолла",
         "words": [
             {
+                "wordId": "",
                 "word": "die Witwe",
                 "translation": "вдова",
                 "transcription": "[ди ВИТ-ве]",
@@ -2555,9 +3227,14 @@
                 ],
                 "collocations": [
                     "Als Witwe bin ich endlich frei. — Как вдова я наконец свободна."
+                ],
+                "sentenceParts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Regan bei der flackernden Kerze.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Witwe“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "begehren",
                 "translation": "вожделеть",
                 "transcription": "[бе-ГЕ-рен]",
@@ -2583,9 +3260,14 @@
                     "Ich begehre Edmund mit brennender Lust. — Я вожделею Эдмунда с пылающей страстью.",
                     "Ich begehre die Krone für mich selbst. — Я вожделею корону для себя.",
                     "Ich begehre Edmund mehr als mein Leben. — Я желаю Эдмунда больше жизни."
+                ],
+                "sentenceParts": [
+                    "Zwischen zerbeulten Rüstungen streicht Regan über ein altes Wappen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „begehren“ gehört mir."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verführen",
                 "translation": "соблазнять",
                 "transcription": "[фер-ФЮ-рен]",
@@ -2611,9 +3293,14 @@
                 "collocations": [
                     "Ich verführe beide Schwestern gleichzeitig. — Я соблазняю обеих сестёр одновременно.",
                     "Ich will Edmund verführen und besitzen. — Я хочу соблазнить и завладеть Эдмундом."
+                ],
+                "sentenceParts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Regan fast den Kopf.",
+                    "Mein Atem zeichnet das Wort „verführen“ in die kalte Luft zwischen uns."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Begierde",
                 "translation": "вожделение",
                 "transcription": "[ди бе-ГИР-де]",
@@ -2635,9 +3322,14 @@
                 ],
                 "collocations": [
                     "Meine Begierde brennt wie Feuer. — Моё вожделение горит как огонь."
+                ],
+                "sentenceParts": [
+                    "Neben der schlafenden Wache flüstert Regan in die schwere Nacht.",
+                    "Ich halte das Wort „die Begierde“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "locken",
                 "translation": "заманивать",
                 "transcription": "[ЛО-кен]",
@@ -2659,9 +3351,14 @@
                 ],
                 "collocations": [
                     "Ich locke ihn mit Versprechungen. — Я заманиваю его обещаниями."
+                ],
+                "sentenceParts": [
+                    "Vor dem einfachen Feldbett betrachtet Regan die Narben vergangener Schlachten.",
+                    "Wie ein stilles Gebet legt sich das Wort „locken“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Lust",
                 "translation": "похоть",
                 "transcription": "[ди ЛУСТ]",
@@ -2687,9 +3384,14 @@
                 "collocations": [
                     "Ihre Lust macht sie blind. — Их похоть делает их слепыми.",
                     "Die Lust macht mich blind für Gefahr. — Похоть делает меня слепой к опасности."
+                ],
+                "sentenceParts": [
+                    "Im Geruch von feuchtem Stroh legt Regan den Mantel zur Seite.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Lust“ wird heute nicht verraten."
                 ]
             },
             {
+                "wordId": "",
                 "word": "werben",
                 "translation": "добиваться",
                 "transcription": "[ВЕР-бен]",
@@ -2711,6 +3413,10 @@
                 "collocations": [
                     "Der Narr spürt, wie das Werben alle verändert. — Шут чувствует, как умение вербовать меняет всех.",
                     "Ich werbe schamlos um seine Gunst. — Я бесстыдно добиваюсь его благосклонности."
+                ],
+                "sentenceParts": [
+                    "Auf dem wackligen Holztisch ordnet Regan zerlesene Briefe.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „werben“ wird heute nicht verraten."
                 ]
             }
         ],
@@ -2719,9 +3425,9 @@
                 "question": "Что означает немецкое слово «die Witwe»?",
                 "choices": [
                     "вдова",
+                    "соблазнять",
                     "вожделеть",
-                    "вожделение",
-                    "соблазнять"
+                    "вожделение"
                 ],
                 "correctIndex": 0
             },
@@ -2738,61 +3444,134 @@
             {
                 "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
-                    "вдова",
+                    "заманивать",
                     "соблазнять",
                     "добиваться",
-                    "похоть"
+                    "вдова"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Begierde»?",
                 "choices": [
-                    "добиваться",
-                    "заманивать",
                     "вожделение",
-                    "соблазнять"
+                    "добиваться",
+                    "вдова",
+                    "вожделеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «locken»?",
                 "choices": [
-                    "вожделеть",
                     "заманивать",
-                    "соблазнять",
+                    "добиваться",
+                    "похоть",
+                    "вожделение"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Lust»?",
+                "choices": [
+                    "заманивать",
+                    "похоть",
+                    "вдова",
                     "добиваться"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Lust»?",
-                "choices": [
-                    "похоть",
-                    "вожделение",
-                    "добиваться",
-                    "заманивать"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «werben»?",
                 "choices": [
+                    "вдова",
+                    "соблазнять",
                     "добиваться",
-                    "вожделение",
-                    "вожделеть",
-                    "вдова"
+                    "похоть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "die Witwe",
+                "translation": "вдова",
+                "parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Regan bei der flackernden Kerze.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Witwe“ mein Nordstern."
+                ],
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Regan bei der flackernden Kerze. Selbst wenn die Welt zerfällt, bleibt das Wort „die Witwe“ mein Nordstern.",
+                "sentenceTranslation": "В тёмном шатре полевых лекарей Регана сидит у мерцающей свечи. Даже если мир распадается, слово «вдова» остаётся моим северным светом."
+            },
+            {
+                "word": "begehren",
+                "translation": "вожделеть",
+                "parts": [
+                    "Zwischen zerbeulten Rüstungen streicht Regan über ein altes Wappen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „begehren“ gehört mir."
+                ],
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Regan über ein altes Wappen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „begehren“ gehört mir.",
+                "sentenceTranslation": "Среди помятых доспехов Регана гладит старый герб. Буря за окнами усиливает клятву: слово «вожделеть» принадлежит мне."
+            },
+            {
+                "word": "verführen",
+                "translation": "соблазнять",
+                "parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Regan fast den Kopf.",
+                    "Mein Atem zeichnet das Wort „verführen“ in die kalte Luft zwischen uns."
+                ],
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Regan fast den Kopf. Mein Atem zeichnet das Wort „verführen“ in die kalte Luft zwischen uns.",
+                "sentenceTranslation": "О низкую балку хижины Регана едва не ударяется головой. Моё дыхание рисует слово «соблазнять» в холодном воздухе между нами."
+            },
+            {
+                "word": "die Begierde",
+                "translation": "вожделение",
+                "parts": [
+                    "Neben der schlafenden Wache flüstert Regan in die schwere Nacht.",
+                    "Ich halte das Wort „die Begierde“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Neben der schlafenden Wache flüstert Regan in die schwere Nacht. Ich halte das Wort „die Begierde“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "Рядом со спящим стражем Регана шепчет в тяжёлую ночь. Я держу слово «вожделение» как факел у сердца."
+            },
+            {
+                "word": "locken",
+                "translation": "заманивать",
+                "parts": [
+                    "Vor dem einfachen Feldbett betrachtet Regan die Narben vergangener Schlachten.",
+                    "Wie ein stilles Gebet legt sich das Wort „locken“ auf meine Lippen."
+                ],
+                "sentence": "Vor dem einfachen Feldbett betrachtet Regan die Narben vergangener Schlachten. Wie ein stilles Gebet legt sich das Wort „locken“ auf meine Lippen.",
+                "sentenceTranslation": "Перед грубой походной койкой Регана разглядывает шрамы прошлых битв. Как тихая молитва слово «заманивать» ложится на мои губы."
+            },
+            {
+                "word": "die Lust",
+                "translation": "похоть",
+                "parts": [
+                    "Im Geruch von feuchtem Stroh legt Regan den Mantel zur Seite.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Lust“ wird heute nicht verraten."
+                ],
+                "sentence": "Im Geruch von feuchtem Stroh legt Regan den Mantel zur Seite. Mit fester Stimme schwöre ich mir: Das Wort „die Lust“ wird heute nicht verraten.",
+                "sentenceTranslation": "В запахе влажной соломы Регана откладывает плащ в сторону. Твёрдым голосом я клянусь себе: слово «похоть» сегодня не будет предано."
+            },
+            {
+                "word": "werben",
+                "translation": "добиваться",
+                "parts": [
+                    "Auf dem wackligen Holztisch ordnet Regan zerlesene Briefe.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „werben“ wird heute nicht verraten."
+                ],
+                "sentence": "Auf dem wackligen Holztisch ordnet Regan zerlesene Briefe. Mit fester Stimme schwöre ich mir: Das Wort „werben“ wird heute nicht verraten.",
+                "sentenceTranslation": "На шатком деревянном столе Регана раскладывает зачитанные письма. Твёрдым голосом я клянусь себе: слово «добиваться» сегодня не будет предано."
+            }
+        ]
     },
     "dover": {
         "title": "Соперничество сестёр",
         "description": "Акт V: Борьба за Эдмунда",
         "words": [
             {
+                "wordId": "",
                 "word": "wettkämpfen",
                 "translation": "соревноваться",
                 "transcription": "[ВЕТ-кемп-фен]",
@@ -2814,9 +3593,14 @@
                 ],
                 "collocations": [
                     "Wir wettkämpfen um Edmunds Liebe. — Мы соревнуемся за любовь Эдмунда."
+                ],
+                "sentenceParts": [
+                    "Auf den weißen Klippen von Dover blickt Regan in den aufgewühlten Kanal.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „wettkämpfen“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "hassen",
                 "translation": "ненавидеть",
                 "transcription": "[ХА-сен]",
@@ -2838,9 +3622,14 @@
                     "Das Hassen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело ненавидеть.",
                     "Ich hasse meine Schwester mehr als je zuvor. — Я ненавижу сестру больше, чем когда-либо.",
                     "Ich hasse seine Schwäche und Güte. — Я ненавижу его слабость и доброту."
+                ],
+                "sentenceParts": [
+                    "Zwischen flatternden Feldzeichen richtet Regan den Helm.",
+                    "Ich zeichne das Wort „hassen“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "bedrohen",
                 "translation": "угрожать",
                 "transcription": "[бе-ДРО-ен]",
@@ -2863,9 +3652,14 @@
                 ],
                 "collocations": [
                     "Ich bedrohe sie mit dem Tod. — Я угрожаю ей смертью."
+                ],
+                "sentenceParts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Regan Marschrouten in den Sand.",
+                    "Das Echo des Wortes „bedrohen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Rivalität",
                 "translation": "соперничество",
                 "transcription": "[ди ри-ва-ли-ТЕТ]",
@@ -2891,9 +3685,15 @@
                 "collocations": [
                     "Ihre Rivalität spielt mir in die Hände. — Их соперничество играет мне на руку.",
                     "Unsere Rivalität wird tödlich enden. — Наше соперничество закончится смертью."
+                ],
+                "sentenceParts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Regan das Siegel.",
+                    "Ich presse das Wort „die Rivalität“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "bekämpfen",
                 "translation": "бороться",
                 "transcription": "[бе-КЕМП-фен]",
@@ -2916,9 +3716,14 @@
                 ],
                 "collocations": [
                     "Ich bekämpfe sie mit allen Mitteln. — Я борюсь с ней всеми средствами."
+                ],
+                "sentenceParts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Regan dem dumpfen Meer.",
+                    "Ich zeichne das Wort „bekämpfen“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "misstrauen",
                 "translation": "не доверять",
                 "transcription": "[МИС-трау-ен]",
@@ -2943,9 +3748,14 @@
                 "collocations": [
                     "Im Sturm zeigt sich, wie wichtig das Misstrauen ist. — Во время бури становится понятно, насколько важно не доверять.",
                     "Ich misstraue jedem ihrer Worte. — Я не доверяю ни одному её слову."
+                ],
+                "sentenceParts": [
+                    "Auf dem sandigen Trainingsplatz übt Regan das Ziehen des Schwerts.",
+                    "Das Echo des Wortes „misstrauen“ übertönt das Flüstern der Höflinge."
                 ]
             },
             {
+                "wordId": "",
                 "word": "argwöhnen",
                 "translation": "подозревать",
                 "transcription": "[АРГ-вё-нен]",
@@ -2968,6 +3778,10 @@
                 ],
                 "collocations": [
                     "Ich argwöhne Gift in meinem Wein. — Я подозреваю яд в моём вине."
+                ],
+                "sentenceParts": [
+                    "Zwischen pochenden Trommeln hebt Regan das Banner der Hoffnung.",
+                    "Ich zeichne das Wort „argwöhnen“ in Gedanken über die Linien des Schicksals."
                 ]
             }
         ],
@@ -2975,81 +3789,155 @@
             {
                 "question": "Что означает немецкое слово «wettkämpfen»?",
                 "choices": [
+                    "соперничество",
+                    "угрожать",
                     "соревноваться",
-                    "соперничество",
-                    "угрожать",
                     "ненавидеть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «hassen»?",
-                "choices": [
-                    "угрожать",
-                    "соперничество",
-                    "ненавидеть",
-                    "соревноваться"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «bedrohen»?",
+                "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
-                    "угрожать",
                     "ненавидеть",
+                    "угрожать",
                     "соревноваться",
-                    "бороться"
+                    "соперничество"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Rivalität»?",
+                "question": "Что означает немецкое слово «bedrohen»?",
                 "choices": [
+                    "бороться",
                     "угрожать",
                     "соперничество",
-                    "не доверять",
                     "ненавидеть"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Rivalität»?",
+                "choices": [
+                    "подозревать",
+                    "соперничество",
+                    "соревноваться",
+                    "бороться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bekämpfen»?",
                 "choices": [
-                    "угрожать",
+                    "ненавидеть",
+                    "соревноваться",
                     "бороться",
-                    "соперничество",
                     "не доверять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «misstrauen»?",
                 "choices": [
+                    "соревноваться",
+                    "подозревать",
                     "бороться",
-                    "не доверять",
-                    "угрожать",
-                    "ненавидеть"
+                    "не доверять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «argwöhnen»?",
                 "choices": [
                     "ненавидеть",
+                    "подозревать",
                     "не доверять",
-                    "соперничество",
-                    "подозревать"
+                    "соперничество"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "wettkämpfen",
+                "translation": "соревноваться",
+                "parts": [
+                    "Auf den weißen Klippen von Dover blickt Regan in den aufgewühlten Kanal.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „wettkämpfen“ mein Nordstern."
+                ],
+                "sentence": "Auf den weißen Klippen von Dover blickt Regan in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „wettkämpfen“ mein Nordstern.",
+                "sentenceTranslation": "На белых скалах Дувра Регана смотрит в вздыбленный пролив. Даже если мир распадается, слово «соревноваться» остаётся моим северным светом."
+            },
+            {
+                "word": "hassen",
+                "translation": "ненавидеть",
+                "parts": [
+                    "Zwischen flatternden Feldzeichen richtet Regan den Helm.",
+                    "Ich zeichne das Wort „hassen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Zwischen flatternden Feldzeichen richtet Regan den Helm. Ich zeichne das Wort „hassen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Среди хлопающих штандартов Регана поправляет шлем. Я вывожу слово «ненавидеть» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "bedrohen",
+                "translation": "угрожать",
+                "parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Regan Marschrouten in den Sand.",
+                    "Das Echo des Wortes „bedrohen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Regan Marschrouten in den Sand. Das Echo des Wortes „bedrohen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "У французского костра Регана рисует в песке путь марша. Эхо слова «угрожать» заглушает шёпот придворных."
+            },
+            {
+                "word": "die Rivalität",
+                "translation": "соперничество",
+                "parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Regan das Siegel.",
+                    "Ich presse das Wort „die Rivalität“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Regan das Siegel. Ich presse das Wort „die Rivalität“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "У перевязанных провиантных ящиков Регана проверяет печати. Я стискиваю слово «соперничество» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "bekämpfen",
+                "translation": "бороться",
+                "parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Regan dem dumpfen Meer.",
+                    "Ich zeichne das Wort „bekämpfen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Regan dem dumpfen Meer. Ich zeichne das Wort „bekämpfen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Перед шёлковым шатром полководцев Регана слушает глухой шум моря. Я вывожу слово «бороться» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "misstrauen",
+                "translation": "не доверять",
+                "parts": [
+                    "Auf dem sandigen Trainingsplatz übt Regan das Ziehen des Schwerts.",
+                    "Das Echo des Wortes „misstrauen“ übertönt das Flüstern der Höflinge."
+                ],
+                "sentence": "Auf dem sandigen Trainingsplatz übt Regan das Ziehen des Schwerts. Das Echo des Wortes „misstrauen“ übertönt das Flüstern der Höflinge.",
+                "sentenceTranslation": "На песчаном плацу Регана отрабатывает выхват меча. Эхо слова «не доверять» заглушает шёпот придворных."
+            },
+            {
+                "word": "argwöhnen",
+                "translation": "подозревать",
+                "parts": [
+                    "Zwischen pochenden Trommeln hebt Regan das Banner der Hoffnung.",
+                    "Ich zeichne das Wort „argwöhnen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "sentence": "Zwischen pochenden Trommeln hebt Regan das Banner der Hoffnung. Ich zeichne das Wort „argwöhnen“ in Gedanken über die Linien des Schicksals.",
+                "sentenceTranslation": "Под гул барабанов Регана поднимает знамя надежды. Я черчу слово «подозревать» в мыслях поверх линий судьбы."
+            }
+        ]
     },
     "prison": {
         "title": "Смерть от яда",
         "description": "Акт V: Отравление сестрой",
         "words": [
             {
+                "wordId": "",
                 "word": "vergiftet",
                 "translation": "отравленный",
                 "transcription": "[фер-ГИФ-тет]",
@@ -3071,9 +3959,14 @@
                 ],
                 "collocations": [
                     "Ich bin von meiner eigenen Schwester vergiftet. — Я отравлена собственной сестрой."
+                ],
+                "sentenceParts": [
+                    "Im feuchten Kerker stützt Regan sich an den tropfenden Stein.",
+                    "Ich atme tief ein und lasse nur das Wort „vergiftet“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "leiden",
                 "translation": "страдать",
                 "transcription": "[ЛАЙ-ден]",
@@ -3098,9 +3991,14 @@
                     "Er muss furchtbar leiden ohne mich. — Он должно быть ужасно страдает без меня.",
                     "Ich leide furchtbare Qualen. — Я страдаю от ужасных мук.",
                     "Zum ersten Mal leide ich selbst. — Впервые я сам страдаю."
+                ],
+                "sentenceParts": [
+                    "Unter der trüben Laterne zählt Regan die eisernen Ringe der Kette.",
+                    "Ich zeichne das Wort „leiden“ mit unsichtbarer Tinte auf meine Handfläche."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verenden",
                 "translation": "издыхать",
                 "transcription": "[фер-ЕН-ден]",
@@ -3125,9 +4023,14 @@
                 ],
                 "collocations": [
                     "Wie ein Tier verende ich elend. — Как зверь я издыхаю жалко."
+                ],
+                "sentenceParts": [
+                    "Neben der schweren Holztür horcht Regan auf entferntes Schluchzen.",
+                    "Wie ein stilles Gebet legt sich das Wort „verenden“ auf meine Lippen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "die Qual",
                 "translation": "мучение",
                 "transcription": "[ди КВАЛЬ]",
@@ -3154,9 +4057,14 @@
                 "collocations": [
                     "Die Qual des Giftes zerreißt mich. — Мучение от яда разрывает меня.",
                     "Seine Qual bereitet mir Vergnügen. — Его мука доставляет мне удовольствие."
+                ],
+                "sentenceParts": [
+                    "Auf der kalten Steinbank zieht Regan den Mantel enger um die Schultern.",
+                    "Ich atme tief ein und lasse nur das Wort „die Qual“ wieder hinaus."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verwünschen",
                 "translation": "проклинать",
                 "transcription": "[фер-ВЮН-шен]",
@@ -3180,9 +4088,14 @@
                 ],
                 "collocations": [
                     "Ich verwünsche meine Schwester mit letzter Kraft. — Я проклинаю сестру последними силами."
+                ],
+                "sentenceParts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Regan das Gesicht zum Licht.",
+                    "Ich presse das Wort „verwünschen“ zwischen die Zähne, damit kein Zweifel entweicht."
                 ]
             },
             {
+                "wordId": "",
                 "word": "das Verhängnis",
                 "translation": "рок",
                 "transcription": "[дас фер-ХЕНГ-нис]",
@@ -3204,9 +4117,14 @@
                 ],
                 "collocations": [
                     "Das Verhängnis ereilt mich gerecht. — Рок настигает меня справедливо."
+                ],
+                "sentenceParts": [
+                    "Am rostigen Wassereimer spiegelt Regan kurz die eigenen Augen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „das Verhängnis“ mein Nordstern."
                 ]
             },
             {
+                "wordId": "",
                 "word": "büßen",
                 "translation": "расплачиваться",
                 "transcription": "[БЮ-сен]",
@@ -3228,9 +4146,14 @@
                 ],
                 "collocations": [
                     "Ich büße für all meine Grausamkeiten. — Я расплачиваюсь за все свои жестокости."
+                ],
+                "sentenceParts": [
+                    "Im dumpfen Hall der Schritte zählt Regan den Rhythmus der Wachen.",
+                    "Ich halte das Wort „büßen“ wie eine Fackel vor meinem Herzen."
                 ]
             },
             {
+                "wordId": "",
                 "word": "verflucht",
                 "translation": "проклятый",
                 "transcription": "[фер-ФЛУХТ]",
@@ -3252,6 +4175,10 @@
                 ],
                 "collocations": [
                     "Verflucht sei unser böses Blut! — Проклята наша злая кровь!"
+                ],
+                "sentenceParts": [
+                    "Vor dem verriegelten Fenster zeichnet Regan Kreise in den Staub.",
+                    "Das kalte Licht lässt das Wort „verflucht“ wie geschmolzenes Gold erscheinen."
                 ]
             }
         ],
@@ -3259,85 +4186,167 @@
             {
                 "question": "Что означает немецкое слово «vergiftet»?",
                 "choices": [
-                    "отравленный",
+                    "издыхать",
                     "страдать",
                     "мучение",
-                    "издыхать"
+                    "отравленный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "отравленный",
-                    "издыхать",
                     "мучение",
-                    "страдать"
+                    "издыхать",
+                    "страдать",
+                    "отравленный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
-                    "страдать",
+                    "расплачиваться",
+                    "издыхать",
                     "проклинать",
-                    "проклятый",
-                    "издыхать"
+                    "рок"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
+                    "проклятый",
+                    "проклинать",
                     "издыхать",
-                    "расплачиваться",
-                    "мучение",
-                    "отравленный"
+                    "мучение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verwünschen»?",
                 "choices": [
-                    "проклинать",
-                    "проклятый",
-                    "отравленный",
-                    "расплачиваться"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «das Verhängnis»?",
-                "choices": [
-                    "издыхать",
-                    "расплачиваться",
                     "рок",
-                    "отравленный"
+                    "мучение",
+                    "проклинать",
+                    "страдать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «das Verhängnis»?",
+                "choices": [
+                    "отравленный",
+                    "страдать",
+                    "расплачиваться",
+                    "рок"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «büßen»?",
                 "choices": [
-                    "мучение",
+                    "рок",
                     "расплачиваться",
                     "издыхать",
-                    "проклинать"
+                    "страдать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verflucht»?",
                 "choices": [
+                    "отравленный",
                     "проклятый",
-                    "страдать",
                     "расплачиваться",
                     "издыхать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
-        "quizAttempts": {}
+        "quizAttempts": {},
+        "sentenceParts": [
+            {
+                "word": "vergiftet",
+                "translation": "отравленный",
+                "parts": [
+                    "Im feuchten Kerker stützt Regan sich an den tropfenden Stein.",
+                    "Ich atme tief ein und lasse nur das Wort „vergiftet“ wieder hinaus."
+                ],
+                "sentence": "Im feuchten Kerker stützt Regan sich an den tropfenden Stein. Ich atme tief ein und lasse nur das Wort „vergiftet“ wieder hinaus.",
+                "sentenceTranslation": "В сыром подземелье Регана опирается на сочащийся камень. Я глубоко вдыхаю и выпускаю только слово «отравленный»."
+            },
+            {
+                "word": "leiden",
+                "translation": "страдать",
+                "parts": [
+                    "Unter der trüben Laterne zählt Regan die eisernen Ringe der Kette.",
+                    "Ich zeichne das Wort „leiden“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "sentence": "Unter der trüben Laterne zählt Regan die eisernen Ringe der Kette. Ich zeichne das Wort „leiden“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentenceTranslation": "Под мутным фонарём Регана пересчитывает железные кольца цепи. Я вывожу слово «страдать» невидимыми чернилами на ладони."
+            },
+            {
+                "word": "verenden",
+                "translation": "издыхать",
+                "parts": [
+                    "Neben der schweren Holztür horcht Regan auf entferntes Schluchzen.",
+                    "Wie ein stilles Gebet legt sich das Wort „verenden“ auf meine Lippen."
+                ],
+                "sentence": "Neben der schweren Holztür horcht Regan auf entferntes Schluchzen. Wie ein stilles Gebet legt sich das Wort „verenden“ auf meine Lippen.",
+                "sentenceTranslation": "У тяжёлой двери Регана прислушивается к далёким рыданиям. Как тихая молитва слово «издыхать» ложится на мои губы."
+            },
+            {
+                "word": "die Qual",
+                "translation": "мучение",
+                "parts": [
+                    "Auf der kalten Steinbank zieht Regan den Mantel enger um die Schultern.",
+                    "Ich atme tief ein und lasse nur das Wort „die Qual“ wieder hinaus."
+                ],
+                "sentence": "Auf der kalten Steinbank zieht Regan den Mantel enger um die Schultern. Ich atme tief ein und lasse nur das Wort „die Qual“ wieder hinaus.",
+                "sentenceTranslation": "На холодной каменной скамье Регана плотнее кутается в плащ. Я глубоко вдыхаю и выпускаю только слово «мучение»."
+            },
+            {
+                "word": "verwünschen",
+                "translation": "проклинать",
+                "parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Regan das Gesicht zum Licht.",
+                    "Ich presse das Wort „verwünschen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Regan das Gesicht zum Licht. Ich presse das Wort „verwünschen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentenceTranslation": "Между тенями решёток Регана поднимает лицо к свету. Я стискиваю слово «проклинать» зубами, чтобы не вырвалось сомнение."
+            },
+            {
+                "word": "das Verhängnis",
+                "translation": "рок",
+                "parts": [
+                    "Am rostigen Wassereimer spiegelt Regan kurz die eigenen Augen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „das Verhängnis“ mein Nordstern."
+                ],
+                "sentence": "Am rostigen Wassereimer spiegelt Regan kurz die eigenen Augen. Selbst wenn die Welt zerfällt, bleibt das Wort „das Verhängnis“ mein Nordstern.",
+                "sentenceTranslation": "У ржавого ведра с водой Регана на мгновение видит отражение глаз. Даже если мир распадается, слово «рок» остаётся моим северным светом."
+            },
+            {
+                "word": "büßen",
+                "translation": "расплачиваться",
+                "parts": [
+                    "Im dumpfen Hall der Schritte zählt Regan den Rhythmus der Wachen.",
+                    "Ich halte das Wort „büßen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "sentence": "Im dumpfen Hall der Schritte zählt Regan den Rhythmus der Wachen. Ich halte das Wort „büßen“ wie eine Fackel vor meinem Herzen.",
+                "sentenceTranslation": "В глухом эхе шагов Регана отсчитывает ритм часовых. Я держу слово «расплачиваться» как факел у сердца."
+            },
+            {
+                "word": "verflucht",
+                "translation": "проклятый",
+                "parts": [
+                    "Vor dem verriegelten Fenster zeichnet Regan Kreise in den Staub.",
+                    "Das kalte Licht lässt das Wort „verflucht“ wie geschmolzenes Gold erscheinen."
+                ],
+                "sentence": "Vor dem verriegelten Fenster zeichnet Regan Kreise in den Staub. Das kalte Licht lässt das Wort „verflucht“ wie geschmolzenes Gold erscheinen.",
+                "sentenceTranslation": "Перед заколоченным окном Регана чертит круги в пыли. Холодный свет заставляет слово «проклятый» сиять словно расплавленное золото."
+            }
+        ]
     }
 };
 
@@ -3353,6 +4362,354 @@ let isTransitioning = false; // Prevent double clicks/taps
 let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
+const constructorState = {};
+
+const STUDY_BUTTON_SELECTOR = '.btn-study';
+
+function normalizeString(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function escapeHtmlAttribute(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function parseJsonList(rawValue) {
+    if (!rawValue) {
+        return [];
+    }
+
+    if (Array.isArray(rawValue)) {
+        return rawValue
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    if (typeof rawValue === 'string') {
+        try {
+            const parsed = JSON.parse(rawValue);
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(item => normalizeString(item))
+                    .filter(Boolean);
+            }
+        } catch (error) {
+            // Fall through to string splitting
+        }
+
+        return rawValue
+            .split(',')
+            .map(item => normalizeString(item))
+            .filter(Boolean);
+    }
+
+    return [];
+}
+
+function readStoredReviewQueueItems() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.filter(item => item && typeof item === 'object');
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read review queue', error);
+        return [];
+    }
+}
+
+function writeStoredReviewQueueItems(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    const items = Array.isArray(queue) ? queue : [];
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(items));
+        return true;
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to persist review queue', error);
+        return false;
+    }
+}
+
+function getStudyQueueKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return 'entry::';
+    }
+
+    const wordId = normalizeString(entry.wordId || entry.wordID || entry.word_id);
+    const character = normalizeString(entry.characterId || entry.characterID || entry.character_id);
+    const phase = normalizeString(entry.phaseId || entry.phaseID || entry.phase_id);
+
+    if (wordId) {
+        return `id::${wordId}`;
+    }
+
+    const word = normalizeString(entry.word);
+    const translation = normalizeString(entry.translation);
+
+    return `word::${character}::${phase}::${word}::${translation}`;
+}
+
+function mergeStudyExamples(existingExamples, newExamples) {
+    const combined = [];
+    const seen = new Set();
+
+    const pushExample = example => {
+        if (!example || typeof example !== 'object') {
+            return;
+        }
+
+        const german = normalizeString(example.german || example.de || example.example || '');
+        const russian = normalizeString(example.russian || example.ru || example.translation || '');
+
+        if (!german && !russian) {
+            return;
+        }
+
+        const key = `${german}::${russian}`;
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        combined.push({ german, russian });
+    };
+
+    if (Array.isArray(existingExamples)) {
+        existingExamples.forEach(pushExample);
+    }
+
+    if (Array.isArray(newExamples)) {
+        newExamples.forEach(pushExample);
+    }
+
+    return combined;
+}
+
+function mergeStudyEntries(existingEntry, incomingEntry) {
+    if (!existingEntry) {
+        return incomingEntry ? { ...incomingEntry } : existingEntry;
+    }
+
+    if (!incomingEntry) {
+        return { ...existingEntry };
+    }
+
+    const merged = { ...existingEntry, ...incomingEntry };
+
+    const tags = new Set();
+    if (Array.isArray(existingEntry.tags)) {
+        existingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+    if (Array.isArray(incomingEntry.tags)) {
+        incomingEntry.tags.forEach(tag => {
+            const normalized = normalizeString(tag);
+            if (normalized) {
+                tags.add(normalized);
+            }
+        });
+    }
+
+    if (tags.size) {
+        merged.tags = Array.from(tags);
+    }
+
+    merged.examples = mergeStudyExamples(existingEntry.examples, incomingEntry.examples);
+
+    return merged;
+}
+
+function upsertReviewQueueEntry(queue, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return Array.isArray(queue) ? queue.slice() : [];
+    }
+
+    const currentQueue = Array.isArray(queue)
+        ? queue.filter(item => item && typeof item === 'object')
+        : [];
+
+    const targetKey = getStudyQueueKey(entry);
+    let replaced = false;
+
+    const updatedQueue = currentQueue.map(item => {
+        if (getStudyQueueKey(item) === targetKey) {
+            replaced = true;
+            return mergeStudyEntries(item, entry);
+        }
+        return item;
+    });
+
+    if (!replaced) {
+        updatedQueue.push(entry);
+    }
+
+    return updatedQueue;
+}
+
+function buildQueueEntryFromDataset(dataset) {
+    if (!dataset) {
+        return null;
+    }
+
+    const fallbackCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    const wordId = normalizeString(dataset.wordId || dataset.wordID || dataset.word_id);
+    const word = normalizeString(dataset.word);
+
+    if (!wordId && !word) {
+        return null;
+    }
+
+    const entry = {};
+
+    const character = normalizeString(
+        dataset.characterId || dataset.characterID || dataset.character_id || fallbackCharacterId
+    );
+    const phase = normalizeString(dataset.phaseId || dataset.phaseID || dataset.phase_id || dataset.phase);
+
+    if (wordId) {
+        entry.wordId = wordId;
+    }
+
+    if (character) {
+        entry.characterId = character;
+    }
+
+    if (phase) {
+        entry.phaseId = phase;
+    }
+
+    if (word) {
+        entry.word = word;
+    }
+
+    const translation = normalizeString(dataset.translation);
+    if (translation) {
+        entry.translation = translation;
+    }
+
+    const transcription = normalizeString(dataset.transcription);
+    if (transcription) {
+        entry.transcription = transcription;
+    }
+
+    const visualHint = normalizeString(dataset.visualHint);
+    if (visualHint) {
+        entry.visualHint = visualHint;
+    }
+
+    const practiceUrl = normalizeString(dataset.practiceUrl);
+    if (practiceUrl) {
+        entry.practiceUrl = practiceUrl;
+    }
+
+    const phaseTitle = normalizeString(dataset.phaseTitle);
+    if (phaseTitle) {
+        entry.phaseTitle = phaseTitle;
+    }
+
+    const source = normalizeString(dataset.source);
+    entry.source = source || 'journey';
+
+    const tags = parseJsonList(dataset.tags || dataset.themes);
+    if (tags.length) {
+        entry.tags = tags;
+    }
+
+    const germanSentence = normalizeString(dataset.sentence);
+    const russianSentence = normalizeString(dataset.sentenceTranslation || dataset.sentence_translation);
+
+    const examples = [];
+    if (germanSentence) {
+        entry.example = germanSentence;
+    }
+    if (russianSentence) {
+        entry.exampleTranslation = russianSentence;
+    }
+    if (germanSentence || russianSentence) {
+        examples.push({
+            german: germanSentence,
+            russian: russianSentence,
+        });
+    }
+
+    entry.examples = examples;
+    entry.addedAt = new Date().toISOString();
+
+    return entry;
+}
+
+function attachStudyButtonHandler(button) {
+    if (!button || typeof button.addEventListener !== 'function') {
+        return;
+    }
+
+    if (button.dataset.studyBound === 'true') {
+        return;
+    }
+
+    button.dataset.studyBound = 'true';
+
+    button.addEventListener('click', event => {
+        event.preventDefault();
+
+        const payload = buildQueueEntryFromDataset(button.dataset);
+        if (!payload) {
+            console.warn('[StudyQueue] Unable to build study payload for button', button);
+            return;
+        }
+
+        const existingQueue = readStoredReviewQueueItems();
+        const updatedQueue = upsertReviewQueueEntry(existingQueue, payload);
+        const saved = writeStoredReviewQueueItems(updatedQueue);
+
+        if (!saved) {
+            return;
+        }
+
+        if (button.classList) {
+            button.classList.add('queued');
+        }
+
+        button.dataset.state = 'queued';
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -3789,6 +5146,323 @@ function initializeProgressLine() {
     updateProgressLineByPercent(startValue);
 }
 
+function getConstructorSets(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    if (!phase) {
+        return [];
+    }
+
+    const sets = phase.sentenceParts;
+    return Array.isArray(sets) ? sets : [];
+}
+
+function ensureConstructorState(phaseKey) {
+    if (!constructorState[phaseKey]) {
+        constructorState[phaseKey] = {
+            index: 0,
+        };
+    }
+    return constructorState[phaseKey];
+}
+
+function buildConstructorFragment(text, index) {
+    const fragment = document.createElement('button');
+    fragment.type = 'button';
+    fragment.className = 'constructor-fragment';
+    fragment.dataset.index = String(index);
+    fragment.textContent = text;
+    return fragment;
+}
+
+function clearConstructorFeedback(panel) {
+    if (!panel) return;
+
+    const feedback = panel.querySelector('.constructor-feedback');
+    if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('success', 'error');
+    }
+
+    const original = panel.querySelector('[data-constructor-original]');
+    if (original) {
+        original.textContent = '';
+    }
+}
+
+function updateConstructorPlaceholder(panel) {
+    if (!panel) return;
+
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!target) return;
+
+    const fragments = target.querySelectorAll('.constructor-fragment');
+    if (fragments.length > 0) {
+        target.classList.add('has-fragments');
+    } else {
+        target.classList.remove('has-fragments');
+    }
+}
+
+function renderConstructorForPhase(phaseKey) {
+    const panel = document.querySelector(`.constructor-panel[data-phase="${phaseKey}"]`);
+    if (!panel) {
+        return;
+    }
+
+    const sets = getConstructorSets(phaseKey);
+    const state = ensureConstructorState(phaseKey);
+
+    const wordElement = panel.querySelector('[data-constructor-word]');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const progressElement = panel.querySelector('[data-constructor-progress]');
+    const hintElement = panel.querySelector('[data-constructor-hint]');
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    const checkBtn = panel.querySelector('.constructor-check');
+    const resetBtn = panel.querySelector('.constructor-reset');
+    const nextBtn = panel.querySelector('.constructor-next');
+
+    clearConstructorFeedback(panel);
+
+    if (!sets.length) {
+        if (wordElement) wordElement.textContent = '—';
+        if (translationElement) translationElement.textContent = '';
+        if (progressElement) progressElement.textContent = '';
+        if (hintElement) {
+            hintElement.textContent = 'Для этой фазы пока нет предложений для конструктора.';
+        }
+        if (source) {
+            source.innerHTML = '';
+        }
+        if (target) {
+            target.innerHTML = '<div class="constructor-placeholder">Предложения появятся позже.</div>';
+            target.classList.remove('has-fragments');
+        }
+        [checkBtn, resetBtn, nextBtn].forEach(btn => {
+            if (btn) {
+                btn.disabled = true;
+            }
+        });
+        return;
+    }
+
+    if (state.index >= sets.length) {
+        state.index = 0;
+    }
+    if (state.index < 0) {
+        state.index = sets.length - 1;
+    }
+
+    const current = sets[state.index];
+
+    if (wordElement) {
+        wordElement.textContent = current.word || '—';
+    }
+
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    if (progressElement) {
+        progressElement.textContent = `${state.index + 1} / ${sets.length}`;
+    }
+
+    if (hintElement) {
+        if (current.translation) {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}». Подсказка: ${current.translation}.`;
+        } else {
+            hintElement.textContent = `Соберите предложение со словом «${current.word}».`;
+        }
+    }
+
+    if (source) {
+        source.innerHTML = '';
+        const indices = current.parts.map((_, idx) => idx);
+        const shuffled = shuffleArray(indices);
+        shuffled.forEach(idx => {
+            const fragment = buildConstructorFragment(current.parts[idx], idx);
+            source.appendChild(fragment);
+        });
+    }
+
+    if (target) {
+        target.innerHTML = '<div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>';
+        target.classList.remove('has-fragments');
+    }
+
+    [checkBtn, resetBtn, nextBtn].forEach(btn => {
+        if (btn) {
+            btn.disabled = false;
+        }
+    });
+
+    panel.dataset.constructorIndex = String(state.index);
+}
+
+function toggleConstructorFragment(panel, fragment) {
+    if (!panel || !fragment) return;
+
+    const source = panel.querySelector('[data-constructor-source]');
+    const target = panel.querySelector('[data-constructor-target]');
+    if (!source || !target) return;
+
+    if (fragment.parentElement === source) {
+        target.appendChild(fragment);
+        fragment.classList.add('in-target');
+    } else {
+        source.appendChild(fragment);
+        fragment.classList.remove('in-target');
+    }
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(10);
+    }
+
+    clearConstructorFeedback(panel);
+
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    if (translationElement) {
+        translationElement.textContent = 'Перевод появится после проверки.';
+    }
+
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorCheck(panel) {
+    if (!panel) return;
+
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    const current = sets[state.index] || sets[0];
+
+    const target = panel.querySelector('[data-constructor-target]');
+    const feedback = panel.querySelector('.constructor-feedback');
+    const translationElement = panel.querySelector('[data-constructor-translation]');
+    const originalElement = panel.querySelector('[data-constructor-original]');
+
+    if (!target || !feedback) {
+        return;
+    }
+
+    const fragments = Array.from(target.querySelectorAll('.constructor-fragment'));
+
+    if (fragments.length !== current.parts.length) {
+        feedback.textContent = 'Используйте все фрагменты, прежде чем проверять.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(30);
+        }
+        return;
+    }
+
+    const indices = fragments.map(fragment => parseInt(fragment.dataset.index || '0', 10));
+    const isCorrect = indices.every((value, idx) => value === idx);
+
+    if (isCorrect) {
+        feedback.textContent = 'Отлично! Предложение собрано верно.';
+        feedback.classList.add('success');
+        feedback.classList.remove('error');
+        if (translationElement) {
+            if (current.sentenceTranslation) {
+                translationElement.textContent = `Перевод: ${current.sentenceTranslation}`;
+            } else {
+                translationElement.textContent = 'Перевод: —';
+            }
+        }
+        if (originalElement) {
+            originalElement.textContent = current.sentence ? `Оригинал: "${current.sentence}"` : '';
+        }
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    } else {
+        feedback.textContent = 'Порядок фрагментов пока неверный. Попробуйте ещё раз.';
+        feedback.classList.add('error');
+        feedback.classList.remove('success');
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(40);
+        }
+    }
+}
+
+function handleConstructorReset(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    if (!phaseKey) return;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+}
+
+function handleConstructorNext(panel) {
+    if (!panel) return;
+    const phaseKey = panel.dataset.phase;
+    const sets = getConstructorSets(phaseKey);
+    if (!sets.length) {
+        return;
+    }
+
+    const state = ensureConstructorState(phaseKey);
+    state.index = (state.index + 1) % sets.length;
+    renderConstructorForPhase(phaseKey);
+    updateConstructorPlaceholder(panel);
+
+    if (navigator.vibrate && isTouchDevice) {
+        navigator.vibrate(15);
+    }
+}
+
+function initializeConstructorSection() {
+    const panels = document.querySelectorAll('.constructor-panel');
+    panels.forEach(panel => {
+        panel.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            if (target.classList.contains('constructor-fragment')) {
+                toggleConstructorFragment(panel, target);
+            }
+        });
+
+        const checkBtn = panel.querySelector('.constructor-check');
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => handleConstructorCheck(panel));
+        }
+
+        const resetBtn = panel.querySelector('.constructor-reset');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => handleConstructorReset(panel));
+        }
+
+        const nextBtn = panel.querySelector('.constructor-next');
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => handleConstructorNext(panel));
+        }
+    });
+}
+
+function activateConstructorPhase(phaseKey) {
+    const panels = document.querySelectorAll('.constructor-panel');
+    let activeRendered = false;
+
+    panels.forEach(panel => {
+        const isCurrent = panel.dataset.phase === phaseKey;
+        panel.classList.toggle('active', isCurrent);
+        if (isCurrent && !activeRendered) {
+            renderConstructorForPhase(phaseKey);
+            updateConstructorPlaceholder(panel);
+            activeRendered = true;
+        }
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -3857,6 +5531,9 @@ function displayVocabulary(phaseKey) {
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
 
+    // Update constructor section
+    activateConstructorPhase(phaseKey);
+
     grid.innerHTML = '';
 
     phase.words.forEach((item, index) => {
@@ -3865,13 +5542,61 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const exampleSentence = item.sentence
+                ? `<p class="sentence-german">${item.sentence}</p>`
+                : '';
+            const exampleTranslation = item.sentenceTranslation
+                ? `<p class="sentence-translation">${item.sentenceTranslation}</p>`
+                : '';
+            const exampleBlock = (exampleSentence || exampleTranslation)
+                ? `<div class="word-sentence">${exampleSentence}${exampleTranslation}</div>`
+                : '';
+            const sentenceAttr = escapeHtmlAttribute(item.sentence || '');
+            const sentenceTranslationAttr = escapeHtmlAttribute(item.sentenceTranslation || '');
+
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
+                ${exampleBlock}
+                <div class="word-actions">
+                    <button class="btn-study" type="button"
+                        data-sentence="${sentenceAttr}"
+                        data-sentence-translation="${sentenceTranslationAttr}"
+                    >Учить слово</button>
+                </div>
             `;
+
+            const studyButton = card.querySelector(STUDY_BUTTON_SELECTOR);
+            if (studyButton) {
+                const wordId = item.wordId || '';
+                const practiceUrl = wordId ? `../trainings/${wordId}.html` : '';
+                const themes = Array.isArray(item.themes) ? item.themes : [];
+
+                studyButton.dataset.word = item.word || '';
+                studyButton.dataset.translation = item.translation || '';
+                studyButton.dataset.transcription = item.transcription || '';
+                studyButton.dataset.characterId = characterId || '';
+                studyButton.dataset.phaseId = phaseKey || '';
+                studyButton.dataset.phaseTitle = phase.title || '';
+                studyButton.dataset.visualHint = item.visual_hint || '';
+                studyButton.dataset.sentence = item.sentence || '';
+                studyButton.dataset.sentenceTranslation = item.sentenceTranslation || '';
+                studyButton.dataset.wordId = wordId;
+                studyButton.dataset.practiceUrl = practiceUrl;
+                studyButton.dataset.source = 'journey';
+                studyButton.dataset.tags = themes.length ? JSON.stringify(themes) : '';
+
+                const ariaLabel = item.word
+                    ? `Учить слово ${item.word}`
+                    : 'Учить слово';
+                studyButton.setAttribute('aria-label', ariaLabel);
+
+                attachStudyButtonHandler(studyButton);
+            }
+
             grid.appendChild(card);
         }, index * 50);
     });
@@ -4782,6 +6507,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
+    initializeConstructorSection();
     attachQuizHandlers();
 
     // Initialize relation toggles

--- a/output/static/css/journey.css
+++ b/output/static/css/journey.css
@@ -199,6 +199,215 @@ body {
     color: #333;
 }
 
+.constructor-section {
+    background: white;
+    border-radius: 20px;
+    padding: 40px;
+    margin-bottom: 40px;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.15);
+}
+
+.constructor-section h2 {
+    font-size: 2em;
+    text-align: center;
+    margin-bottom: 20px;
+    color: #333;
+}
+
+.constructor-intro {
+    text-align: center;
+    color: #555;
+    margin-bottom: 24px;
+}
+
+.constructor-panel {
+    display: none;
+}
+
+.constructor-panel.active {
+    display: block;
+}
+
+.constructor-empty {
+    margin-top: 16px;
+    text-align: center;
+    color: #777;
+    font-style: italic;
+}
+
+.constructor-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.constructor-word {
+    font-size: 1.5em;
+    font-weight: 600;
+    color: #4a3f8c;
+}
+
+.constructor-translation {
+    color: #666;
+    font-size: 1em;
+}
+
+.constructor-progress {
+    margin-left: auto;
+    font-size: 0.9em;
+    color: #888;
+}
+
+.constructor-hint {
+    color: #555;
+    margin-bottom: 20px;
+}
+
+.constructor-areas {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    margin-bottom: 24px;
+}
+
+.constructor-source,
+.constructor-target {
+    background: #f7f7ff;
+    border: 2px dashed rgba(118, 75, 162, 0.3);
+    border-radius: 16px;
+    padding: 20px;
+    min-height: 140px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: flex-start;
+    position: relative;
+}
+
+.constructor-target {
+    border-style: solid;
+    background: #fbf8ff;
+}
+
+.constructor-placeholder {
+    color: #aaa;
+    font-size: 0.95em;
+}
+
+.constructor-target.has-fragments .constructor-placeholder {
+    display: none;
+}
+
+.constructor-fragment {
+    background: white;
+    border: 1px solid rgba(102, 126, 234, 0.4);
+    border-radius: 12px;
+    padding: 10px 14px;
+    font-size: 0.95em;
+    color: #4a3f8c;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s;
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.15);
+}
+
+.constructor-fragment:active {
+    transform: scale(0.98);
+}
+
+.constructor-fragment.in-target {
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.1), rgba(118, 75, 162, 0.2));
+    border-color: rgba(118, 75, 162, 0.5);
+}
+
+.constructor-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
+    margin-bottom: 16px;
+}
+
+.constructor-control {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    border: none;
+    border-radius: 999px;
+    padding: 12px 24px;
+    font-size: 0.95em;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.constructor-control:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 20px rgba(102, 126, 234, 0.3);
+}
+
+.constructor-control:disabled,
+.constructor-control[disabled] {
+    background: #ccc;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.constructor-feedback {
+    text-align: center;
+    min-height: 24px;
+    font-weight: 600;
+}
+
+.constructor-feedback.success {
+    color: #2e8b57;
+}
+
+.constructor-feedback.error {
+    color: #c0392b;
+}
+
+.constructor-original {
+    text-align: center;
+    color: #555;
+    font-size: 0.95em;
+}
+
+@media (max-width: 900px) {
+    .constructor-areas {
+        grid-template-columns: 1fr;
+    }
+
+    .constructor-source,
+    .constructor-target {
+        min-height: 120px;
+    }
+}
+
+@media (max-width: 600px) {
+    .constructor-section {
+        padding: 28px 20px;
+    }
+
+    .constructor-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .constructor-word {
+        font-size: 1.3em;
+    }
+
+    .constructor-controls {
+        flex-direction: column;
+    }
+
+    .constructor-control {
+        width: 100%;
+        text-align: center;
+    }
+}
+
 .vocabulary-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));


### PR DESCRIPTION
## Summary
- populate journey vocabulary items with word identifiers and helper utilities for study queue integration
- render study buttons with sample sentences, metadata attributes, and example payloads for localStorage
- regenerate journey pages so cards expose the new study attributes and example data

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68cde96dd4e88320a05496c4414f70b0